### PR TITLE
Simplify AST for expression statements

### DIFF
--- a/crates/escalier_ast/src/values/expr.rs
+++ b/crates/escalier_ast/src/values/expr.rs
@@ -51,16 +51,7 @@ pub enum Statement {
         type_ann: TypeAnn,
         type_params: Option<Vec<TypeParam>>,
     },
-    // TODO: Rename this to `ExprStmt`.
-    // NOTE: This will never contain a `let` expression since that case is
-    // covered by `VarDecl`.
-    Expr {
-        #[drive(skip)]
-        loc: SourceLocation,
-        #[drive(skip)]
-        span: Span,
-        expr: Box<Expr>,
-    },
+    ExprStmt(Expr),
 }
 
 #[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]

--- a/crates/escalier_cli/tests/integration_test.rs
+++ b/crates/escalier_cli/tests/integration_test.rs
@@ -13,7 +13,7 @@ fn infer(input: &str) -> String {
     let prog = parse(input).unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = match stmt {
-        Statement::Expr { expr, .. } => {
+        Statement::ExprStmt(expr) => {
             let mut expr = expr.to_owned();
             infer_expr(&mut ctx, &mut expr)
         }

--- a/crates/escalier_codegen/src/d_ts.rs
+++ b/crates/escalier_codegen/src/d_ts.rs
@@ -88,7 +88,7 @@ fn build_d_ts(program: &values::Program, ctx: &Context) -> Program {
             values::Statement::TypeDecl { id, .. } => {
                 type_exports.insert(id.name.to_owned());
             }
-            values::Statement::Expr { .. } => (), // nothing is exported
+            values::Statement::ExprStmt(_) => (), // nothing is exported
         }
     }
 

--- a/crates/escalier_codegen/src/js.rs
+++ b/crates/escalier_codegen/src/js.rs
@@ -126,7 +126,7 @@ fn build_js(program: &values::Program, ctx: &mut Context) -> Program {
                 values::Statement::TypeDecl { .. } => {
                     ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP }))
                 }
-                values::Statement::Expr { expr, .. } => ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                values::Statement::ExprStmt(expr) => ModuleItem::Stmt(Stmt::Expr(ExprStmt {
                     span: DUMMY_SP,
                     expr: Box::from(build_expr(expr, &mut stmts, ctx)),
                 })),

--- a/crates/escalier_infer/src/infer_stmt.rs
+++ b/crates/escalier_infer/src/infer_stmt.rs
@@ -100,7 +100,7 @@ pub fn infer_stmt(
 
             Ok((s, t))
         }
