### PR TITLE
Put some of the building blocks in place to allow statements in blocks

### DIFF
--- a/crates/escalier_ast/src/values/class.rs
+++ b/crates/escalier_ast/src/values/class.rs
@@ -1,4 +1,4 @@
-use crate::values::expr::{EFnParam, Expr, Lambda};
+use crate::values::expr::{Block, EFnParam, Expr, Lambda};
 use crate::values::ident::Ident;
 use crate::values::type_ann::{TypeAnn, TypeParam};
 
@@ -19,7 +19,7 @@ pub enum ClassMember {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Constructor {
     pub params: Vec<EFnParam>,
-    pub body: Vec<Expr>,
+    pub body: Block,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/escalier_ast/src/values/expr.rs
+++ b/crates/escalier_ast/src/values/expr.rs
@@ -49,11 +49,11 @@ pub enum Statement {
     },
 }
 
-// #[derive(Debug, Clone, PartialEq, Eq)]
-// struct Block {
-//     pub span: Span,
-//     pub stmts: Vec<Expr>,
-// }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block {
+    pub span: Span,
+    pub stmts: Vec<Expr>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct App {
@@ -70,8 +70,8 @@ pub struct Fix {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IfElse {
     pub cond: Box<Expr>,
-    pub consequent: Vec<Expr>,
-    pub alternate: Option<Vec<Expr>>,
+    pub consequent: Block,
+    pub alternate: Option<Block>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,7 +83,7 @@ pub struct LetExpr {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Lambda {
     pub params: Vec<EFnParam>,
-    pub body: Vec<Expr>,
+    pub body: Block,
     pub is_async: bool,
     pub return_type: Option<TypeAnn>,
     pub type_params: Option<Vec<TypeParam>>,
@@ -261,7 +261,7 @@ pub struct Arm {
     pub span: Span,
     pub pattern: Pattern,
     pub guard: Option<Expr>,
-    pub body: Vec<Expr>,
+    pub body: Block,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -279,7 +279,7 @@ pub struct Regex {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DoExpr {
-    pub body: Vec<Expr>,
+    pub body: Block,
 }
 
 // Later on we can make this a real decl.  For now, it's here to ease the move

--- a/crates/escalier_infer/src/infer.rs
+++ b/crates/escalier_infer/src/infer.rs
@@ -1,15 +1,10 @@
-use escalier_ast::types::{TObjElem, TObject, TProp, TPropKey, TRef, Type, TypeKind};
+use escalier_ast::types::{TObjElem, TObject, TProp, TPropKey, Type, TypeKind};
 use escalier_ast::values::*;
 
-use crate::context::{Context, Env};
-use crate::infer_class::infer_class;
+use crate::context::Context;
 use crate::infer_expr::infer_expr as infer_expr_rec;
-use crate::infer_pattern::*;
-use crate::infer_type_ann::*;
-use crate::scheme::generalize;
-use crate::substitutable::Substitutable;
+use crate::infer_stmt::infer_stmt;
 use crate::type_error::TypeError;
-use crate::update::*;
 use crate::util::close_over;
 
 pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<TypeError>> {
@@ -46,119 +41,10 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
 
     // TODO: figure out how report multiple errors
     for stmt in &mut prog.body {
-        match stmt {
-            Statement::VarDecl {
-                declare,
-                init,
-                pattern,
-                type_ann,
-                ..
-            } => {
-                match declare {
-                    true => {
-                        match &mut pattern.kind {
-                            PatternKind::Ident(BindingIdent { name, .. }) => {
-                                match type_ann {
-                                    Some(type_ann) => {
-                                        match infer_type_ann(type_ann, ctx, &mut None) {
-                                            Ok((s, t)) => {
-                                                let t = close_over(&s, &t, ctx);
-                                                ctx.insert_value(name.to_owned(), t);
-
-                                                update_type_ann(type_ann, &s);
-                                                update_pattern(pattern, &s);
-                                            }
-                                            Err(mut report) => reports.append(&mut report),
-                                        }
-                                    }
-                                    None => {
-                                        // A type annotation should always be provided when using `declare`
-                                        return Err(vec![TypeError::MissingTypeAnnotation(
-                                            Box::from(stmt.to_owned()),
-                                        )]);
-                                    }
-                                }
-                            }
-                            _ => todo!(),
-                        }
-                    }
-                    false => {
-                        // An initial value should always be used when using a normal
-                        // `let` statement
-                        let init = init.as_mut().unwrap();
-
-                        match infer_pattern_and_init(
-                            pattern,
-                            type_ann,
-                            init,
-                            ctx,
-                            &PatternUsage::Assign,
-                        ) {
-                            Ok((pa, s)) => {
-                                // Inserts the new variables from infer_pattern() into the
-                                // current context.
-                                for (name, mut binding) in pa {
-                                    binding.t = close_over(&s, &binding.t, ctx);
-                                    ctx.insert_binding(name, binding);
-                                }
-
-                                update_expr(init, &s);
-                                update_pattern(pattern, &s);
-                            }
-                            Err(mut report) => reports.append(&mut report),
-                        }
-                    }
-                };
-            }
-            Statement::TypeDecl {
-                id: Ident { name, .. },
-                type_ann,
-                type_params,
-                ..
-            } => match infer_type_ann(type_ann, ctx, type_params) {
-                Ok((s, t)) => {
-                    let t = t.apply(&s);
-
-                    let empty_env = Env::default();
-                    let scheme = generalize(&empty_env, &t);
-
-                    ctx.insert_scheme(name.to_owned(), scheme);
-
-                    update_type_ann(type_ann, &s);
-                }
-                Err(mut report) => reports.append(&mut report),
-            },
-            Statement::Expr { expr, .. } => {
-                match infer_expr_rec(ctx, expr, false) {
-                    // We ignore the type that was inferred, we only care that
-                    // it succeeds since we aren't assigning it to variable.
-                    Ok((s, _)) => update_expr(expr, &s),
-                    Err(mut report) => reports.append(&mut report),
-                }
-            }
-            Statement::ClassDecl {
-                loc: _,
-                span: _,
-                ident,
-                class,
-            } => {
-                let (s, t) = infer_class(ctx, class)?;
-
-                let t = t.apply(&s);
-
-                // This follows the same pattern found in lib.es5.d.ts.
-                let name = ident.name.to_owned();
-                eprintln!("inserting {name}Constructor = {t}");
-                ctx.insert_type(format!("{name}Constructor"), t);
-                ctx.insert_value(
-                    name.to_owned(),
-                    Type::from(TypeKind::Ref(TRef {
-                        name: format!("{name}Constructor"),
-                        type_args: None,
-                    })),
-                );
-            }
-        };
+        match infer_stmt(stmt, ctx) {
+            Ok(_) => (),
+            Err(mut errors) => reports.append(&mut errors),
+        }
     }
 
     if reports.is_empty() {

--- a/crates/escalier_infer/src/infer_class.rs
+++ b/crates/escalier_infer/src/infer_class.rs
@@ -53,7 +53,7 @@ pub fn infer_class(ctx: &mut Context, class: &mut Class) -> Result<(Subst, Type)
 
                 // TODO: ensure that constructors don't have a return statement
                 // TODO: add `self` and `Self` to new_ctx
-                let (body_s, _body_t) = infer_body(body, &mut new_ctx)?;
+                let (body_s, _body_t) = infer_block(body, &mut new_ctx)?;
                 ss.push(body_s);
 
                 ctx.count = new_ctx.count;
@@ -170,7 +170,7 @@ pub fn infer_class(ctx: &mut Context, class: &mut Class) -> Result<(Subst, Type)
                     t: interface_t,
                 };
                 new_ctx.insert_binding("self".to_string(), binding);
-                let (body_s, mut body_t) = infer_body(body, &mut new_ctx)?;
+                let (body_s, mut body_t) = infer_block(body, &mut new_ctx)?;
                 ss.push(body_s);
 
                 ctx.count = new_ctx.count;

--- a/crates/escalier_infer/src/infer_expr.rs
+++ b/crates/escalier_infer/src/infer_expr.rs
@@ -860,15 +860,12 @@ pub fn infer_expr(
     Ok((s, t))
 }
 
-pub fn infer_body(
-    body: &mut Vec<Expr>,
-    ctx: &mut Context,
-) -> Result<(Subst, Type), Vec<TypeError>> {
+pub fn infer_body(body: &mut Block, ctx: &mut Context) -> Result<(Subst, Type), Vec<TypeError>> {
     let mut new_ctx = ctx.clone();
     let mut t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
     let mut s = Subst::new();
 
-    for expr in body {
+    for expr in &mut body.stmts {
         new_ctx = new_ctx.clone();
         let (new_s, new_t) = infer_expr(&mut new_ctx, expr, false)?;
 

--- a/crates/escalier_infer/src/infer_expr.rs
+++ b/crates/escalier_infer/src/infer_expr.rs
@@ -267,14 +267,14 @@ pub fn infer_expr(
                             new_ctx.insert_binding(name.to_owned(), binding.to_owned());
                         }
 
-                        let (s1, t1) = infer_body(consequent, &mut new_ctx)?;
+                        let (s1, t1) = infer_block(consequent, &mut new_ctx)?;
 
                         ctx.count = new_ctx.count;
 
                         let s = compose_subs(&s1, &s0);
 
                         update_pattern(pat, &s);
-                        let (s2, t2) = infer_body(alternate, ctx)?;
+                        let (s2, t2) = infer_block(alternate, ctx)?;
 
                         let s = compose_many_subs(&[s, s2]);
                         let t = union_types(&t1, &t2);
@@ -282,8 +282,8 @@ pub fn infer_expr(
                     }
                     _ => {
                         let (s1, t1) = infer_expr(ctx, cond, false)?;
-                        let (s2, t2) = infer_body(consequent, ctx)?;
-                        let (s3, t3) = infer_body(alternate, ctx)?;
+                        let (s2, t2) = infer_block(consequent, ctx)?;
+                        let (s3, t3) = infer_block(alternate, ctx)?;
                         let s4 =
                             unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Boolean)), ctx)?;
 
@@ -314,7 +314,7 @@ pub fn infer_expr(
                         new_ctx.insert_binding(name.to_owned(), binding.to_owned());
                     }
 
-                    let (s1, t1) = infer_body(consequent, &mut new_ctx)?;
+                    let (s1, t1) = infer_block(consequent, &mut new_ctx)?;
 
                     ctx.count = new_ctx.count;
 
@@ -330,7 +330,7 @@ pub fn infer_expr(
                 }
                 _ => {
                     let (s1, t1) = infer_expr(ctx, cond, false)?;
-                    let (s2, t2) = infer_body(consequent, ctx)?;
+                    let (s2, t2) = infer_block(consequent, ctx)?;
                     let s3 = unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Boolean)), ctx)?;
 
                     let s = compose_many_subs(&[s1, s2, s3]);
@@ -469,7 +469,7 @@ pub fn infer_expr(
 
             let (mut ss, t_params): (Vec<_>, Vec<_>) = params?.iter().cloned().unzip();
 
-            let (body_s, mut body_t) = infer_body(body, &mut new_ctx)?;
+            let (body_s, mut body_t) = infer_block(body, &mut new_ctx)?;
             ss.push(body_s);
 
             ctx.count = new_ctx.count;
@@ -773,7 +773,7 @@ pub fn infer_expr(
                     new_ctx.insert_binding(name.to_owned(), binding.to_owned());
                 }
 
-                let (s2, t2) = infer_body(&mut arm.body, &mut new_ctx)?;
+                let (s2, t2) = infer_block(&mut arm.body, &mut new_ctx)?;
 
                 ctx.count = new_ctx.count;
 
@@ -824,7 +824,7 @@ pub fn infer_expr(
         // This is only need for classes that are expressions.  Allowing this
         // seems like a bad idea.
         ExprKind::Class(_) => todo!(),
-        ExprKind::DoExpr(DoExpr { body }) => infer_body(body, ctx),
+        ExprKind::DoExpr(DoExpr { body }) => infer_block(body, ctx),
         ExprKind::LetDecl(LetDecl {
             pattern,
             type_ann,
@@ -860,7 +860,7 @@ pub fn infer_expr(
     Ok((s, t))
 }
 
-pub fn infer_body(body: &mut Block, ctx: &mut Context) -> Result<(Subst, Type), Vec<TypeError>> {
+pub fn infer_block(body: &mut Block, ctx: &mut Context) -> Result<(Subst, Type), Vec<TypeError>> {
     let mut new_ctx = ctx.clone();
     let mut t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
     let mut s = Subst::new();

--- a/crates/escalier_infer/src/infer_stmt.rs
+++ b/crates/escalier_infer/src/infer_stmt.rs
@@ -1,4 +1,4 @@
-use escalier_ast::types::{TRef, Type, TypeKind};
+use escalier_ast::types::{TKeyword, TRef, Type, TypeKind};
 use escalier_ast::values::*;
 
 use crate::context::{Context, Env};
@@ -7,12 +7,16 @@ use crate::infer_expr::infer_expr as infer_expr_rec;
 use crate::infer_pattern::*;
 use crate::infer_type_ann::*;
 use crate::scheme::generalize;
+use crate::substitutable::Subst;
 use crate::substitutable::Substitutable;
 use crate::type_error::TypeError;
 use crate::update::*;
-use crate::util::close_over;
+use crate::util::{close_over, compose_subs};
 
-pub fn infer_stmt(stmt: &mut Statement, ctx: &mut Context) -> Result<(), Vec<TypeError>> {
+pub fn infer_stmt(
+    stmt: &mut Statement,
+    ctx: &mut Context,
+) -> Result<(Subst, Type), Vec<TypeError>> {
     match stmt {
         Statement::VarDecl {
             declare,
@@ -30,16 +34,18 @@ pub fn infer_stmt(stmt: &mut Statement, ctx: &mut Context) -> Result<(), Vec<Typ
                                     let (s, t) = infer_type_ann(type_ann, ctx, &mut None)?;
 
                                     let t = close_over(&s, &t, ctx);
-                                    ctx.insert_value(name.to_owned(), t);
+                                    ctx.insert_value(name.to_owned(), t.to_owned());
 
                                     update_type_ann(type_ann, &s);
                                     update_pattern(pattern, &s);
+
+                                    Ok((s, t))
                                 }
                                 None => {
                                     // A type annotation should always be provided when using `declare`
-                                    return Err(vec![TypeError::MissingTypeAnnotation(Box::from(
+                                    Err(vec![TypeError::MissingTypeAnnotation(Box::from(
                                         stmt.to_owned(),
-                                    ))]);
+                                    ))])
                                 }
                             }
                         }
@@ -68,8 +74,12 @@ pub fn infer_stmt(stmt: &mut Statement, ctx: &mut Context) -> Result<(), Vec<Typ
 
                     update_expr(init, &s);
                     update_pattern(pattern, &s);
+
+                    let t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
+
+                    Ok((s, t))
                 }
-            };
+            }
         }
         Statement::TypeDecl {
             id: Ident { name, .. },
@@ -87,12 +97,16 @@ pub fn infer_stmt(stmt: &mut Statement, ctx: &mut Context) -> Result<(), Vec<Typ
             ctx.insert_scheme(name.to_owned(), scheme);
 
             update_type_ann(type_ann, &s);
+
+            Ok((s, t))
         }
         Statement::Expr { expr, .. } => {
-            let (s, _) = infer_expr_rec(ctx, expr, false)?;
+            let (s, t) = infer_expr_rec(ctx, expr, false)?;
             // We ignore the type that was inferred, we only care that
             // it succeeds since we aren't assigning it to variable.
             update_expr(expr, &s);
+
+            Ok((s, t))
         }
         Statement::ClassDecl {
             loc: _,
@@ -107,7 +121,7 @@ pub fn infer_stmt(stmt: &mut Statement, ctx: &mut Context) -> Result<(), Vec<Typ
             // This follows the same pattern found in lib.es5.d.ts.
             let name = ident.name.to_owned();
             eprintln!("inserting {name}Constructor = {t}");
-            ctx.insert_type(format!("{name}Constructor"), t);
+            ctx.insert_type(format!("{name}Constructor"), t.to_owned());
             ctx.insert_value(
                 name.to_owned(),
                 Type::from(TypeKind::Ref(TRef {
@@ -115,8 +129,32 @@ pub fn infer_stmt(stmt: &mut Statement, ctx: &mut Context) -> Result<(), Vec<Typ
                     type_args: None,
                 })),
             );
-        }
-    };
 
-    Ok(())
+            Ok((s, t))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block {
+    pub span: Span,
+    pub stmts: Vec<Statement>,
+}
+
+pub fn infer_block(block: &mut Block, ctx: &mut Context) -> Result<(Subst, Type), Vec<TypeError>> {
+    let mut new_ctx = ctx.clone();
+    let mut t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
+    let mut s = Subst::new();
+
+    for stmt in &mut block.stmts {
+        new_ctx = new_ctx.clone();
+        let (new_s, new_t) = infer_stmt(stmt, &mut new_ctx)?;
+
+        t = new_t.apply(&s);
+        s = compose_subs(&new_s, &s);
+    }
+
+    ctx.count = new_ctx.count;
+
+    Ok((s, t))
 }

--- a/crates/escalier_infer/src/infer_stmt.rs
+++ b/crates/escalier_infer/src/infer_stmt.rs
@@ -1,0 +1,122 @@
+use escalier_ast::types::{TRef, Type, TypeKind};
+use escalier_ast::values::*;
+
+use crate::context::{Context, Env};
+use crate::infer_class::infer_class;
+use crate::infer_expr::infer_expr as infer_expr_rec;
+use crate::infer_pattern::*;
+use crate::infer_type_ann::*;
+use crate::scheme::generalize;
+use crate::substitutable::Substitutable;
+use crate::type_error::TypeError;
+use crate::update::*;
+use crate::util::close_over;
+
+pub fn infer_stmt(stmt: &mut Statement, ctx: &mut Context) -> Result<(), Vec<TypeError>> {
+    match stmt {
+        Statement::VarDecl {
+            declare,
+            init,
+            pattern,
+            type_ann,
+            ..
+        } => {
+            match declare {
+                true => {
+                    match &mut pattern.kind {
+                        PatternKind::Ident(BindingIdent { name, .. }) => {
+                            match type_ann {
+                                Some(type_ann) => {
+                                    let (s, t) = infer_type_ann(type_ann, ctx, &mut None)?;
+
+                                    let t = close_over(&s, &t, ctx);
+                                    ctx.insert_value(name.to_owned(), t);
+
+                                    update_type_ann(type_ann, &s);
+                                    update_pattern(pattern, &s);
+                                }
+                                None => {
+                                    // A type annotation should always be provided when using `declare`
+                                    return Err(vec![TypeError::MissingTypeAnnotation(Box::from(
+                                        stmt.to_owned(),
+                                    ))]);
+                                }
+                            }
+                        }
+                        _ => todo!(),
+                    }
+                }
+                false => {
+                    // An initial value should always be used when using a normal
+                    // `let` statement
+                    let init = init.as_mut().unwrap();
+
+                    let (pa, s) = infer_pattern_and_init(
+                        pattern,
+                        type_ann,
+                        init,
+                        ctx,
+                        &PatternUsage::Assign,
+                    )?;
+
+                    // Inserts the new variables from infer_pattern() into the
+                    // current context.
+                    for (name, mut binding) in pa {
+                        binding.t = close_over(&s, &binding.t, ctx);
+                        ctx.insert_binding(name, binding);
+                    }
+
+                    update_expr(init, &s);
+                    update_pattern(pattern, &s);
+                }
+            };
+        }
+        Statement::TypeDecl {
+            id: Ident { name, .. },
+            type_ann,
+            type_params,
+            ..
+        } => {
+            let (s, t) = infer_type_ann(type_ann, ctx, type_params)?;
+
+            let t = t.apply(&s);
+
+            let empty_env = Env::default();
+            let scheme = generalize(&empty_env, &t);
+
+            ctx.insert_scheme(name.to_owned(), scheme);
+
+            update_type_ann(type_ann, &s);
+        }
+        Statement::Expr { expr, .. } => {
+            let (s, _) = infer_expr_rec(ctx, expr, false)?;
+            // We ignore the type that was inferred, we only care that
+            // it succeeds since we aren't assigning it to variable.
+            update_expr(expr, &s);
+        }
+        Statement::ClassDecl {
+            loc: _,
+            span: _,
+            ident,
+            class,
+        } => {
+            let (s, t) = infer_class(ctx, class)?;
+
+            let t = t.apply(&s);
+
+            // This follows the same pattern found in lib.es5.d.ts.
+            let name = ident.name.to_owned();
+            eprintln!("inserting {name}Constructor = {t}");
+            ctx.insert_type(format!("{name}Constructor"), t);
+            ctx.insert_value(
+                name.to_owned(),
+                Type::from(TypeKind::Ref(TRef {
+                    name: format!("{name}Constructor"),
+                    type_args: None,
+                })),
+            );
+        }
+    };
+
+    Ok(())
+}

--- a/crates/escalier_infer/src/lib.rs
+++ b/crates/escalier_infer/src/lib.rs
@@ -6,6 +6,7 @@ mod infer_expr;
 mod infer_fn_param;
 mod infer_pattern;
 mod infer_regex;
+mod infer_stmt;
 mod infer_type_ann;
 mod scheme;
 mod substitutable;

--- a/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
@@ -432,117 +432,120 @@ Program {
                                                     optional: false,
                                                 },
                                             ],
-                                            body: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 20,
+                                            body: Block {
+                                                span: 20..25,
+                                                stmts: [
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 20,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 25,
-                                                        },
+                                                        span: 20..25,
+                                                        kind: BinaryExpr(
+                                                            BinaryExpr {
+                                                                op: Add,
+                                                                left: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 20,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 21,
+                                                                        },
+                                                                    },
+                                                                    span: 20..21,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 21,
+                                                                                },
+                                                                            },
+                                                                            span: 20..21,
+                                                                            name: "a",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: Some(
+                                                                        Type {
+                                                                            kind: Var(
+                                                                                TVar {
+                                                                                    id: 2,
+                                                                                    constraint: None,
+                                                                                },
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: None,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                                right: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 24,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                    },
+                                                                    span: 24..25,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 24,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 25,
+                                                                                },
+                                                                            },
+                                                                            span: 24..25,
+                                                                            name: "b",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: Some(
+                                                                        Type {
+                                                                            kind: Var(
+                                                                                TVar {
+                                                                                    id: 3,
+                                                                                    constraint: None,
+                                                                                },
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: None,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: Some(
+                                                            Type {
+                                                                kind: Keyword(
+                                                                    Number,
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: None,
+                                                            },
+                                                        ),
                                                     },
-                                                    span: 20..25,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Add,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 20,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 21,
-                                                                    },
-                                                                },
-                                                                span: 20..21,
-                                                                kind: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 20,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 21,
-                                                                            },
-                                                                        },
-                                                                        span: 20..21,
-                                                                        name: "a",
-                                                                    },
-                                                                ),
-                                                                inferred_type: Some(
-                                                                    Type {
-                                                                        kind: Var(
-                                                                            TVar {
-                                                                                id: 2,
-                                                                                constraint: None,
-                                                                            },
-                                                                        ),
-                                                                        mutable: false,
-                                                                        provenance: None,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 24,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 25,
-                                                                    },
-                                                                },
-                                                                span: 24..25,
-                                                                kind: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 24,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 25,
-                                                                            },
-                                                                        },
-                                                                        span: 24..25,
-                                                                        name: "b",
-                                                                    },
-                                                                ),
-                                                                inferred_type: Some(
-                                                                    Type {
-                                                                        kind: Var(
-                                                                            TVar {
-                                                                                id: 3,
-                                                                                constraint: None,
-                                                                            },
-                                                                        ),
-                                                                        mutable: false,
-                                                                        provenance: None,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: Some(
-                                                        Type {
-                                                            kind: Keyword(
-                                                                Number,
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: None,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
+                                                ],
+                                            },
                                             is_async: false,
                                             return_type: None,
                                             type_params: None,
@@ -944,137 +947,140 @@ Program {
                                     optional: false,
                                 },
                             ],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 20,
+                            body: Block {
+                                span: 20..25,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 20,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 25,
+                                            },
                                         },
-                                        end: Position {
-                                            line: 0,
-                                            column: 25,
-                                        },
+                                        span: 20..25,
+                                        kind: BinaryExpr(
+                                            BinaryExpr {
+                                                op: Add,
+                                                left: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 20,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 21,
+                                                        },
+                                                    },
+                                                    span: 20..21,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                            },
+                                                            span: 20..21,
+                                                            name: "a",
+                                                        },
+                                                    ),
+                                                    inferred_type: Some(
+                                                        Type {
+                                                            kind: Keyword(
+                                                                Number,
+                                                            ),
+                                                            mutable: false,
+                                                            provenance: Some(
+                                                                Type(
+                                                                    Type {
+                                                                        kind: Var(
+                                                                            TVar {
+                                                                                id: 2,
+                                                                                constraint: None,
+                                                                            },
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: None,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                },
+                                                right: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 24,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                    },
+                                                    span: 24..25,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 24..25,
+                                                            name: "b",
+                                                        },
+                                                    ),
+                                                    inferred_type: Some(
+                                                        Type {
+                                                            kind: Keyword(
+                                                                Number,
+                                                            ),
+                                                            mutable: false,
+                                                            provenance: Some(
+                                                                Type(
+                                                                    Type {
+                                                                        kind: Var(
+                                                                            TVar {
+                                                                                id: 3,
+                                                                                constraint: None,
+                                                                            },
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: None,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                        inferred_type: Some(
+                                            Type {
+                                                kind: Keyword(
+                                                    Number,
+                                                ),
+                                                mutable: false,
+                                                provenance: None,
+                                            },
+                                        ),
                                     },
-                                    span: 20..25,
-                                    kind: BinaryExpr(
-                                        BinaryExpr {
-                                            op: Add,
-                                            left: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 20,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 21,
-                                                    },
-                                                },
-                                                span: 20..21,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 20,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 21,
-                                                            },
-                                                        },
-                                                        span: 20..21,
-                                                        name: "a",
-                                                    },
-                                                ),
-                                                inferred_type: Some(
-                                                    Type {
-                                                        kind: Keyword(
-                                                            Number,
-                                                        ),
-                                                        mutable: false,
-                                                        provenance: Some(
-                                                            Type(
-                                                                Type {
-                                                                    kind: Var(
-                                                                        TVar {
-                                                                            id: 2,
-                                                                            constraint: None,
-                                                                        },
-                                                                    ),
-                                                                    mutable: false,
-                                                                    provenance: None,
-                                                                },
-                                                            ),
-                                                        ),
-                                                    },
-                                                ),
-                                            },
-                                            right: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 24,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 25,
-                                                    },
-                                                },
-                                                span: 24..25,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 24,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 25,
-                                                            },
-                                                        },
-                                                        span: 24..25,
-                                                        name: "b",
-                                                    },
-                                                ),
-                                                inferred_type: Some(
-                                                    Type {
-                                                        kind: Keyword(
-                                                            Number,
-                                                        ),
-                                                        mutable: false,
-                                                        provenance: Some(
-                                                            Type(
-                                                                Type {
-                                                                    kind: Var(
-                                                                        TVar {
-                                                                            id: 3,
-                                                                            constraint: None,
-                                                                        },
-                                                                    ),
-                                                                    mutable: false,
-                                                                    provenance: None,
-                                                                },
-                                                            ),
-                                                        ),
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    inferred_type: Some(
-                                        Type {
-                                            kind: Keyword(
-                                                Number,
-                                            ),
-                                            mutable: false,
-                                            provenance: None,
-                                        },
-                                    ),
-                                },
-                            ],
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_infer/src/update.rs
+++ b/crates/escalier_infer/src/update.rs
@@ -103,11 +103,11 @@ pub fn update_expr(expr: &mut Expr, s: &Subst) {
             alternate,
         }) => {
             update_expr(cond, s);
-            consequent.iter_mut().for_each(|child| {
+            consequent.stmts.iter_mut().for_each(|child| {
                 update_expr(child, s);
             });
             if let Some(alternate) = alternate {
-                alternate.iter_mut().for_each(|child| {
+                alternate.stmts.iter_mut().for_each(|child| {
                     update_expr(child, s);
                 });
             }
@@ -137,7 +137,7 @@ pub fn update_expr(expr: &mut Expr, s: &Subst) {
             params.iter_mut().for_each(|param| {
                 update_fn_param_pat(&mut param.pat, s);
             });
-            body.iter_mut().for_each(|expr| {
+            body.stmts.iter_mut().for_each(|expr| {
                 update_expr(expr, s);
             });
         }
@@ -216,14 +216,14 @@ pub fn update_expr(expr: &mut Expr, s: &Subst) {
                 if let Some(guard) = guard {
                     update_expr(guard, s);
                 }
-                body.iter_mut().for_each(|child| {
+                body.stmts.iter_mut().for_each(|child| {
                     update_expr(child, s);
                 });
             })
         }
         ExprKind::Class(_) => todo!(),
         ExprKind::Regex(_) => (), // leaf node
-        ExprKind::DoExpr(DoExpr { body }) => body.iter_mut().for_each(|expr| {
+        ExprKind::DoExpr(DoExpr { body }) => body.stmts.iter_mut().for_each(|expr| {
             update_expr(expr, s);
         }),
     }

--- a/crates/escalier_lsp/src/visitor.rs
+++ b/crates/escalier_lsp/src/visitor.rs
@@ -160,11 +160,11 @@ pub trait Visitor {
                 alternate,
             }) => {
                 self._visit_expr(cond);
-                consequent.iter_mut().for_each(|child| {
+                consequent.stmts.iter_mut().for_each(|child| {
                     self._visit_expr(child);
                 });
                 if let Some(alternate) = alternate {
-                    alternate.iter_mut().for_each(|child| {
+                    alternate.stmts.iter_mut().for_each(|child| {
                         self._visit_expr(child);
                     });
                 }
@@ -199,7 +199,7 @@ pub trait Visitor {
                 if let Some(return_type) = return_type {
                     self._visit_type_ann(return_type);
                 }
-                body.iter_mut().for_each(|child| {
+                body.stmts.iter_mut().for_each(|child| {
                     self._visit_expr(child);
                 });
             }
@@ -260,7 +260,9 @@ pub trait Visitor {
                     if let Some(guard) = guard {
                         self._visit_expr(guard);
                     }
-                    body.iter_mut().for_each(|child| self._visit_expr(child));
+                    body.stmts
+                        .iter_mut()
+                        .for_each(|child| self._visit_expr(child));
                 })
             }
             // TODO: finish implementing this
@@ -280,7 +282,7 @@ pub trait Visitor {
                                     self._visit_type_ann(type_ann);
                                 }
                             });
-                            body.iter_mut().for_each(|child| {
+                            body.stmts.iter_mut().for_each(|child| {
                                 self._visit_expr(child);
                             });
                         }
@@ -299,7 +301,7 @@ pub trait Visitor {
                                     self._visit_type_ann(type_ann);
                                 }
                             });
-                            lambda.body.iter_mut().for_each(|child| {
+                            lambda.body.stmts.iter_mut().for_each(|child| {
                                 self._visit_expr(child);
                             });
                         }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-2.snap
@@ -65,58 +65,61 @@ Ok(
                         kind: Lambda(
                             Lambda {
                                 params: [],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 24,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 32,
-                                            },
-                                        },
-                                        span: 24..32,
-                                        kind: Await(
-                                            Await {
-                                                expr: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 30,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 32,
-                                                        },
-                                                    },
-                                                    span: 30..32,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 30,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 32,
-                                                                    },
-                                                                },
-                                                                span: 30..32,
-                                                                value: "10",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
+                                body: Block {
+                                    span: 22..34,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 24,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 32,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 24..32,
+                                            kind: Await(
+                                                Await {
+                                                    expr: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 30,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 32,
+                                                            },
+                                                        },
+                                                        span: 30..32,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 30,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 32,
+                                                                        },
+                                                                    },
+                                                                    span: 30..32,
+                                                                    value: "10",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: true,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-3.snap
@@ -65,123 +65,126 @@ Ok(
                         kind: Lambda(
                             Lambda {
                                 params: [],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 22,
+                                body: Block {
+                                    span: 22..39,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 39,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 39,
-                                            },
+                                            span: 22..39,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 29,
+                                                            },
+                                                        },
+                                                        span: 22..29,
+                                                        kind: Await(
+                                                            Await {
+                                                                expr: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 28,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 29,
+                                                                        },
+                                                                    },
+                                                                    span: 28..29,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 28,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 29,
+                                                                                },
+                                                                            },
+                                                                            span: 28..29,
+                                                                            name: "a",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 32,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 39,
+                                                            },
+                                                        },
+                                                        span: 32..39,
+                                                        kind: Await(
+                                                            Await {
+                                                                expr: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 38,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 39,
+                                                                        },
+                                                                    },
+                                                                    span: 38..39,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 38,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 39,
+                                                                                },
+                                                                            },
+                                                                            span: 38..39,
+                                                                            name: "b",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 22..39,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 29,
-                                                        },
-                                                    },
-                                                    span: 22..29,
-                                                    kind: Await(
-                                                        Await {
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 28,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 29,
-                                                                    },
-                                                                },
-                                                                span: 28..29,
-                                                                kind: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 28,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 29,
-                                                                            },
-                                                                        },
-                                                                        span: 28..29,
-                                                                        name: "a",
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 32,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 39,
-                                                        },
-                                                    },
-                                                    span: 32..39,
-                                                    kind: Await(
-                                                        Await {
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 38,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 39,
-                                                                    },
-                                                                },
-                                                                span: 38..39,
-                                                                kind: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 38,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 39,
-                                                                            },
-                                                                        },
-                                                                        span: 38..39,
-                                                                        name: "b",
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                    ],
+                                },
                                 is_async: true,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-4.snap
