### PR TITLE
Use im HashMap in escalier_infer instead of the one from std::collections

### DIFF
--- a/crates/escalier_infer/src/assump.rs
+++ b/crates/escalier_infer/src/assump.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use im::hashmap::HashMap;
 
 use crate::context::Binding;
 

--- a/crates/escalier_infer/src/context.rs
+++ b/crates/escalier_infer/src/context.rs
@@ -1,6 +1,6 @@
 use escalier_ast::types::*;
+use im::hashmap::HashMap;
 use std::cell::Cell;
-use std::collections::HashMap;
 
 use crate::scheme::{generalize, instantiate, Scheme};
 use crate::substitutable::*;

--- a/crates/escalier_infer/src/expand_type.rs
+++ b/crates/escalier_infer/src/expand_type.rs
@@ -3,8 +3,8 @@ use escalier_ast::types::*;
 use escalier_ast::types::{
     TIndex, TIndexKey, TLit, TObjElem, TObject, TProp, TPropKey, Type, TypeKind,
 };
+use im::hashmap::HashMap;
 use itertools::Itertools;
-use std::collections::HashMap;
 
 use crate::context::Context;
 use crate::scheme::Scheme;
@@ -390,7 +390,7 @@ fn expand_mapped_type(mapped: &TMappedType, ctx: &mut Context) -> Result<Type, V
         .iter()
         .map(|key| {
             let name = mapped.type_param.name.to_owned();
-            let type_arg_map = HashMap::from([(name, key.to_owned())]);
+            let type_arg_map = HashMap::from(vec![(name, key.to_owned())]);
             let t = replace_aliases_rec(mapped.t.as_ref(), &type_arg_map);
 
             let t = match &t.kind {

--- a/crates/escalier_infer/src/infer_class.rs
+++ b/crates/escalier_infer/src/infer_class.rs
@@ -1,6 +1,6 @@
 use escalier_ast::types::*;
 use escalier_ast::values::{class::*, Lambda, PatternKind};
-use std::collections::HashMap;
+use im::hashmap::HashMap;
 
 use crate::context::{Binding, Context};
 use crate::infer_expr::infer_expr;

--- a/crates/escalier_infer/src/infer_expr.rs
+++ b/crates/escalier_infer/src/infer_expr.rs
@@ -1,5 +1,5 @@
 use derive_visitor::{DriveMut, VisitorMut};
-use std::collections::HashMap;
+use im::hashmap::HashMap;
 
 use escalier_ast::types::{
     self as types, Provenance, TCallable, TFnParam, TKeyword, TLam, TLit, TObjElem, TObject, TPat,

--- a/crates/escalier_infer/src/infer_fn_param.rs
+++ b/crates/escalier_infer/src/infer_fn_param.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use im::hashmap::HashMap;
 
 use escalier_ast::types::{self as types, TFnParam, TKeyword, TPat, Type, TypeKind};
 use escalier_ast::values::*;

--- a/crates/escalier_infer/src/infer_pattern.rs
+++ b/crates/escalier_infer/src/infer_pattern.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use im::hashmap::HashMap;
 
 use escalier_ast::types::{self as types, Provenance, TObject, TPropKey, Type, TypeKind};
 use escalier_ast::values::{self as values, *};

--- a/crates/escalier_infer/src/infer_type_ann.rs
+++ b/crates/escalier_infer/src/infer_type_ann.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use im::hashmap::HashMap;
 use std::iter::Iterator;
 
 use escalier_ast::types::{

--- a/crates/escalier_infer/src/scheme.rs
+++ b/crates/escalier_infer/src/scheme.rs
@@ -1,6 +1,6 @@
 use array_tool::vec::*;
+use im::hashmap::HashMap;
 use itertools::join;
-use std::collections::HashMap;
 use std::fmt;
 use std::iter::Iterator;
 

--- a/crates/escalier_infer/src/substitutable.rs
+++ b/crates/escalier_infer/src/substitutable.rs
@@ -1,5 +1,6 @@
 use array_tool::vec::*;
-use std::collections::{BTreeSet, HashMap};
+use im::hashmap::HashMap;
+use std::collections::BTreeSet;
 use std::iter::IntoIterator;
 
 use escalier_ast::types::*;
@@ -384,7 +385,7 @@ impl Substitutable for TFnParam {
 
 impl<I> Substitutable for HashMap<String, I>
 where
-    I: Substitutable,
+    I: Substitutable + Clone,
 {
     fn apply(&self, sub: &Subst) -> Self {
         self.iter()
@@ -396,27 +397,6 @@ where
         self.iter().flat_map(|(_, b)| b.ftv()).collect()
     }
 }
-
-// TODO: update apply() to not mutate so that we can use `im::hashmap` _et al_.
-// TODO: figure out if doing so will affect our ability to update exprs with
-// inferred types (it shouldn't be we need to be diligent).
-// impl<I> ImSubstitutable for hashmap::HashMap<String, I>
-// where
-//     I: ImSubstitutable,
-// {
-//     fn apply(&self, sub: &Subst) -> Subst {
-//         self.into_iter()
-//             .map(|(key, val)| (key.to_owned(), val.apply(sub).to_owned()))
-//             .collect()
-//         // for val in self.values() {
-//         //     val.apply(sub)
-//         // }
-//     }
-//     fn ftv(&self) -> Vec<TVar> {
-//         // we can't use iter_values() here because it's a consuming iterator
-//         self.iter().flat_map(|(_, b)| b.ftv()).collect()
-//     }
-// }
 
 impl<I> Substitutable for Vec<I>
 where

--- a/crates/escalier_infer/src/unify.rs
+++ b/crates/escalier_infer/src/unify.rs
@@ -770,7 +770,7 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &mut Context) -> Result<Subst, 
                             Type::from(TypeKind::Union(types))
                         };
 
-                        return Ok(Subst::from([(tv.id.to_owned(), t)]));
+                        return Ok(Subst::from(vec![(tv.id.to_owned(), t)]));
                     }
                 }
 
@@ -792,7 +792,7 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &mut Context) -> Result<Subst, 
                         constraint: None,
                     }) = t.kind
                     {
-                        let s: Subst = Subst::from([(
+                        let s: Subst = Subst::from(vec![(
                             id.to_owned(),
                             Type::from(TypeKind::Var(tv.to_owned())),
                         )]);
@@ -802,7 +802,7 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &mut Context) -> Result<Subst, 
                     // TODO: handle the case where both type variables have constraints
                 }
 
-                Ok(Subst::from([(tv.id.to_owned(), t.to_owned())]))
+                Ok(Subst::from(vec![(tv.id.to_owned(), t.to_owned())]))
             }
         }
     }

--- a/crates/escalier_infer/src/util.rs
+++ b/crates/escalier_infer/src/util.rs
@@ -1,5 +1,6 @@
 use defaultmap::*;
-use std::collections::{BTreeSet, HashMap};
+use im::hashmap::HashMap;
+use std::collections::BTreeSet;
 use std::iter::Iterator;
 
 use escalier_ast::types::*;


### PR DESCRIPTION
This should hopefully reduce memory consumption.  In a future PR, I'll update `Context` to store a single `Scope` instead of a stack of `Scope`s.

Fixes #455.