-        Statement::Expr { expr, .. } => {
+        Statement::ExprStmt(expr) => {
             let (s, t) = infer_expr_rec(ctx, expr, false)?;
             // We ignore the type that was inferred, we only care that
             // it succeeds since we aren't assigning it to variable.

--- a/crates/escalier_lsp/src/visitor.rs
+++ b/crates/escalier_lsp/src/visitor.rs
@@ -46,7 +46,7 @@ pub trait Visitor {
             } => {
                 self._visit_type_ann(type_ann);
             }
-            Statement::Expr { expr, .. } => {
+            Statement::ExprStmt(expr) => {
                 self._visit_expr(expr);
             }
         }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a.b = c;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 8,
-                    },
-                },
-                span: 0..8,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -130,7 +119,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a[b] = c;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 9,
-                    },
-                },
-                span: 0..9,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -159,7 +148,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-4.snap
@@ -5,19 +5,8 @@ expression: "parse(r#\"a[\"b\"] = c;\"#)"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 11,
-                    },
-                },
-                span: 0..11,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -161,7 +150,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments.snap
@@ -5,19 +5,8 @@ expression: "parse(\"x = 5;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 6,
-                    },
-                },
-                span: 0..6,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -98,7 +87,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
@@ -5,19 +5,8 @@ expression: "parse(\"async () => 10;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 15,
-                    },
-                },
-                span: 0..15,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -76,7 +65,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"do {let x = 5; let y = 10; x + y};\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 34,
-                    },
-                },
-                span: 0..34,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -283,7 +272,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
@@ -5,19 +5,8 @@ expression: "parse(\"do {let sum = do {let x = 5; let y = 10; x + y}; sum};\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 54,
-                    },
-                },
-                span: 0..54,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -386,7 +375,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"foo(a, b);\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 10,
-                    },
-                },
-                span: 0..10,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -134,7 +123,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"foo(10, \\\"hello\\\");\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 17,
-                    },
-                },
-                span: 0..17,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -138,7 +127,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-4.snap
@@ -5,19 +5,8 @@ expression: "parse(\"f(x)(g(x));\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 11,
-                    },
-                },
-                span: 0..11,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -209,7 +198,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-5.snap
@@ -5,19 +5,8 @@ expression: "parse(\"foo(a, ...b);\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 13,
-                    },
-                },
-                span: 0..13,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -136,7 +125,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application.snap
@@ -5,19 +5,8 @@ expression: "parse(\"foo();\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 6,
-                    },
-                },
-                span: 0..6,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -67,7 +56,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"() => 10;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 9,
-                    },
-                },
-                span: 0..9,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -76,7 +65,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"(a) => \\\"hello\\\";\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 15,
-                    },
-                },
-                span: 0..15,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -112,7 +101,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
@@ -5,19 +5,8 @@ expression: "parse(\"(a, ...b) => true;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 18,
-                    },
-                },
-                span: 0..18,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -165,7 +154,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
@@ -5,19 +5,8 @@ expression: "parse(\"({x, y}) => x + y;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 18,
-                    },
-                },
-                span: 0..18,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -211,7 +200,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
@@ -5,19 +5,8 @@ expression: "parse(\"({x: p, y: q}) => p + q;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 24,
-                    },
-                },
-                span: 0..24,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -271,7 +260,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
@@ -5,19 +5,8 @@ expression: "parse(\"(a?: boolean, b?) => c;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 23,
-                    },
-                },
-                span: 0..23,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -165,7 +154,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
@@ -5,19 +5,8 @@ expression: "parse(\"(a, b) => c;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 12,
-                    },
-                },
-                span: 0..12,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -145,7 +134,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"if (a) { 5 } else if (b) { 10 } else { 20 };\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 44,
-                    },
-                },
-                span: 0..44,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -233,7 +222,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
@@ -5,19 +5,8 @@ expression: "parse(\"if (true) { 5 } else { 10 };\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 28,
-                    },
-                },
-                span: 0..28,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -143,7 +132,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo>{bar}</Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 16,
-                    },
-                },
-                span: 0..16,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -95,7 +84,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo>Hello {world}!</Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 25,
-                    },
-                },
-                span: 0..25,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -127,7 +116,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-4.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo>{<Bar>{baz}</Bar>}</Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 29,
-                    },
-                },
-                span: 0..29,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -143,7 +132,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-5.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo></Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 11,
-                    },
-                },
-                span: 0..11,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-6.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo bar={baz} />\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 17,
-                    },
-                },
-                span: 0..17,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -122,7 +111,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-7.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo msg=\\\"hello\\\" bar={baz}></Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 33,
-                    },
-                },
-                span: 0..33,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -167,7 +156,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-8.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo><Bar>{baz}</Bar></Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 27,
-                    },
-                },
-                span: 0..27,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -114,7 +103,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-9.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo>hello<Bar/>{world}<Baz/></Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 35,
-                    },
-                },
-                span: 0..35,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -147,7 +136,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx.snap
@@ -5,19 +5,8 @@ expression: "parse(\"<Foo>Hello</Foo>\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 16,
-                    },
-                },
-                span: 0..16,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -66,7 +55,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"foo.bar();\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 10,
-                    },
-                },
-                span: 0..10,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -101,7 +90,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"p.x * p.x + p.y * p.y;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 22,
-                    },
-                },
-                span: 0..22,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -330,7 +319,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-4.snap
@@ -5,19 +5,8 @@ expression: "parse(\"foo().bar();\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 12,
-                    },
-                },
-                span: 0..12,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -121,7 +110,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-5.snap
@@ -5,19 +5,8 @@ expression: "parse(\"arr[0][1];\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 10,
-                    },
-                },
-                span: 0..10,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -177,7 +166,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-6.snap
@@ -5,19 +5,8 @@ expression: "parse(\"arr[x](y);\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 10,
-                    },
-                },
-                span: 0..10,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -164,7 +153,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-7.snap
@@ -5,19 +5,8 @@ expression: "parse(\"arr[arr.length - 1];\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 20,
-                    },
-                },
-                span: 0..20,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -195,7 +184,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-8.snap
@@ -5,19 +5,8 @@ expression: "parse(\"foo[bar[-1]];\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 13,
-                    },
-                },
-                span: 0..13,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -194,7 +183,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a.b.c;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 6,
-                    },
-                },
-                span: 0..6,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -115,7 +104,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"new Array(1, 2, 3);\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 19,
-                    },
-                },
-                span: 0..19,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -173,7 +162,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression.snap
@@ -5,19 +5,8 @@ expression: "parse(\"new Array();\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 12,
-                    },
-                },
-                span: 0..12,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -67,7 +56,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"1.23;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 5,
-                    },
-                },
-                span: 0..5,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"-10;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 4,
-                    },
-                },
-                span: 0..4,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -68,7 +57,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers.snap
@@ -5,19 +5,8 @@ expression: "parse(\"10;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 3,
-                    },
-                },
-                span: 0..3,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects.snap
@@ -5,19 +5,8 @@ expression: "parse(\"{x: 5, y: 10};\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 14,
-                    },
-                },
-                span: 0..14,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -141,7 +130,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-11.snap
@@ -5,19 +5,8 @@ expression: "parse(\"-a;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 3,
-                    },
-                },
-                span: 0..3,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -66,7 +55,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-12.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-12.snap
@@ -5,19 +5,8 @@ expression: "parse(\"-(a + b);\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 9,
-                    },
-                },
-                span: 0..9,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -115,7 +104,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"x * y / z;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 10,
-                    },
-                },
-                span: 0..10,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -145,7 +134,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"(a + b) * c;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 12,
-                    },
-                },
-                span: 0..12,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -145,7 +134,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-4.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a == b;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 7,
-                    },
-                },
-                span: 0..7,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -96,7 +85,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-5.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a != b;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 7,
-                    },
-                },
-                span: 0..7,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -96,7 +85,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-6.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a > b;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 6,
-                    },
-                },
-                span: 0..6,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -96,7 +85,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-7.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a >= b;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 7,
-                    },
-                },
-                span: 0..7,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -96,7 +85,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-8.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a < b;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 6,
-                    },
-                },
-                span: 0..6,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -96,7 +85,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-9.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a <= b;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 7,
-                    },
-                },
-                span: 0..7,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -96,7 +85,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations.snap
@@ -5,19 +5,8 @@ expression: "parse(\"1 + 2 - 3;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 10,
-                    },
-                },
-                span: 0..10,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -151,7 +140,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-2.snap
@@ -5,19 +5,8 @@ expression: "parse(r#\"\"hello\";\"#)"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 8,
-                    },
-                },
-                span: 0..8,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"\\\"line 1\\\\nline 2\\\\nline 3\\\";\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 25,
-                    },
-                },
-                span: 0..25,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-4.snap
@@ -5,19 +5,8 @@ expression: "parse(\"\\\"a \\\\u2212 b\\\";\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 13,
-                    },
-                },
-                span: 0..13,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-5.snap
@@ -5,19 +5,8 @@ expression: "parse(\"\\\"hello, \\\\\\\"world\\\\\\\"!\\\";\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 20,
-                    },
-                },
-                span: 0..20,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings.snap
@@ -5,19 +5,8 @@ expression: "parse(r#\"\"\";\"#)"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 3,
-                    },
-                },
-                span: 0..3,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,7 +38,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tagged_template_literals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tagged_template_literals.snap
@@ -5,19 +5,8 @@ expression: "parse(\"sql`SELECT * FROM ${table} WHERE id = ${id}`\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 44,
-                    },
-                },
-                span: 0..44,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -250,7 +239,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"`Hello, ${name}`\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 16,
-                    },
-                },
-                span: 0..16,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -159,7 +148,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-3.snap
@@ -5,19 +5,8 @@ expression: "parse(\"`(${x}, ${y})`\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 14,
-                    },
-                },
-                span: 0..14,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -234,7 +223,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-4.snap
@@ -5,19 +5,8 @@ expression: "parse(r#\"`Hello, \"world\"`\"#)"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 16,
-                    },
-                },
-                span: 0..16,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -83,7 +72,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-5.snap
@@ -5,19 +5,8 @@ expression: "parse(\"`foo ${`bar ${baz}`}`\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 21,
-                    },
-                },
-                span: 0..21,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -271,7 +260,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-6.snap
@@ -5,19 +5,8 @@ expression: "parse(\"`line 1\\\\nline 2\\\\nline 3`\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 24,
-                    },
-                },
-                span: 0..24,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -83,7 +72,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-7.snap
@@ -5,19 +5,8 @@ expression: "parse(\"`a \\\\u2212 b`\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 12,
-                    },
-                },
-                span: 0..12,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -83,7 +72,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals.snap
@@ -5,19 +5,8 @@ expression: "parse(\"`Hello, world`\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 14,
-                    },
-                },
-                span: 0..14,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -83,7 +72,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions-2.snap
@@ -5,19 +5,8 @@ expression: "parse(\"123;\\n\\\"hello\\\";\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 4,
-                    },
-                },
-                span: 0..4,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -49,20 +38,9 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
-                span: 5..13,
-                expr: Expr {
+            ),
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 1,
@@ -94,7 +72,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions.snap
@@ -5,19 +5,8 @@ expression: "parse(\"a + b;\")"
 Ok(
     Program {
         body: [
-            Expr {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 0,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 6,
-                    },
-                },
-                span: 0..6,
-                expr: Expr {
+            ExprStmt(
+                Expr {
                     loc: SourceLocation {
                         start: Position {
                             line: 0,
@@ -96,7 +85,7 @@ Ok(
                     ),
                     inferred_type: None,
                 },
-            },
+            ),
         ],
     },
 )

--- a/crates/escalier_parser/src/stmt.rs
+++ b/crates/escalier_parser/src/stmt.rs
@@ -16,11 +16,7 @@ pub fn parse_statement(node: &tree_sitter::Node, src: &str) -> Result<Vec<Statem
         "expression_statement" => {
             let expr = node.named_child(0).unwrap();
             let expr = parse_expression(&expr, src)?;
-            Ok(vec![Statement::Expr {
-                loc: SourceLocation::from(node),
-                span: node.byte_range(),
-                expr: Box::from(expr),
-            }])
+            Ok(vec![Statement::ExprStmt(expr)])
         }
         "ambient_declaration" => {
             let decl = node.named_child(0).unwrap();
@@ -309,11 +305,7 @@ pub fn parse_block_statement(node: &tree_sitter::Node, src: &str) -> Result<Bloc
             if child.kind() == "expression" {
                 let expr = child.named_child(0).unwrap();
                 let expr = parse_expression(&expr, src)?;
-                stmts.push(Statement::Expr {
-                    loc: SourceLocation::from(&child),
-                    span: child.byte_range(),
-                    expr: Box::from(expr),
-                })
+                stmts.push(Statement::ExprStmt(expr))
             } else {
                 let mut result = parse_statement(&child, src)?;
                 stmts.append(&mut result);
@@ -391,7 +383,7 @@ pub fn parse_block_statement(node: &tree_sitter::Node, src: &str) -> Result<Bloc
                 // will also help with handling statements like loops.
                 todo!("decide how to handle type decls within BlockStatements")
             }
-            Statement::Expr { expr, .. } => *expr.to_owned(),
+            Statement::ExprStmt(expr) => expr.to_owned(),
         };
         result.push(expr);
     }


### PR DESCRIPTION
`Expr` already has the location data, we don't need to repeat it.