@@ -65,76 +65,79 @@ Ok(
                         kind: Lambda(
                             Lambda {
                                 params: [],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 22,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 33,
-                                            },
-                                        },
-                                        span: 22..33,
-                                        kind: Await(
-                                            Await {
-                                                expr: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 28,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 33,
-                                                        },
-                                                    },
-                                                    span: 28..33,
-                                                    kind: App(
-                                                        App {
-                                                            lam: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 28,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 31,
-                                                                    },
-                                                                },
-                                                                span: 28..31,
-                                                                kind: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 28,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 31,
-                                                                            },
-                                                                        },
-                                                                        span: 28..31,
-                                                                        name: "bar",
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            args: [],
-                                                            type_args: None,
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                body: Block {
+                                    span: 22..33,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 33,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 22..33,
+                                            kind: Await(
+                                                Await {
+                                                    expr: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 28,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 33,
+                                                            },
+                                                        },
+                                                        span: 28..33,
+                                                        kind: App(
+                                                            App {
+                                                                lam: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 28,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 31,
+                                                                        },
+                                                                    },
+                                                                    span: 28..31,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 28,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 31,
+                                                                                },
+                                                                            },
+                                                                            span: 28..31,
+                                                                            name: "bar",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                args: [],
+                                                                type_args: None,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: true,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
@@ -32,40 +32,43 @@ Ok(
                     kind: Lambda(
                         Lambda {
                             params: [],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 14,
-                                        },
-                                    },
-                                    span: 12..14,
-                                    kind: Lit(
-                                        Num(
-                                            Num {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 12,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 14,
-                                                    },
-                                                },
-                                                span: 12..14,
-                                                value: "10",
+                            body: Block {
+                                span: 12..14,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 12,
                                             },
+                                            end: Position {
+                                                line: 0,
+                                                column: 14,
+                                            },
+                                        },
+                                        span: 12..14,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
+                                                    },
+                                                    span: 12..14,
+                                                    value: "10",
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                             is_async: true,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-2.snap
@@ -64,251 +64,254 @@ Ok(
                         span: 10..43,
                         kind: DoExpr(
                             DoExpr {
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
+                                body: Block {
+                                    span: 13..43,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 24,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 24,
-                                            },
-                                        },
-                                        span: 14..24,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                    },
-                                                    span: 18..19,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "x",
-                                                            mutable: false,
-                                                            span: 18..19,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
+                                            span: 14..24,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 19,
                                                             },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
+                                                        span: 18..19,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 18..19,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 22,
+                                                                        column: 18,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 23,
+                                                                        column: 19,
                                                                     },
                                                                 },
-                                                                span: 22..23,
-                                                                value: "5",
                                                             },
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 36,
-                                            },
-                                        },
-                                        span: 25..36,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 29,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 30,
-                                                        },
+                                                        inferred_type: None,
                                                     },
-                                                    span: 29..30,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "y",
-                                                            mutable: false,
-                                                            span: 29..30,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 29,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 30,
-                                                                },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
                                                             },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 33,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 35,
-                                                        },
+                                                        span: 22..23,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    value: "5",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                    span: 33..35,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 25,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 36,
+                                                },
+                                            },
+                                            span: 25..36,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 29,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 30,
+                                                            },
+                                                        },
+                                                        span: 29..30,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "y",
+                                                                mutable: false,
+                                                                span: 29..30,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 33,
+                                                                        column: 29,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 35,
+                                                                        column: 30,
                                                                     },
                                                                 },
-                                                                span: 33..35,
-                                                                value: "10",
                                                             },
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 33,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 35,
+                                                            },
+                                                        },
+                                                        span: 33..35,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 33,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 35,
+                                                                        },
+                                                                    },
+                                                                    span: 33..35,
+                                                                    value: "10",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 37,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 42,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 37..42,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 37,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 38,
-                                                        },
-                                                    },
-                                                    span: 37..38,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 37,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 38,
-                                                                },
-                                                            },
-                                                            span: 37..38,
-                                                            name: "x",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 37,
                                                 },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 41,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 42,
-                                                        },
-                                                    },
-                                                    span: 41..42,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 41,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 42,
-                                                                },
-                                                            },
-                                                            span: 41..42,
-                                                            name: "y",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 42,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 37..42,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 37,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 38,
+                                                            },
+                                                        },
+                                                        span: 37..38,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 37,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 38,
+                                                                    },
+                                                                },
+                                                                span: 37..38,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 41,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 42,
+                                                            },
+                                                        },
+                                                        span: 41..42,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 41,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 42,
+                                                                    },
+                                                                },
+                                                                span: 41..42,
+                                                                name: "y",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             },
                         ),
                         inferred_type: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
@@ -31,251 +31,254 @@ Ok(
                     span: 0..33,
                     kind: DoExpr(
                         DoExpr {
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 4,
+                            body: Block {
+                                span: 3..33,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 4,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 14,
+                                            },
                                         },
-                                        end: Position {
-                                            line: 0,
-                                            column: 14,
-                                        },
-                                    },
-                                    span: 4..14,
-                                    kind: LetDecl(
-                                        LetDecl {
-                                            pattern: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 8,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 9,
-                                                    },
-                                                },
-                                                span: 8..9,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "x",
-                                                        mutable: false,
-                                                        span: 8..9,
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 8,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 9,
-                                                            },
+                                        span: 4..14,
+                                        kind: LetDecl(
+                                            LetDecl {
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 9,
                                                         },
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            type_ann: None,
-                                            init: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 12,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 13,
-                                                    },
-                                                },
-                                                span: 12..13,
-                                                kind: Lit(
-                                                    Num(
-                                                        Num {
+                                                    span: 8..9,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "x",
+                                                            mutable: false,
+                                                            span: 8..9,
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
-                                                                    column: 12,
+                                                                    column: 8,
                                                                 },
                                                                 end: Position {
                                                                     line: 0,
-                                                                    column: 13,
+                                                                    column: 9,
                                                                 },
                                                             },
-                                                            span: 12..13,
-                                                            value: "5",
                                                         },
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 15,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 26,
-                                        },
-                                    },
-                                    span: 15..26,
-                                    kind: LetDecl(
-                                        LetDecl {
-                                            pattern: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 19,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 20,
-                                                    },
+                                                    inferred_type: None,
                                                 },
-                                                span: 19..20,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "y",
-                                                        mutable: false,
-                                                        span: 19..20,
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 20,
-                                                            },
+                                                type_ann: None,
+                                                init: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 13,
                                                         },
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            type_ann: None,
-                                            init: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 23,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 25,
-                                                    },
+                                                    span: 12..13,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 13,
+                                                                    },
+                                                                },
+                                                                span: 12..13,
+                                                                value: "5",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                                span: 23..25,
-                                                kind: Lit(
-                                                    Num(
-                                                        Num {
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 15,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 26,
+                                            },
+                                        },
+                                        span: 15..26,
+                                        kind: LetDecl(
+                                            LetDecl {
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 19,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 20,
+                                                        },
+                                                    },
+                                                    span: 19..20,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "y",
+                                                            mutable: false,
+                                                            span: 19..20,
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
-                                                                    column: 23,
+                                                                    column: 19,
                                                                 },
                                                                 end: Position {
                                                                     line: 0,
-                                                                    column: 25,
+                                                                    column: 20,
                                                                 },
                                                             },
-                                                            span: 23..25,
-                                                            value: "10",
                                                         },
                                                     ),
-                                                ),
-                                                inferred_type: None,
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                init: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 23,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                    },
+                                                    span: 23..25,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 25,
+                                                                    },
+                                                                },
+                                                                span: 23..25,
+                                                                value: "10",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             },
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 27,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 32,
-                                        },
+                                        ),
+                                        inferred_type: None,
                                     },
-                                    span: 27..32,
-                                    kind: BinaryExpr(
-                                        BinaryExpr {
-                                            op: Add,
-                                            left: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 27,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 28,
-                                                    },
-                                                },
-                                                span: 27..28,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 27,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 28,
-                                                            },
-                                                        },
-                                                        span: 27..28,
-                                                        name: "x",
-                                                    },
-                                                ),
-                                                inferred_type: None,
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 27,
                                             },
-                                            right: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 31,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 32,
-                                                    },
-                                                },
-                                                span: 31..32,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 31,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 32,
-                                                            },
-                                                        },
-                                                        span: 31..32,
-                                                        name: "y",
-                                                    },
-                                                ),
-                                                inferred_type: None,
+                                            end: Position {
+                                                line: 0,
+                                                column: 32,
                                             },
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        span: 27..32,
+                                        kind: BinaryExpr(
+                                            BinaryExpr {
+                                                op: Add,
+                                                left: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 27,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 28,
+                                                        },
+                                                    },
+                                                    span: 27..28,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 27,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 28,
+                                                                },
+                                                            },
+                                                            span: 27..28,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                right: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 31,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 31..32,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 31,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 32,
+                                                                },
+                                                            },
+                                                            span: 31..32,
+                                                            name: "y",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                         },
                     ),
                     inferred_type: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
@@ -31,99 +31,87 @@ Ok(
                     span: 0..53,
                     kind: DoExpr(
                         DoExpr {
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 4,
+                            body: Block {
+                                span: 3..53,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 4,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 48,
+                                            },
                                         },
-                                        end: Position {
-                                            line: 0,
-                                            column: 48,
-                                        },
-                                    },
-                                    span: 4..48,
-                                    kind: LetDecl(
-                                        LetDecl {
-                                            pattern: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 8,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 11,
-                                                    },
-                                                },
-                                                span: 8..11,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "sum",
-                                                        mutable: false,
-                                                        span: 8..11,
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 8,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 11,
-                                                            },
+                                        span: 4..48,
+                                        kind: LetDecl(
+                                            LetDecl {
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 11,
                                                         },
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            type_ann: None,
-                                            init: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 14,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 47,
-                                                    },
-                                                },
-                                                span: 14..47,
-                                                kind: DoExpr(
-                                                    DoExpr {
-                                                        body: [
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 18,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 28,
-                                                                    },
+                                                    span: 8..11,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "sum",
+                                                            mutable: false,
+                                                            span: 8..11,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 8,
                                                                 },
-                                                                span: 18..28,
-                                                                kind: LetDecl(
-                                                                    LetDecl {
-                                                                        pattern: Pattern {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 22,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 23,
-                                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 11,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                init: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 47,
+                                                        },
+                                                    },
+                                                    span: 14..47,
+                                                    kind: DoExpr(
+                                                        DoExpr {
+                                                            body: Block {
+                                                                span: 17..47,
+                                                                stmts: [
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
                                                                             },
-                                                                            span: 22..23,
-                                                                            kind: Ident(
-                                                                                BindingIdent {
-                                                                                    name: "x",
-                                                                                    mutable: false,
-                                                                                    span: 22..23,
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 28,
+                                                                            },
+                                                                        },
+                                                                        span: 18..28,
+                                                                        kind: LetDecl(
+                                                                            LetDecl {
+                                                                                pattern: Pattern {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -134,78 +122,78 @@ Ok(
                                                                                             column: 23,
                                                                                         },
                                                                                     },
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        type_ann: None,
-                                                                        init: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 26,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 27,
-                                                                                },
-                                                                            },
-                                                                            span: 26..27,
-                                                                            kind: Lit(
-                                                                                Num(
-                                                                                    Num {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 26,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 27,
+                                                                                    span: 22..23,
+                                                                                    kind: Ident(
+                                                                                        BindingIdent {
+                                                                                            name: "x",
+                                                                                            mutable: false,
+                                                                                            span: 22..23,
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 22,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 23,
+                                                                                                },
                                                                                             },
                                                                                         },
-                                                                                        span: 26..27,
-                                                                                        value: "5",
-                                                                                    },
-                                                                                ),
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 29,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 40,
-                                                                    },
-                                                                },
-                                                                span: 29..40,
-                                                                kind: LetDecl(
-                                                                    LetDecl {
-                                                                        pattern: Pattern {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 33,
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 34,
+                                                                                type_ann: None,
+                                                                                init: Expr {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 26,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 27,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 26..27,
+                                                                                    kind: Lit(
+                                                                                        Num(
+                                                                                            Num {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 26,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 27,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 26..27,
+                                                                                                value: "5",
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
                                                                             },
-                                                                            span: 33..34,
-                                                                            kind: Ident(
-                                                                                BindingIdent {
-                                                                                    name: "y",
-                                                                                    mutable: false,
-                                                                                    span: 33..34,
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 29,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 40,
+                                                                            },
+                                                                        },
+                                                                        span: 29..40,
+                                                                        kind: LetDecl(
+                                                                            LetDecl {
+                                                                                pattern: Pattern {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -216,76 +204,79 @@ Ok(
                                                                                             column: 34,
                                                                                         },
                                                                                     },
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        type_ann: None,
-                                                                        init: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 37,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 39,
-                                                                                },
-                                                                            },
-                                                                            span: 37..39,
-                                                                            kind: Lit(
-                                                                                Num(
-                                                                                    Num {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 37,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 39,
+                                                                                    span: 33..34,
+                                                                                    kind: Ident(
+                                                                                        BindingIdent {
+                                                                                            name: "y",
+                                                                                            mutable: false,
+                                                                                            span: 33..34,
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 33,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 34,
+                                                                                                },
                                                                                             },
                                                                                         },
-                                                                                        span: 37..39,
-                                                                                        value: "10",
-                                                                                    },
-                                                                                ),
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 41,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 46,
-                                                                    },
-                                                                },
-                                                                span: 41..46,
-                                                                kind: BinaryExpr(
-                                                                    BinaryExpr {
-                                                                        op: Add,
-                                                                        left: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 41,
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 42,
+                                                                                type_ann: None,
+                                                                                init: Expr {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 37,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 39,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 37..39,
+                                                                                    kind: Lit(
+                                                                                        Num(
+                                                                                            Num {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 37,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 39,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 37..39,
+                                                                                                value: "10",
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
                                                                             },
-                                                                            span: 41..42,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 41,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 46,
+                                                                            },
+                                                                        },
+                                                                        span: 41..46,
+                                                                        kind: BinaryExpr(
+                                                                            BinaryExpr {
+                                                                                op: Add,
+                                                                                left: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -297,25 +288,25 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 41..42,
-                                                                                    name: "x",
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 41,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 42,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 41..42,
+                                                                                            name: "x",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        right: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 45,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 46,
-                                                                                },
-                                                                            },
-                                                                            span: 45..46,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                                right: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -327,55 +318,70 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 45..46,
-                                                                                    name: "y",
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 45,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 46,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 45..46,
+                                                                                            name: "y",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
+                                                                ],
                                                             },
-                                                        ],
-                                                    },
-                                                ),
-                                                inferred_type: None,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             },
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 49,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 52,
-                                        },
+                                        ),
+                                        inferred_type: None,
                                     },
-                                    span: 49..52,
-                                    kind: Ident(
-                                        Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 49,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 52,
-                                                },
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 49,
                                             },
-                                            span: 49..52,
-                                            name: "sum",
+                                            end: Position {
+                                                line: 0,
+                                                column: 52,
+                                            },
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        span: 49..52,
+                                        kind: Ident(
+                                            Ident {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 49,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 52,
+                                                    },
+                                                },
+                                                span: 49..52,
+                                                name: "sum",
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                         },
                     ),
                     inferred_type: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-5.snap
@@ -64,238 +64,241 @@ Ok(
                         span: 10..43,
                         kind: DoExpr(
                             DoExpr {
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
+                                body: Block {
+                                    span: 13..43,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 24,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 24,
-                                            },
-                                        },
-                                        span: 14..24,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                    },
-                                                    span: 18..19,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "x",
-                                                            mutable: false,
-                                                            span: 18..19,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
+                                            span: 14..24,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 19,
                                                             },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
+                                                        span: 18..19,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 18..19,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 22,
+                                                                        column: 18,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 23,
+                                                                        column: 19,
                                                                     },
                                                                 },
-                                                                span: 22..23,
-                                                                value: "5",
                                                             },
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                        },
+                                                        span: 22..23,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    value: "5",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 25,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 39,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 39,
-                                            },
-                                        },
-                                        span: 25..39,
-                                        kind: App(
-                                            App {
-                                                lam: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 25,
+                                            span: 25..39,
+                                            kind: App(
+                                                App {
+                                                    lam: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 36,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 36,
-                                                        },
+                                                        span: 25..36,
+                                                        kind: Member(
+                                                            Member {
+                                                                obj: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 32,
+                                                                        },
+                                                                    },
+                                                                    span: 25..32,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 25,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 32,
+                                                                                },
+                                                                            },
+                                                                            span: 25..32,
+                                                                            name: "console",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                prop: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 33,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 36,
+                                                                            },
+                                                                        },
+                                                                        span: 33..36,
+                                                                        name: "log",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                    span: 25..36,
-                                                    kind: Member(
-                                                        Member {
-                                                            obj: Expr {
+                                                    args: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 25,
+                                                                        column: 37,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 32,
+                                                                        column: 38,
                                                                     },
                                                                 },
-                                                                span: 25..32,
+                                                                span: 37..38,
                                                                 kind: Ident(
                                                                     Ident {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
-                                                                                column: 25,
+                                                                                column: 37,
                                                                             },
                                                                             end: Position {
                                                                                 line: 0,
-                                                                                column: 32,
+                                                                                column: 38,
                                                                             },
                                                                         },
-                                                                        span: 25..32,
-                                                                        name: "console",
+                                                                        span: 37..38,
+                                                                        name: "x",
                                                                     },
                                                                 ),
                                                                 inferred_type: None,
                                                             },
-                                                            prop: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 33,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 36,
-                                                                        },
-                                                                    },
-                                                                    span: 33..36,
-                                                                    name: "log",
-                                                                },
-                                                            ),
                                                         },
-                                                    ),
-                                                    inferred_type: None,
+                                                    ],
+                                                    type_args: None,
                                                 },
-                                                args: [
-                                                    ExprOrSpread {
-                                                        spread: None,
-                                                        expr: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 37,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 38,
-                                                                },
-                                                            },
-                                                            span: 37..38,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 37,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 38,
-                                                                        },
-                                                                    },
-                                                                    span: 37..38,
-                                                                    name: "x",
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ],
-                                                type_args: None,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 41,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 42,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 41..42,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 41,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 42,
-                                                    },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 41,
                                                 },
-                                                span: 41..42,
-                                                name: "x",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 42,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 41..42,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 42,
+                                                        },
+                                                    },
+                                                    span: 41..42,
+                                                    name: "x",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             },
                         ),
                         inferred_type: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-6.snap
@@ -64,156 +64,159 @@ Ok(
                         span: 10..32,
                         kind: DoExpr(
                             DoExpr {
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
+                                body: Block {
+                                    span: 13..32,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 28,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 28,
-                                            },
-                                        },
-                                        span: 14..28,
-                                        kind: App(
-                                            App {
-                                                lam: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 14,
+                                            span: 14..28,
+                                            kind: App(
+                                                App {
+                                                    lam: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 25,
-                                                        },
+                                                        span: 14..25,
+                                                        kind: Member(
+                                                            Member {
+                                                                obj: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 14,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 21,
+                                                                        },
+                                                                    },
+                                                                    span: 14..21,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 14,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 21,
+                                                                                },
+                                                                            },
+                                                                            span: 14..21,
+                                                                            name: "console",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                prop: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 22,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 25,
+                                                                            },
+                                                                        },
+                                                                        span: 22..25,
+                                                                        name: "log",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                    span: 14..25,
-                                                    kind: Member(
-                                                        Member {
-                                                            obj: Expr {
+                                                    args: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 14,
+                                                                        column: 26,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 21,
+                                                                        column: 27,
                                                                     },
                                                                 },
-                                                                span: 14..21,
+                                                                span: 26..27,
                                                                 kind: Ident(
                                                                     Ident {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
-                                                                                column: 14,
+                                                                                column: 26,
                                                                             },
                                                                             end: Position {
                                                                                 line: 0,
-                                                                                column: 21,
+                                                                                column: 27,
                                                                             },
                                                                         },
-                                                                        span: 14..21,
-                                                                        name: "console",
+                                                                        span: 26..27,
+                                                                        name: "x",
                                                                     },
                                                                 ),
                                                                 inferred_type: None,
                                                             },
-                                                            prop: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 25,
-                                                                        },
-                                                                    },
-                                                                    span: 22..25,
-                                                                    name: "log",
-                                                                },
-                                                            ),
                                                         },
-                                                    ),
-                                                    inferred_type: None,
+                                                    ],
+                                                    type_args: None,
                                                 },
-                                                args: [
-                                                    ExprOrSpread {
-                                                        spread: None,
-                                                        expr: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 26,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 27,
-                                                                },
-                                                            },
-                                                            span: 26..27,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 26,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 27,
-                                                                        },
-                                                                    },
-                                                                    span: 26..27,
-                                                                    name: "x",
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ],
-                                                type_args: None,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 30,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 31,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 30..31,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 30,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 31,
-                                                    },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 30,
                                                 },
-                                                span: 30..31,
-                                                name: "x",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 31,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 30..31,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 30,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 31,
+                                                        },
+                                                    },
+                                                    span: 30..31,
+                                                    name: "x",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             },
                         ),
                         inferred_type: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks.snap
@@ -64,120 +64,123 @@ Ok(
                         span: 10..27,
                         kind: DoExpr(
                             DoExpr {
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
+                                body: Block {
+                                    span: 13..27,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 24,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 24,
-                                            },
-                                        },
-                                        span: 14..24,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                    },
-                                                    span: 18..19,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "x",
-                                                            mutable: false,
-                                                            span: 18..19,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
+                                            span: 14..24,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 19,
                                                             },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
+                                                        span: 18..19,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 18..19,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 22,
+                                                                        column: 18,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 23,
+                                                                        column: 19,
                                                                     },
                                                                 },
-                                                                span: 22..23,
-                                                                value: "5",
                                                             },
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                        },
+                                                        span: 22..23,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    value: "5",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 26,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 25..26,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 25,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 26,
-                                                    },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 25,
                                                 },
-                                                span: 25..26,
-                                                name: "x",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 26,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 25..26,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 26,
+                                                        },
+                                                    },
+                                                    span: 25..26,
+                                                    name: "x",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             },
                         ),
                         inferred_type: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-10.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-10.snap
@@ -86,7 +86,10 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [],
+                                body: Block {
+                                    span: 27..29,
+                                    stmts: [],
+                                },
                             },
                         ),
                     ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-11.snap
@@ -121,121 +121,124 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 3,
-                                                column: 16,
+                                body: Block {
+                                    span: 54..97,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 3,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 3,
+                                                    column: 26,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 3,
-                                                column: 26,
-                                            },
-                                        },
-                                        span: 72..82,
-                                        kind: Assign(
-                                            Assign {
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 3,
-                                                            column: 16,
+                                            span: 72..82,
+                                            kind: Assign(
+                                                Assign {
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 3,
+                                                                column: 16,
+                                                            },
+                                                            end: Position {
+                                                                line: 3,
+                                                                column: 22,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 3,
-                                                            column: 22,
-                                                        },
-                                                    },
-                                                    span: 72..78,
-                                                    kind: Member(
-                                                        Member {
-                                                            obj: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 3,
-                                                                        column: 16,
+                                                        span: 72..78,
+                                                        kind: Member(
+                                                            Member {
+                                                                obj: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 20,
+                                                                        },
                                                                     },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 20,
-                                                                    },
+                                                                    span: 72..76,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 3,
+                                                                                    column: 16,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 3,
+                                                                                    column: 20,
+                                                                                },
+                                                                            },
+                                                                            span: 72..76,
+                                                                            name: "self",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                                span: 72..76,
-                                                                kind: Ident(
+                                                                prop: Ident(
                                                                     Ident {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 3,
-                                                                                column: 16,
+                                                                                column: 21,
                                                                             },
                                                                             end: Position {
                                                                                 line: 3,
-                                                                                column: 20,
+                                                                                column: 22,
                                                                             },
                                                                         },
-                                                                        span: 72..76,
-                                                                        name: "self",
+                                                                        span: 77..78,
+                                                                        name: "x",
                                                                     },
                                                                 ),
-                                                                inferred_type: None,
                                                             },
-                                                            prop: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 21,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 22,
-                                                                        },
-                                                                    },
-                                                                    span: 77..78,
-                                                                    name: "x",
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 3,
-                                                            column: 25,
-                                                        },
-                                                        end: Position {
-                                                            line: 3,
-                                                            column: 26,
-                                                        },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                    span: 81..82,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 25,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 26,
-                                                                },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 3,
+                                                                column: 25,
                                                             },
-                                                            span: 81..82,
-                                                            name: "x",
+                                                            end: Position {
+                                                                line: 3,
+                                                                column: 26,
+                                                            },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
+                                                        span: 81..82,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 25,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 26,
+                                                                    },
+                                                                },
+                                                                span: 81..82,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    op: Eq,
                                                 },
-                                                op: Eq,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             },
                         ),
                         Method(
@@ -328,121 +331,124 @@ Ok(
                                             optional: false,
                                         },
                                     ],
-                                    body: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 6,
-                                                    column: 16,
+                                    body: Block {
+                                        span: 123..166,
+                                        stmts: [
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 6,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 6,
+                                                        column: 26,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 6,
-                                                    column: 26,
-                                                },
-                                            },
-                                            span: 141..151,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 6,
-                                                                column: 16,
+                                                span: 141..151,
+                                                kind: BinaryExpr(
+                                                    BinaryExpr {
+                                                        op: Add,
+                                                        left: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 6,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 6,
+                                                                    column: 22,
+                                                                },
                                                             },
-                                                            end: Position {
-                                                                line: 6,
-                                                                column: 22,
-                                                            },
-                                                        },
-                                                        span: 141..147,
-                                                        kind: Member(
-                                                            Member {
-                                                                obj: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 6,
-                                                                            column: 16,
+                                                            span: 141..147,
+                                                            kind: Member(
+                                                                Member {
+                                                                    obj: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 6,
+                                                                                column: 16,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 6,
+                                                                                column: 20,
+                                                                            },
                                                                         },
-                                                                        end: Position {
-                                                                            line: 6,
-                                                                            column: 20,
-                                                                        },
+                                                                        span: 141..145,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 6,
+                                                                                        column: 16,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 6,
+                                                                                        column: 20,
+                                                                                    },
+                                                                                },
+                                                                                span: 141..145,
+                                                                                name: "self",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                    span: 141..145,
-                                                                    kind: Ident(
+                                                                    prop: Ident(
                                                                         Ident {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 6,
-                                                                                    column: 16,
+                                                                                    column: 21,
                                                                                 },
                                                                                 end: Position {
                                                                                     line: 6,
-                                                                                    column: 20,
+                                                                                    column: 22,
                                                                                 },
                                                                             },
-                                                                            span: 141..145,
-                                                                            name: "self",
+                                                                            span: 146..147,
+                                                                            name: "x",
                                                                         },
                                                                     ),
-                                                                    inferred_type: None,
                                                                 },
-                                                                prop: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 6,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 6,
-                                                                                column: 22,
-                                                                            },
-                                                                        },
-                                                                        span: 146..147,
-                                                                        name: "x",
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 6,
-                                                                column: 25,
-                                                            },
-                                                            end: Position {
-                                                                line: 6,
-                                                                column: 26,
-                                                            },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
-                                                        span: 150..151,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 6,
-                                                                        column: 25,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 6,
-                                                                        column: 26,
-                                                                    },
+                                                        right: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 6,
+                                                                    column: 25,
                                                                 },
-                                                                span: 150..151,
-                                                                name: "y",
+                                                                end: Position {
+                                                                    line: 6,
+                                                                    column: 26,
+                                                                },
                                                             },
-                                                        ),
-                                                        inferred_type: None,
+                                                            span: 150..151,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 6,
+                                                                            column: 25,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 6,
+                                                                            column: 26,
+                                                                        },
+                                                                    },
+                                                                    span: 150..151,
+                                                                    name: "y",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    ],
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ],
+                                    },
                                     is_async: false,
                                     return_type: None,
                                     type_params: None,
@@ -541,121 +547,124 @@ Ok(
                                             optional: false,
                                         },
                                     ],
-                                    body: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 9,
-                                                    column: 16,
+                                    body: Block {
+                                        span: 196..239,
+                                        stmts: [
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 9,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 9,
+                                                        column: 26,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 9,
-                                                    column: 26,
-                                                },
-                                            },
-                                            span: 214..224,
-                                            kind: Assign(
-                                                Assign {
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 9,
-                                                                column: 16,
+                                                span: 214..224,
+                                                kind: Assign(
+                                                    Assign {
+                                                        left: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 9,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 9,
+                                                                    column: 22,
+                                                                },
                                                             },
-                                                            end: Position {
-                                                                line: 9,
-                                                                column: 22,
-                                                            },
-                                                        },
-                                                        span: 214..220,
-                                                        kind: Member(
-                                                            Member {
-                                                                obj: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 9,
-                                                                            column: 16,
+                                                            span: 214..220,
+                                                            kind: Member(
+                                                                Member {
+                                                                    obj: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 9,
+                                                                                column: 16,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 9,
+                                                                                column: 20,
+                                                                            },
                                                                         },
-                                                                        end: Position {
-                                                                            line: 9,
-                                                                            column: 20,
-                                                                        },
+                                                                        span: 214..218,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 9,
+                                                                                        column: 16,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 9,
+                                                                                        column: 20,
+                                                                                    },
+                                                                                },
+                                                                                span: 214..218,
+                                                                                name: "self",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                    span: 214..218,
-                                                                    kind: Ident(
+                                                                    prop: Ident(
                                                                         Ident {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 9,
-                                                                                    column: 16,
+                                                                                    column: 21,
                                                                                 },
                                                                                 end: Position {
                                                                                     line: 9,
-                                                                                    column: 20,
+                                                                                    column: 22,
                                                                                 },
                                                                             },
-                                                                            span: 214..218,
-                                                                            name: "self",
+                                                                            span: 219..220,
+                                                                            name: "x",
                                                                         },
                                                                     ),
-                                                                    inferred_type: None,
                                                                 },
-                                                                prop: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 9,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 9,
-                                                                                column: 22,
-                                                                            },
-                                                                        },
-                                                                        span: 219..220,
-                                                                        name: "x",
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 9,
-                                                                column: 25,
-                                                            },
-                                                            end: Position {
-                                                                line: 9,
-                                                                column: 26,
-                                                            },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
-                                                        span: 223..224,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 9,
-                                                                        column: 25,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 9,
-                                                                        column: 26,
-                                                                    },
+                                                        right: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 9,
+                                                                    column: 25,
                                                                 },
-                                                                span: 223..224,
-                                                                name: "x",
+                                                                end: Position {
+                                                                    line: 9,
+                                                                    column: 26,
+                                                                },
                                                             },
-                                                        ),
-                                                        inferred_type: None,
+                                                            span: 223..224,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 9,
+                                                                            column: 25,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 9,
+                                                                            column: 26,
+                                                                        },
+                                                                    },
+                                                                    span: 223..224,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        op: Eq,
                                                     },
-                                                    op: Eq,
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    ],
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ],
+                                    },
                                     is_async: false,
                                     return_type: None,
                                     type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-5.snap
@@ -66,7 +66,10 @@ Ok(
                                 kind: Method,
                                 lambda: Lambda {
                                     params: [],
-                                    body: [],
+                                    body: Block {
+                                        span: 18..20,
+                                        stmts: [],
+                                    },
                                     is_async: false,
                                     return_type: None,
                                     type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-6.snap
@@ -66,7 +66,10 @@ Ok(
                                 kind: Method,
                                 lambda: Lambda {
                                     params: [],
-                                    body: [],
+                                    body: Block {
+                                        span: 26..28,
+                                        stmts: [],
+                                    },
                                     is_async: false,
                                     return_type: Some(
                                         TypeAnn {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-7.snap
@@ -66,7 +66,10 @@ Ok(
                                 kind: Method,
                                 lambda: Lambda {
                                     params: [],
-                                    body: [],
+                                    body: Block {
+                                        span: 33..35,
+                                        stmts: [],
+                                    },
                                     is_async: false,
                                     return_type: Some(
                                         TypeAnn {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-8.snap
@@ -66,7 +66,10 @@ Ok(
                                 kind: Getter,
                                 lambda: Lambda {
                                     params: [],
-                                    body: [],
+                                    body: Block {
+                                        span: 22..24,
+                                        stmts: [],
+                                    },
                                     is_async: false,
                                     return_type: None,
                                     type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-9.snap
@@ -102,7 +102,10 @@ Ok(
                                             optional: false,
                                         },
                                     ],
-                                    body: [],
+                                    body: Block {
+                                        span: 23..25,
+                                        stmts: [],
+                                    },
                                     is_async: false,
                                     return_type: None,
                                     type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-2.snap
@@ -136,87 +136,90 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 18,
+                                body: Block {
+                                    span: 18..23,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 23,
-                                            },
+                                            span: 18..23,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 19,
+                                                            },
+                                                        },
+                                                        span: 18..19,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 18,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 19,
+                                                                    },
+                                                                },
+                                                                span: 18..19,
+                                                                name: "a",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                        },
+                                                        span: 22..23,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
+                                                                },
+                                                                span: 22..23,
+                                                                name: "b",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 18..23,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                    },
-                                                    span: 18..19,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
-                                                            },
-                                                            span: 18..19,
-                                                            name: "a",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 22,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 23,
-                                                                },
-                                                            },
-                                                            span: 22..23,
-                                                            name: "b",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-3.snap
@@ -64,120 +64,123 @@ Ok(
                         span: 10..27,
                         kind: DoExpr(
                             DoExpr {
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
+                                body: Block {
+                                    span: 13..27,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 24,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 24,
-                                            },
-                                        },
-                                        span: 14..24,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                    },
-                                                    span: 18..19,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "x",
-                                                            mutable: false,
-                                                            span: 18..19,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
+                                            span: 14..24,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 19,
                                                             },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
+                                                        span: 18..19,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 18..19,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 22,
+                                                                        column: 18,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 23,
+                                                                        column: 19,
                                                                     },
                                                                 },
-                                                                span: 22..23,
-                                                                value: "5",
                                                             },
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                        },
+                                                        span: 22..23,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    value: "5",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 26,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 25..26,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 25,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 26,
-                                                    },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 25,
                                                 },
-                                                span: 25..26,
-                                                name: "x",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 26,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 25..26,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 26,
+                                                        },
+                                                    },
+                                                    span: 25..26,
+                                                    name: "x",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             },
                         ),
                         inferred_type: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-4.snap
@@ -115,51 +115,42 @@ Ok(
                                                     optional: false,
                                                 },
                                             ],
-                                            body: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 12,
+                                            body: Block {
+                                                span: 12..21,
+                                                stmts: [
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 21,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 21,
-                                                        },
-                                                    },
-                                                    span: 12..21,
-                                                    kind: Lambda(
-                                                        Lambda {
-                                                            params: [],
-                                                            body: [
-                                                                Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 18,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 21,
-                                                                        },
-                                                                    },
+                                                        span: 12..21,
+                                                        kind: Lambda(
+                                                            Lambda {
+                                                                params: [],
+                                                                body: Block {
                                                                     span: 18..21,
-                                                                    kind: App(
-                                                                        App {
-                                                                            lam: Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 18,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 19,
-                                                                                    },
+                                                                    stmts: [
+                                                                        Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 18,
                                                                                 },
-                                                                                span: 18..19,
-                                                                                kind: Ident(
-                                                                                    Ident {
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 21,
+                                                                                },
+                                                                            },
+                                                                            span: 18..21,
+                                                                            kind: App(
+                                                                                App {
+                                                                                    lam: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
@@ -171,26 +162,41 @@ Ok(
                                                                                             },
                                                                                         },
                                                                                         span: 18..19,
-                                                                                        name: "f",
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 18,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 19,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 18..19,
+                                                                                                name: "f",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            args: [],
-                                                                            type_args: None,
+                                                                                    args: [],
+                                                                                    type_args: None,
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
+                                                                    ],
                                                                 },
-                                                            ],
-                                                            is_async: false,
-                                                            return_type: None,
-                                                            type_params: None,
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
+                                                                is_async: false,
+                                                                return_type: None,
+                                                                type_params: None,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                ],
+                                            },
                                             is_async: false,
                                             return_type: None,
                                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-6.snap
@@ -65,140 +65,143 @@ Ok(
                         kind: Lambda(
                             Lambda {
                                 params: [],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 2,
-                                                column: 53,
-                                            },
-                                        },
-                                        span: 47..84,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 20,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 27,
-                                                        },
-                                                    },
-                                                    span: 51..58,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "msg",
-                                                            mutable: true,
-                                                            span: 51..58,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 20,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 27,
-                                                                },
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                body: Block {
+                                    span: 29..118,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 2,
+                                                    column: 16,
                                                 },
-                                                type_ann: Some(
-                                                    TypeAnn {
-                                                        kind: Keyword(
-                                                            KeywordType {
-                                                                keyword: String,
-                                                            },
-                                                        ),
+                                                end: Position {
+                                                    line: 2,
+                                                    column: 53,
+                                                },
+                                            },
+                                            span: 47..84,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 2,
-                                                                column: 29,
+                                                                column: 20,
                                                             },
                                                             end: Position {
                                                                 line: 2,
-                                                                column: 35,
+                                                                column: 27,
                                                             },
                                                         },
-                                                        span: 60..66,
-                                                        inferred_type: None,
-                                                    },
-                                                ),
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 38,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 52,
-                                                        },
-                                                    },
-                                                    span: 69..83,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
+                                                        span: 51..58,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "msg",
+                                                                mutable: true,
+                                                                span: 51..58,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 2,
-                                                                        column: 38,
+                                                                        column: 20,
                                                                     },
                                                                     end: Position {
                                                                         line: 2,
-                                                                        column: 52,
+                                                                        column: 27,
                                                                     },
                                                                 },
-                                                                span: 69..83,
-                                                                value: "hello, world",
                                                             },
                                                         ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: Some(
+                                                        TypeAnn {
+                                                            kind: Keyword(
+                                                                KeywordType {
+                                                                    keyword: String,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 29,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 35,
+                                                                },
+                                                            },
+                                                            span: 60..66,
+                                                            inferred_type: None,
+                                                        },
                                                     ),
-                                                    inferred_type: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 2,
+                                                                column: 38,
+                                                            },
+                                                            end: Position {
+                                                                line: 2,
+                                                                column: 52,
+                                                            },
+                                                        },
+                                                        span: 69..83,
+                                                        kind: Lit(
+                                                            Str(
+                                                                Str {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 38,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 52,
+                                                                        },
+                                                                    },
+                                                                    span: 69..83,
+                                                                    value: "hello, world",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 3,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 3,
-                                                column: 19,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 101..104,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 19,
-                                                    },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 3,
+                                                    column: 16,
                                                 },
-                                                span: 101..104,
-                                                name: "msg",
+                                                end: Position {
+                                                    line: 3,
+                                                    column: 19,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 101..104,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 19,
+                                                        },
+                                                    },
+                                                    span: 101..104,
+                                                    name: "msg",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-11.snap
@@ -183,7 +183,10 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [],
+                                body: Block {
+                                    span: 33..35,
+                                    stmts: [],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-13.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-13.snap
@@ -217,7 +217,10 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [],
+                                body: Block {
+                                    span: 35..37,
+                                    stmts: [],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-6.snap
@@ -163,38 +163,41 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 22,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 23,
-                                            },
-                                        },
-                                        span: 22..23,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 22,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 23,
-                                                    },
+                                body: Block {
+                                    span: 22..23,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 22,
                                                 },
-                                                span: 22..23,
-                                                name: "a",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 22..23,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 22,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 23,
+                                                        },
+                                                    },
+                                                    span: 22..23,
+                                                    name: "a",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-7.snap
@@ -222,38 +222,41 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 40,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 41,
-                                            },
-                                        },
-                                        span: 40..41,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 40,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 41,
-                                                    },
+                                body: Block {
+                                    span: 40..41,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 40,
                                                 },
-                                                span: 40..41,
-                                                name: "a",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 41,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 40..41,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 40,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                    },
+                                                    span: 40..41,
+                                                    name: "a",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-8.snap
@@ -153,38 +153,41 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 22,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 23,
-                                            },
-                                        },
-                                        span: 22..23,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 22,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 23,
-                                                    },
+                                body: Block {
+                                    span: 22..23,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 22,
                                                 },
-                                                span: 22..23,
-                                                name: "b",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 22..23,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 22,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 23,
+                                                        },
+                                                    },
+                                                    span: 22..23,
+                                                    name: "b",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-9.snap
@@ -248,38 +248,41 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 46,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 47,
-                                            },
-                                        },
-                                        span: 46..47,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 46,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 47,
-                                                    },
+                                body: Block {
+                                    span: 46..47,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 46,
                                                 },
-                                                span: 46..47,
-                                                name: "b",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 47,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 46..47,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 46,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 47,
+                                                        },
+                                                    },
+                                                    span: 46..47,
+                                                    name: "b",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-6.snap
@@ -101,92 +101,80 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 23,
+                                body: Block {
+                                    span: 24..48,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 1,
+                                                    column: 23,
+                                                },
+                                                end: Position {
+                                                    line: 1,
+                                                    column: 47,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 1,
-                                                column: 47,
-                                            },
-                                        },
-                                        span: 24..48,
-                                        kind: Lambda(
-                                            Lambda {
-                                                params: [
-                                                    EFnParam {
-                                                        pat: Pattern {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 1,
-                                                                    column: 24,
-                                                                },
-                                                                end: Position {
-                                                                    line: 1,
-                                                                    column: 25,
-                                                                },
-                                                            },
-                                                            span: 25..26,
-                                                            kind: Ident(
-                                                                BindingIdent {
-                                                                    name: "g",
-                                                                    mutable: false,
-                                                                    span: 25..26,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 1,
-                                                                            column: 24,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 1,
-                                                                            column: 25,
-                                                                        },
+                                            span: 24..48,
+                                            kind: Lambda(
+                                                Lambda {
+                                                    params: [
+                                                        EFnParam {
+                                                            pat: Pattern {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 1,
+                                                                        column: 24,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 1,
+                                                                        column: 25,
                                                                     },
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        type_ann: None,
-                                                        optional: false,
-                                                    },
-                                                ],
-                                                body: [
-                                                    Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 30,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 47,
-                                                            },
-                                                        },
-                                                        span: 31..48,
-                                                        kind: Lambda(
-                                                            Lambda {
-                                                                params: [
-                                                                    EFnParam {
-                                                                        pat: Pattern {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 1,
-                                                                                    column: 31,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 1,
-                                                                                    column: 32,
-                                                                                },
+                                                                span: 25..26,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "g",
+                                                                        mutable: false,
+                                                                        span: 25..26,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 1,
+                                                                                column: 24,
                                                                             },
-                                                                            span: 32..33,
-                                                                            kind: Ident(
-                                                                                BindingIdent {
-                                                                                    name: "x",
-                                                                                    mutable: false,
-                                                                                    span: 32..33,
+                                                                            end: Position {
+                                                                                line: 1,
+                                                                                column: 25,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            type_ann: None,
+                                                            optional: false,
+                                                        },
+                                                    ],
+                                                    body: Block {
+                                                        span: 31..48,
+                                                        stmts: [
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 1,
+                                                                        column: 30,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 1,
+                                                                        column: 47,
+                                                                    },
+                                                                },
+                                                                span: 31..48,
+                                                                kind: Lambda(
+                                                                    Lambda {
+                                                                        params: [
+                                                                            EFnParam {
+                                                                                pat: Pattern {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 1,
@@ -197,30 +185,34 @@ Ok(
                                                                                             column: 32,
                                                                                         },
                                                                                     },
+                                                                                    span: 32..33,
+                                                                                    kind: Ident(
+                                                                                        BindingIdent {
+                                                                                            name: "x",
+                                                                                            mutable: false,
+                                                                                            span: 32..33,
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 31,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 32,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        type_ann: None,
-                                                                        optional: false,
-                                                                    },
-                                                                ],
-                                                                body: [
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 37,
+                                                                                type_ann: None,
+                                                                                optional: false,
                                                                             },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 47,
-                                                                            },
-                                                                        },
-                                                                        span: 38..48,
-                                                                        kind: App(
-                                                                            App {
-                                                                                lam: Expr {
+                                                                        ],
+                                                                        body: Block {
+                                                                            span: 38..48,
+                                                                            stmts: [
+                                                                                Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 1,
@@ -228,10 +220,10 @@ Ok(
                                                                                         },
                                                                                         end: Position {
                                                                                             line: 1,
-                                                                                            column: 41,
+                                                                                            column: 47,
                                                                                         },
                                                                                     },
-                                                                                    span: 38..42,
+                                                                                    span: 38..48,
                                                                                     kind: App(
                                                                                         App {
                                                                                             lam: Expr {
@@ -242,24 +234,78 @@ Ok(
                                                                                                     },
                                                                                                     end: Position {
                                                                                                         line: 1,
-                                                                                                        column: 38,
+                                                                                                        column: 41,
                                                                                                     },
                                                                                                 },
-                                                                                                span: 38..39,
-                                                                                                kind: Ident(
-                                                                                                    Ident {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 37,
+                                                                                                span: 38..42,
+                                                                                                kind: App(
+                                                                                                    App {
+                                                                                                        lam: Expr {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 1,
+                                                                                                                    column: 37,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 1,
+                                                                                                                    column: 38,
+                                                                                                                },
                                                                                                             },
-                                                                                                            end: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 38,
-                                                                                                            },
+                                                                                                            span: 38..39,
+                                                                                                            kind: Ident(
+                                                                                                                Ident {
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 37,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 38,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    span: 38..39,
+                                                                                                                    name: "f",
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            inferred_type: None,
                                                                                                         },
-                                                                                                        span: 38..39,
-                                                                                                        name: "f",
+                                                                                                        args: [
+                                                                                                            ExprOrSpread {
+                                                                                                                spread: None,
+                                                                                                                expr: Expr {
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 39,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 40,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    span: 40..41,
+                                                                                                                    kind: Ident(
+                                                                                                                        Ident {
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 39,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 40,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            span: 40..41,
+                                                                                                                            name: "x",
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    inferred_type: None,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        ],
+                                                                                                        type_args: None,
                                                                                                     },
                                                                                                 ),
                                                                                                 inferred_type: None,
@@ -271,28 +317,82 @@ Ok(
                                                                                                         loc: SourceLocation {
                                                                                                             start: Position {
                                                                                                                 line: 1,
-                                                                                                                column: 39,
+                                                                                                                column: 42,
                                                                                                             },
                                                                                                             end: Position {
                                                                                                                 line: 1,
-                                                                                                                column: 40,
+                                                                                                                column: 46,
                                                                                                             },
                                                                                                         },
-                                                                                                        span: 40..41,
-                                                                                                        kind: Ident(
-                                                                                                            Ident {
-                                                                                                                loc: SourceLocation {
-                                                                                                                    start: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 39,
+                                                                                                        span: 43..47,
+                                                                                                        kind: App(
+                                                                                                            App {
+                                                                                                                lam: Expr {
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 42,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 43,
+                                                                                                                        },
                                                                                                                     },
-                                                                                                                    end: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 40,
-                                                                                                                    },
+                                                                                                                    span: 43..44,
+                                                                                                                    kind: Ident(
+                                                                                                                        Ident {
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 42,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 43,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            span: 43..44,
+                                                                                                                            name: "g",
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    inferred_type: None,
                                                                                                                 },
-                                                                                                                span: 40..41,
-                                                                                                                name: "x",
+                                                                                                                args: [
+                                                                                                                    ExprOrSpread {
+                                                                                                                        spread: None,
+                                                                                                                        expr: Expr {
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 44,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 45,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            span: 45..46,
+                                                                                                                            kind: Ident(
+                                                                                                                                Ident {
+                                                                                                                                    loc: SourceLocation {
+                                                                                                                                        start: Position {
+                                                                                                                                            line: 1,
+                                                                                                                                            column: 44,
+                                                                                                                                        },
+                                                                                                                                        end: Position {
+                                                                                                                                            line: 1,
+                                                                                                                                            column: 45,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    span: 45..46,
+                                                                                                                                    name: "x",
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                            inferred_type: None,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                                type_args: None,
                                                                                                             },
                                                                                                         ),
                                                                                                         inferred_type: None,
@@ -304,117 +404,26 @@ Ok(
                                                                                     ),
                                                                                     inferred_type: None,
                                                                                 },
-                                                                                args: [
-                                                                                    ExprOrSpread {
-                                                                                        spread: None,
-                                                                                        expr: Expr {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 1,
-                                                                                                    column: 42,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 1,
-                                                                                                    column: 46,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 43..47,
-                                                                                            kind: App(
-                                                                                                App {
-                                                                                                    lam: Expr {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 42,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 43,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 43..44,
-                                                                                                        kind: Ident(
-                                                                                                            Ident {
-                                                                                                                loc: SourceLocation {
-                                                                                                                    start: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 42,
-                                                                                                                    },
-                                                                                                                    end: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 43,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                span: 43..44,
-                                                                                                                name: "g",
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    args: [
-                                                                                                        ExprOrSpread {
-                                                                                                            spread: None,
-                                                                                                            expr: Expr {
-                                                                                                                loc: SourceLocation {
-                                                                                                                    start: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 44,
-                                                                                                                    },
-                                                                                                                    end: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 45,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                span: 45..46,
-                                                                                                                kind: Ident(
-                                                                                                                    Ident {
-                                                                                                                        loc: SourceLocation {
-                                                                                                                            start: Position {
-                                                                                                                                line: 1,
-                                                                                                                                column: 44,
-                                                                                                                            },
-                                                                                                                            end: Position {
-                                                                                                                                line: 1,
-                                                                                                                                column: 45,
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        span: 45..46,
-                                                                                                                        name: "x",
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                                inferred_type: None,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    ],
-                                                                                                    type_args: None,
-                                                                                                },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                    },
-                                                                                ],
-                                                                                type_args: None,
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
+                                                                            ],
+                                                                        },
+                                                                        is_async: false,
+                                                                        return_type: None,
+                                                                        type_params: None,
                                                                     },
-                                                                ],
-                                                                is_async: false,
-                                                                return_type: None,
-                                                                type_params: None,
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
+                                                        ],
                                                     },
-                                                ],
-                                                is_async: false,
-                                                return_type: None,
-                                                type_params: None,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                                    is_async: false,
+                                                    return_type: None,
+                                                    type_params: None,
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,
@@ -521,73 +530,64 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 23,
+                                body: Block {
+                                    span: 73..81,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 2,
+                                                    column: 23,
+                                                },
+                                                end: Position {
+                                                    line: 2,
+                                                    column: 31,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 2,
-                                                column: 31,
-                                            },
-                                        },
-                                        span: 73..81,
-                                        kind: Lambda(
-                                            Lambda {
-                                                params: [
-                                                    EFnParam {
-                                                        pat: Pattern {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 24,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 25,
-                                                                },
-                                                            },
-                                                            span: 74..75,
-                                                            kind: Ident(
-                                                                BindingIdent {
-                                                                    name: "y",
-                                                                    mutable: false,
-                                                                    span: 74..75,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 24,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 25,
-                                                                        },
+                                            span: 73..81,
+                                            kind: Lambda(
+                                                Lambda {
+                                                    params: [
+                                                        EFnParam {
+                                                            pat: Pattern {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 24,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 25,
                                                                     },
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        type_ann: None,
-                                                        optional: false,
-                                                    },
-                                                ],
-                                                body: [
-                                                    Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 30,
+                                                                span: 74..75,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "y",
+                                                                        mutable: false,
+                                                                        span: 74..75,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 24,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 25,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 31,
-                                                            },
+                                                            type_ann: None,
+                                                            optional: false,
                                                         },
+                                                    ],
+                                                    body: Block {
                                                         span: 80..81,
-                                                        kind: Ident(
-                                                            Ident {
+                                                        stmts: [
+                                                            Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 2,
@@ -599,20 +599,35 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 80..81,
-                                                                name: "x",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 30,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 31,
+                                                                            },
+                                                                        },
+                                                                        span: 80..81,
+                                                                        name: "x",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
+                                                        ],
                                                     },
-                                                ],
-                                                is_async: false,
-                                                return_type: None,
-                                                type_params: None,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                                    is_async: false,
+                                                    return_type: None,
+                                                    type_params: None,
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
@@ -32,40 +32,43 @@ Ok(
                     kind: Lambda(
                         Lambda {
                             params: [],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 6,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 8,
-                                        },
-                                    },
-                                    span: 6..8,
-                                    kind: Lit(
-                                        Num(
-                                            Num {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 6,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 8,
-                                                    },
-                                                },
-                                                span: 6..8,
-                                                value: "10",
+                            body: Block {
+                                span: 6..8,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 6,
                                             },
+                                            end: Position {
+                                                line: 0,
+                                                column: 8,
+                                            },
+                                        },
+                                        span: 6..8,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 6,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                    },
+                                                    span: 6..8,
+                                                    value: "10",
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
@@ -68,40 +68,43 @@ Ok(
                                     optional: false,
                                 },
                             ],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 7,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 14,
-                                        },
-                                    },
-                                    span: 7..14,
-                                    kind: Lit(
-                                        Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 7,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 14,
-                                                    },
-                                                },
-                                                span: 7..14,
-                                                value: "hello",
+                            body: Block {
+                                span: 7..14,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 7,
                                             },
+                                            end: Position {
+                                                line: 0,
+                                                column: 14,
+                                            },
+                                        },
+                                        span: 7..14,
+                                        kind: Lit(
+                                            Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 7,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
+                                                    },
+                                                    span: 7..14,
+                                                    value: "hello",
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
@@ -121,40 +121,43 @@ Ok(
                                     optional: false,
                                 },
                             ],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 13,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
-                                    },
-                                    span: 13..17,
-                                    kind: Lit(
-                                        Bool(
-                                            Bool {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 13,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 17,
-                                                    },
-                                                },
-                                                span: 13..17,
-                                                value: true,
+                            body: Block {
+                                span: 13..17,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 13,
                                             },
+                                            end: Position {
+                                                line: 0,
+                                                column: 17,
+                                            },
+                                        },
+                                        span: 13..17,
+                                        kind: Lit(
+                                            Bool(
+                                                Bool {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 13,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 13..17,
+                                                    value: true,
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
@@ -120,87 +120,90 @@ Ok(
                                     optional: false,
                                 },
                             ],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
+                            body: Block {
+                                span: 12..17,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 12,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 17,
+                                            },
                                         },
-                                        end: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
+                                        span: 12..17,
+                                        kind: BinaryExpr(
+                                            BinaryExpr {
+                                                op: Add,
+                                                left: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 13,
+                                                        },
+                                                    },
+                                                    span: 12..13,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 12,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 13,
+                                                                },
+                                                            },
+                                                            span: 12..13,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                right: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 16..17,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 17,
+                                                                },
+                                                            },
+                                                            span: 16..17,
+                                                            name: "y",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                        inferred_type: None,
                                     },
-                                    span: 12..17,
-                                    kind: BinaryExpr(
-                                        BinaryExpr {
-                                            op: Add,
-                                            left: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 12,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 13,
-                                                    },
-                                                },
-                                                span: 12..13,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
-                                                        },
-                                                        span: 12..13,
-                                                        name: "x",
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            right: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 17,
-                                                    },
-                                                },
-                                                span: 16..17,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 16,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 17,
-                                                            },
-                                                        },
-                                                        span: 16..17,
-                                                        name: "y",
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
@@ -180,87 +180,90 @@ Ok(
                                     optional: false,
                                 },
                             ],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 18,
+                            body: Block {
+                                span: 18..23,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 18,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 23,
+                                            },
                                         },
-                                        end: Position {
-                                            line: 0,
-                                            column: 23,
-                                        },
+                                        span: 18..23,
+                                        kind: BinaryExpr(
+                                            BinaryExpr {
+                                                op: Add,
+                                                left: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 18,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 19,
+                                                        },
+                                                    },
+                                                    span: 18..19,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 18,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 19,
+                                                                },
+                                                            },
+                                                            span: 18..19,
+                                                            name: "p",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                right: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 22,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 23,
+                                                        },
+                                                    },
+                                                    span: 22..23,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                            },
+                                                            span: 22..23,
+                                                            name: "q",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                        inferred_type: None,
                                     },
-                                    span: 18..23,
-                                    kind: BinaryExpr(
-                                        BinaryExpr {
-                                            op: Add,
-                                            left: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 18,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 19,
-                                                    },
-                                                },
-                                                span: 18..19,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
-                                                        },
-                                                        span: 18..19,
-                                                        name: "p",
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            right: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 22,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 23,
-                                                    },
-                                                },
-                                                span: 22..23,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                        },
-                                                        span: 22..23,
-                                                        name: "q",
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
@@ -123,38 +123,41 @@ Ok(
                                     optional: true,
                                 },
                             ],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 21,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 22,
-                                        },
-                                    },
-                                    span: 21..22,
-                                    kind: Ident(
-                                        Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
+                            body: Block {
+                                span: 21..22,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 21,
                                             },
-                                            span: 21..22,
-                                            name: "c",
+                                            end: Position {
+                                                line: 0,
+                                                column: 22,
+                                            },
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        span: 21..22,
+                                        kind: Ident(
+                                            Ident {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 22,
+                                                    },
+                                                },
+                                                span: 21..22,
+                                                name: "c",
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
@@ -103,38 +103,41 @@ Ok(
                                     optional: false,
                                 },
                             ],
-                            body: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 10,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 11,
-                                        },
-                                    },
-                                    span: 10..11,
-                                    kind: Ident(
-                                        Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
+                            body: Block {
+                                span: 10..11,
+                                stmts: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 10,
                                             },
-                                            span: 10..11,
-                                            name: "c",
+                                            end: Position {
+                                                line: 0,
+                                                column: 11,
+                                            },
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
+                                        span: 10..11,
+                                        kind: Ident(
+                                            Ident {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 10,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 11,
+                                                    },
+                                                },
+                                                span: 10..11,
+                                                name: "c",
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ],
+                            },
                             is_async: false,
                             return_type: None,
                             type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
@@ -61,161 +61,173 @@ Ok(
                                 ),
                                 inferred_type: None,
                             },
-                            consequent: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 9,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 10,
-                                        },
-                                    },
-                                    span: 9..10,
-                                    kind: Lit(
-                                        Num(
-                                            Num {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 9,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 10,
-                                                    },
-                                                },
-                                                span: 9..10,
-                                                value: "5",
-                                            },
-                                        ),
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
-                            alternate: Some(
-                                [
+                            consequent: Block {
+                                span: 7..12,
+                                stmts: [
                                     Expr {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 18,
+                                                column: 9,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 43,
+                                                column: 10,
                                             },
                                         },
-                                        span: 18..43,
-                                        kind: IfElse(
-                                            IfElse {
-                                                cond: Expr {
+                                        span: 9..10,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 22,
+                                                            column: 9,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 23,
+                                                            column: 10,
                                                         },
                                                     },
-                                                    span: 22..23,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 22,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 23,
-                                                                },
-                                                            },
-                                                            span: 22..23,
-                                                            name: "b",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                                    span: 9..10,
+                                                    value: "5",
                                                 },
-                                                consequent: [
-                                                    Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 27,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 29,
-                                                            },
-                                                        },
-                                                        span: 27..29,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 27,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 29,
-                                                                        },
-                                                                    },
-                                                                    span: 27..29,
-                                                                    value: "10",
-                                                                },
-                                                            ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                ],
-                                                alternate: Some(
-                                                    [
-                                                        Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 39,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 41,
-                                                                },
-                                                            },
-                                                            span: 39..41,
-                                                            kind: Lit(
-                                                                Num(
-                                                                    Num {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 39,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 41,
-                                                                            },
-                                                                        },
-                                                                        span: 39..41,
-                                                                        value: "20",
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    ],
-                                                ),
-                                            },
+                                            ),
                                         ),
                                         inferred_type: None,
                                     },
                                 ],
+                            },
+                            alternate: Some(
+                                Block {
+                                    span: 18..43,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 43,
+                                                },
+                                            },
+                                            span: 18..43,
+                                            kind: IfElse(
+                                                IfElse {
+                                                    cond: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                        },
+                                                        span: 22..23,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
+                                                                },
+                                                                span: 22..23,
+                                                                name: "b",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    consequent: Block {
+                                                        span: 25..31,
+                                                        stmts: [
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 27,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 29,
+                                                                    },
+                                                                },
+                                                                span: 27..29,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 27,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 29,
+                                                                                },
+                                                                            },
+                                                                            span: 27..29,
+                                                                            value: "10",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        ],
+                                                    },
+                                                    alternate: Some(
+                                                        Block {
+                                                            span: 37..43,
+                                                            stmts: [
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 39,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 41,
+                                                                        },
+                                                                    },
+                                                                    span: 39..41,
+                                                                    kind: Lit(
+                                                                        Num(
+                                                                            Num {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 39,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 41,
+                                                                                    },
+                                                                                },
+                                                                                span: 39..41,
+                                                                                value: "20",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             ),
                         },
                     ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
@@ -63,75 +63,81 @@ Ok(
                                 ),
                                 inferred_type: None,
                             },
-                            consequent: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 13,
-                                        },
-                                    },
-                                    span: 12..13,
-                                    kind: Lit(
-                                        Num(
-                                            Num {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 12,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 13,
-                                                    },
-                                                },
-                                                span: 12..13,
-                                                value: "5",
-                                            },
-                                        ),
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
-                            alternate: Some(
-                                [
+                            consequent: Block {
+                                span: 10..15,
+                                stmts: [
                                     Expr {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 23,
+                                                column: 12,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 25,
+                                                column: 13,
                                             },
                                         },
-                                        span: 23..25,
+                                        span: 12..13,
                                         kind: Lit(
                                             Num(
                                                 Num {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 23,
+                                                            column: 12,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 25,
+                                                            column: 13,
                                                         },
                                                     },
-                                                    span: 23..25,
-                                                    value: "10",
+                                                    span: 12..13,
+                                                    value: "5",
                                                 },
                                             ),
                                         ),
                                         inferred_type: None,
                                     },
                                 ],
+                            },
+                            alternate: Some(
+                                Block {
+                                    span: 21..27,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 25,
+                                                },
+                                            },
+                                            span: 23..25,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
+                                                        },
+                                                        span: 23..25,
+                                                        value: "10",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                             ),
                         },
                     ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let-2.snap
@@ -210,326 +210,338 @@ Ok(
                                     ),
                                     inferred_type: None,
                                 },
-                                consequent: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 2,
-                                                column: 24,
-                                            },
-                                        },
-                                        span: 73..81,
-                                        kind: Lit(
-                                            Str(
-                                                Str {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 16,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 24,
-                                                        },
-                                                    },
-                                                    span: 73..81,
-                                                    value: "object",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
-                                alternate: Some(
-                                    [
+                                consequent: Block {
+                                    span: 55..95,
+                                    stmts: [
                                         Expr {
                                             loc: SourceLocation {
                                                 start: Position {
-                                                    line: 3,
-                                                    column: 19,
+                                                    line: 2,
+                                                    column: 16,
                                                 },
                                                 end: Position {
-                                                    line: 7,
-                                                    column: 13,
+                                                    line: 2,
+                                                    column: 24,
                                                 },
                                             },
-                                            span: 101..225,
-                                            kind: IfElse(
-                                                IfElse {
-                                                    cond: Expr {
+                                            span: 73..81,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
                                                         loc: SourceLocation {
                                                             start: Position {
-                                                                line: 3,
-                                                                column: 23,
+                                                                line: 2,
+                                                                column: 16,
                                                             },
                                                             end: Position {
-                                                                line: 3,
-                                                                column: 57,
+                                                                line: 2,
+                                                                column: 24,
                                                             },
                                                         },
-                                                        span: 105..139,
-                                                        kind: LetExpr(
-                                                            LetExpr {
-                                                                pat: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 27,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 51,
-                                                                        },
-                                                                    },
-                                                                    span: 109..133,
-                                                                    kind: Array(
-                                                                        ArrayPat {
-                                                                            elems: [
-                                                                                Some(
-                                                                                    ArrayPatElem {
-                                                                                        pattern: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 28,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 38,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 110..120,
-                                                                                            kind: Is(
-                                                                                                IsPat {
-                                                                                                    ident: BindingIdent {
-                                                                                                        name: "a",
-                                                                                                        mutable: false,
-                                                                                                        span: 110..111,
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 28,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 29,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    is_id: Ident {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 33,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 38,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 115..120,
-                                                                                                        name: "Array",
-                                                                                                    },
-                                                                                                },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                        init: None,
-                                                                                    },
-                                                                                ),
-                                                                                Some(
-                                                                                    ArrayPatElem {
-                                                                                        pattern: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 40,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 41,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 122..123,
-                                                                                            kind: Wildcard,
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                        init: None,
-                                                                                    },
-                                                                                ),
-                                                                                Some(
-                                                                                    ArrayPatElem {
-                                                                                        pattern: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 43,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 50,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 125..132,
-                                                                                            kind: Rest(
-                                                                                                RestPat {
-                                                                                                    arg: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 46,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 50,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 128..132,
-                                                                                                        kind: Ident(
-                                                                                                            BindingIdent {
-                                                                                                                name: "rest",
-                                                                                                                mutable: false,
-                                                                                                                span: 128..132,
-                                                                                                                loc: SourceLocation {
-                                                                                                                    start: Position {
-                                                                                                                        line: 3,
-                                                                                                                        column: 46,
-                                                                                                                    },
-                                                                                                                    end: Position {
-                                                                                                                        line: 3,
-                                                                                                                        column: 50,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                        init: None,
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                            optional: false,
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                expr: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 54,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 57,
-                                                                        },
-                                                                    },
-                                                                    span: 136..139,
-                                                                    kind: Ident(
-                                                                        Ident {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 3,
-                                                                                    column: 54,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 3,
-                                                                                    column: 57,
-                                                                                },
-                                                                            },
-                                                                            span: 136..139,
-                                                                            name: "foo",
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
+                                                        span: 73..81,
+                                                        value: "object",
                                                     },
-                                                    consequent: [
-                                                        Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 4,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 4,
-                                                                    column: 23,
-                                                                },
-                                                            },
-                                                            span: 159..166,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 4,
-                                                                                column: 16,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 4,
-                                                                                column: 23,
-                                                                            },
-                                                                        },
-                                                                        span: 159..166,
-                                                                        value: "array",
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    ],
-                                                    alternate: Some(
-                                                        [
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 6,
-                                                                        column: 16,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 6,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 204..211,
-                                                                kind: Lit(
-                                                                    Str(
-                                                                        Str {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 6,
-                                                                                    column: 16,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 6,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 204..211,
-                                                                            value: "other",
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        ],
-                                                    ),
-                                                },
+                                                ),
                                             ),
                                             inferred_type: None,
                                         },
                                     ],
+                                },
+                                alternate: Some(
+                                    Block {
+                                        span: 101..225,
+                                        stmts: [
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 3,
+                                                        column: 19,
+                                                    },
+                                                    end: Position {
+                                                        line: 7,
+                                                        column: 13,
+                                                    },
+                                                },
+                                                span: 101..225,
+                                                kind: IfElse(
+                                                    IfElse {
+                                                        cond: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 23,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 57,
+                                                                },
+                                                            },
+                                                            span: 105..139,
+                                                            kind: LetExpr(
+                                                                LetExpr {
+                                                                    pat: Pattern {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 27,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 51,
+                                                                            },
+                                                                        },
+                                                                        span: 109..133,
+                                                                        kind: Array(
+                                                                            ArrayPat {
+                                                                                elems: [
+                                                                                    Some(
+                                                                                        ArrayPatElem {
+                                                                                            pattern: Pattern {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 28,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 38,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 110..120,
+                                                                                                kind: Is(
+                                                                                                    IsPat {
+                                                                                                        ident: BindingIdent {
+                                                                                                            name: "a",
+                                                                                                            mutable: false,
+                                                                                                            span: 110..111,
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 28,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 29,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        is_id: Ident {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 33,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 38,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 115..120,
+                                                                                                            name: "Array",
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                            init: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    Some(
+                                                                                        ArrayPatElem {
+                                                                                            pattern: Pattern {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 40,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 41,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 122..123,
+                                                                                                kind: Wildcard,
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                            init: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    Some(
+                                                                                        ArrayPatElem {
+                                                                                            pattern: Pattern {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 43,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 50,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 125..132,
+                                                                                                kind: Rest(
+                                                                                                    RestPat {
+                                                                                                        arg: Pattern {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 46,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 50,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 128..132,
+                                                                                                            kind: Ident(
+                                                                                                                BindingIdent {
+                                                                                                                    name: "rest",
+                                                                                                                    mutable: false,
+                                                                                                                    span: 128..132,
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 46,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 50,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            inferred_type: None,
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                            init: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                optional: false,
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                    expr: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 54,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 57,
+                                                                            },
+                                                                        },
+                                                                        span: 136..139,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 54,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 57,
+                                                                                    },
+                                                                                },
+                                                                                span: 136..139,
+                                                                                name: "foo",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        consequent: Block {
+                                                            span: 141..180,
+                                                            stmts: [
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 4,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 4,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 159..166,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 4,
+                                                                                        column: 16,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 4,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 159..166,
+                                                                                value: "array",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            ],
+                                                        },
+                                                        alternate: Some(
+                                                            Block {
+                                                                span: 186..225,
+                                                                stmts: [
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 6,
+                                                                                column: 16,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 6,
+                                                                                column: 23,
+                                                                            },
+                                                                        },
+                                                                        span: 204..211,
+                                                                        kind: Lit(
+                                                                            Str(
+                                                                                Str {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 6,
+                                                                                            column: 16,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 6,
+                                                                                            column: 23,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 204..211,
+                                                                                    value: "other",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ],
+                                    },
                                 ),
                             },
                         ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let.snap
@@ -260,310 +260,322 @@ Ok(
                                     ),
                                     inferred_type: None,
                                 },
-                                consequent: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 2,
-                                                column: 24,
-                                            },
-                                        },
-                                        span: 75..83,
-                                        kind: Lit(
-                                            Str(
-                                                Str {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 16,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 24,
-                                                        },
-                                                    },
-                                                    span: 75..83,
-                                                    value: "object",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
-                                alternate: Some(
-                                    [
+                                consequent: Block {
+                                    span: 57..97,
+                                    stmts: [
                                         Expr {
                                             loc: SourceLocation {
                                                 start: Position {
-                                                    line: 3,
-                                                    column: 19,
+                                                    line: 2,
+                                                    column: 16,
                                                 },
                                                 end: Position {
-                                                    line: 7,
-                                                    column: 13,
+                                                    line: 2,
+                                                    column: 24,
                                                 },
                                             },
-                                            span: 103..218,
-                                            kind: IfElse(
-                                                IfElse {
-                                                    cond: Expr {
+                                            span: 75..83,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
                                                         loc: SourceLocation {
                                                             start: Position {
-                                                                line: 3,
-                                                                column: 23,
+                                                                line: 2,
+                                                                column: 16,
                                                             },
                                                             end: Position {
-                                                                line: 3,
-                                                                column: 48,
+                                                                line: 2,
+                                                                column: 24,
                                                             },
                                                         },
-                                                        span: 107..132,
-                                                        kind: LetExpr(
-                                                            LetExpr {
-                                                                pat: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 27,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 42,
-                                                                        },
-                                                                    },
-                                                                    span: 111..126,
-                                                                    kind: Array(
-                                                                        ArrayPat {
-                                                                            elems: [
-                                                                                Some(
-                                                                                    ArrayPatElem {
-                                                                                        pattern: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 28,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 29,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 112..113,
-                                                                                            kind: Ident(
-                                                                                                BindingIdent {
-                                                                                                    name: "a",
-                                                                                                    mutable: false,
-                                                                                                    span: 112..113,
-                                                                                                    loc: SourceLocation {
-                                                                                                        start: Position {
-                                                                                                            line: 3,
-                                                                                                            column: 28,
-                                                                                                        },
-                                                                                                        end: Position {
-                                                                                                            line: 3,
-                                                                                                            column: 29,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                        init: None,
-                                                                                    },
-                                                                                ),
-                                                                                Some(
-                                                                                    ArrayPatElem {
-                                                                                        pattern: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 31,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 32,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 115..116,
-                                                                                            kind: Wildcard,
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                        init: None,
-                                                                                    },
-                                                                                ),
-                                                                                Some(
-                                                                                    ArrayPatElem {
-                                                                                        pattern: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 34,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 3,
-                                                                                                    column: 41,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 118..125,
-                                                                                            kind: Rest(
-                                                                                                RestPat {
-                                                                                                    arg: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 37,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 41,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 121..125,
-                                                                                                        kind: Ident(
-                                                                                                            BindingIdent {
-                                                                                                                name: "rest",
-                                                                                                                mutable: false,
-                                                                                                                span: 121..125,
-                                                                                                                loc: SourceLocation {
-                                                                                                                    start: Position {
-                                                                                                                        line: 3,
-                                                                                                                        column: 37,
-                                                                                                                    },
-                                                                                                                    end: Position {
-                                                                                                                        line: 3,
-                                                                                                                        column: 41,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                        init: None,
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                            optional: false,
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                expr: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 45,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 48,
-                                                                        },
-                                                                    },
-                                                                    span: 129..132,
-                                                                    kind: Ident(
-                                                                        Ident {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 3,
-                                                                                    column: 45,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 3,
-                                                                                    column: 48,
-                                                                                },
-                                                                            },
-                                                                            span: 129..132,
-                                                                            name: "foo",
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
+                                                        span: 75..83,
+                                                        value: "object",
                                                     },
-                                                    consequent: [
-                                                        Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 4,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 4,
-                                                                    column: 23,
-                                                                },
-                                                            },
-                                                            span: 152..159,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 4,
-                                                                                column: 16,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 4,
-                                                                                column: 23,
-                                                                            },
-                                                                        },
-                                                                        span: 152..159,
-                                                                        value: "array",
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    ],
-                                                    alternate: Some(
-                                                        [
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 6,
-                                                                        column: 16,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 6,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 197..204,
-                                                                kind: Lit(
-                                                                    Str(
-                                                                        Str {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 6,
-                                                                                    column: 16,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 6,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 197..204,
-                                                                            value: "other",
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        ],
-                                                    ),
-                                                },
+                                                ),
                                             ),
                                             inferred_type: None,
                                         },
                                     ],
+                                },
+                                alternate: Some(
+                                    Block {
+                                        span: 103..218,
+                                        stmts: [
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 3,
+                                                        column: 19,
+                                                    },
+                                                    end: Position {
+                                                        line: 7,
+                                                        column: 13,
+                                                    },
+                                                },
+                                                span: 103..218,
+                                                kind: IfElse(
+                                                    IfElse {
+                                                        cond: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 23,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 48,
+                                                                },
+                                                            },
+                                                            span: 107..132,
+                                                            kind: LetExpr(
+                                                                LetExpr {
+                                                                    pat: Pattern {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 27,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 42,
+                                                                            },
+                                                                        },
+                                                                        span: 111..126,
+                                                                        kind: Array(
+                                                                            ArrayPat {
+                                                                                elems: [
+                                                                                    Some(
+                                                                                        ArrayPatElem {
+                                                                                            pattern: Pattern {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 28,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 29,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 112..113,
+                                                                                                kind: Ident(
+                                                                                                    BindingIdent {
+                                                                                                        name: "a",
+                                                                                                        mutable: false,
+                                                                                                        span: 112..113,
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 28,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 29,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                            init: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    Some(
+                                                                                        ArrayPatElem {
+                                                                                            pattern: Pattern {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 31,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 32,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 115..116,
+                                                                                                kind: Wildcard,
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                            init: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    Some(
+                                                                                        ArrayPatElem {
+                                                                                            pattern: Pattern {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 34,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 41,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 118..125,
+                                                                                                kind: Rest(
+                                                                                                    RestPat {
+                                                                                                        arg: Pattern {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 37,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 3,
+                                                                                                                    column: 41,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 121..125,
+                                                                                                            kind: Ident(
+                                                                                                                BindingIdent {
+                                                                                                                    name: "rest",
+                                                                                                                    mutable: false,
+                                                                                                                    span: 121..125,
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 37,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 41,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            inferred_type: None,
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                            init: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                optional: false,
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                    expr: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 45,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 48,
+                                                                            },
+                                                                        },
+                                                                        span: 129..132,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 45,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 48,
+                                                                                    },
+                                                                                },
+                                                                                span: 129..132,
+                                                                                name: "foo",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        consequent: Block {
+                                                            span: 134..173,
+                                                            stmts: [
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 4,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 4,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 152..159,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 4,
+                                                                                        column: 16,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 4,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 152..159,
+                                                                                value: "array",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            ],
+                                                        },
+                                                        alternate: Some(
+                                                            Block {
+                                                                span: 179..218,
+                                                                stmts: [
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 6,
+                                                                                column: 16,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 6,
+                                                                                column: 23,
+                                                                            },
+                                                                        },
+                                                                        span: 197..204,
+                                                                        kind: Lit(
+                                                                            Str(
+                                                                                Str {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 6,
+                                                                                            column: 16,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 6,
+                                                                                            column: 23,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 197..204,
+                                                                                    value: "other",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ],
+                                    },
                                 ),
                             },
                         ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__it_works.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__it_works.snap
@@ -136,87 +136,90 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 28,
+                                body: Block {
+                                    span: 29..34,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 1,
+                                                    column: 28,
+                                                },
+                                                end: Position {
+                                                    line: 1,
+                                                    column: 33,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 1,
-                                                column: 33,
-                                            },
+                                            span: 29..34,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 1,
+                                                                column: 28,
+                                                            },
+                                                            end: Position {
+                                                                line: 1,
+                                                                column: 29,
+                                                            },
+                                                        },
+                                                        span: 29..30,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 1,
+                                                                        column: 28,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 1,
+                                                                        column: 29,
+                                                                    },
+                                                                },
+                                                                span: 29..30,
+                                                                name: "a",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 1,
+                                                                column: 32,
+                                                            },
+                                                            end: Position {
+                                                                line: 1,
+                                                                column: 33,
+                                                            },
+                                                        },
+                                                        span: 33..34,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 1,
+                                                                        column: 32,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 1,
+                                                                        column: 33,
+                                                                    },
+                                                                },
+                                                                span: 33..34,
+                                                                name: "b",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 29..34,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 28,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 29,
-                                                        },
-                                                    },
-                                                    span: 29..30,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 1,
-                                                                    column: 28,
-                                                                },
-                                                                end: Position {
-                                                                    line: 1,
-                                                                    column: 29,
-                                                                },
-                                                            },
-                                                            span: 29..30,
-                                                            name: "a",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 32,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 33,
-                                                        },
-                                                    },
-                                                    span: 33..34,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 1,
-                                                                    column: 32,
-                                                                },
-                                                                end: Position {
-                                                                    line: 1,
-                                                                    column: 33,
-                                                                },
-                                                            },
-                                                            span: 33..34,
-                                                            name: "b",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,
@@ -358,87 +361,90 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 28,
+                                body: Block {
+                                    span: 64..69,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 2,
+                                                    column: 28,
+                                                },
+                                                end: Position {
+                                                    line: 2,
+                                                    column: 33,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 2,
-                                                column: 33,
-                                            },
+                                            span: 64..69,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Sub,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 2,
+                                                                column: 28,
+                                                            },
+                                                            end: Position {
+                                                                line: 2,
+                                                                column: 29,
+                                                            },
+                                                        },
+                                                        span: 64..65,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 28,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 29,
+                                                                    },
+                                                                },
+                                                                span: 64..65,
+                                                                name: "a",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 2,
+                                                                column: 32,
+                                                            },
+                                                            end: Position {
+                                                                line: 2,
+                                                                column: 33,
+                                                            },
+                                                        },
+                                                        span: 68..69,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 32,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 33,
+                                                                    },
+                                                                },
+                                                                span: 68..69,
+                                                                name: "b",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 64..69,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Sub,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 28,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 29,
-                                                        },
-                                                    },
-                                                    span: 64..65,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 28,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 29,
-                                                                },
-                                                            },
-                                                            span: 64..65,
-                                                            name: "a",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 32,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 33,
-                                                        },
-                                                    },
-                                                    span: 68..69,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 32,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 33,
-                                                                },
-                                                            },
-                                                            span: 68..69,
-                                                            name: "b",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-2.snap
@@ -262,40 +262,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 2,
-                                                        column: 33,
-                                                    },
-                                                    end: Position {
-                                                        line: 2,
-                                                        column: 41,
-                                                    },
-                                                },
-                                                span: 70..78,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 33,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 41,
-                                                                },
-                                                            },
-                                                            span: 70..78,
-                                                            value: "object",
+                                        body: Block {
+                                            span: 70..78,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 33,
                                                         },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 41,
+                                                        },
+                                                    },
+                                                    span: 70..78,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 33,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 41,
+                                                                    },
+                                                                },
+                                                                span: 70..78,
+                                                                value: "object",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -325,40 +328,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 34,
-                                                    },
-                                                },
-                                                span: 101..114,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 21,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 34,
-                                                                },
-                                                            },
-                                                            span: 101..114,
-                                                            value: "fallthrough",
+                                        body: Block {
+                                            span: 101..114,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 21,
                                                         },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 34,
+                                                        },
+                                                    },
+                                                    span: 101..114,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 21,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 34,
+                                                                    },
+                                                                },
+                                                                span: 101..114,
+                                                                value: "fallthrough",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                 ],
                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-3.snap
@@ -155,40 +155,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 2,
-                                                        column: 31,
-                                                    },
-                                                    end: Position {
-                                                        line: 2,
-                                                        column: 39,
-                                                    },
-                                                },
-                                                span: 68..76,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 31,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 39,
-                                                                },
-                                                            },
-                                                            span: 68..76,
-                                                            value: "number",
+                                        body: Block {
+                                            span: 68..76,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 31,
                                                         },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 39,
+                                                        },
+                                                    },
+                                                    span: 68..76,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 31,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 39,
+                                                                    },
+                                                                },
+                                                                span: 68..76,
+                                                                value: "number",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -301,40 +304,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 35,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 42,
-                                                    },
-                                                },
-                                                span: 113..120,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 35,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 42,
-                                                                },
-                                                            },
-                                                            span: 113..120,
-                                                            value: "Array",
+                                        body: Block {
+                                            span: 113..120,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 35,
                                                         },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 42,
+                                                        },
+                                                    },
+                                                    span: 113..120,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 35,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 42,
+                                                                    },
+                                                                },
+                                                                span: 113..120,
+                                                                value: "Array",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -364,40 +370,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 4,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 4,
-                                                        column: 34,
-                                                    },
-                                                },
-                                                span: 143..156,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 4,
-                                                                    column: 21,
-                                                                },
-                                                                end: Position {
-                                                                    line: 4,
-                                                                    column: 34,
-                                                                },
-                                                            },
-                                                            span: 143..156,
-                                                            value: "fallthrough",
+                                        body: Block {
+                                            span: 143..156,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 4,
+                                                            column: 21,
                                                         },
+                                                        end: Position {
+                                                            line: 4,
+                                                            column: 34,
+                                                        },
+                                                    },
+                                                    span: 143..156,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 4,
+                                                                        column: 21,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 4,
+                                                                        column: 34,
+                                                                    },
+                                                                },
+                                                                span: 143..156,
+                                                                value: "fallthrough",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                 ],
                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-4.snap
@@ -142,40 +142,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 2,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 2,
-                                                        column: 26,
-                                                    },
-                                                },
-                                                span: 58..63,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 21,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 26,
-                                                                },
-                                                            },
-                                                            span: 58..63,
-                                                            value: "one",
+                                        body: Block {
+                                            span: 58..63,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 21,
                                                         },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 26,
+                                                        },
+                                                    },
+                                                    span: 58..63,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 21,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 26,
+                                                                    },
+                                                                },
+                                                                span: 58..63,
+                                                                value: "one",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -224,40 +227,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 26,
-                                                    },
-                                                },
-                                                span: 86..91,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 21,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 26,
-                                                                },
-                                                            },
-                                                            span: 86..91,
-                                                            value: "two",
+                                        body: Block {
+                                            span: 86..91,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 21,
                                                         },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 26,
+                                                        },
+                                                    },
+                                                    span: 86..91,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 21,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 26,
+                                                                    },
+                                                                },
+                                                                span: 86..91,
+                                                                value: "two",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -385,40 +391,43 @@ Ok(
                                                 inferred_type: None,
                                             },
                                         ),
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 4,
-                                                        column: 32,
-                                                    },
-                                                    end: Position {
-                                                        line: 4,
-                                                        column: 37,
-                                                    },
-                                                },
-                                                span: 125..130,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 4,
-                                                                    column: 32,
-                                                                },
-                                                                end: Position {
-                                                                    line: 4,
-                                                                    column: 37,
-                                                                },
-                                                            },
-                                                            span: 125..130,
-                                                            value: "few",
+                                        body: Block {
+                                            span: 125..130,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 4,
+                                                            column: 32,
                                                         },
+                                                        end: Position {
+                                                            line: 4,
+                                                            column: 37,
+                                                        },
+                                                    },
+                                                    span: 125..130,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 4,
+                                                                        column: 32,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 4,
+                                                                        column: 37,
+                                                                    },
+                                                                },
+                                                                span: 125..130,
+                                                                value: "few",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -448,40 +457,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 27,
-                                                    },
-                                                },
-                                                span: 153..159,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 5,
-                                                                    column: 21,
-                                                                },
-                                                                end: Position {
-                                                                    line: 5,
-                                                                    column: 27,
-                                                                },
-                                                            },
-                                                            span: 153..159,
-                                                            value: "many",
+                                        body: Block {
+                                            span: 153..159,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 5,
+                                                            column: 21,
                                                         },
+                                                        end: Position {
+                                                            line: 5,
+                                                            column: 27,
+                                                        },
+                                                    },
+                                                    span: 153..159,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 5,
+                                                                        column: 21,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 5,
+                                                                        column: 27,
+                                                                    },
+                                                                },
+                                                                span: 153..159,
+                                                                value: "many",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                 ],
                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching.snap
@@ -320,40 +320,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 2,
-                                                        column: 44,
-                                                    },
-                                                    end: Position {
-                                                        line: 2,
-                                                        column: 52,
-                                                    },
-                                                },
-                                                span: 81..89,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 44,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 52,
-                                                                },
-                                                            },
-                                                            span: 81..89,
-                                                            value: "object",
+                                        body: Block {
+                                            span: 81..89,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 44,
                                                         },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 52,
+                                                        },
+                                                    },
+                                                    span: 81..89,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 44,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 52,
+                                                                    },
+                                                                },
+                                                                span: 81..89,
+                                                                value: "object",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -499,40 +502,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 35,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 42,
-                                                    },
-                                                },
-                                                span: 126..133,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 35,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 42,
-                                                                },
-                                                            },
-                                                            span: 126..133,
-                                                            value: "array",
+                                        body: Block {
+                                            span: 126..133,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 35,
                                                         },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 42,
+                                                        },
+                                                    },
+                                                    span: 126..133,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 35,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 42,
+                                                                    },
+                                                                },
+                                                                span: 126..133,
+                                                                value: "array",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -581,40 +587,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 4,
-                                                        column: 28,
-                                                    },
-                                                    end: Position {
-                                                        line: 4,
-                                                        column: 36,
-                                                    },
-                                                },
-                                                span: 163..171,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 4,
-                                                                    column: 28,
-                                                                },
-                                                                end: Position {
-                                                                    line: 4,
-                                                                    column: 36,
-                                                                },
-                                                            },
-                                                            span: 163..171,
-                                                            value: "string",
+                                        body: Block {
+                                            span: 163..171,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 4,
+                                                            column: 28,
                                                         },
+                                                        end: Position {
+                                                            line: 4,
+                                                            column: 36,
+                                                        },
+                                                    },
+                                                    span: 163..171,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 4,
+                                                                        column: 28,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 4,
+                                                                        column: 36,
+                                                                    },
+                                                                },
+                                                                span: 163..171,
+                                                                value: "string",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -663,40 +672,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 24,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 30,
-                                                    },
-                                                },
-                                                span: 197..203,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 5,
-                                                                    column: 24,
-                                                                },
-                                                                end: Position {
-                                                                    line: 5,
-                                                                    column: 30,
-                                                                },
-                                                            },
-                                                            span: 197..203,
-                                                            value: "true",
+                                        body: Block {
+                                            span: 197..203,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 5,
+                                                            column: 24,
                                                         },
+                                                        end: Position {
+                                                            line: 5,
+                                                            column: 30,
+                                                        },
+                                                    },
+                                                    span: 197..203,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 5,
+                                                                        column: 24,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 5,
+                                                                        column: 30,
+                                                                    },
+                                                                },
+                                                                span: 197..203,
+                                                                value: "true",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -745,40 +757,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 6,
-                                                        column: 25,
-                                                    },
-                                                    end: Position {
-                                                        line: 6,
-                                                        column: 32,
-                                                    },
-                                                },
-                                                span: 230..237,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 6,
-                                                                    column: 25,
-                                                                },
-                                                                end: Position {
-                                                                    line: 6,
-                                                                    column: 32,
-                                                                },
-                                                            },
-                                                            span: 230..237,
-                                                            value: "false",
+                                        body: Block {
+                                            span: 230..237,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 6,
+                                                            column: 25,
                                                         },
+                                                        end: Position {
+                                                            line: 6,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 230..237,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 6,
+                                                                        column: 25,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 6,
+                                                                        column: 32,
+                                                                    },
+                                                                },
+                                                                span: 230..237,
+                                                                value: "false",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -824,40 +839,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 7,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 7,
-                                                        column: 31,
-                                                    },
-                                                },
-                                                span: 260..270,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 7,
-                                                                    column: 21,
-                                                                },
-                                                                end: Position {
-                                                                    line: 7,
-                                                                    column: 31,
-                                                                },
-                                                            },
-                                                            span: 260..270,
-                                                            value: "variable",
+                                        body: Block {
+                                            span: 260..270,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 7,
+                                                            column: 21,
                                                         },
+                                                        end: Position {
+                                                            line: 7,
+                                                            column: 31,
+                                                        },
+                                                    },
+                                                    span: 260..270,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 7,
+                                                                        column: 21,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 7,
+                                                                        column: 31,
+                                                                    },
+                                                                },
+                                                                span: 260..270,
+                                                                value: "variable",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                     Arm {
                                         loc: SourceLocation {
@@ -887,40 +905,43 @@ Ok(
                                             inferred_type: None,
                                         },
                                         guard: None,
-                                        body: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 8,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 8,
-                                                        column: 31,
-                                                    },
-                                                },
-                                                span: 293..303,
-                                                kind: Lit(
-                                                    Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 8,
-                                                                    column: 21,
-                                                                },
-                                                                end: Position {
-                                                                    line: 8,
-                                                                    column: 31,
-                                                                },
-                                                            },
-                                                            span: 293..303,
-                                                            value: "wildcard",
+                                        body: Block {
+                                            span: 293..303,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 8,
+                                                            column: 21,
                                                         },
+                                                        end: Position {
+                                                            line: 8,
+                                                            column: 31,
+                                                        },
+                                                    },
+                                                    span: 293..303,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 8,
+                                                                        column: 21,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 8,
+                                                                        column: 31,
+                                                                    },
+                                                                },
+                                                                span: 293..303,
+                                                                value: "wildcard",
+                                                            },
+                                                        ),
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ],
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
                                     },
                                 ],
                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions-2.snap
@@ -65,172 +65,175 @@ Ok(
                         kind: Lambda(
                             Lambda {
                                 params: [],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 18,
+                                body: Block {
+                                    span: 16..45,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 40,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 40,
-                                            },
-                                        },
-                                        span: 18..40,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "x",
-                                                            mutable: false,
-                                                            span: 22..23,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 22,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 23,
-                                                                },
+                                            span: 18..40,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
                                                             },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 26,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 39,
-                                                        },
-                                                    },
-                                                    span: 26..39,
-                                                    kind: App(
-                                                        App {
-                                                            lam: Expr {
+                                                        span: 22..23,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 22..23,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 26,
+                                                                        column: 22,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 37,
+                                                                        column: 23,
                                                                     },
                                                                 },
-                                                                span: 26..37,
-                                                                kind: Member(
-                                                                    Member {
-                                                                        obj: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 26,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 26,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 39,
+                                                            },
+                                                        },
+                                                        span: 26..39,
+                                                        kind: App(
+                                                            App {
+                                                                lam: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 26,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 37,
+                                                                        },
+                                                                    },
+                                                                    span: 26..37,
+                                                                    kind: Member(
+                                                                        Member {
+                                                                            obj: Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 30,
+                                                                                    },
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 30,
-                                                                                },
+                                                                                span: 26..30,
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 26,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 30,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 26..30,
+                                                                                        name: "Math",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                            span: 26..30,
-                                                                            kind: Ident(
+                                                                            prop: Ident(
                                                                                 Ident {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
-                                                                                            column: 26,
+                                                                                            column: 31,
                                                                                         },
                                                                                         end: Position {
                                                                                             line: 0,
-                                                                                            column: 30,
+                                                                                            column: 37,
                                                                                         },
                                                                                     },
-                                                                                    span: 26..30,
-                                                                                    name: "Math",
+                                                                                    span: 31..37,
+                                                                                    name: "random",
                                                                                 },
                                                                             ),
-                                                                            inferred_type: None,
                                                                         },
-                                                                        prop: Ident(
-                                                                            Ident {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 31,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 37,
-                                                                                    },
-                                                                                },
-                                                                                span: 31..37,
-                                                                                name: "random",
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                args: [],
+                                                                type_args: None,
                                                             },
-                                                            args: [],
-                                                            type_args: None,
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 41,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 42,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 41..42,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 41,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 42,
-                                                    },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 41,
                                                 },
-                                                span: 41..42,
-                                                name: "x",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 42,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 41..42,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 42,
+                                                        },
+                                                    },
+                                                    span: 41..42,
+                                                    name: "x",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions.snap
@@ -65,172 +65,175 @@ Ok(
                         kind: Lambda(
                             Lambda {
                                 params: [],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 18,
+                                body: Block {
+                                    span: 16..44,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 40,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 40,
-                                            },
-                                        },
-                                        span: 18..40,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "x",
-                                                            mutable: false,
-                                                            span: 22..23,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 22,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 23,
-                                                                },
+                                            span: 18..40,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
                                                             },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 26,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 39,
-                                                        },
-                                                    },
-                                                    span: 26..39,
-                                                    kind: App(
-                                                        App {
-                                                            lam: Expr {
+                                                        span: 22..23,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 22..23,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 26,
+                                                                        column: 22,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 37,
+                                                                        column: 23,
                                                                     },
                                                                 },
-                                                                span: 26..37,
-                                                                kind: Member(
-                                                                    Member {
-                                                                        obj: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 26,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 26,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 39,
+                                                            },
+                                                        },
+                                                        span: 26..39,
+                                                        kind: App(
+                                                            App {
+                                                                lam: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 26,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 37,
+                                                                        },
+                                                                    },
+                                                                    span: 26..37,
+                                                                    kind: Member(
+                                                                        Member {
+                                                                            obj: Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 30,
+                                                                                    },
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 30,
-                                                                                },
+                                                                                span: 26..30,
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 26,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 30,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 26..30,
+                                                                                        name: "Math",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                            span: 26..30,
-                                                                            kind: Ident(
+                                                                            prop: Ident(
                                                                                 Ident {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
-                                                                                            column: 26,
+                                                                                            column: 31,
                                                                                         },
                                                                                         end: Position {
                                                                                             line: 0,
-                                                                                            column: 30,
+                                                                                            column: 37,
                                                                                         },
                                                                                     },
-                                                                                    span: 26..30,
-                                                                                    name: "Math",
+                                                                                    span: 31..37,
+                                                                                    name: "random",
                                                                                 },
                                                                             ),
-                                                                            inferred_type: None,
                                                                         },
-                                                                        prop: Ident(
-                                                                            Ident {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 31,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 37,
-                                                                                    },
-                                                                                },
-                                                                                span: 31..37,
-                                                                                name: "random",
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                args: [],
+                                                                type_args: None,
                                                             },
-                                                            args: [],
-                                                            type_args: None,
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 41,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 42,
-                                            },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 41..42,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 41,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 42,
-                                                    },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 41,
                                                 },
-                                                span: 41..42,
-                                                name: "x",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 42,
+                                                },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            span: 41..42,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 42,
+                                                        },
+                                                    },
+                                                    span: 41..42,
+                                                    name: "x",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-4.snap
@@ -65,94 +65,97 @@ Ok(
                         kind: Lambda(
                             Lambda {
                                 params: [],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 16,
+                                body: Block {
+                                    span: 16..22,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 22,
-                                            },
+                                            span: 16..22,
+                                            kind: Tuple(
+                                                Tuple {
+                                                    elems: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 17,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 18,
+                                                                    },
+                                                                },
+                                                                span: 17..18,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 17,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                        },
+                                                                        span: 17..18,
+                                                                        name: "a",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 20,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 21,
+                                                                    },
+                                                                },
+                                                                span: 20..21,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 20,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 21,
+                                                                            },
+                                                                        },
+                                                                        span: 20..21,
+                                                                        name: "b",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 16..22,
-                                        kind: Tuple(
-                                            Tuple {
-                                                elems: [
-                                                    ExprOrSpread {
-                                                        spread: None,
-                                                        expr: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 17,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                            },
-                                                            span: 17..18,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 17,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 18,
-                                                                        },
-                                                                    },
-                                                                    span: 17..18,
-                                                                    name: "a",
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                    ExprOrSpread {
-                                                        spread: None,
-                                                        expr: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 20,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 21,
-                                                                },
-                                                            },
-                                                            span: 20..21,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 20,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 21,
-                                                                        },
-                                                                    },
-                                                                    span: 20..21,
-                                                                    name: "b",
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ],
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-3.snap
@@ -176,87 +176,90 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 44,
+                                body: Block {
+                                    span: 44..49,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 44,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 49,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 49,
-                                            },
+                                            span: 44..49,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 44,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 45,
+                                                            },
+                                                        },
+                                                        span: 44..45,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 44,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 45,
+                                                                    },
+                                                                },
+                                                                span: 44..45,
+                                                                name: "a",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 48,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 49,
+                                                            },
+                                                        },
+                                                        span: 48..49,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 48,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 49,
+                                                                    },
+                                                                },
+                                                                span: 48..49,
+                                                                name: "b",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 44..49,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 44,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 45,
-                                                        },
-                                                    },
-                                                    span: 44..45,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 44,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 45,
-                                                                },
-                                                            },
-                                                            span: 44..45,
-                                                            name: "a",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 48,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 49,
-                                                        },
-                                                    },
-                                                    span: 48..49,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 48,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 49,
-                                                                },
-                                                            },
-                                                            span: 48..49,
-                                                            name: "b",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: Some(
                                     TypeAnn {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types.snap
@@ -145,72 +145,75 @@ Ok(
                                         optional: false,
                                     },
                                 ],
-                                body: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 34,
+                                body: Block {
+                                    span: 34..41,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 34,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 41,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 41,
-                                            },
-                                        },
-                                        span: 34..41,
-                                        kind: Member(
-                                            Member {
-                                                obj: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 34,
+                                            span: 34..41,
+                                            kind: Member(
+                                                Member {
+                                                    obj: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 34,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 37,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 37,
-                                                        },
+                                                        span: 34..37,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 34,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 37,
+                                                                    },
+                                                                },
+                                                                span: 34..37,
+                                                                name: "foo",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                    span: 34..37,
-                                                    kind: Ident(
+                                                    prop: Ident(
                                                         Ident {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
-                                                                    column: 34,
+                                                                    column: 38,
                                                                 },
                                                                 end: Position {
                                                                     line: 0,
-                                                                    column: 37,
+                                                                    column: 41,
                                                                 },
                                                             },
-                                                            span: 34..37,
-                                                            name: "foo",
+                                                            span: 38..41,
+                                                            name: "bar",
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                prop: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 38,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 41,
-                                                            },
-                                                        },
-                                                        span: 38..41,
-                                                        name: "bar",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
                                 is_async: false,
                                 return_type: None,
                                 type_params: Some(


### PR DESCRIPTION
We'd like to allow statements in blocks instead of expressions.  This change is necessary if we want to eventually support `for` loops in blocks.  This PR puts some of the building blocks in place for this but doesn't actually make the change yet.  I'm going to take a slight detour in the next PR to refactor update.rs (and other tree-walking code) to use derive-visitor.  This should reduce the amount of code that needs to be touched when making changes to the AST now and in the future.