### PR TITLE
Refactor Statement to be more like other AST nodes

### DIFF
--- a/crates/escalier_ast/src/values/expr.rs
+++ b/crates/escalier_ast/src/values/expr.rs
@@ -8,50 +8,12 @@ use crate::values::jsx::JSXElement;
 use crate::values::keyword::Keyword;
 use crate::values::lit::Lit;
 use crate::values::pattern::{Pattern, PatternKind};
+use crate::values::stmt::Statement;
 use crate::values::type_ann::{TypeAnn, TypeParam};
 
 #[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
 pub struct Program {
     pub body: Vec<Statement>,
-}
-
-// TODO: Update Statement to mimic structure of Expr/ExprKind
-// TODO: Update Statement to have an .inferred_type field like Expr
-#[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
-pub enum Statement {
-    ClassDecl {
-        #[drive(skip)]
-        loc: SourceLocation,
-        #[drive(skip)]
-        span: Span,
-        #[drive(skip)]
-        ident: Ident, // Why do have `ident` here an in `Class`?
-        class: Box<Class>,
-    },
-    VarDecl {
-        #[drive(skip)]
-        loc: SourceLocation,
-        #[drive(skip)]
-        span: Span,
-        pattern: Pattern,
-        type_ann: Option<TypeAnn>,
-        init: Option<Box<Expr>>,
-        #[drive(skip)]
-        declare: bool,
-    },
-    TypeDecl {
-        #[drive(skip)]
-        loc: SourceLocation,
-        #[drive(skip)]
-        span: Span,
-        #[drive(skip)]
-        declare: bool,
-        #[drive(skip)]
-        id: Ident,
-        type_ann: TypeAnn,
-        type_params: Option<Vec<TypeParam>>,
-    },
-    ExprStmt(Expr),
 }
 
 #[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]

--- a/crates/escalier_ast/src/values/mod.rs
+++ b/crates/escalier_ast/src/values/mod.rs
@@ -6,6 +6,7 @@ pub mod jsx;
 pub mod keyword;
 pub mod lit;
 pub mod pattern;
+pub mod stmt;
 pub mod type_ann;
 
 pub use class::*;
@@ -16,4 +17,5 @@ pub use jsx::*;
 pub use keyword::*;
 pub use lit::*;
 pub use pattern::*;
+pub use stmt::*;
 pub use type_ann::*;

--- a/crates/escalier_ast/src/values/stmt.rs
+++ b/crates/escalier_ast/src/values/stmt.rs
@@ -1,0 +1,52 @@
+use derive_visitor::{Drive, DriveMut};
+
+use crate::values::class::Class;
+use crate::values::common::{SourceLocation, Span};
+use crate::values::expr::Expr;
+use crate::values::ident::Ident;
+use crate::values::pattern::Pattern;
+use crate::values::type_ann::{TypeAnn, TypeParam};
+
+#[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
+pub struct ClassDecl {
+    #[drive(skip)]
+    pub ident: Ident, // Why do have `ident` here an in `Class`?
+    pub class: Box<Class>,
+}
+
+#[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
+pub struct VarDecl {
+    pub pattern: Pattern,
+    pub type_ann: Option<TypeAnn>,
+    pub init: Option<Box<Expr>>,
+    #[drive(skip)]
+    pub declare: bool,
+}
+
+#[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
+pub struct TypeDecl {
+    #[drive(skip)]
+    pub declare: bool,
+    #[drive(skip)]
+    pub id: Ident,
+    pub type_ann: TypeAnn,
+    pub type_params: Option<Vec<TypeParam>>,
+}
+
+#[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
+pub enum StmtKind {
+    ClassDecl(ClassDecl),
+    VarDecl(VarDecl),
+    TypeDecl(TypeDecl),
+    ExprStmt(Expr),
+}
+
+#[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
+pub struct Statement {
+    #[drive(skip)]
+    pub loc: SourceLocation,
+    #[drive(skip)]
+    pub span: Span,
+    pub kind: StmtKind,
+    // pub inferred_type: Option<Type>,
+}

--- a/crates/escalier_cli/tests/integration_test.rs
+++ b/crates/escalier_cli/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use escalier_ast::values::{Program, Statement};
+use escalier_ast::values::{Program, StmtKind};
 use escalier_codegen::*;
 use escalier_infer::TypeError;
 use escalier_infer::*;
@@ -12,8 +12,8 @@ fn infer(input: &str) -> String {
     let mut ctx = escalier_infer::Context::default();
     let prog = parse(input).unwrap();
     let stmt = prog.body.get(0).unwrap();
-    let result = match stmt {
-        Statement::ExprStmt(expr) => {
+    let result = match &stmt.kind {
+        StmtKind::ExprStmt(expr) => {
             let mut expr = expr.to_owned();
             infer_expr(&mut ctx, &mut expr)
         }

--- a/crates/escalier_codegen/src/d_ts.rs
+++ b/crates/escalier_codegen/src/d_ts.rs
@@ -69,9 +69,9 @@ fn build_d_ts(program: &values::Program, ctx: &Context) -> Program {
     let mut value_exports: BTreeSet<String> = BTreeSet::new();
 
     for stmt in &program.body {
-        match stmt {
-            values::Statement::ClassDecl { ident, .. } => {
-                let name = ident.name.to_owned();
+        match &stmt.kind {
+            values::StmtKind::ClassDecl(class_decl) => {
+                let name = class_decl.ident.name.to_owned();
                 value_exports.insert(name.to_owned());
                 type_exports.insert(name.to_owned());
                 type_exports.insert(format!("{name}Constructor"));
@@ -79,16 +79,16 @@ fn build_d_ts(program: &values::Program, ctx: &Context) -> Program {
                 // NOTE: The Readonly version of the interface type is generated
                 // when we process `type_exports`.
             }
-            values::Statement::VarDecl { pattern, .. } => {
-                let bindings = values::pattern::get_binding(pattern);
+            values::StmtKind::VarDecl(var_decl) => {
+                let bindings = values::pattern::get_binding(&var_decl.pattern);
                 for name in bindings {
                     value_exports.insert(name);
                 }
             }
-            values::Statement::TypeDecl { id, .. } => {
-                type_exports.insert(id.name.to_owned());
+            values::StmtKind::TypeDecl(type_decl) => {
+                type_exports.insert(type_decl.id.name.to_owned());
             }
-            values::Statement::ExprStmt(_) => (), // nothing is exported
+            values::StmtKind::ExprStmt(_) => (), // nothing is exported
         }
     }
 

--- a/crates/escalier_codegen/src/js.rs
+++ b/crates/escalier_codegen/src/js.rs
@@ -87,13 +87,13 @@ fn build_js(program: &values::Program, ctx: &mut Context) -> Program {
         .iter()
         .flat_map(|child| {
             let mut stmts: Vec<Stmt> = vec![];
-            let result = match child {
-                values::Statement::VarDecl {
+            let result = match &child.kind {
+                values::StmtKind::VarDecl(values::VarDecl {
                     pattern,
                     init,
                     declare,
                     ..
-                } => match declare {
+                }) => match declare {
                     true => ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
                     false => {
                         // It should be okay to unwrap this here since any decl that isn't
@@ -123,14 +123,14 @@ fn build_js(program: &values::Program, ctx: &mut Context) -> Program {
                         }
                     }
                 },
-                values::Statement::TypeDecl { .. } => {
+                values::StmtKind::TypeDecl(_) => {
                     ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP }))
                 }
-                values::Statement::ExprStmt(expr) => ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                values::StmtKind::ExprStmt(expr) => ModuleItem::Stmt(Stmt::Expr(ExprStmt {
                     span: DUMMY_SP,
                     expr: Box::from(build_expr(expr, &mut stmts, ctx)),
                 })),
-                values::Statement::ClassDecl { class, ident, .. } => {
+                values::StmtKind::ClassDecl(values::ClassDecl { class, ident, .. }) => {
                     let ident = Ident::from(ident);
                     let class = build_class(class, &mut stmts, ctx);
 

--- a/crates/escalier_infer/src/infer_stmt.rs
+++ b/crates/escalier_infer/src/infer_stmt.rs
@@ -17,14 +17,14 @@ pub fn infer_stmt(
     stmt: &mut Statement,
     ctx: &mut Context,
 ) -> Result<(Subst, Type), Vec<TypeError>> {
-    match stmt {
-        Statement::VarDecl {
+    match &mut stmt.kind {
+        StmtKind::VarDecl(VarDecl {
             declare,
             init,
             pattern,
             type_ann,
             ..
-        } => {
+        }) => {
             match declare {
                 true => {
                     match &mut pattern.kind {
@@ -81,12 +81,12 @@ pub fn infer_stmt(
                 }
             }
         }
-        Statement::TypeDecl {
+        StmtKind::TypeDecl(TypeDecl {
             id: Ident { name, .. },
             type_ann,
             type_params,
             ..
-        } => {
+        }) => {
             let (s, t) = infer_type_ann(type_ann, ctx, type_params)?;
 
             let t = t.apply(&s);
@@ -100,7 +100,7 @@ pub fn infer_stmt(
 
             Ok((s, t))
         }
-        Statement::ExprStmt(expr) => {
+        StmtKind::ExprStmt(expr) => {
             let (s, t) = infer_expr_rec(ctx, expr, false)?;
             // We ignore the type that was inferred, we only care that
             // it succeeds since we aren't assigning it to variable.
@@ -108,12 +108,7 @@ pub fn infer_stmt(
 
             Ok((s, t))
         }
-        Statement::ClassDecl {
-            loc: _,
-            span: _,
-            ident,
-            class,
-        } => {
+        StmtKind::ClassDecl(ClassDecl { ident, class }) => {
             let (s, t) = infer_class(ctx, class)?;
 
             let t = t.apply(&s);

--- a/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
@@ -4,7 +4,7 @@ expression: prog
 ---
 Program {
     body: [
-        VarDecl {
+        Statement {
             loc: SourceLocation {
                 start: Position {
                     line: 0,
@@ -16,23 +16,9 @@ Program {
                 },
             },
             span: 0..26,
-            pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 0,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 0,
-                        column: 7,
-                    },
-                },
-                span: 4..7,
-                kind: Ident(
-                    BindingIdent {
-                        name: "add",
-                        mutable: false,
-                        span: 4..7,
+            kind: VarDecl(
+                VarDecl {
+                    pattern: Pattern {
                         loc: SourceLocation {
                             start: Position {
                                 line: 0,
@@ -43,54 +29,54 @@ Program {
                                 column: 7,
                             },
                         },
-                    },
-                ),
-                inferred_type: Some(
-                    Type {
-                        kind: Lam(
-                            TLam {
-                                params: [
-                                    TFnParam {
-                                        pat: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
-                                            },
-                                        ),
-                                        t: Type {
-                                            kind: Keyword(
-                                                Number,
-                                            ),
-                                            mutable: false,
-                                            provenance: Some(
-                                                Type(
-                                                    Type {
-                                                        kind: Var(
-                                                            TVar {
-                                                                id: 2,
-                                                                constraint: None,
-                                                            },
-                                                        ),
+                        span: 4..7,
+                        kind: Ident(
+                            BindingIdent {
+                                name: "add",
+                                mutable: false,
+                                span: 4..7,
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 4,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 7,
+                                    },
+                                },
+                            },
+                        ),
+                        inferred_type: Some(
+                            Type {
+                                kind: Lam(
+                                    TLam {
+                                        params: [
+                                            TFnParam {
+                                                pat: Ident(
+                                                    BindingIdent {
+                                                        name: "a",
                                                         mutable: false,
-                                                        provenance: Some(
-                                                            Pattern(
-                                                                Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 11,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 12,
-                                                                        },
+                                                    },
+                                                ),
+                                                t: Type {
+                                                    kind: Keyword(
+                                                        Number,
+                                                    ),
+                                                    mutable: false,
+                                                    provenance: Some(
+                                                        Type(
+                                                            Type {
+                                                                kind: Var(
+                                                                    TVar {
+                                                                        id: 2,
+                                                                        constraint: None,
                                                                     },
-                                                                    span: 11..12,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "a",
-                                                                            mutable: false,
-                                                                            span: 11..12,
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: Some(
+                                                                    Pattern(
+                                                                        Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -101,70 +87,70 @@ Program {
                                                                                     column: 12,
                                                                                 },
                                                                             },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: Some(
-                                                                        Type {
-                                                                            kind: Var(
-                                                                                TVar {
-                                                                                    id: 2,
-                                                                                    constraint: None,
+                                                                            span: 11..12,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "a",
+                                                                                    mutable: false,
+                                                                                    span: 11..12,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 11,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 12,
+                                                                                        },
+                                                                                    },
                                                                                 },
                                                                             ),
-                                                                            mutable: false,
-                                                                            provenance: None,
+                                                                            inferred_type: Some(
+                                                                                Type {
+                                                                                    kind: Var(
+                                                                                        TVar {
+                                                                                            id: 2,
+                                                                                            constraint: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    mutable: false,
+                                                                                    provenance: None,
+                                                                                },
+                                                                            ),
                                                                         },
                                                                     ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                        optional: false,
-                                    },
-                                    TFnParam {
-                                        pat: Ident(
-                                            BindingIdent {
-                                                name: "b",
-                                                mutable: false,
-                                            },
-                                        ),
-                                        t: Type {
-                                            kind: Keyword(
-                                                Number,
-                                            ),
-                                            mutable: false,
-                                            provenance: Some(
-                                                Type(
-                                                    Type {
-                                                        kind: Var(
-                                                            TVar {
-                                                                id: 3,
-                                                                constraint: None,
+                                                                ),
                                                             },
                                                         ),
+                                                    ),
+                                                },
+                                                optional: false,
+                                            },
+                                            TFnParam {
+                                                pat: Ident(
+                                                    BindingIdent {
+                                                        name: "b",
                                                         mutable: false,
-                                                        provenance: Some(
-                                                            Pattern(
-                                                                Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 14,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 15,
-                                                                        },
+                                                    },
+                                                ),
+                                                t: Type {
+                                                    kind: Keyword(
+                                                        Number,
+                                                    ),
+                                                    mutable: false,
+                                                    provenance: Some(
+                                                        Type(
+                                                            Type {
+                                                                kind: Var(
+                                                                    TVar {
+                                                                        id: 3,
+                                                                        constraint: None,
                                                                     },
-                                                                    span: 14..15,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "b",
-                                                                            mutable: false,
-                                                                            span: 14..15,
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: Some(
+                                                                    Pattern(
+                                                                        Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -175,266 +161,53 @@ Program {
                                                                                     column: 15,
                                                                                 },
                                                                             },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: Some(
-                                                                        Type {
-                                                                            kind: Var(
-                                                                                TVar {
-                                                                                    id: 3,
-                                                                                    constraint: None,
+                                                                            span: 14..15,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "b",
+                                                                                    mutable: false,
+                                                                                    span: 14..15,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 14,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 15,
+                                                                                        },
+                                                                                    },
                                                                                 },
                                                                             ),
-                                                                            mutable: false,
-                                                                            provenance: None,
+                                                                            inferred_type: Some(
+                                                                                Type {
+                                                                                    kind: Var(
+                                                                                        TVar {
+                                                                                            id: 3,
+                                                                                            constraint: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    mutable: false,
+                                                                                    provenance: None,
+                                                                                },
+                                                                            ),
                                                                         },
                                                                     ),
-                                                                },
-                                                            ),
+                                                                ),
+                                                            },
                                                         ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                        optional: false,
-                                    },
-                                ],
-                                ret: Type {
-                                    kind: Keyword(
-                                        Number,
-                                    ),
-                                    mutable: false,
-                                    provenance: Some(
-                                        Expr(
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 20,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 25,
-                                                    },
+                                                    ),
                                                 },
-                                                span: 20..25,
-                                                kind: BinaryExpr(
-                                                    BinaryExpr {
-                                                        op: Add,
-                                                        left: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 20,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 21,
-                                                                },
-                                                            },
-                                                            span: 20..21,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 20,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 21,
-                                                                        },
-                                                                    },
-                                                                    span: 20..21,
-                                                                    name: "a",
-                                                                },
-                                                            ),
-                                                            inferred_type: Some(
-                                                                Type {
-                                                                    kind: Var(
-                                                                        TVar {
-                                                                            id: 2,
-                                                                            constraint: None,
-                                                                        },
-                                                                    ),
-                                                                    mutable: false,
-                                                                    provenance: None,
-                                                                },
-                                                            ),
-                                                        },
-                                                        right: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 24,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 25,
-                                                                },
-                                                            },
-                                                            span: 24..25,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 24,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 25,
-                                                                        },
-                                                                    },
-                                                                    span: 24..25,
-                                                                    name: "b",
-                                                                },
-                                                            ),
-                                                            inferred_type: Some(
-                                                                Type {
-                                                                    kind: Var(
-                                                                        TVar {
-                                                                            id: 3,
-                                                                            constraint: None,
-                                                                        },
-                                                                    ),
-                                                                    mutable: false,
-                                                                    provenance: None,
-                                                                },
-                                                            ),
-                                                        },
-                                                    },
-                                                ),
-                                                inferred_type: Some(
-                                                    Type {
-                                                        kind: Keyword(
-                                                            Number,
-                                                        ),
-                                                        mutable: false,
-                                                        provenance: None,
-                                                    },
-                                                ),
+                                                optional: false,
                                             },
-                                        ),
-                                    ),
-                                },
-                                type_params: None,
-                            },
-                        ),
-                        mutable: false,
-                        provenance: Some(
-                            Expr(
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 10,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 25,
-                                        },
-                                    },
-                                    span: 10..25,
-                                    kind: Lambda(
-                                        Lambda {
-                                            params: [
-                                                EFnParam {
-                                                    pat: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 11,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                        },
-                                                        span: 11..12,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "a",
-                                                                mutable: false,
-                                                                span: 11..12,
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 11,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 12,
-                                                                    },
-                                                                },
-                                                            },
-                                                        ),
-                                                        inferred_type: Some(
-                                                            Type {
-                                                                kind: Var(
-                                                                    TVar {
-                                                                        id: 2,
-                                                                        constraint: None,
-                                                                    },
-                                                                ),
-                                                                mutable: false,
-                                                                provenance: None,
-                                                            },
-                                                        ),
-                                                    },
-                                                    type_ann: None,
-                                                    optional: false,
-                                                },
-                                                EFnParam {
-                                                    pat: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 14,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 15,
-                                                            },
-                                                        },
-                                                        span: 14..15,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "b",
-                                                                mutable: false,
-                                                                span: 14..15,
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 14,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 15,
-                                                                    },
-                                                                },
-                                                            },
-                                                        ),
-                                                        inferred_type: Some(
-                                                            Type {
-                                                                kind: Var(
-                                                                    TVar {
-                                                                        id: 3,
-                                                                        constraint: None,
-                                                                    },
-                                                                ),
-                                                                mutable: false,
-                                                                provenance: None,
-                                                            },
-                                                        ),
-                                                    },
-                                                    type_ann: None,
-                                                    optional: false,
-                                                },
-                                            ],
-                                            body: Block {
-                                                span: 20..25,
-                                                stmts: [
+                                        ],
+                                        ret: Type {
+                                            kind: Keyword(
+                                                Number,
+                                            ),
+                                            mutable: false,
+                                            provenance: Some(
+                                                Expr(
                                                     Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
@@ -544,59 +317,272 @@ Program {
                                                             },
                                                         ),
                                                     },
-                                                ],
-                                            },
-                                            is_async: false,
-                                            return_type: None,
-                                            type_params: None,
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                    inferred_type: Some(
-                                        Type {
-                                            kind: Lam(
-                                                TLam {
+                                        type_params: None,
+                                    },
+                                ),
+                                mutable: false,
+                                provenance: Some(
+                                    Expr(
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 10,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 25,
+                                                },
+                                            },
+                                            span: 10..25,
+                                            kind: Lambda(
+                                                Lambda {
                                                     params: [
-                                                        TFnParam {
-                                                            pat: Ident(
-                                                                BindingIdent {
-                                                                    name: "a",
-                                                                    mutable: false,
+                                                        EFnParam {
+                                                            pat: Pattern {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 11,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
                                                                 },
-                                                            ),
-                                                            t: Type {
-                                                                kind: Keyword(
-                                                                    Number,
+                                                                span: 11..12,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "a",
+                                                                        mutable: false,
+                                                                        span: 11..12,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 11,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 12,
+                                                                            },
+                                                                        },
+                                                                    },
                                                                 ),
-                                                                mutable: false,
-                                                                provenance: Some(
-                                                                    Type(
-                                                                        Type {
-                                                                            kind: Var(
-                                                                                TVar {
-                                                                                    id: 2,
-                                                                                    constraint: None,
+                                                                inferred_type: Some(
+                                                                    Type {
+                                                                        kind: Var(
+                                                                            TVar {
+                                                                                id: 2,
+                                                                                constraint: None,
+                                                                            },
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: None,
+                                                                    },
+                                                                ),
+                                                            },
+                                                            type_ann: None,
+                                                            optional: false,
+                                                        },
+                                                        EFnParam {
+                                                            pat: Pattern {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 15,
+                                                                    },
+                                                                },
+                                                                span: 14..15,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "b",
+                                                                        mutable: false,
+                                                                        span: 14..15,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 14,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 15,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: Some(
+                                                                    Type {
+                                                                        kind: Var(
+                                                                            TVar {
+                                                                                id: 3,
+                                                                                constraint: None,
+                                                                            },
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: None,
+                                                                    },
+                                                                ),
+                                                            },
+                                                            type_ann: None,
+                                                            optional: false,
+                                                        },
+                                                    ],
+                                                    body: Block {
+                                                        span: 20..25,
+                                                        stmts: [
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 20,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 25,
+                                                                    },
+                                                                },
+                                                                span: 20..25,
+                                                                kind: BinaryExpr(
+                                                                    BinaryExpr {
+                                                                        op: Add,
+                                                                        left: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 21,
+                                                                                },
+                                                                            },
+                                                                            span: 20..21,
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 20,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 21,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 20..21,
+                                                                                    name: "a",
                                                                                 },
                                                                             ),
-                                                                            mutable: false,
-                                                                            provenance: Some(
-                                                                                Pattern(
-                                                                                    Pattern {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 11,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 12,
-                                                                                            },
+                                                                            inferred_type: Some(
+                                                                                Type {
+                                                                                    kind: Var(
+                                                                                        TVar {
+                                                                                            id: 2,
+                                                                                            constraint: None,
                                                                                         },
-                                                                                        span: 11..12,
-                                                                                        kind: Ident(
-                                                                                            BindingIdent {
-                                                                                                name: "a",
-                                                                                                mutable: false,
-                                                                                                span: 11..12,
+                                                                                    ),
+                                                                                    mutable: false,
+                                                                                    provenance: None,
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                        right: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 24,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 25,
+                                                                                },
+                                                                            },
+                                                                            span: 24..25,
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 24,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 25,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 24..25,
+                                                                                    name: "b",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: Some(
+                                                                                Type {
+                                                                                    kind: Var(
+                                                                                        TVar {
+                                                                                            id: 3,
+                                                                                            constraint: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    mutable: false,
+                                                                                    provenance: None,
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: Some(
+                                                                    Type {
+                                                                        kind: Keyword(
+                                                                            Number,
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: None,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ],
+                                                    },
+                                                    is_async: false,
+                                                    return_type: None,
+                                                    type_params: None,
+                                                },
+                                            ),
+                                            inferred_type: Some(
+                                                Type {
+                                                    kind: Lam(
+                                                        TLam {
+                                                            params: [
+                                                                TFnParam {
+                                                                    pat: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                        },
+                                                                    ),
+                                                                    t: Type {
+                                                                        kind: Keyword(
+                                                                            Number,
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: Some(
+                                                                            Type(
+                                                                                Type {
+                                                                                    kind: Var(
+                                                                                        TVar {
+                                                                                            id: 2,
+                                                                                            constraint: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    mutable: false,
+                                                                                    provenance: Some(
+                                                                                        Pattern(
+                                                                                            Pattern {
                                                                                                 loc: SourceLocation {
                                                                                                     start: Position {
                                                                                                         line: 0,
@@ -607,6 +593,168 @@ Program {
                                                                                                         column: 12,
                                                                                                     },
                                                                                                 },
+                                                                                                span: 11..12,
+                                                                                                kind: Ident(
+                                                                                                    BindingIdent {
+                                                                                                        name: "a",
+                                                                                                        mutable: false,
+                                                                                                        span: 11..12,
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 0,
+                                                                                                                column: 11,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 0,
+                                                                                                                column: 12,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                inferred_type: Some(
+                                                                                                    Type {
+                                                                                                        kind: Var(
+                                                                                                            TVar {
+                                                                                                                id: 2,
+                                                                                                                constraint: None,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        mutable: false,
+                                                                                                        provenance: None,
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                    optional: false,
+                                                                },
+                                                                TFnParam {
+                                                                    pat: Ident(
+                                                                        BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                        },
+                                                                    ),
+                                                                    t: Type {
+                                                                        kind: Keyword(
+                                                                            Number,
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: Some(
+                                                                            Type(
+                                                                                Type {
+                                                                                    kind: Var(
+                                                                                        TVar {
+                                                                                            id: 3,
+                                                                                            constraint: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    mutable: false,
+                                                                                    provenance: Some(
+                                                                                        Pattern(
+                                                                                            Pattern {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 14,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 15,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 14..15,
+                                                                                                kind: Ident(
+                                                                                                    BindingIdent {
+                                                                                                        name: "b",
+                                                                                                        mutable: false,
+                                                                                                        span: 14..15,
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 0,
+                                                                                                                column: 14,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 0,
+                                                                                                                column: 15,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                inferred_type: Some(
+                                                                                                    Type {
+                                                                                                        kind: Var(
+                                                                                                            TVar {
+                                                                                                                id: 3,
+                                                                                                                constraint: None,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        mutable: false,
+                                                                                                        provenance: None,
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                    optional: false,
+                                                                },
+                                                            ],
+                                                            ret: Type {
+                                                                kind: Keyword(
+                                                                    Number,
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: Some(
+                                                                    Expr(
+                                                                        Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 25,
+                                                                                },
+                                                                            },
+                                                                            span: 20..25,
+                                                                            kind: BinaryExpr(
+                                                                                BinaryExpr {
+                                                                                    op: Add,
+                                                                                    left: Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 20,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 21,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 20..21,
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 20,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 21,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 20..21,
+                                                                                                name: "a",
                                                                                             },
                                                                                         ),
                                                                                         inferred_type: Some(
@@ -622,65 +770,32 @@ Program {
                                                                                             },
                                                                                         ),
                                                                                     },
-                                                                                ),
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                            optional: false,
-                                                        },
-                                                        TFnParam {
-                                                            pat: Ident(
-                                                                BindingIdent {
-                                                                    name: "b",
-                                                                    mutable: false,
-                                                                },
-                                                            ),
-                                                            t: Type {
-                                                                kind: Keyword(
-                                                                    Number,
-                                                                ),
-                                                                mutable: false,
-                                                                provenance: Some(
-                                                                    Type(
-                                                                        Type {
-                                                                            kind: Var(
-                                                                                TVar {
-                                                                                    id: 3,
-                                                                                    constraint: None,
-                                                                                },
-                                                                            ),
-                                                                            mutable: false,
-                                                                            provenance: Some(
-                                                                                Pattern(
-                                                                                    Pattern {
+                                                                                    right: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
-                                                                                                column: 14,
+                                                                                                column: 24,
                                                                                             },
                                                                                             end: Position {
                                                                                                 line: 0,
-                                                                                                column: 15,
+                                                                                                column: 25,
                                                                                             },
                                                                                         },
-                                                                                        span: 14..15,
+                                                                                        span: 24..25,
                                                                                         kind: Ident(
-                                                                                            BindingIdent {
-                                                                                                name: "b",
-                                                                                                mutable: false,
-                                                                                                span: 14..15,
+                                                                                            Ident {
                                                                                                 loc: SourceLocation {
                                                                                                     start: Position {
                                                                                                         line: 0,
-                                                                                                        column: 14,
+                                                                                                        column: 24,
                                                                                                     },
                                                                                                     end: Position {
                                                                                                         line: 0,
-                                                                                                        column: 15,
+                                                                                                        column: 25,
                                                                                                     },
                                                                                                 },
+                                                                                                span: 24..25,
+                                                                                                name: "b",
                                                                                             },
                                                                                         ),
                                                                                         inferred_type: Some(
@@ -696,23 +811,196 @@ Program {
                                                                                             },
                                                                                         ),
                                                                                     },
-                                                                                ),
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: Some(
+                                                                                Type {
+                                                                                    kind: Keyword(
+                                                                                        Number,
+                                                                                    ),
+                                                                                    mutable: false,
+                                                                                    provenance: None,
+                                                                                },
                                                                             ),
                                                                         },
                                                                     ),
                                                                 ),
                                                             },
-                                                            optional: false,
+                                                            type_params: None,
                                                         },
-                                                    ],
-                                                    ret: Type {
+                                                    ),
+                                                    mutable: false,
+                                                    provenance: None,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    },
+                    type_ann: None,
+                    init: Some(
+                        Expr {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 10,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 25,
+                                },
+                            },
+                            span: 10..25,
+                            kind: Lambda(
+                                Lambda {
+                                    params: [
+                                        EFnParam {
+                                            pat: Pattern {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 11,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 12,
+                                                    },
+                                                },
+                                                span: 11..12,
+                                                kind: Ident(
+                                                    BindingIdent {
+                                                        name: "a",
+                                                        mutable: false,
+                                                        span: 11..12,
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 11,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                        },
+                                                    },
+                                                ),
+                                                inferred_type: Some(
+                                                    Type {
                                                         kind: Keyword(
                                                             Number,
                                                         ),
                                                         mutable: false,
                                                         provenance: Some(
-                                                            Expr(
-                                                                Expr {
+                                                            Type(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 2,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: None,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                            type_ann: None,
+                                            optional: false,
+                                        },
+                                        EFnParam {
+                                            pat: Pattern {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 14,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                },
+                                                span: 14..15,
+                                                kind: Ident(
+                                                    BindingIdent {
+                                                        name: "b",
+                                                        mutable: false,
+                                                        span: 14..15,
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 15,
+                                                            },
+                                                        },
+                                                    },
+                                                ),
+                                                inferred_type: Some(
+                                                    Type {
+                                                        kind: Keyword(
+                                                            Number,
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: Some(
+                                                            Type(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 3,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: None,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                            type_ann: None,
+                                            optional: false,
+                                        },
+                                    ],
+                                    body: Block {
+                                        span: 20..25,
+                                        stmts: [
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 20,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 25,
+                                                    },
+                                                },
+                                                span: 20..25,
+                                                kind: BinaryExpr(
+                                                    BinaryExpr {
+                                                        op: Add,
+                                                        left: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                            },
+                                                            span: 20..21,
+                                                            kind: Ident(
+                                                                Ident {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -720,39 +1008,162 @@ Program {
                                                                         },
                                                                         end: Position {
                                                                             line: 0,
+                                                                            column: 21,
+                                                                        },
+                                                                    },
+                                                                    span: 20..21,
+                                                                    name: "a",
+                                                                },
+                                                            ),
+                                                            inferred_type: Some(
+                                                                Type {
+                                                                    kind: Keyword(
+                                                                        Number,
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: Some(
+                                                                        Type(
+                                                                            Type {
+                                                                                kind: Var(
+                                                                                    TVar {
+                                                                                        id: 2,
+                                                                                        constraint: None,
+                                                                                    },
+                                                                                ),
+                                                                                mutable: false,
+                                                                                provenance: None,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                        right: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 24..25,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 24,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
                                                                             column: 25,
                                                                         },
                                                                     },
-                                                                    span: 20..25,
-                                                                    kind: BinaryExpr(
-                                                                        BinaryExpr {
-                                                                            op: Add,
-                                                                            left: Expr {
+                                                                    span: 24..25,
+                                                                    name: "b",
+                                                                },
+                                                            ),
+                                                            inferred_type: Some(
+                                                                Type {
+                                                                    kind: Keyword(
+                                                                        Number,
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: Some(
+                                                                        Type(
+                                                                            Type {
+                                                                                kind: Var(
+                                                                                    TVar {
+                                                                                        id: 3,
+                                                                                        constraint: None,
+                                                                                    },
+                                                                                ),
+                                                                                mutable: false,
+                                                                                provenance: None,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                                inferred_type: Some(
+                                                    Type {
+                                                        kind: Keyword(
+                                                            Number,
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: None,
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                    is_async: false,
+                                    return_type: None,
+                                    type_params: None,
+                                },
+                            ),
+                            inferred_type: Some(
+                                Type {
+                                    kind: Lam(
+                                        TLam {
+                                            params: [
+                                                TFnParam {
+                                                    pat: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                        },
+                                                    ),
+                                                    t: Type {
+                                                        kind: Keyword(
+                                                            Number,
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: Some(
+                                                            Type(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 2,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: Some(
+                                                                        Pattern(
+                                                                            Pattern {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
-                                                                                        column: 20,
+                                                                                        column: 11,
                                                                                     },
                                                                                     end: Position {
                                                                                         line: 0,
-                                                                                        column: 21,
+                                                                                        column: 12,
                                                                                     },
                                                                                 },
-                                                                                span: 20..21,
+                                                                                span: 11..12,
                                                                                 kind: Ident(
-                                                                                    Ident {
+                                                                                    BindingIdent {
+                                                                                        name: "a",
+                                                                                        mutable: false,
+                                                                                        span: 11..12,
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
-                                                                                                column: 20,
+                                                                                                column: 11,
                                                                                             },
                                                                                             end: Position {
                                                                                                 line: 0,
-                                                                                                column: 21,
+                                                                                                column: 12,
                                                                                             },
                                                                                         },
-                                                                                        span: 20..21,
-                                                                                        name: "a",
                                                                                     },
                                                                                 ),
                                                                                 inferred_type: Some(
@@ -768,32 +1179,65 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                            right: Expr {
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    optional: false,
+                                                },
+                                                TFnParam {
+                                                    pat: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: false,
+                                                        },
+                                                    ),
+                                                    t: Type {
+                                                        kind: Keyword(
+                                                            Number,
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: Some(
+                                                            Type(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 3,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: Some(
+                                                                        Pattern(
+                                                                            Pattern {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
-                                                                                        column: 24,
+                                                                                        column: 14,
                                                                                     },
                                                                                     end: Position {
                                                                                         line: 0,
-                                                                                        column: 25,
+                                                                                        column: 15,
                                                                                     },
                                                                                 },
-                                                                                span: 24..25,
+                                                                                span: 14..15,
                                                                                 kind: Ident(
-                                                                                    Ident {
+                                                                                    BindingIdent {
+                                                                                        name: "b",
+                                                                                        mutable: false,
+                                                                                        span: 14..15,
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
-                                                                                                column: 24,
+                                                                                                column: 14,
                                                                                             },
                                                                                             end: Position {
                                                                                                 line: 0,
-                                                                                                column: 25,
+                                                                                                column: 15,
                                                                                             },
                                                                                         },
-                                                                                        span: 24..25,
-                                                                                        name: "b",
                                                                                     },
                                                                                 ),
                                                                                 inferred_type: Some(
@@ -809,196 +1253,23 @@ Program {
                                                                                     },
                                                                                 ),
                                                                             },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: Some(
-                                                                        Type {
-                                                                            kind: Keyword(
-                                                                                Number,
-                                                                            ),
-                                                                            mutable: false,
-                                                                            provenance: None,
-                                                                        },
+                                                                        ),
                                                                     ),
                                                                 },
                                                             ),
                                                         ),
                                                     },
-                                                    type_params: None,
+                                                    optional: false,
                                                 },
-                                            ),
-                                            mutable: false,
-                                            provenance: None,
-                                        },
-                                    ),
-                                },
-                            ),
-                        ),
-                    },
-                ),
-            },
-            type_ann: None,
-            init: Some(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 10,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 25,
-                        },
-                    },
-                    span: 10..25,
-                    kind: Lambda(
-                        Lambda {
-                            params: [
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 11,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 12,
-                                            },
-                                        },
-                                        span: 11..12,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
-                                                span: 11..12,
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 11,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 12,
-                                                    },
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: Some(
-                                            Type {
+                                            ],
+                                            ret: Type {
                                                 kind: Keyword(
                                                     Number,
                                                 ),
                                                 mutable: false,
                                                 provenance: Some(
-                                                    Type(
-                                                        Type {
-                                                            kind: Var(
-                                                                TVar {
-                                                                    id: 2,
-                                                                    constraint: None,
-                                                                },
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: None,
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 15,
-                                            },
-                                        },
-                                        span: 14..15,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "b",
-                                                mutable: false,
-                                                span: 14..15,
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 14,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 15,
-                                                    },
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: Some(
-                                            Type {
-                                                kind: Keyword(
-                                                    Number,
-                                                ),
-                                                mutable: false,
-                                                provenance: Some(
-                                                    Type(
-                                                        Type {
-                                                            kind: Var(
-                                                                TVar {
-                                                                    id: 3,
-                                                                    constraint: None,
-                                                                },
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: None,
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                            ],
-                            body: Block {
-                                span: 20..25,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 20,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                        },
-                                        span: 20..25,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 20,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 21,
-                                                        },
-                                                    },
-                                                    span: 20..21,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    Expr(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -1006,162 +1277,39 @@ Program {
                                                                 },
                                                                 end: Position {
                                                                     line: 0,
-                                                                    column: 21,
-                                                                },
-                                                            },
-                                                            span: 20..21,
-                                                            name: "a",
-                                                        },
-                                                    ),
-                                                    inferred_type: Some(
-                                                        Type {
-                                                            kind: Keyword(
-                                                                Number,
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: Some(
-                                                                Type(
-                                                                    Type {
-                                                                        kind: Var(
-                                                                            TVar {
-                                                                                id: 2,
-                                                                                constraint: None,
-                                                                            },
-                                                                        ),
-                                                                        mutable: false,
-                                                                        provenance: None,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 24,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 25,
-                                                        },
-                                                    },
-                                                    span: 24..25,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 24,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
                                                                     column: 25,
                                                                 },
                                                             },
-                                                            span: 24..25,
-                                                            name: "b",
-                                                        },
-                                                    ),
-                                                    inferred_type: Some(
-                                                        Type {
-                                                            kind: Keyword(
-                                                                Number,
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: Some(
-                                                                Type(
-                                                                    Type {
-                                                                        kind: Var(
-                                                                            TVar {
-                                                                                id: 3,
-                                                                                constraint: None,
-                                                                            },
-                                                                        ),
-                                                                        mutable: false,
-                                                                        provenance: None,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: Some(
-                                            Type {
-                                                kind: Keyword(
-                                                    Number,
-                                                ),
-                                                mutable: false,
-                                                provenance: None,
-                                            },
-                                        ),
-                                    },
-                                ],
-                            },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: Some(
-                        Type {
-                            kind: Lam(
-                                TLam {
-                                    params: [
-                                        TFnParam {
-                                            pat: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                },
-                                            ),
-                                            t: Type {
-                                                kind: Keyword(
-                                                    Number,
-                                                ),
-                                                mutable: false,
-                                                provenance: Some(
-                                                    Type(
-                                                        Type {
-                                                            kind: Var(
-                                                                TVar {
-                                                                    id: 2,
-                                                                    constraint: None,
-                                                                },
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: Some(
-                                                                Pattern(
-                                                                    Pattern {
+                                                            span: 20..25,
+                                                            kind: BinaryExpr(
+                                                                BinaryExpr {
+                                                                    op: Add,
+                                                                    left: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
-                                                                                column: 11,
+                                                                                column: 20,
                                                                             },
                                                                             end: Position {
                                                                                 line: 0,
-                                                                                column: 12,
+                                                                                column: 21,
                                                                             },
                                                                         },
-                                                                        span: 11..12,
+                                                                        span: 20..21,
                                                                         kind: Ident(
-                                                                            BindingIdent {
-                                                                                name: "a",
-                                                                                mutable: false,
-                                                                                span: 11..12,
+                                                                            Ident {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
-                                                                                        column: 11,
+                                                                                        column: 20,
                                                                                     },
                                                                                     end: Position {
                                                                                         line: 0,
-                                                                                        column: 12,
+                                                                                        column: 21,
                                                                                     },
                                                                                 },
+                                                                                span: 20..21,
+                                                                                name: "a",
                                                                             },
                                                                         ),
                                                                         inferred_type: Some(
@@ -1177,65 +1325,32 @@ Program {
                                                                             },
                                                                         ),
                                                                     },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                            optional: false,
-                                        },
-                                        TFnParam {
-                                            pat: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: false,
-                                                },
-                                            ),
-                                            t: Type {
-                                                kind: Keyword(
-                                                    Number,
-                                                ),
-                                                mutable: false,
-                                                provenance: Some(
-                                                    Type(
-                                                        Type {
-                                                            kind: Var(
-                                                                TVar {
-                                                                    id: 3,
-                                                                    constraint: None,
-                                                                },
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: Some(
-                                                                Pattern(
-                                                                    Pattern {
+                                                                    right: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
-                                                                                column: 14,
+                                                                                column: 24,
                                                                             },
                                                                             end: Position {
                                                                                 line: 0,
-                                                                                column: 15,
+                                                                                column: 25,
                                                                             },
                                                                         },
-                                                                        span: 14..15,
+                                                                        span: 24..25,
                                                                         kind: Ident(
-                                                                            BindingIdent {
-                                                                                name: "b",
-                                                                                mutable: false,
-                                                                                span: 14..15,
+                                                                            Ident {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
-                                                                                        column: 14,
+                                                                                        column: 24,
                                                                                     },
                                                                                     end: Position {
                                                                                         line: 0,
-                                                                                        column: 15,
+                                                                                        column: 25,
                                                                                     },
                                                                                 },
+                                                                                span: 24..25,
+                                                                                name: "b",
                                                                             },
                                                                         ),
                                                                         inferred_type: Some(
@@ -1251,144 +1366,33 @@ Program {
                                                                             },
                                                                         ),
                                                                     },
-                                                                ),
+                                                                },
+                                                            ),
+                                                            inferred_type: Some(
+                                                                Type {
+                                                                    kind: Keyword(
+                                                                        Number,
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: None,
+                                                                },
                                                             ),
                                                         },
                                                     ),
                                                 ),
                                             },
-                                            optional: false,
+                                            type_params: None,
                                         },
-                                    ],
-                                    ret: Type {
-                                        kind: Keyword(
-                                            Number,
-                                        ),
-                                        mutable: false,
-                                        provenance: Some(
-                                            Expr(
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 20,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 25,
-                                                        },
-                                                    },
-                                                    span: 20..25,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Add,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 20,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 21,
-                                                                    },
-                                                                },
-                                                                span: 20..21,
-                                                                kind: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 20,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 21,
-                                                                            },
-                                                                        },
-                                                                        span: 20..21,
-                                                                        name: "a",
-                                                                    },
-                                                                ),
-                                                                inferred_type: Some(
-                                                                    Type {
-                                                                        kind: Var(
-                                                                            TVar {
-                                                                                id: 2,
-                                                                                constraint: None,
-                                                                            },
-                                                                        ),
-                                                                        mutable: false,
-                                                                        provenance: None,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 24,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 25,
-                                                                    },
-                                                                },
-                                                                span: 24..25,
-                                                                kind: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 24,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 25,
-                                                                            },
-                                                                        },
-                                                                        span: 24..25,
-                                                                        name: "b",
-                                                                    },
-                                                                ),
-                                                                inferred_type: Some(
-                                                                    Type {
-                                                                        kind: Var(
-                                                                            TVar {
-                                                                                id: 3,
-                                                                                constraint: None,
-                                                                            },
-                                                                        ),
-                                                                        mutable: false,
-                                                                        provenance: None,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: Some(
-                                                        Type {
-                                                            kind: Keyword(
-                                                                Number,
-                                                            ),
-                                                            mutable: false,
-                                                            provenance: None,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                    type_params: None,
+                                    ),
+                                    mutable: false,
+                                    provenance: None,
                                 },
                             ),
-                            mutable: false,
-                            provenance: None,
                         },
                     ),
+                    declare: false,
                 },
             ),
-            declare: false,
         },
     ],
 }

--- a/crates/escalier_lsp/src/semantic_tokens.rs
+++ b/crates/escalier_lsp/src/semantic_tokens.rs
@@ -122,14 +122,8 @@ impl SemanticTokenVisitor {
     }
 
     fn enter_statement(&mut self, stmt: &Statement) {
-        if let Statement::TypeDecl {
-            id,
-            type_ann: _,
-            type_params: _,
-            ..
-        } = stmt
-        {
-            let Ident { loc, .. } = id;
+        if let StmtKind::TypeDecl(type_decl) = &stmt.kind {
+            let Ident { loc, .. } = type_decl.id;
             self.raw_tokens.push(RawSemanticToken {
                 line: loc.start.line,
                 start: loc.start.column,

--- a/crates/escalier_parser/src/lib.rs
+++ b/crates/escalier_parser/src/lib.rs
@@ -66,8 +66,9 @@ pub fn parse(src: &str) -> Result<Program, ParseError> {
 
         let mut body: Vec<Statement> = vec![];
         for child in children {
-            let mut stmts = parse_statement(&child, src)?;
-            body.append(&mut stmts);
+            if let Some(stmt) = parse_statement(&child, src)? {
+                body.push(stmt);
+            }
         }
 
         Ok(Program { body })

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__array_spread-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__array_spread-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let tuple = [a, ...b];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..22,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 4..9,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "tuple",
-                            mutable: false,
-                            span: 4..9,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,43 +30,46 @@ Ok(
                                     column: 9,
                                 },
                             },
+                            span: 4..9,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "tuple",
+                                    mutable: false,
+                                    span: 4..9,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 21,
-                            },
-                        },
-                        span: 12..21,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 13,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                            },
-                                            span: 13..14,
-                                            kind: Ident(
-                                                Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 12,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 21,
+                                    },
+                                },
+                                span: 12..21,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -92,30 +81,30 @@ Ok(
                                                         },
                                                     },
                                                     span: 13..14,
-                                                    name: "a",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                    ExprOrSpread {
-                                        spread: Some(
-                                            16..20,
-                                        ),
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 19,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 20,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 13,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 14,
+                                                                },
+                                                            },
+                                                            span: 13..14,
+                                                            name: "a",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 19..20,
-                                            kind: Ident(
-                                                Ident {
+                                            ExprOrSpread {
+                                                spread: Some(
+                                                    16..20,
+                                                ),
+                                                expr: Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -127,19 +116,34 @@ Ok(
                                                         },
                                                     },
                                                     span: 19..20,
-                                                    name: "b",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 19,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                            },
+                                                            span: 19..20,
+                                                            name: "b",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__array_spread-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__array_spread-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let tuple = [1, ...[2, 3]];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..27,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 4..9,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "tuple",
-                            mutable: false,
-                            span: 4..9,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,164 +30,182 @@ Ok(
                                     column: 9,
                                 },
                             },
+                            span: 4..9,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "tuple",
+                                    mutable: false,
+                                    span: 4..9,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 26,
-                            },
-                        },
-                        span: 12..26,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 13,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                            },
-                                            span: 13..14,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 14,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 12,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 26,
+                                    },
+                                },
+                                span: 12..26,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 13,
                                                         },
-                                                        span: 13..14,
-                                                        value: "1",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
                                                     },
-                                                ),
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                    ExprOrSpread {
-                                        spread: Some(
-                                            16..25,
-                                        ),
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 19,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 25,
+                                                    span: 13..14,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 13,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                },
+                                                                span: 13..14,
+                                                                value: "1",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 19..25,
-                                            kind: Tuple(
-                                                Tuple {
-                                                    elems: [
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 20,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 21,
+                                            ExprOrSpread {
+                                                spread: Some(
+                                                    16..25,
+                                                ),
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 19,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                    },
+                                                    span: 19..25,
+                                                    kind: Tuple(
+                                                        Tuple {
+                                                            elems: [
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 20,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 21,
+                                                                            },
+                                                                        },
+                                                                        span: 20..21,
+                                                                        kind: Lit(
+                                                                            Num(
+                                                                                Num {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 20,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 21,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 20..21,
+                                                                                    value: "2",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
                                                                 },
-                                                                span: 20..21,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 20,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 21,
-                                                                                },
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 23,
                                                                             },
-                                                                            span: 20..21,
-                                                                            value: "2",
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 24,
+                                                                            },
                                                                         },
-                                                                    ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        },
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 24,
+                                                                        span: 23..24,
+                                                                        kind: Lit(
+                                                                            Num(
+                                                                                Num {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 23,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 24,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 23..24,
+                                                                                    value: "3",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
                                                                 },
-                                                                span: 23..24,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 23,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 24,
-                                                                                },
-                                                                            },
-                                                                            span: 23..24,
-                                                                            value: "3",
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                            ],
                                                         },
-                                                    ],
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__array_spread.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__array_spread.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let tuple = [...a, b];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..22,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 4..9,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "tuple",
-                            mutable: false,
-                            span: 4..9,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,45 +30,48 @@ Ok(
                                     column: 9,
                                 },
                             },
+                            span: 4..9,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "tuple",
+                                    mutable: false,
+                                    span: 4..9,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 21,
-                            },
-                        },
-                        span: 12..21,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [
-                                    ExprOrSpread {
-                                        spread: Some(
-                                            13..17,
-                                        ),
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 16..17,
-                                            kind: Ident(
-                                                Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 12,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 21,
+                                    },
+                                },
+                                span: 12..21,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [
+                                            ExprOrSpread {
+                                                spread: Some(
+                                                    13..17,
+                                                ),
+                                                expr: Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -94,28 +83,28 @@ Ok(
                                                         },
                                                     },
                                                     span: 16..17,
-                                                    name: "a",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 19,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 20,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 17,
+                                                                },
+                                                            },
+                                                            span: 16..17,
+                                                            name: "a",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 19..20,
-                                            kind: Ident(
-                                                Ident {
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -127,19 +116,34 @@ Ok(
                                                         },
                                                     },
                                                     span: 19..20,
-                                                    name: "b",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 19,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                            },
+                                                            span: 19..20,
+                                                            name: "b",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-2.snap
@@ -5,121 +5,134 @@ expression: "parse(\"a.b = c;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..7,
-                    kind: Assign(
-                        Assign {
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
+                    end: Position {
+                        line: 0,
+                        column: 8,
+                    },
+                },
+                span: 0..8,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 7,
+                            },
+                        },
+                        span: 0..7,
+                        kind: Assign(
+                            Assign {
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
+                                    span: 0..3,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 1,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
+                                                span: 0..1,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 1,
+                                                            },
+                                                        },
+                                                        span: 0..1,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                                inferred_type: None,
                                             },
-                                            span: 0..1,
-                                            kind: Ident(
+                                            prop: Ident(
                                                 Ident {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 0,
+                                                            column: 2,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 1,
+                                                            column: 3,
                                                         },
                                                     },
-                                                    span: 0..1,
-                                                    name: "a",
+                                                    span: 2..3,
+                                                    name: "b",
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
-                                        prop: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 2,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 3,
-                                                    },
-                                                },
-                                                span: 2..3,
-                                                name: "b",
-                                            },
-                                        ),
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 7,
-                                    },
+                                    ),
+                                    inferred_type: None,
                                 },
-                                span: 6..7,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 7,
-                                            },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 6,
                                         },
-                                        span: 6..7,
-                                        name: "c",
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
                                     },
-                                ),
-                                inferred_type: None,
+                                    span: 6..7,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 6,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 7,
+                                                },
+                                            },
+                                            span: 6..7,
+                                            name: "c",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                op: Eq,
                             },
-                            op: Eq,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-3.snap
@@ -5,79 +5,79 @@ expression: "parse(\"a[b] = c;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..8,
-                    kind: Assign(
-                        Assign {
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                },
-                                span: 0..4,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
-                                            },
-                                            span: 0..1,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 0,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 1,
-                                                        },
-                                                    },
-                                                    span: 0..1,
-                                                    name: "a",
-                                                },
-                                            ),
-                                            inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 9,
+                    },
+                },
+                span: 0..9,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 8,
+                            },
+                        },
+                        span: 0..8,
+                        kind: Assign(
+                            Assign {
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
                                         },
-                                        prop: Computed(
-                                            ComputedPropName {
+                                        end: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                    },
+                                    span: 0..4,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 2,
+                                                        column: 0,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 3,
+                                                        column: 1,
                                                     },
                                                 },
-                                                span: 2..3,
-                                                expr: Expr {
+                                                span: 0..1,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 1,
+                                                            },
+                                                        },
+                                                        span: 0..1,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            prop: Computed(
+                                                ComputedPropName {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -89,66 +89,79 @@ Ok(
                                                         },
                                                     },
                                                     span: 2..3,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 2,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 3,
-                                                                },
+                                                    expr: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 2,
                                                             },
-                                                            span: 2..3,
-                                                            name: "b",
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 3,
+                                                            },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
+                                                        span: 2..3,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 2,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 3,
+                                                                    },
+                                                                },
+                                                                span: 2..3,
+                                                                name: "b",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 8,
+                                        },
+                                    },
+                                    span: 7..8,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 7,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 8,
                                                 },
                                             },
-                                        ),
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 7,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 8,
-                                    },
-                                },
-                                span: 7..8,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 7,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
+                                            span: 7..8,
+                                            name: "c",
                                         },
-                                        span: 7..8,
-                                        name: "c",
-                                    },
-                                ),
-                                inferred_type: None,
+                                    ),
+                                    inferred_type: None,
+                                },
+                                op: Eq,
                             },
-                            op: Eq,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments-4.snap
@@ -5,79 +5,79 @@ expression: "parse(r#\"a[\"b\"] = c;\"#)"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 10,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..10,
-                    kind: Assign(
-                        Assign {
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 0..6,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
-                                            },
-                                            span: 0..1,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 0,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 1,
-                                                        },
-                                                    },
-                                                    span: 0..1,
-                                                    name: "a",
-                                                },
-                                            ),
-                                            inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 11,
+                    },
+                },
+                span: 0..11,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 10,
+                            },
+                        },
+                        span: 0..10,
+                        kind: Assign(
+                            Assign {
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
                                         },
-                                        prop: Computed(
-                                            ComputedPropName {
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 0..6,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 2,
+                                                        column: 0,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 5,
+                                                        column: 1,
                                                     },
                                                 },
-                                                span: 2..5,
-                                                expr: Expr {
+                                                span: 0..1,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 1,
+                                                            },
+                                                        },
+                                                        span: 0..1,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            prop: Computed(
+                                                ComputedPropName {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -89,68 +89,81 @@ Ok(
                                                         },
                                                     },
                                                     span: 2..5,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 2,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 5,
-                                                                    },
-                                                                },
-                                                                span: 2..5,
-                                                                value: "b",
+                                                    expr: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 2,
                                                             },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 5,
+                                                            },
+                                                        },
+                                                        span: 2..5,
+                                                        kind: Lit(
+                                                            Str(
+                                                                Str {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 2,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 5,
+                                                                        },
+                                                                    },
+                                                                    span: 2..5,
+                                                                    value: "b",
+                                                                },
+                                                            ),
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 10,
+                                        },
+                                    },
+                                    span: 9..10,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 9,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 10,
                                                 },
                                             },
-                                        ),
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                },
-                                span: 9..10,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
+                                            span: 9..10,
+                                            name: "c",
                                         },
-                                        span: 9..10,
-                                        name: "c",
-                                    },
-                                ),
-                                inferred_type: None,
+                                    ),
+                                    inferred_type: None,
+                                },
+                                op: Eq,
                             },
-                            op: Eq,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__assignments.snap
@@ -5,89 +5,102 @@ expression: "parse(\"x = 5;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..5,
-                    kind: Assign(
-                        Assign {
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "x",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 6,
+                    },
+                },
+                span: 0..6,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
+                            end: Position {
+                                line: 0,
+                                column: 5,
+                            },
+                        },
+                        span: 0..5,
+                        kind: Assign(
+                            Assign {
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                },
-                                span: 4..5,
-                                kind: Lit(
-                                    Num(
-                                        Num {
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 4,
+                                                    column: 0,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 5,
+                                                    column: 1,
                                                 },
                                             },
-                                            span: 4..5,
-                                            value: "5",
+                                            span: 0..1,
+                                            name: "x",
                                         },
                                     ),
-                                ),
-                                inferred_type: None,
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                    span: 4..5,
+                                    kind: Lit(
+                                        Num(
+                                            Num {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 4,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                },
+                                                span: 4..5,
+                                                value: "5",
+                                            },
+                                        ),
+                                    ),
+                                    inferred_type: None,
+                                },
+                                op: Eq,
                             },
-                            op: Eq,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = async () => { await 10 };\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..35,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,91 +30,109 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 34,
-                            },
-                        },
-                        span: 10..34,
-                        kind: Lambda(
-                            Lambda {
-                                params: [],
-                                body: Block {
-                                    span: 22..34,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 32,
-                                                },
-                                            },
-                                            span: 24..32,
-                                            kind: Await(
-                                                Await {
-                                                    expr: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 30,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 32,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 34,
+                                    },
+                                },
+                                span: 10..34,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [],
+                                        body: Block {
+                                            span: 22..34,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 24,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 24..32,
+                                                    kind: Await(
+                                                        Await {
+                                                            expr: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 30,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 32,
+                                                                    },
+                                                                },
+                                                                span: 30..32,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 30,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 32,
+                                                                                },
+                                                                            },
+                                                                            span: 30..32,
+                                                                            value: "10",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
                                                             },
                                                         },
-                                                        span: 30..32,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 30,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 32,
-                                                                        },
-                                                                    },
-                                                                    span: 30..32,
-                                                                    value: "10",
-                                                                },
-                                                            ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: true,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: true,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = async () => await a + await b;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..40,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,73 +30,76 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 39,
-                            },
-                        },
-                        span: 10..39,
-                        kind: Lambda(
-                            Lambda {
-                                params: [],
-                                body: Block {
-                                    span: 22..39,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 39,
-                                                },
-                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 39,
+                                    },
+                                },
+                                span: 10..39,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [],
+                                        body: Block {
                                             span: 22..39,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 29,
-                                                            },
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 22,
                                                         },
-                                                        span: 22..29,
-                                                        kind: Await(
-                                                            Await {
-                                                                expr: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 28,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 29,
-                                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 39,
+                                                        },
+                                                    },
+                                                    span: 22..39,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
                                                                     },
-                                                                    span: 28..29,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 29,
+                                                                    },
+                                                                },
+                                                                span: 22..29,
+                                                                kind: Await(
+                                                                    Await {
+                                                                        expr: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -122,43 +111,43 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 28..29,
-                                                                            name: "a",
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 32,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 39,
-                                                            },
-                                                        },
-                                                        span: 32..39,
-                                                        kind: Await(
-                                                            Await {
-                                                                expr: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 38,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 39,
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 28,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 29,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 28..29,
+                                                                                    name: "a",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
                                                                     },
-                                                                    span: 38..39,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            right: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 32,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 39,
+                                                                    },
+                                                                },
+                                                                span: 32..39,
+                                                                kind: Await(
+                                                                    Await {
+                                                                        expr: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -170,30 +159,45 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 38..39,
-                                                                            name: "b",
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 38,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 39,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 38..39,
+                                                                                    name: "b",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: true,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: true,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = async () => await bar();\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..34,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,72 +30,75 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 33,
-                            },
-                        },
-                        span: 10..33,
-                        kind: Lambda(
-                            Lambda {
-                                params: [],
-                                body: Block {
-                                    span: 22..33,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 33,
-                                                },
-                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 33,
+                                    },
+                                },
+                                span: 10..33,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [],
+                                        body: Block {
                                             span: 22..33,
-                                            kind: Await(
-                                                Await {
-                                                    expr: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 28,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 33,
-                                                            },
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 22,
                                                         },
-                                                        span: 28..33,
-                                                        kind: App(
-                                                            App {
-                                                                lam: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 28,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 31,
-                                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 33,
+                                                        },
+                                                    },
+                                                    span: 22..33,
+                                                    kind: Await(
+                                                        Await {
+                                                            expr: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 28,
                                                                     },
-                                                                    span: 28..31,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 33,
+                                                                    },
+                                                                },
+                                                                span: 28..33,
+                                                                kind: App(
+                                                                    App {
+                                                                        lam: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -121,32 +110,47 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 28..31,
-                                                                            name: "bar",
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 28,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 31,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 28..31,
+                                                                                    name: "bar",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                args: [],
-                                                                type_args: None,
+                                                                        args: [],
+                                                                        type_args: None,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: true,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: true,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
@@ -5,67 +5,80 @@ expression: "parse(\"async () => 10;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 14,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..14,
-                    kind: Lambda(
-                        Lambda {
-                            params: [],
-                            body: Block {
-                                span: 12..14,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 12,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 14,
-                                            },
-                                        },
-                                        span: 12..14,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 12,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 14,
-                                                        },
-                                                    },
-                                                    span: 12..14,
-                                                    value: "10",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
-                            },
-                            is_async: true,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 15,
+                    },
                 },
-            ),
+                span: 0..15,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 14,
+                            },
+                        },
+                        span: 0..14,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Block {
+                                    span: 12..14,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 12,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                            },
+                                            span: 12..14,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                        },
+                                                        span: 12..14,
+                                                        value: "10",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: true,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = do {let x = 5; let y = 10; x + y};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..44,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,60 +30,60 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 43,
-                            },
-                        },
-                        span: 10..43,
-                        kind: DoExpr(
-                            DoExpr {
-                                body: Block {
-                                    span: 13..43,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 14..24,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 43,
+                                    },
+                                },
+                                span: 10..43,
+                                kind: DoExpr(
+                                    DoExpr {
+                                        body: Block {
+                                            span: 13..43,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 14,
                                                         },
-                                                        span: 18..19,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "x",
-                                                                mutable: false,
-                                                                span: 18..19,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 24,
+                                                        },
+                                                    },
+                                                    span: 14..24,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -108,78 +94,78 @@ Ok(
                                                                         column: 19,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                        },
-                                                        span: 22..23,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 23,
+                                                                span: 18..19,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "x",
+                                                                        mutable: false,
+                                                                        span: 18..19,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
                                                                         },
                                                                     },
-                                                                    span: 22..23,
-                                                                    value: "5",
-                                                                },
-                                                            ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 36,
-                                                },
-                                            },
-                                            span: 25..36,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 29,
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 30,
+                                                            type_ann: None,
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
+                                                                },
+                                                                span: 22..23,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 22,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                            span: 22..23,
+                                                                            value: "5",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
                                                             },
                                                         },
-                                                        span: 29..30,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "y",
-                                                                mutable: false,
-                                                                span: 29..30,
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 36,
+                                                        },
+                                                    },
+                                                    span: 25..36,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -190,76 +176,79 @@ Ok(
                                                                         column: 30,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 33,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 35,
-                                                            },
-                                                        },
-                                                        span: 33..35,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 33,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 35,
+                                                                span: 29..30,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "y",
+                                                                        mutable: false,
+                                                                        span: 29..30,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 29,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 30,
+                                                                            },
                                                                         },
                                                                     },
-                                                                    span: 33..35,
-                                                                    value: "10",
-                                                                },
-                                                            ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 37,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 42,
-                                                },
-                                            },
-                                            span: 37..42,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 37,
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 38,
+                                                            type_ann: None,
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 33,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 35,
+                                                                    },
+                                                                },
+                                                                span: 33..35,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 33,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 35,
+                                                                                },
+                                                                            },
+                                                                            span: 33..35,
+                                                                            value: "10",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
                                                             },
                                                         },
-                                                        span: 37..38,
-                                                        kind: Ident(
-                                                            Ident {
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 37,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 42,
+                                                        },
+                                                    },
+                                                    span: 37..42,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -271,25 +260,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 37..38,
-                                                                name: "x",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 37,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 38,
+                                                                            },
+                                                                        },
+                                                                        span: 37..38,
+                                                                        name: "x",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 41,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 42,
-                                                            },
-                                                        },
-                                                        span: 41..42,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -301,23 +290,38 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 41..42,
-                                                                name: "y",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 41,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 42,
+                                                                            },
+                                                                        },
+                                                                        span: 41..42,
+                                                                        name: "y",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
@@ -5,274 +5,287 @@ expression: "parse(\"do {let x = 5; let y = 10; x + y};\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 33,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..33,
-                    kind: DoExpr(
-                        DoExpr {
-                            body: Block {
-                                span: 3..33,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 14,
-                                            },
-                                        },
-                                        span: 4..14,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 8,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 9,
-                                                        },
-                                                    },
-                                                    span: 8..9,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "x",
-                                                            mutable: false,
-                                                            span: 8..9,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 8,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 9,
-                                                                },
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 12,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 13,
-                                                        },
-                                                    },
-                                                    span: 12..13,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 12,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 13,
-                                                                    },
-                                                                },
-                                                                span: 12..13,
-                                                                value: "5",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 15,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 26,
-                                            },
-                                        },
-                                        span: 15..26,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 20,
-                                                        },
-                                                    },
-                                                    span: 19..20,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "y",
-                                                            mutable: false,
-                                                            span: 19..20,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 20,
-                                                                },
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 25,
-                                                        },
-                                                    },
-                                                    span: 23..25,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 25,
-                                                                    },
-                                                                },
-                                                                span: 23..25,
-                                                                value: "10",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 27,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 32,
-                                            },
-                                        },
-                                        span: 27..32,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 27,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 28,
-                                                        },
-                                                    },
-                                                    span: 27..28,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 27,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 28,
-                                                                },
-                                                            },
-                                                            span: 27..28,
-                                                            name: "x",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 31,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 32,
-                                                        },
-                                                    },
-                                                    span: 31..32,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 31,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 32,
-                                                                },
-                                                            },
-                                                            span: 31..32,
-                                                            name: "y",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                    end: Position {
+                        line: 0,
+                        column: 34,
+                    },
+                },
+                span: 0..34,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 33,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..33,
+                        kind: DoExpr(
+                            DoExpr {
+                                body: Block {
+                                    span: 3..33,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                            },
+                                            span: 4..14,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 8,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 9,
+                                                            },
+                                                        },
+                                                        span: 8..9,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 8..9,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 8,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 9,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 13,
+                                                            },
+                                                        },
+                                                        span: 12..13,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 12,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 13,
+                                                                        },
+                                                                    },
+                                                                    span: 12..13,
+                                                                    value: "5",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 15,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 26,
+                                                },
+                                            },
+                                            span: 15..26,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 19,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 20,
+                                                            },
+                                                        },
+                                                        span: 19..20,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "y",
+                                                                mutable: false,
+                                                                span: 19..20,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 19,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 20,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
+                                                        },
+                                                        span: 23..25,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                    },
+                                                                    span: 23..25,
+                                                                    value: "10",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 27,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 32,
+                                                },
+                                            },
+                                            span: 27..32,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 27,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 28,
+                                                            },
+                                                        },
+                                                        span: 27..28,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 27,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 28,
+                                                                    },
+                                                                },
+                                                                span: 27..28,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 31,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 32,
+                                                            },
+                                                        },
+                                                        span: 31..32,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 31,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 32,
+                                                                    },
+                                                                },
+                                                                span: 31..32,
+                                                                name: "y",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
@@ -5,377 +5,390 @@ expression: "parse(\"do {let sum = do {let x = 5; let y = 10; x + y}; sum};\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 53,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..53,
-                    kind: DoExpr(
-                        DoExpr {
-                            body: Block {
-                                span: 3..53,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 48,
-                                            },
-                                        },
-                                        span: 4..48,
-                                        kind: LetDecl(
-                                            LetDecl {
-                                                pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 8,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 11,
-                                                        },
-                                                    },
-                                                    span: 8..11,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "sum",
-                                                            mutable: false,
-                                                            span: 8..11,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 8,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 11,
-                                                                },
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: None,
-                                                init: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 14,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 47,
-                                                        },
-                                                    },
-                                                    span: 14..47,
-                                                    kind: DoExpr(
-                                                        DoExpr {
-                                                            body: Block {
-                                                                span: 17..47,
-                                                                stmts: [
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 18,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 28,
-                                                                            },
-                                                                        },
-                                                                        span: 18..28,
-                                                                        kind: LetDecl(
-                                                                            LetDecl {
-                                                                                pattern: Pattern {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 22,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 23,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 22..23,
-                                                                                    kind: Ident(
-                                                                                        BindingIdent {
-                                                                                            name: "x",
-                                                                                            mutable: false,
-                                                                                            span: 22..23,
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 22,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 23,
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                                type_ann: None,
-                                                                                init: Expr {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 26,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 27,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 26..27,
-                                                                                    kind: Lit(
-                                                                                        Num(
-                                                                                            Num {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 26,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 27,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 26..27,
-                                                                                                value: "5",
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 29,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 40,
-                                                                            },
-                                                                        },
-                                                                        span: 29..40,
-                                                                        kind: LetDecl(
-                                                                            LetDecl {
-                                                                                pattern: Pattern {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 33,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 34,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 33..34,
-                                                                                    kind: Ident(
-                                                                                        BindingIdent {
-                                                                                            name: "y",
-                                                                                            mutable: false,
-                                                                                            span: 33..34,
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 33,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 34,
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                                type_ann: None,
-                                                                                init: Expr {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 37,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 39,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 37..39,
-                                                                                    kind: Lit(
-                                                                                        Num(
-                                                                                            Num {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 37,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 39,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 37..39,
-                                                                                                value: "10",
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 41,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 46,
-                                                                            },
-                                                                        },
-                                                                        span: 41..46,
-                                                                        kind: BinaryExpr(
-                                                                            BinaryExpr {
-                                                                                op: Add,
-                                                                                left: Expr {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 41,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 42,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 41..42,
-                                                                                    kind: Ident(
-                                                                                        Ident {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 41,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 42,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 41..42,
-                                                                                            name: "x",
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                                right: Expr {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 45,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 46,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 45..46,
-                                                                                    kind: Ident(
-                                                                                        Ident {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 45,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 46,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 45..46,
-                                                                                            name: "y",
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                ],
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 49,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 52,
-                                            },
-                                        },
-                                        span: 49..52,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 49,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 52,
-                                                    },
-                                                },
-                                                span: 49..52,
-                                                name: "sum",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
+                    end: Position {
+                        line: 0,
+                        column: 54,
+                    },
+                },
+                span: 0..54,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 53,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..53,
+                        kind: DoExpr(
+                            DoExpr {
+                                body: Block {
+                                    span: 3..53,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 48,
+                                                },
+                                            },
+                                            span: 4..48,
+                                            kind: LetDecl(
+                                                LetDecl {
+                                                    pattern: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 8,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 11,
+                                                            },
+                                                        },
+                                                        span: 8..11,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "sum",
+                                                                mutable: false,
+                                                                span: 8..11,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 8,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 11,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 47,
+                                                            },
+                                                        },
+                                                        span: 14..47,
+                                                        kind: DoExpr(
+                                                            DoExpr {
+                                                                body: Block {
+                                                                    span: 17..47,
+                                                                    stmts: [
+                                                                        Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 18,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 28,
+                                                                                },
+                                                                            },
+                                                                            span: 18..28,
+                                                                            kind: LetDecl(
+                                                                                LetDecl {
+                                                                                    pattern: Pattern {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 22,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 23,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 22..23,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "x",
+                                                                                                mutable: false,
+                                                                                                span: 22..23,
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 22,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 23,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    type_ann: None,
+                                                                                    init: Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 26,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 27,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 26..27,
+                                                                                        kind: Lit(
+                                                                                            Num(
+                                                                                                Num {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 26,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 27,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 26..27,
+                                                                                                    value: "5",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 29,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 40,
+                                                                                },
+                                                                            },
+                                                                            span: 29..40,
+                                                                            kind: LetDecl(
+                                                                                LetDecl {
+                                                                                    pattern: Pattern {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 33,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 34,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 33..34,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "y",
+                                                                                                mutable: false,
+                                                                                                span: 33..34,
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 33,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 34,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    type_ann: None,
+                                                                                    init: Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 37,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 39,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 37..39,
+                                                                                        kind: Lit(
+                                                                                            Num(
+                                                                                                Num {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 37,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 39,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 37..39,
+                                                                                                    value: "10",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 41,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 46,
+                                                                                },
+                                                                            },
+                                                                            span: 41..46,
+                                                                            kind: BinaryExpr(
+                                                                                BinaryExpr {
+                                                                                    op: Add,
+                                                                                    left: Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 41,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 42,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 41..42,
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 41,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 42,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 41..42,
+                                                                                                name: "x",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    right: Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 45,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 46,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 45..46,
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 45,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 46,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 45..46,
+                                                                                                name: "y",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 49,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 52,
+                                                },
+                                            },
+                                            span: 49..52,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 49,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 52,
+                                                        },
+                                                    },
+                                                    span: 49..52,
+                                                    name: "sum",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-5.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = do {let x = 5; console.log(x); x};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..44,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,60 +30,60 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 43,
-                            },
-                        },
-                        span: 10..43,
-                        kind: DoExpr(
-                            DoExpr {
-                                body: Block {
-                                    span: 13..43,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 14..24,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 43,
+                                    },
+                                },
+                                span: 10..43,
+                                kind: DoExpr(
+                                    DoExpr {
+                                        body: Block {
+                                            span: 13..43,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 14,
                                                         },
-                                                        span: 18..19,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "x",
-                                                                mutable: false,
-                                                                span: 18..19,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 24,
+                                                        },
+                                                    },
+                                                    span: 14..24,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -108,89 +94,92 @@ Ok(
                                                                         column: 19,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                        },
-                                                        span: 22..23,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 23,
+                                                                span: 18..19,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "x",
+                                                                        mutable: false,
+                                                                        span: 18..19,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
                                                                         },
                                                                     },
-                                                                    span: 22..23,
-                                                                    value: "5",
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            type_ann: None,
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
                                                                 },
-                                                            ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 39,
-                                                },
-                                            },
-                                            span: 25..39,
-                                            kind: App(
-                                                App {
-                                                    lam: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 25,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 36,
+                                                                span: 22..23,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 22,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                            span: 22..23,
+                                                                            value: "5",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
                                                             },
                                                         },
-                                                        span: 25..36,
-                                                        kind: Member(
-                                                            Member {
-                                                                obj: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 25,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 32,
-                                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 39,
+                                                        },
+                                                    },
+                                                    span: 25..39,
+                                                    kind: App(
+                                                        App {
+                                                            lam: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 25,
                                                                     },
-                                                                    span: 25..32,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 36,
+                                                                    },
+                                                                },
+                                                                span: 25..36,
+                                                                kind: Member(
+                                                                    Member {
+                                                                        obj: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -202,48 +191,48 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 25..32,
-                                                                            name: "console",
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 25,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 32,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 25..32,
+                                                                                    name: "console",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                prop: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 33,
+                                                                        prop: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 33,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 36,
+                                                                                    },
+                                                                                },
+                                                                                span: 33..36,
+                                                                                name: "log",
                                                                             },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 36,
-                                                                            },
-                                                                        },
-                                                                        span: 33..36,
-                                                                        name: "log",
+                                                                        ),
                                                                     },
                                                                 ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    args: [
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 37,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 38,
-                                                                    },
-                                                                },
-                                                                span: 37..38,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                            args: [
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -255,32 +244,32 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 37..38,
-                                                                        name: "x",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 37,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 38,
+                                                                                    },
+                                                                                },
+                                                                                span: 37..38,
+                                                                                name: "x",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ],
+                                                            type_args: None,
                                                         },
-                                                    ],
-                                                    type_args: None,
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 42,
-                                                },
-                                            },
-                                            span: 41..42,
-                                            kind: Ident(
-                                                Ident {
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -292,19 +281,34 @@ Ok(
                                                         },
                                                     },
                                                     span: 41..42,
-                                                    name: "x",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 41,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 42,
+                                                                },
+                                                            },
+                                                            span: 41..42,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-6.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = do {console.log(x); x};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..33,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,71 +30,74 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 32,
-                            },
-                        },
-                        span: 10..32,
-                        kind: DoExpr(
-                            DoExpr {
-                                body: Block {
-                                    span: 13..32,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 28,
-                                                },
-                                            },
-                                            span: 14..28,
-                                            kind: App(
-                                                App {
-                                                    lam: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 14,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 25,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 32,
+                                    },
+                                },
+                                span: 10..32,
+                                kind: DoExpr(
+                                    DoExpr {
+                                        body: Block {
+                                            span: 13..32,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 14,
                                                         },
-                                                        span: 14..25,
-                                                        kind: Member(
-                                                            Member {
-                                                                obj: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 14,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 21,
-                                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 28,
+                                                        },
+                                                    },
+                                                    span: 14..28,
+                                                    kind: App(
+                                                        App {
+                                                            lam: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 14,
                                                                     },
-                                                                    span: 14..21,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 25,
+                                                                    },
+                                                                },
+                                                                span: 14..25,
+                                                                kind: Member(
+                                                                    Member {
+                                                                        obj: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -120,48 +109,48 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 14..21,
-                                                                            name: "console",
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 14,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 21,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 14..21,
+                                                                                    name: "console",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                prop: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 22,
+                                                                        prop: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 22,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 25,
+                                                                                    },
+                                                                                },
+                                                                                span: 22..25,
+                                                                                name: "log",
                                                                             },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 25,
-                                                                            },
-                                                                        },
-                                                                        span: 22..25,
-                                                                        name: "log",
+                                                                        ),
                                                                     },
                                                                 ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    args: [
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 26,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 27,
-                                                                    },
-                                                                },
-                                                                span: 26..27,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                            args: [
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -173,32 +162,32 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 26..27,
-                                                                        name: "x",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 27,
+                                                                                    },
+                                                                                },
+                                                                                span: 26..27,
+                                                                                name: "x",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ],
+                                                            type_args: None,
                                                         },
-                                                    ],
-                                                    type_args: None,
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 30,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 31,
-                                                },
-                                            },
-                                            span: 30..31,
-                                            kind: Ident(
-                                                Ident {
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -210,19 +199,34 @@ Ok(
                                                         },
                                                     },
                                                     span: 30..31,
-                                                    name: "x",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 30,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 31,
+                                                                },
+                                                            },
+                                                            span: 30..31,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = do {let x = 5; x};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..28,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,60 +30,60 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 27,
-                            },
-                        },
-                        span: 10..27,
-                        kind: DoExpr(
-                            DoExpr {
-                                body: Block {
-                                    span: 13..27,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 14..24,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 27,
+                                    },
+                                },
+                                span: 10..27,
+                                kind: DoExpr(
+                                    DoExpr {
+                                        body: Block {
+                                            span: 13..27,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 14,
                                                         },
-                                                        span: 18..19,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "x",
-                                                                mutable: false,
-                                                                span: 18..19,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 24,
+                                                        },
+                                                    },
+                                                    span: 14..24,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -108,61 +94,64 @@ Ok(
                                                                         column: 19,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                        },
-                                                        span: 22..23,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 23,
+                                                                span: 18..19,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "x",
+                                                                        mutable: false,
+                                                                        span: 18..19,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
                                                                         },
                                                                     },
-                                                                    span: 22..23,
-                                                                    value: "5",
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            type_ann: None,
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
                                                                 },
-                                                            ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                                span: 22..23,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 22,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                            span: 22..23,
+                                                                            value: "5",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 26,
-                                                },
-                                            },
-                                            span: 25..26,
-                                            kind: Ident(
-                                                Ident {
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -174,19 +163,34 @@ Ok(
                                                         },
                                                     },
                                                     span: 25..26,
-                                                    name: "x",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 26,
+                                                                },
+                                                            },
+                                                            span: 25..26,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-10.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-10.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { constructor(x) {} }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,57 +17,43 @@ Ok(
                     },
                 },
                 span: 0..31,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
                             },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
+                            span: 6..9,
+                            name: "Foo",
                         },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Constructor(
-                            Constructor {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 25,
-                                                },
-                                            },
-                                            span: 24..25,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "x",
-                                                    mutable: false,
-                                                    span: 24..25,
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Constructor(
+                                    Constructor {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -78,23 +64,41 @@ Ok(
                                                             column: 25,
                                                         },
                                                     },
+                                                    span: 24..25,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "x",
+                                                            mutable: false,
+                                                            span: 24..25,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 27..29,
+                                            stmts: [],
                                         },
-                                        type_ann: None,
-                                        optional: false,
                                     },
-                                ],
-                                body: Block {
-                                    span: 27..29,
-                                    stmts: [],
-                                },
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                                ),
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-11.snap
@@ -5,7 +5,7 @@ expression: parse(src)
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,57 +17,43 @@ Ok(
                     },
                 },
                 span: 9..249,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 14,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                    },
-                    span: 15..18,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 14,
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 1,
+                                    column: 14,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    column: 17,
+                                },
                             },
-                            end: Position {
-                                line: 1,
-                                column: 17,
-                            },
+                            span: 15..18,
+                            name: "Foo",
                         },
-                        span: 15..18,
-                        name: "Foo",
-                    },
-                    body: [
-                        Constructor(
-                            Constructor {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 24,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 28,
-                                                },
-                                            },
-                                            span: 45..49,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "self",
-                                                    mutable: false,
-                                                    span: 45..49,
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 14,
+                                    },
+                                    end: Position {
+                                        line: 1,
+                                        column: 17,
+                                    },
+                                },
+                                span: 15..18,
+                                name: "Foo",
+                            },
+                            body: [
+                                Constructor(
+                                    Constructor {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -78,31 +64,31 @@ Ok(
                                                             column: 28,
                                                         },
                                                     },
+                                                    span: 45..49,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "self",
+                                                            mutable: false,
+                                                            span: 45..49,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 28,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 30,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 31,
-                                                },
+                                                type_ann: None,
+                                                optional: false,
                                             },
-                                            span: 51..52,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "x",
-                                                    mutable: false,
-                                                    span: 51..52,
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -113,59 +99,62 @@ Ok(
                                                             column: 31,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 54..97,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 26,
-                                                },
-                                            },
-                                            span: 72..82,
-                                            kind: Assign(
-                                                Assign {
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 3,
-                                                                column: 16,
-                                                            },
-                                                            end: Position {
-                                                                line: 3,
-                                                                column: 22,
+                                                    span: 51..52,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "x",
+                                                            mutable: false,
+                                                            span: 51..52,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 30,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 31,
+                                                                },
                                                             },
                                                         },
-                                                        span: 72..78,
-                                                        kind: Member(
-                                                            Member {
-                                                                obj: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 16,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 20,
-                                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 54..97,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 26,
+                                                        },
+                                                    },
+                                                    span: 72..82,
+                                                    kind: Assign(
+                                                        Assign {
+                                                            left: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 16,
                                                                     },
-                                                                    span: 72..76,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 22,
+                                                                    },
+                                                                },
+                                                                span: 72..78,
+                                                                kind: Member(
+                                                                    Member {
+                                                                        obj: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 3,
@@ -177,45 +166,45 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 72..76,
-                                                                            name: "self",
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 3,
+                                                                                            column: 16,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 3,
+                                                                                            column: 20,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 72..76,
+                                                                                    name: "self",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                prop: Ident(
-                                                                    Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 21,
+                                                                        prop: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 22,
+                                                                                    },
+                                                                                },
+                                                                                span: 77..78,
+                                                                                name: "x",
                                                                             },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 22,
-                                                                            },
-                                                                        },
-                                                                        span: 77..78,
-                                                                        name: "x",
+                                                                        ),
                                                                     },
                                                                 ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 3,
-                                                                column: 25,
-                                                            },
-                                                            end: Position {
-                                                                line: 3,
-                                                                column: 26,
-                                                            },
-                                                        },
-                                                        span: 81..82,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 3,
@@ -227,57 +216,54 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 81..82,
-                                                                name: "x",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 25,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 26,
+                                                                            },
+                                                                        },
+                                                                        span: 81..82,
+                                                                        name: "x",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    op: Eq,
+                                                            op: Eq,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    ],
-                                },
-                            },
-                        ),
-                        Method(
-                            ClassMethod {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 5,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 5,
-                                            column: 15,
+                                            ],
                                         },
                                     },
-                                    span: 110..113,
-                                    name: "bar",
-                                },
-                                kind: Method,
-                                lambda: Lambda {
-                                    params: [
-                                        EFnParam {
-                                            pat: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 20,
-                                                    },
+                                ),
+                                Method(
+                                    ClassMethod {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 5,
+                                                    column: 12,
                                                 },
-                                                span: 114..118,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "self",
-                                                        mutable: false,
-                                                        span: 114..118,
+                                                end: Position {
+                                                    line: 5,
+                                                    column: 15,
+                                                },
+                                            },
+                                            span: 110..113,
+                                            name: "bar",
+                                        },
+                                        kind: Method,
+                                        lambda: Lambda {
+                                            params: [
+                                                EFnParam {
+                                                    pat: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 5,
@@ -288,31 +274,31 @@ Ok(
                                                                 column: 20,
                                                             },
                                                         },
+                                                        span: 114..118,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "self",
+                                                                mutable: false,
+                                                                span: 114..118,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 5,
+                                                                        column: 16,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 5,
+                                                                        column: 20,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            type_ann: None,
-                                            optional: false,
-                                        },
-                                        EFnParam {
-                                            pat: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 22,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 23,
-                                                    },
+                                                    type_ann: None,
+                                                    optional: false,
                                                 },
-                                                span: 120..121,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "y",
-                                                        mutable: false,
-                                                        span: 120..121,
+                                                EFnParam {
+                                                    pat: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 5,
@@ -323,60 +309,63 @@ Ok(
                                                                 column: 23,
                                                             },
                                                         },
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            type_ann: None,
-                                            optional: false,
-                                        },
-                                    ],
-                                    body: Block {
-                                        span: 123..166,
-                                        stmts: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 6,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 6,
-                                                        column: 26,
-                                                    },
-                                                },
-                                                span: 141..151,
-                                                kind: BinaryExpr(
-                                                    BinaryExpr {
-                                                        op: Add,
-                                                        left: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 6,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 6,
-                                                                    column: 22,
+                                                        span: 120..121,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "y",
+                                                                mutable: false,
+                                                                span: 120..121,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 5,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 5,
+                                                                        column: 23,
+                                                                    },
                                                                 },
                                                             },
-                                                            span: 141..147,
-                                                            kind: Member(
-                                                                Member {
-                                                                    obj: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 6,
-                                                                                column: 16,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 6,
-                                                                                column: 20,
-                                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    optional: false,
+                                                },
+                                            ],
+                                            body: Block {
+                                                span: 123..166,
+                                                stmts: [
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 6,
+                                                                column: 16,
+                                                            },
+                                                            end: Position {
+                                                                line: 6,
+                                                                column: 26,
+                                                            },
+                                                        },
+                                                        span: 141..151,
+                                                        kind: BinaryExpr(
+                                                            BinaryExpr {
+                                                                op: Add,
+                                                                left: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 6,
+                                                                            column: 16,
                                                                         },
-                                                                        span: 141..145,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                        end: Position {
+                                                                            line: 6,
+                                                                            column: 22,
+                                                                        },
+                                                                    },
+                                                                    span: 141..147,
+                                                                    kind: Member(
+                                                                        Member {
+                                                                            obj: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 6,
@@ -388,45 +377,45 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 141..145,
-                                                                                name: "self",
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 6,
+                                                                                                column: 16,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 6,
+                                                                                                column: 20,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 141..145,
+                                                                                        name: "self",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    prop: Ident(
-                                                                        Ident {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 6,
-                                                                                    column: 21,
+                                                                            prop: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 6,
+                                                                                            column: 21,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 6,
+                                                                                            column: 22,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 146..147,
+                                                                                    name: "x",
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 6,
-                                                                                    column: 22,
-                                                                                },
-                                                                            },
-                                                                            span: 146..147,
-                                                                            name: "x",
+                                                                            ),
                                                                         },
                                                                     ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        right: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 6,
-                                                                    column: 25,
-                                                                },
-                                                                end: Position {
-                                                                    line: 6,
-                                                                    column: 26,
-                                                                },
-                                                            },
-                                                            span: 150..151,
-                                                            kind: Ident(
-                                                                Ident {
+                                                                right: Expr {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 6,
@@ -438,62 +427,59 @@ Ok(
                                                                         },
                                                                     },
                                                                     span: 150..151,
-                                                                    name: "y",
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 6,
+                                                                                    column: 25,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 6,
+                                                                                    column: 26,
+                                                                                },
+                                                                            },
+                                                                            span: 150..151,
+                                                                            name: "y",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                ],
                                             },
-                                        ],
-                                    },
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
-                                },
-                                is_static: false,
-                                is_mutating: false,
-                            },
-                        ),
-                        Method(
-                            ClassMethod {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 8,
-                                            column: 12,
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
                                         },
-                                        end: Position {
-                                            line: 8,
-                                            column: 15,
-                                        },
+                                        is_static: false,
+                                        is_mutating: false,
                                     },
-                                    span: 179..182,
-                                    name: "baz",
-                                },
-                                kind: Method,
-                                lambda: Lambda {
-                                    params: [
-                                        EFnParam {
-                                            pat: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 8,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 8,
-                                                        column: 24,
-                                                    },
+                                ),
+                                Method(
+                                    ClassMethod {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 8,
+                                                    column: 12,
                                                 },
-                                                span: 183..191,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "self",
-                                                        mutable: true,
-                                                        span: 183..191,
+                                                end: Position {
+                                                    line: 8,
+                                                    column: 15,
+                                                },
+                                            },
+                                            span: 179..182,
+                                            name: "baz",
+                                        },
+                                        kind: Method,
+                                        lambda: Lambda {
+                                            params: [
+                                                EFnParam {
+                                                    pat: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 8,
@@ -504,31 +490,31 @@ Ok(
                                                                 column: 24,
                                                             },
                                                         },
+                                                        span: 183..191,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "self",
+                                                                mutable: true,
+                                                                span: 183..191,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 8,
+                                                                        column: 16,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 8,
+                                                                        column: 24,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            type_ann: None,
-                                            optional: false,
-                                        },
-                                        EFnParam {
-                                            pat: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 8,
-                                                        column: 26,
-                                                    },
-                                                    end: Position {
-                                                        line: 8,
-                                                        column: 27,
-                                                    },
+                                                    type_ann: None,
+                                                    optional: false,
                                                 },
-                                                span: 193..194,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "x",
-                                                        mutable: false,
-                                                        span: 193..194,
+                                                EFnParam {
+                                                    pat: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 8,
@@ -539,59 +525,62 @@ Ok(
                                                                 column: 27,
                                                             },
                                                         },
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            type_ann: None,
-                                            optional: false,
-                                        },
-                                    ],
-                                    body: Block {
-                                        span: 196..239,
-                                        stmts: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 9,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 9,
-                                                        column: 26,
-                                                    },
-                                                },
-                                                span: 214..224,
-                                                kind: Assign(
-                                                    Assign {
-                                                        left: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 9,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 9,
-                                                                    column: 22,
+                                                        span: 193..194,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 193..194,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 8,
+                                                                        column: 26,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 8,
+                                                                        column: 27,
+                                                                    },
                                                                 },
                                                             },
-                                                            span: 214..220,
-                                                            kind: Member(
-                                                                Member {
-                                                                    obj: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 9,
-                                                                                column: 16,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 9,
-                                                                                column: 20,
-                                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    type_ann: None,
+                                                    optional: false,
+                                                },
+                                            ],
+                                            body: Block {
+                                                span: 196..239,
+                                                stmts: [
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 9,
+                                                                column: 16,
+                                                            },
+                                                            end: Position {
+                                                                line: 9,
+                                                                column: 26,
+                                                            },
+                                                        },
+                                                        span: 214..224,
+                                                        kind: Assign(
+                                                            Assign {
+                                                                left: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 9,
+                                                                            column: 16,
                                                                         },
-                                                                        span: 214..218,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                        end: Position {
+                                                                            line: 9,
+                                                                            column: 22,
+                                                                        },
+                                                                    },
+                                                                    span: 214..220,
+                                                                    kind: Member(
+                                                                        Member {
+                                                                            obj: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 9,
@@ -603,45 +592,45 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 214..218,
-                                                                                name: "self",
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 9,
+                                                                                                column: 16,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 9,
+                                                                                                column: 20,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 214..218,
+                                                                                        name: "self",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    prop: Ident(
-                                                                        Ident {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 9,
-                                                                                    column: 21,
+                                                                            prop: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 9,
+                                                                                            column: 21,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 9,
+                                                                                            column: 22,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 219..220,
+                                                                                    name: "x",
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 9,
-                                                                                    column: 22,
-                                                                                },
-                                                                            },
-                                                                            span: 219..220,
-                                                                            name: "x",
+                                                                            ),
                                                                         },
                                                                     ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        right: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 9,
-                                                                    column: 25,
-                                                                },
-                                                                end: Position {
-                                                                    line: 9,
-                                                                    column: 26,
-                                                                },
-                                                            },
-                                                            span: 223..224,
-                                                            kind: Ident(
-                                                                Ident {
+                                                                right: Expr {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 9,
@@ -653,29 +642,44 @@ Ok(
                                                                         },
                                                                     },
                                                                     span: 223..224,
-                                                                    name: "x",
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 9,
+                                                                                    column: 25,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 9,
+                                                                                    column: 26,
+                                                                                },
+                                                                            },
+                                                                            span: 223..224,
+                                                                            name: "x",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        op: Eq,
+                                                                op: Eq,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                ],
                                             },
-                                        ],
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
+                                        },
+                                        is_static: false,
+                                        is_mutating: false,
                                     },
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
-                                },
-                                is_static: false,
-                                is_mutating: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                                ),
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { a: number = 5; }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,115 +17,119 @@ Ok(
                     },
                 },
                 span: 0..28,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Prop(
-                            ClassProp {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 13,
-                                        },
-                                    },
-                                    span: 12..13,
-                                    name: "a",
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
                                 },
-                                value: Some(
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 24,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                        },
-                                        span: 24..25,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 24,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 25,
-                                                        },
-                                                    },
-                                                    span: 24..25,
-                                                    value: "5",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ),
-                                type_ann: Some(
-                                    TypeAnn {
-                                        kind: Keyword(
-                                            KeywordType {
-                                                keyword: Number,
-                                            },
-                                        ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 15,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 21,
-                                            },
-                                        },
-                                        span: 15..21,
-                                        inferred_type: None,
-                                    },
-                                ),
-                                is_static: false,
-                                is_optional: false,
-                                is_mutable: false,
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
                             },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                            span: 6..9,
+                            name: "Foo",
+                        },
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Prop(
+                                    ClassProp {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 12,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 13,
+                                                },
+                                            },
+                                            span: 12..13,
+                                            name: "a",
+                                        },
+                                        value: Some(
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 24,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 25,
+                                                    },
+                                                },
+                                                span: 24..25,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 24..25,
+                                                            value: "5",
+                                                        },
+                                                    ),
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        type_ann: Some(
+                                            TypeAnn {
+                                                kind: Keyword(
+                                                    KeywordType {
+                                                        keyword: Number,
+                                                    },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                },
+                                                span: 15..21,
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        is_static: false,
+                                        is_optional: false,
+                                        is_mutable: false,
+                                    },
+                                ),
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { a = 5; }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,95 +17,99 @@ Ok(
                     },
                 },
                 span: 0..20,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Prop(
-                            ClassProp {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 13,
-                                        },
-                                    },
-                                    span: 12..13,
-                                    name: "a",
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
                                 },
-                                value: Some(
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
-                                        },
-                                        span: 16..17,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 16,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                    },
-                                                    span: 16..17,
-                                                    value: "5",
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
+                        },
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Prop(
+                                    ClassProp {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 12,
                                                 },
-                                            ),
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 13,
+                                                },
+                                            },
+                                            span: 12..13,
+                                            name: "a",
+                                        },
+                                        value: Some(
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 17,
+                                                    },
+                                                },
+                                                span: 16..17,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 17,
+                                                                },
+                                                            },
+                                                            span: 16..17,
+                                                            value: "5",
+                                                        },
+                                                    ),
+                                                ),
+                                                inferred_type: None,
+                                            },
                                         ),
-                                        inferred_type: None,
+                                        type_ann: None,
+                                        is_static: false,
+                                        is_optional: false,
+                                        is_mutable: false,
                                     },
                                 ),
-                                type_ann: None,
-                                is_static: false,
-                                is_optional: false,
-                                is_mutable: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { static a: number; }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,82 +17,86 @@ Ok(
                     },
                 },
                 span: 0..31,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Prop(
-                            ClassProp {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 19,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 20,
-                                        },
-                                    },
-                                    span: 19..20,
-                                    name: "a",
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
                                 },
-                                value: None,
-                                type_ann: Some(
-                                    TypeAnn {
-                                        kind: Keyword(
-                                            KeywordType {
-                                                keyword: Number,
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
+                        },
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Prop(
+                                    ClassProp {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 19,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 20,
+                                                },
+                                            },
+                                            span: 19..20,
+                                            name: "a",
+                                        },
+                                        value: None,
+                                        type_ann: Some(
+                                            TypeAnn {
+                                                kind: Keyword(
+                                                    KeywordType {
+                                                        keyword: Number,
+                                                    },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 22,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 28,
+                                                    },
+                                                },
+                                                span: 22..28,
+                                                inferred_type: None,
                                             },
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 22,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 28,
-                                            },
-                                        },
-                                        span: 22..28,
-                                        inferred_type: None,
+                                        is_static: true,
+                                        is_optional: false,
+                                        is_mutable: false,
                                     },
                                 ),
-                                is_static: true,
-                                is_optional: false,
-                                is_mutable: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-5.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { foo() {} }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,70 +17,74 @@ Ok(
                     },
                 },
                 span: 0..22,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 9,
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Method(
+                                    ClassMethod {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 12,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 15,
+                                                },
+                                            },
+                                            span: 12..15,
+                                            name: "foo",
+                                        },
+                                        kind: Method,
+                                        lambda: Lambda {
+                                            params: [],
+                                            body: Block {
+                                                span: 18..20,
+                                                stmts: [],
+                                            },
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
+                                        },
+                                        is_static: false,
+                                        is_mutating: false,
+                                    },
+                                ),
+                            ],
+                            type_params: None,
                         },
                     },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Method(
-                            ClassMethod {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 15,
-                                        },
-                                    },
-                                    span: 12..15,
-                                    name: "foo",
-                                },
-                                kind: Method,
-                                lambda: Lambda {
-                                    params: [],
-                                    body: Block {
-                                        span: 18..20,
-                                        stmts: [],
-                                    },
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
-                                },
-                                is_static: false,
-                                is_mutating: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-6.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { foo(): string {} }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,90 +17,94 @@ Ok(
                     },
                 },
                 span: 0..30,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Method(
-                            ClassMethod {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 15,
-                                        },
-                                    },
-                                    span: 12..15,
-                                    name: "foo",
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
                                 },
-                                kind: Method,
-                                lambda: Lambda {
-                                    params: [],
-                                    body: Block {
-                                        span: 26..28,
-                                        stmts: [],
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
+                        },
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
                                     },
-                                    is_async: false,
-                                    return_type: Some(
-                                        TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: String,
-                                                },
-                                            ),
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Method(
+                                    ClassMethod {
+                                        key: Ident {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 19,
+                                                    column: 12,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 25,
+                                                    column: 15,
                                                 },
                                             },
-                                            span: 19..25,
-                                            inferred_type: None,
+                                            span: 12..15,
+                                            name: "foo",
                                         },
-                                    ),
-                                    type_params: None,
-                                },
-                                is_static: false,
-                                is_mutating: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                                        kind: Method,
+                                        lambda: Lambda {
+                                            params: [],
+                                            body: Block {
+                                                span: 26..28,
+                                                stmts: [],
+                                            },
+                                            is_async: false,
+                                            return_type: Some(
+                                                TypeAnn {
+                                                    kind: Keyword(
+                                                        KeywordType {
+                                                            keyword: String,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 19,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                    },
+                                                    span: 19..25,
+                                                    inferred_type: None,
+                                                },
+                                            ),
+                                            type_params: None,
+                                        },
+                                        is_static: false,
+                                        is_mutating: false,
+                                    },
+                                ),
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-7.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { static foo(): string {} }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,90 +17,94 @@ Ok(
                     },
                 },
                 span: 0..37,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Method(
-                            ClassMethod {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 19,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 22,
-                                        },
-                                    },
-                                    span: 19..22,
-                                    name: "foo",
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
                                 },
-                                kind: Method,
-                                lambda: Lambda {
-                                    params: [],
-                                    body: Block {
-                                        span: 33..35,
-                                        stmts: [],
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
+                        },
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
                                     },
-                                    is_async: false,
-                                    return_type: Some(
-                                        TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: String,
-                                                },
-                                            ),
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Method(
+                                    ClassMethod {
+                                        key: Ident {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 26,
+                                                    column: 19,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 32,
+                                                    column: 22,
                                                 },
                                             },
-                                            span: 26..32,
-                                            inferred_type: None,
+                                            span: 19..22,
+                                            name: "foo",
                                         },
-                                    ),
-                                    type_params: None,
-                                },
-                                is_static: true,
-                                is_mutating: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                                        kind: Method,
+                                        lambda: Lambda {
+                                            params: [],
+                                            body: Block {
+                                                span: 33..35,
+                                                stmts: [],
+                                            },
+                                            is_async: false,
+                                            return_type: Some(
+                                                TypeAnn {
+                                                    kind: Keyword(
+                                                        KeywordType {
+                                                            keyword: String,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 26,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 26..32,
+                                                    inferred_type: None,
+                                                },
+                                            ),
+                                            type_params: None,
+                                        },
+                                        is_static: true,
+                                        is_mutating: false,
+                                    },
+                                ),
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-8.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { get foo() {} }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,70 +17,74 @@ Ok(
                     },
                 },
                 span: 0..26,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 9,
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Method(
+                                    ClassMethod {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 19,
+                                                },
+                                            },
+                                            span: 16..19,
+                                            name: "foo",
+                                        },
+                                        kind: Getter,
+                                        lambda: Lambda {
+                                            params: [],
+                                            body: Block {
+                                                span: 22..24,
+                                                stmts: [],
+                                            },
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
+                                        },
+                                        is_static: false,
+                                        is_mutating: false,
+                                    },
+                                ),
+                            ],
+                            type_params: None,
                         },
                     },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Method(
-                            ClassMethod {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 19,
-                                        },
-                                    },
-                                    span: 16..19,
-                                    name: "foo",
-                                },
-                                kind: Getter,
-                                lambda: Lambda {
-                                    params: [],
-                                    body: Block {
-                                        span: 22..24,
-                                        stmts: [],
-                                    },
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
-                                },
-                                is_static: false,
-                                is_mutating: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-9.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { set foo(x) {} }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,73 +17,59 @@ Ok(
                     },
                 },
                 span: 0..27,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Method(
-                            ClassMethod {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 19,
-                                        },
-                                    },
-                                    span: 16..19,
-                                    name: "foo",
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
                                 },
-                                kind: Setter,
-                                lambda: Lambda {
-                                    params: [
-                                        EFnParam {
-                                            pat: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 20,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 21,
-                                                    },
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
+                        },
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Method(
+                                    ClassMethod {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
                                                 },
-                                                span: 20..21,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "x",
-                                                        mutable: false,
-                                                        span: 20..21,
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 19,
+                                                },
+                                            },
+                                            span: 16..19,
+                                            name: "foo",
+                                        },
+                                        kind: Setter,
+                                        lambda: Lambda {
+                                            params: [
+                                                EFnParam {
+                                                    pat: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
@@ -94,29 +80,47 @@ Ok(
                                                                 column: 21,
                                                             },
                                                         },
+                                                        span: 20..21,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "x",
+                                                                mutable: false,
+                                                                span: 20..21,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 20,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 21,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                    type_ann: None,
+                                                    optional: false,
+                                                },
+                                            ],
+                                            body: Block {
+                                                span: 23..25,
+                                                stmts: [],
                                             },
-                                            type_ann: None,
-                                            optional: false,
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
                                         },
-                                    ],
-                                    body: Block {
-                                        span: 23..25,
-                                        stmts: [],
+                                        is_static: false,
+                                        is_mutating: false,
                                     },
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
-                                },
-                                is_static: false,
-                                is_mutating: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                                ),
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes.snap
@@ -5,7 +5,7 @@ expression: "parse(\"class Foo { a: number; }\")"
 Ok(
     Program {
         body: [
-            ClassDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,82 +17,86 @@ Ok(
                     },
                 },
                 span: 0..24,
-                ident: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 6..9,
-                    name: "Foo",
-                },
-                class: Class {
-                    ident: Ident {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 6..9,
-                        name: "Foo",
-                    },
-                    body: [
-                        Prop(
-                            ClassProp {
-                                key: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 13,
-                                        },
-                                    },
-                                    span: 12..13,
-                                    name: "a",
+                kind: ClassDecl(
+                    ClassDecl {
+                        ident: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 6,
                                 },
-                                value: None,
-                                type_ann: Some(
-                                    TypeAnn {
-                                        kind: Keyword(
-                                            KeywordType {
-                                                keyword: Number,
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                            },
+                            span: 6..9,
+                            name: "Foo",
+                        },
+                        class: Class {
+                            ident: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 6,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 6..9,
+                                name: "Foo",
+                            },
+                            body: [
+                                Prop(
+                                    ClassProp {
+                                        key: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 12,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 13,
+                                                },
+                                            },
+                                            span: 12..13,
+                                            name: "a",
+                                        },
+                                        value: None,
+                                        type_ann: Some(
+                                            TypeAnn {
+                                                kind: Keyword(
+                                                    KeywordType {
+                                                        keyword: Number,
+                                                    },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                },
+                                                span: 15..21,
+                                                inferred_type: None,
                                             },
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 15,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 21,
-                                            },
-                                        },
-                                        span: 15..21,
-                                        inferred_type: None,
+                                        is_static: false,
+                                        is_optional: false,
+                                        is_mutable: false,
                                     },
                                 ),
-                                is_static: false,
-                                is_optional: false,
-                                is_mutable: false,
-                            },
-                        ),
-                    ],
-                    type_params: None,
-                },
+                            ],
+                            type_params: None,
+                        },
+                    },
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__conditional_types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__conditional_types-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Flatten<Type> = Type extends Array<infer Item> ? Item 
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,163 +17,167 @@ Ok(
                     },
                 },
                 span: 0..66,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 12,
-                        },
-                    },
-                    span: 5..12,
-                    name: "Flatten",
-                },
-                type_ann: TypeAnn {
-                    kind: Conditional(
-                        ConditionalType {
-                            check_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "Type",
-                                        type_args: None,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 21,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 25,
-                                    },
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                span: 21..25,
-                                inferred_type: None,
+                                end: Position {
+                                    line: 0,
+                                    column: 12,
+                                },
                             },
-                            extends_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "Array",
-                                        type_args: Some(
-                                            [
-                                                TypeAnn {
-                                                    kind: Infer(
-                                                        InferType {
-                                                            name: "Item",
-                                                        },
-                                                    ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 40,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 50,
-                                                        },
-                                                    },
-                                                    span: 40..50,
-                                                    inferred_type: None,
-                                                },
-                                            ],
+                            span: 5..12,
+                            name: "Flatten",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Conditional(
+                                ConditionalType {
+                                    check_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "Type",
+                                                type_args: None,
+                                            },
                                         ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 21,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 25,
+                                            },
+                                        },
+                                        span: 21..25,
+                                        inferred_type: None,
                                     },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 34,
+                                    extends_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "Array",
+                                                type_args: Some(
+                                                    [
+                                                        TypeAnn {
+                                                            kind: Infer(
+                                                                InferType {
+                                                                    name: "Item",
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 40,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 50,
+                                                                },
+                                                            },
+                                                            span: 40..50,
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                ),
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 34,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 51,
+                                            },
+                                        },
+                                        span: 34..51,
+                                        inferred_type: None,
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 51,
+                                    true_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "Item",
+                                                type_args: None,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 54,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 58,
+                                            },
+                                        },
+                                        span: 54..58,
+                                        inferred_type: None,
+                                    },
+                                    false_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "Type",
+                                                type_args: None,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 61,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 65,
+                                            },
+                                        },
+                                        span: 61..65,
+                                        inferred_type: None,
                                     },
                                 },
-                                span: 34..51,
-                                inferred_type: None,
-                            },
-                            true_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "Item",
-                                        type_args: None,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 54,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 58,
-                                    },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 21,
                                 },
-                                span: 54..58,
-                                inferred_type: None,
+                                end: Position {
+                                    line: 0,
+                                    column: 65,
+                                },
                             },
-                            false_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
+                            span: 21..65,
+                            inferred_type: None,
+                        },
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 13..17,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 13,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 17,
+                                            },
+                                        },
+                                        span: 13..17,
                                         name: "Type",
-                                        type_args: None,
                                     },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 61,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 65,
-                                    },
+                                    constraint: None,
+                                    default: None,
                                 },
-                                span: 61..65,
-                                inferred_type: None,
-                            },
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 21,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 65,
-                        },
+                            ],
+                        ),
                     },
-                    span: 21..65,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 13..17,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 13,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 17,
-                                    },
-                                },
-                                span: 13..17,
-                                name: "Type",
-                            },
-                            constraint: None,
-                            default: None,
-                        },
-                    ],
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__conditional_types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__conditional_types-3.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"type GetReturnType<Type> = Type extends (...args: never[]
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,80 +17,66 @@ Ok(
                     },
                 },
                 span: 0..124,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 18,
-                        },
-                    },
-                    span: 5..18,
-                    name: "GetReturnType",
-                },
-                type_ann: TypeAnn {
-                    kind: Conditional(
-                        ConditionalType {
-                            check_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "Type",
-                                        type_args: None,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 27,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 31,
-                                    },
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                span: 27..31,
-                                inferred_type: None,
+                                end: Position {
+                                    line: 0,
+                                    column: 18,
+                                },
                             },
-                            extends_type: TypeAnn {
-                                kind: Lam(
-                                    LamType {
-                                        params: [
-                                            TypeAnnFnParam {
-                                                pat: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 41,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 48,
-                                                        },
-                                                    },
-                                                    span: 41..48,
-                                                    kind: Rest(
-                                                        RestPat {
-                                                            arg: Pattern {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 44,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 48,
-                                                                    },
+                            span: 5..18,
+                            name: "GetReturnType",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Conditional(
+                                ConditionalType {
+                                    check_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "Type",
+                                                type_args: None,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 27,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 31,
+                                            },
+                                        },
+                                        span: 27..31,
+                                        inferred_type: None,
+                                    },
+                                    extends_type: TypeAnn {
+                                        kind: Lam(
+                                            LamType {
+                                                params: [
+                                                    TypeAnnFnParam {
+                                                        pat: Pattern {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 41,
                                                                 },
-                                                                span: 44..48,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "args",
-                                                                        mutable: false,
-                                                                        span: 44..48,
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 48,
+                                                                },
+                                                            },
+                                                            span: 41..48,
+                                                            kind: Rest(
+                                                                RestPat {
+                                                                    arg: Pattern {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -101,165 +87,183 @@ Ok(
                                                                                 column: 48,
                                                                             },
                                                                         },
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                type_ann: TypeAnn {
-                                                    kind: Array(
-                                                        ArrayType {
-                                                            elem_type: TypeAnn {
-                                                                kind: Keyword(
-                                                                    KeywordType {
-                                                                        keyword: Never,
-                                                                    },
-                                                                ),
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 50,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 55,
+                                                                        span: 44..48,
+                                                                        kind: Ident(
+                                                                            BindingIdent {
+                                                                                name: "args",
+                                                                                mutable: false,
+                                                                                span: 44..48,
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 44,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 48,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
                                                                 },
-                                                                span: 50..55,
-                                                                inferred_type: None,
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        type_ann: TypeAnn {
+                                                            kind: Array(
+                                                                ArrayType {
+                                                                    elem_type: TypeAnn {
+                                                                        kind: Keyword(
+                                                                            KeywordType {
+                                                                                keyword: Never,
+                                                                            },
+                                                                        ),
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 50,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 55,
+                                                                            },
+                                                                        },
+                                                                        span: 50..55,
+                                                                        inferred_type: None,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 50,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 57,
+                                                                },
                                                             },
+                                                            span: 50..57,
+                                                            inferred_type: None,
+                                                        },
+                                                        optional: false,
+                                                    },
+                                                ],
+                                                ret: TypeAnn {
+                                                    kind: Infer(
+                                                        InferType {
+                                                            name: "Return",
                                                         },
                                                     ),
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 50,
+                                                            column: 62,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 57,
+                                                            column: 74,
                                                         },
                                                     },
-                                                    span: 50..57,
+                                                    span: 62..74,
                                                     inferred_type: None,
                                                 },
-                                                optional: false,
+                                                type_params: None,
                                             },
-                                        ],
-                                        ret: TypeAnn {
-                                            kind: Infer(
-                                                InferType {
-                                                    name: "Return",
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 62,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 74,
-                                                },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 40,
                                             },
-                                            span: 62..74,
-                                            inferred_type: None,
+                                            end: Position {
+                                                line: 0,
+                                                column: 74,
+                                            },
                                         },
-                                        type_params: None,
+                                        span: 40..74,
+                                        inferred_type: None,
                                     },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 40,
+                                    true_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "Return",
+                                                type_args: None,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 1,
+                                                column: 18,
+                                            },
+                                            end: Position {
+                                                line: 1,
+                                                column: 24,
+                                            },
+                                        },
+                                        span: 93..99,
+                                        inferred_type: None,
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 74,
-                                    },
-                                },
-                                span: 40..74,
-                                inferred_type: None,
-                            },
-                            true_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "Return",
-                                        type_args: None,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 18,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 24,
-                                    },
-                                },
-                                span: 93..99,
-                                inferred_type: None,
-                            },
-                            false_type: TypeAnn {
-                                kind: Keyword(
-                                    KeywordType {
-                                        keyword: Never,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 2,
-                                        column: 18,
-                                    },
-                                    end: Position {
-                                        line: 2,
-                                        column: 23,
+                                    false_type: TypeAnn {
+                                        kind: Keyword(
+                                            KeywordType {
+                                                keyword: Never,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 2,
+                                                column: 18,
+                                            },
+                                            end: Position {
+                                                line: 2,
+                                                column: 23,
+                                            },
+                                        },
+                                        span: 118..123,
+                                        inferred_type: None,
                                     },
                                 },
-                                span: 118..123,
-                                inferred_type: None,
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 27,
+                                },
+                                end: Position {
+                                    line: 2,
+                                    column: 23,
+                                },
                             },
+                            span: 27..123,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 27,
-                        },
-                        end: Position {
-                            line: 2,
-                            column: 23,
-                        },
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 19..23,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 19,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 23,
+                                            },
+                                        },
+                                        span: 19..23,
+                                        name: "Type",
+                                    },
+                                    constraint: None,
+                                    default: None,
+                                },
+                            ],
+                        ),
                     },
-                    span: 27..123,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 19..23,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 19,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 23,
-                                    },
-                                },
-                                span: 19..23,
-                                name: "Type",
-                            },
-                            constraint: None,
-                            default: None,
-                        },
-                    ],
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__conditional_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__conditional_types.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"type GetTypeName<T extends number | string> = T extends n
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,223 +17,227 @@ Ok(
                     },
                 },
                 span: 0..85,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 16,
-                        },
-                    },
-                    span: 5..16,
-                    name: "GetTypeName",
-                },
-                type_ann: TypeAnn {
-                    kind: Conditional(
-                        ConditionalType {
-                            check_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "T",
-                                        type_args: None,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 46,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 47,
-                                    },
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                span: 46..47,
-                                inferred_type: None,
-                            },
-                            extends_type: TypeAnn {
-                                kind: Keyword(
-                                    KeywordType {
-                                        keyword: Number,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 56,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 62,
-                                    },
+                                end: Position {
+                                    line: 0,
+                                    column: 16,
                                 },
-                                span: 56..62,
-                                inferred_type: None,
                             },
-                            true_type: TypeAnn {
-                                kind: Lit(
-                                    Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 65,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 73,
-                                                },
+                            span: 5..16,
+                            name: "GetTypeName",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Conditional(
+                                ConditionalType {
+                                    check_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "T",
+                                                type_args: None,
                                             },
-                                            span: 65..73,
-                                            value: "number",
-                                        },
-                                    ),
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 65,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 73,
-                                    },
-                                },
-                                span: 65..73,
-                                inferred_type: None,
-                            },
-                            false_type: TypeAnn {
-                                kind: Lit(
-                                    Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 76,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 84,
-                                                },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 46,
                                             },
-                                            span: 76..84,
-                                            value: "string",
+                                            end: Position {
+                                                line: 0,
+                                                column: 47,
+                                            },
                                         },
-                                    ),
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 76,
+                                        span: 46..47,
+                                        inferred_type: None,
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 84,
+                                    extends_type: TypeAnn {
+                                        kind: Keyword(
+                                            KeywordType {
+                                                keyword: Number,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 56,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 62,
+                                            },
+                                        },
+                                        span: 56..62,
+                                        inferred_type: None,
                                     },
-                                },
-                                span: 76..84,
-                                inferred_type: None,
-                            },
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 46,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 84,
-                        },
-                    },
-                    span: 46..84,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 17..42,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 17,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 18,
-                                    },
-                                },
-                                span: 17..18,
-                                name: "T",
-                            },
-                            constraint: Some(
-                                TypeAnn {
-                                    kind: Union(
-                                        UnionType {
-                                            types: [
-                                                TypeAnn {
-                                                    kind: Keyword(
-                                                        KeywordType {
-                                                            keyword: Number,
-                                                        },
-                                                    ),
+                                    true_type: TypeAnn {
+                                        kind: Lit(
+                                            Str(
+                                                Str {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 27,
+                                                            column: 65,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 33,
+                                                            column: 73,
                                                         },
                                                     },
-                                                    span: 27..33,
-                                                    inferred_type: None,
+                                                    span: 65..73,
+                                                    value: "number",
                                                 },
-                                                TypeAnn {
-                                                    kind: Keyword(
-                                                        KeywordType {
-                                                            keyword: String,
-                                                        },
-                                                    ),
+                                            ),
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 65,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 73,
+                                            },
+                                        },
+                                        span: 65..73,
+                                        inferred_type: None,
+                                    },
+                                    false_type: TypeAnn {
+                                        kind: Lit(
+                                            Str(
+                                                Str {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 36,
+                                                            column: 76,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 42,
+                                                            column: 84,
                                                         },
                                                     },
-                                                    span: 36..42,
-                                                    inferred_type: None,
+                                                    span: 76..84,
+                                                    value: "string",
                                                 },
-                                            ],
+                                            ),
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 76,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 84,
+                                            },
                                         },
-                                    ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 27,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 42,
-                                        },
+                                        span: 76..84,
+                                        inferred_type: None,
                                     },
-                                    span: 27..42,
-                                    inferred_type: None,
                                 },
                             ),
-                            default: None,
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 46,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 84,
+                                },
+                            },
+                            span: 46..84,
+                            inferred_type: None,
                         },
-                    ],
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 17..42,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 17,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 18,
+                                            },
+                                        },
+                                        span: 17..18,
+                                        name: "T",
+                                    },
+                                    constraint: Some(
+                                        TypeAnn {
+                                            kind: Union(
+                                                UnionType {
+                                                    types: [
+                                                        TypeAnn {
+                                                            kind: Keyword(
+                                                                KeywordType {
+                                                                    keyword: Number,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 27,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 33,
+                                                                },
+                                                            },
+                                                            span: 27..33,
+                                                            inferred_type: None,
+                                                        },
+                                                        TypeAnn {
+                                                            kind: Keyword(
+                                                                KeywordType {
+                                                                    keyword: String,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 36,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 42,
+                                                                },
+                                                            },
+                                                            span: 36..42,
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 27,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 42,
+                                                },
+                                            },
+                                            span: 27..42,
+                                            inferred_type: None,
+                                        },
+                                    ),
+                                    default: None,
+                                },
+                            ],
+                        ),
+                    },
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let x = (a, b) => a + b;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..24,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,45 +30,45 @@ Ok(
                                     column: 5,
                                 },
                             },
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 4..5,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 23,
-                            },
-                        },
-                        span: 8..23,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                            },
-                                            span: 9..10,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                    span: 9..10,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 8,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 23,
+                                    },
+                                },
+                                span: 8..23,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -93,31 +79,31 @@ Ok(
                                                             column: 10,
                                                         },
                                                     },
+                                                    span: 9..10,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                            span: 9..10,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 9,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 10,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 13,
-                                                },
+                                                type_ann: None,
+                                                optional: false,
                                             },
-                                            span: 12..13,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: false,
-                                                    span: 12..13,
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -128,46 +114,49 @@ Ok(
                                                             column: 13,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 18..23,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 23,
-                                                },
-                                            },
-                                            span: 18..23,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
+                                                    span: 12..13,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: false,
+                                                            span: 12..13,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 12,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 13,
+                                                                },
                                                             },
                                                         },
-                                                        span: 18..19,
-                                                        kind: Ident(
-                                                            Ident {
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 18..23,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 18,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 23,
+                                                        },
+                                                    },
+                                                    span: 18..23,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -179,25 +168,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 18..19,
-                                                                name: "a",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
+                                                                        },
+                                                                        span: 18..19,
+                                                                        name: "a",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                        },
-                                                        span: 22..23,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -209,26 +198,41 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 22..23,
-                                                                name: "b",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 22,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 23,
+                                                                            },
+                                                                        },
+                                                                        span: 22..23,
+                                                                        name: "b",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = do {let x = 5; x};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..28,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,60 +30,60 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 27,
-                            },
-                        },
-                        span: 10..27,
-                        kind: DoExpr(
-                            DoExpr {
-                                body: Block {
-                                    span: 13..27,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 14..24,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 27,
+                                    },
+                                },
+                                span: 10..27,
+                                kind: DoExpr(
+                                    DoExpr {
+                                        body: Block {
+                                            span: 13..27,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 14,
                                                         },
-                                                        span: 18..19,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "x",
-                                                                mutable: false,
-                                                                span: 18..19,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 24,
+                                                        },
+                                                    },
+                                                    span: 14..24,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -108,61 +94,64 @@ Ok(
                                                                         column: 19,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                        },
-                                                        span: 22..23,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 23,
+                                                                span: 18..19,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "x",
+                                                                        mutable: false,
+                                                                        span: 18..19,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
                                                                         },
                                                                     },
-                                                                    span: 22..23,
-                                                                    value: "5",
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            type_ann: None,
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
                                                                 },
-                                                            ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                                span: 22..23,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 22,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                            span: 22..23,
+                                                                            value: "5",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 26,
-                                                },
-                                            },
-                                            span: 25..26,
-                                            kind: Ident(
-                                                Ident {
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -174,19 +163,34 @@ Ok(
                                                         },
                                                     },
                                                     span: 25..26,
-                                                    name: "x",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 26,
+                                                                },
+                                                            },
+                                                            span: 25..26,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let rec f = () => f();\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..22,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 8..9,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "f",
-                            mutable: false,
-                            span: 8..9,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,27 +30,12 @@ Ok(
                                     column: 9,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 21,
-                            },
-                        },
-                        span: 8..21,
-                        kind: Fix(
-                            Fix {
-                                expr: Expr {
+                            span: 8..9,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "f",
+                                    mutable: false,
+                                    span: 8..9,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
@@ -72,31 +43,46 @@ Ok(
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 21,
+                                            column: 9,
                                         },
                                     },
-                                    span: 8..21,
-                                    kind: Lambda(
-                                        Lambda {
-                                            params: [
-                                                EFnParam {
-                                                    pat: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 8,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 9,
-                                                            },
-                                                        },
-                                                        span: 8..9,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "f",
-                                                                mutable: false,
-                                                                span: 8..9,
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 8,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 21,
+                                    },
+                                },
+                                span: 8..21,
+                                kind: Fix(
+                                    Fix {
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 21,
+                                                },
+                                            },
+                                            span: 8..21,
+                                            kind: Lambda(
+                                                Lambda {
+                                                    params: [
+                                                        EFnParam {
+                                                            pat: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -107,63 +93,66 @@ Ok(
                                                                         column: 9,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    optional: false,
-                                                },
-                                            ],
-                                            body: Block {
-                                                span: 12..21,
-                                                stmts: [
-                                                    Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 21,
-                                                            },
-                                                        },
-                                                        span: 12..21,
-                                                        kind: Lambda(
-                                                            Lambda {
-                                                                params: [],
-                                                                body: Block {
-                                                                    span: 18..21,
-                                                                    stmts: [
-                                                                        Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 18,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 21,
-                                                                                },
+                                                                span: 8..9,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "f",
+                                                                        mutable: false,
+                                                                        span: 8..9,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 8,
                                                                             },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 9,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            type_ann: None,
+                                                            optional: false,
+                                                        },
+                                                    ],
+                                                    body: Block {
+                                                        span: 12..21,
+                                                        stmts: [
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 21,
+                                                                    },
+                                                                },
+                                                                span: 12..21,
+                                                                kind: Lambda(
+                                                                    Lambda {
+                                                                        params: [],
+                                                                        body: Block {
                                                                             span: 18..21,
-                                                                            kind: App(
-                                                                                App {
-                                                                                    lam: Expr {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 18,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 19,
-                                                                                            },
+                                                                            stmts: [
+                                                                                Expr {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 18,
                                                                                         },
-                                                                                        span: 18..19,
-                                                                                        kind: Ident(
-                                                                                            Ident {
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 21,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 18..21,
+                                                                                    kind: App(
+                                                                                        App {
+                                                                                            lam: Expr {
                                                                                                 loc: SourceLocation {
                                                                                                     start: Position {
                                                                                                         line: 0,
@@ -175,41 +164,56 @@ Ok(
                                                                                                     },
                                                                                                 },
                                                                                                 span: 18..19,
-                                                                                                name: "f",
+                                                                                                kind: Ident(
+                                                                                                    Ident {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 0,
+                                                                                                                column: 18,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 0,
+                                                                                                                column: 19,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 18..19,
+                                                                                                        name: "f",
+                                                                                                    },
+                                                                                                ),
+                                                                                                inferred_type: None,
                                                                                             },
-                                                                                        ),
-                                                                                        inferred_type: None,
-                                                                                    },
-                                                                                    args: [],
-                                                                                    type_args: None,
+                                                                                            args: [],
+                                                                                            type_args: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
+                                                                            ],
                                                                         },
-                                                                    ],
-                                                                },
-                                                                is_async: false,
-                                                                return_type: None,
-                                                                type_params: None,
+                                                                        is_async: false,
+                                                                        return_type: None,
+                                                                        type_params: None,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
+                                                        ],
                                                     },
-                                                ],
-                                            },
-                                            is_async: false,
-                                            return_type: None,
-                                            type_params: None,
+                                                    is_async: false,
+                                                    return_type: None,
+                                                    type_params: None,
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-5.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"let mut msg: string = \"hello, world\";\"#)"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..37,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
-                    },
-                    span: 4..11,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "msg",
-                            mutable: true,
-                            span: 4..11,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,66 +30,84 @@ Ok(
                                     column: 11,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Keyword(
-                            KeywordType {
-                                keyword: String,
-                            },
-                        ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 13,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 19,
-                            },
-                        },
-                        span: 13..19,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 36,
-                            },
-                        },
-                        span: 22..36,
-                        kind: Lit(
-                            Str(
-                                Str {
+                            span: 4..11,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "msg",
+                                    mutable: true,
+                                    span: 4..11,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 22,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 36,
+                                            column: 11,
                                         },
                                     },
-                                    span: 22..36,
-                                    value: "hello, world",
                                 },
                             ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Keyword(
+                                    KeywordType {
+                                        keyword: String,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 13,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 19,
+                                    },
+                                },
+                                span: 13..19,
+                                inferred_type: None,
+                            },
                         ),
-                        inferred_type: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 36,
+                                    },
+                                },
+                                span: 22..36,
+                                kind: Lit(
+                                    Str(
+                                        Str {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 36,
+                                                },
+                                            },
+                                            span: 22..36,
+                                            value: "hello, world",
+                                        },
+                                    ),
+                                ),
+                                inferred_type: None,
+                            },
+                        ),
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-6.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"\n            let foo = () => {\n                let mut 
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 13..119,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
-                    span: 17..20,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 17..20,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,61 +30,61 @@ Ok(
                                     column: 19,
                                 },
                             },
+                            span: 17..20,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 17..20,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 1,
+                                            column: 16,
+                                        },
+                                        end: Position {
+                                            line: 1,
+                                            column: 19,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 4,
-                                column: 13,
-                            },
-                        },
-                        span: 23..118,
-                        kind: Lambda(
-                            Lambda {
-                                params: [],
-                                body: Block {
-                                    span: 29..118,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 53,
-                                                },
-                                            },
-                                            span: 47..84,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 20,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 27,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 4,
+                                        column: 13,
+                                    },
+                                },
+                                span: 23..118,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [],
+                                        body: Block {
+                                            span: 29..118,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 16,
                                                         },
-                                                        span: 51..58,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "msg",
-                                                                mutable: true,
-                                                                span: 51..58,
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 53,
+                                                        },
+                                                    },
+                                                    span: 47..84,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 2,
@@ -109,81 +95,84 @@ Ok(
                                                                         column: 27,
                                                                     },
                                                                 },
+                                                                span: 51..58,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "msg",
+                                                                        mutable: true,
+                                                                        span: 51..58,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 20,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 27,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: Some(
-                                                        TypeAnn {
-                                                            kind: Keyword(
-                                                                KeywordType {
-                                                                    keyword: String,
-                                                                },
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 29,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 35,
-                                                                },
-                                                            },
-                                                            span: 60..66,
-                                                            inferred_type: None,
-                                                        },
-                                                    ),
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 38,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 52,
-                                                            },
-                                                        },
-                                                        span: 69..83,
-                                                        kind: Lit(
-                                                            Str(
-                                                                Str {
+                                                            type_ann: Some(
+                                                                TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: String,
+                                                                        },
+                                                                    ),
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 2,
-                                                                            column: 38,
+                                                                            column: 29,
                                                                         },
                                                                         end: Position {
                                                                             line: 2,
-                                                                            column: 52,
+                                                                            column: 35,
                                                                         },
                                                                     },
-                                                                    span: 69..83,
-                                                                    value: "hello, world",
+                                                                    span: 60..66,
+                                                                    inferred_type: None,
                                                                 },
                                                             ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 38,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 52,
+                                                                    },
+                                                                },
+                                                                span: 69..83,
+                                                                kind: Lit(
+                                                                    Str(
+                                                                        Str {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 2,
+                                                                                    column: 38,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 2,
+                                                                                    column: 52,
+                                                                                },
+                                                                            },
+                                                                            span: 69..83,
+                                                                            value: "hello, world",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 19,
-                                                },
-                                            },
-                                            span: 101..104,
-                                            kind: Ident(
-                                                Ident {
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 3,
@@ -195,22 +184,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 101..104,
-                                                    name: "msg",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 19,
+                                                                },
+                                                            },
+                                                            span: 101..104,
+                                                            name: "msg",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let x = 5;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..10,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,46 +30,64 @@ Ok(
                                     column: 5,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 8..9,
-                        kind: Lit(
-                            Num(
-                                Num {
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 4..5,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 8,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 9,
+                                            column: 5,
                                         },
                                     },
-                                    span: 8..9,
-                                    value: "5",
                                 },
                             ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 8,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 8..9,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 9,
+                                                },
+                                            },
+                                            span: 8..9,
+                                            value: "5",
+                                        },
+                                    ),
+                                ),
+                                inferred_type: None,
+                            },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"   let x = 5;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 3..13,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                    },
-                    span: 7..8,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 7..8,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,46 +30,64 @@ Ok(
                                     column: 8,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 11,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 12,
-                            },
-                        },
-                        span: 11..12,
-                        kind: Lit(
-                            Num(
-                                Num {
+                            span: 7..8,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 7..8,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 11,
+                                            column: 7,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 12,
+                                            column: 8,
                                         },
                                     },
-                                    span: 11..12,
-                                    value: "5",
                                 },
                             ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 11,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 12,
+                                    },
+                                },
+                                span: 11..12,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 11,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 12,
+                                                },
+                                            },
+                                            span: 11..12,
+                                            value: "5",
+                                        },
+                                    ),
+                                ),
+                                inferred_type: None,
+                            },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"declare let x: number;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 8..22,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 13,
-                        },
-                    },
-                    span: 12..13,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 12..13,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,33 +30,51 @@ Ok(
                                     column: 13,
                                 },
                             },
+                            span: 12..13,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 12..13,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 13,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Keyword(
-                            KeywordType {
-                                keyword: Number,
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Keyword(
+                                    KeywordType {
+                                        keyword: Number,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 15,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 21,
+                                    },
+                                },
+                                span: 15..21,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 15,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 21,
-                            },
-                        },
-                        span: 15..21,
-                        inferred_type: None,
+                        init: None,
+                        declare: true,
                     },
                 ),
-                init: None,
-                declare: true,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"declare let foo: Foo<string>;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 8..29,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 15,
-                        },
-                    },
-                    span: 12..15,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 12..15,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,56 +30,74 @@ Ok(
                                     column: 15,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: TypeRef(
-                            TypeRef {
-                                name: "Foo",
-                                type_args: Some(
-                                    [
-                                        TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: String,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 27,
-                                                },
-                                            },
-                                            span: 21..27,
-                                            inferred_type: None,
+                            span: 12..15,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 12..15,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 12,
                                         },
-                                    ],
+                                        end: Position {
+                                            line: 0,
+                                            column: 15,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Foo",
+                                        type_args: Some(
+                                            [
+                                                TypeAnn {
+                                                    kind: Keyword(
+                                                        KeywordType {
+                                                            keyword: String,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 21,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 27,
+                                                        },
+                                                    },
+                                                    span: 21..27,
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        ),
+                                    },
                                 ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 28,
+                                    },
+                                },
+                                span: 17..28,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 17,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 28,
-                            },
-                        },
-                        span: 17..28,
-                        inferred_type: None,
+                        init: None,
+                        declare: true,
                     },
                 ),
-                init: None,
-                declare: true,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__decls.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let x = 5;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..10,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,46 +30,64 @@ Ok(
                                     column: 5,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                        },
-                        span: 8..9,
-                        kind: Lit(
-                            Num(
-                                Num {
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 4..5,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 8,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 9,
+                                            column: 5,
                                         },
                                     },
-                                    span: 8..9,
-                                    value: "5",
                                 },
                             ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 8,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                },
+                                span: 8..9,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 9,
+                                                },
+                                            },
+                                            span: 8..9,
+                                            value: "5",
+                                        },
+                                    ),
+                                ),
+                                inferred_type: None,
+                            },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-10.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-10.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let {mut x, y: mut z} = point;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,96 +17,82 @@ Ok(
                     },
                 },
                 span: 0..30,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 21,
-                        },
-                    },
-                    span: 4..21,
-                    kind: Object(
-                        ObjectPat {
-                            props: [
-                                Shorthand(
-                                    ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                        },
-                                        span: 5..10,
-                                        ident: BindingIdent {
-                                            name: "x",
-                                            mutable: true,
-                                            span: 9..10,
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 9,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 21,
+                                },
+                            },
+                            span: 4..21,
+                            kind: Object(
+                                ObjectPat {
+                                    props: [
+                                        Shorthand(
+                                            ShorthandPatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 10,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                            },
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                KeyValue(
-                                    KeyValuePatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 12,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 20,
-                                            },
-                                        },
-                                        span: 12..20,
-                                        key: Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 13,
-                                                },
-                                            },
-                                            span: 12..13,
-                                            name: "y",
-                                        },
-                                        value: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 15,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 20,
-                                                },
-                                            },
-                                            span: 15..20,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "z",
+                                                span: 5..10,
+                                                ident: BindingIdent {
+                                                    name: "x",
                                                     mutable: true,
-                                                    span: 15..20,
+                                                    span: 9..10,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
+                                                    },
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        KeyValue(
+                                            KeyValuePatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 12,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 20,
+                                                    },
+                                                },
+                                                span: 12..20,
+                                                key: Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 13,
+                                                        },
+                                                    },
+                                                    span: 12..13,
+                                                    name: "y",
+                                                },
+                                                value: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -117,35 +103,38 @@ Ok(
                                                             column: 20,
                                                         },
                                                     },
+                                                    span: 15..20,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "z",
+                                                            mutable: true,
+                                                            span: 15..20,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 15,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                            ],
-                            optional: false,
+                                                init: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 24,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 29,
-                            },
-                        },
-                        span: 24..29,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -157,13 +146,28 @@ Ok(
                                     },
                                 },
                                 span: 24..29,
-                                name: "point",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 24,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 29,
+                                            },
+                                        },
+                                        span: 24..29,
+                                        name: "point",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-11.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = ({mut x, y: mut z}) => {};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..36,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,118 +30,118 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 35,
-                            },
-                        },
-                        span: 10..35,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 28,
-                                                },
-                                            },
-                                            span: 11..28,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 12,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 17,
-                                                                    },
-                                                                },
-                                                                span: 12..17,
-                                                                ident: BindingIdent {
-                                                                    name: "x",
-                                                                    mutable: true,
-                                                                    span: 16..17,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 16,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 35,
+                                    },
+                                },
+                                span: 10..35,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 28,
+                                                        },
+                                                    },
+                                                    span: 11..28,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 12,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 17,
+                                                                            },
                                                                         },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 17,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        KeyValue(
-                                                            KeyValuePatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 19,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 27,
-                                                                    },
-                                                                },
-                                                                span: 19..27,
-                                                                key: Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 19,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 20,
-                                                                        },
-                                                                    },
-                                                                    span: 19..20,
-                                                                    name: "y",
-                                                                },
-                                                                value: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 27,
-                                                                        },
-                                                                    },
-                                                                    span: 22..27,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "z",
+                                                                        span: 12..17,
+                                                                        ident: BindingIdent {
+                                                                            name: "x",
                                                                             mutable: true,
-                                                                            span: 22..27,
+                                                                            span: 16..17,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 16,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 17,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                KeyValue(
+                                                                    KeyValuePatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 27,
+                                                                            },
+                                                                        },
+                                                                        span: 19..27,
+                                                                        key: Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 19,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 20,
+                                                                                },
+                                                                            },
+                                                                            span: 19..20,
+                                                                            name: "y",
+                                                                        },
+                                                                        value: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -166,36 +152,54 @@ Ok(
                                                                                     column: 27,
                                                                                 },
                                                                             },
+                                                                            span: 22..27,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "z",
+                                                                                    mutable: true,
+                                                                                    span: 22..27,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 22,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 27,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 33..35,
+                                            stmts: [],
                                         },
-                                        type_ann: None,
-                                        optional: false,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
                                     },
-                                ],
-                                body: Block {
-                                    span: 33..35,
-                                    stmts: [],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-12.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-12.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let [a, mut b, ...rest] = letters;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,40 +17,26 @@ Ok(
                     },
                 },
                 span: 0..34,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 23,
-                        },
-                    },
-                    span: 4..23,
-                    kind: Array(
-                        ArrayPat {
-                            elems: [
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                            span: 5..6,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                    span: 5..6,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 23,
+                                },
+                            },
+                            span: 4..23,
+                            kind: Array(
+                                ArrayPat {
+                                    elems: [
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -61,32 +47,32 @@ Ok(
                                                             column: 6,
                                                         },
                                                     },
+                                                    span: 5..6,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                            span: 5..6,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 5,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 6,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 13,
-                                                },
+                                                init: None,
                                             },
-                                            span: 8..13,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: true,
-                                                    span: 8..13,
+                                        ),
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -97,46 +83,46 @@ Ok(
                                                             column: 13,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 15,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
-                                            },
-                                            span: 15..22,
-                                            kind: Rest(
-                                                RestPat {
-                                                    arg: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 22,
+                                                    span: 8..13,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: true,
+                                                            span: 8..13,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 8,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 13,
+                                                                },
                                                             },
                                                         },
-                                                        span: 18..22,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "rest",
-                                                                mutable: false,
-                                                                span: 18..22,
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 15,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 22,
+                                                        },
+                                                    },
+                                                    span: 15..22,
+                                                    kind: Rest(
+                                                        RestPat {
+                                                            arg: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -147,39 +133,42 @@ Ok(
                                                                         column: 22,
                                                                     },
                                                                 },
+                                                                span: 18..22,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "rest",
+                                                                        mutable: false,
+                                                                        span: 18..22,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 22,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                            ],
-                            optional: false,
+                                                init: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 26,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 33,
-                            },
-                        },
-                        span: 26..33,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -191,13 +180,28 @@ Ok(
                                     },
                                 },
                                 span: 26..33,
-                                name: "letters",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 26,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 33,
+                                            },
+                                        },
+                                        span: 26..33,
+                                        name: "letters",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-13.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-13.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = ([a, mut b, ...rest]) => {};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..38,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,62 +30,62 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 37,
-                            },
-                        },
-                        span: 10..37,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 30,
-                                                },
-                                            },
-                                            span: 11..30,
-                                            kind: Array(
-                                                ArrayPat {
-                                                    elems: [
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 12,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 13,
-                                                                        },
-                                                                    },
-                                                                    span: 12..13,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "a",
-                                                                            mutable: false,
-                                                                            span: 12..13,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 37,
+                                    },
+                                },
+                                span: 10..37,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 30,
+                                                        },
+                                                    },
+                                                    span: 11..30,
+                                                    kind: Array(
+                                                        ArrayPat {
+                                                            elems: [
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -110,32 +96,32 @@ Ok(
                                                                                     column: 13,
                                                                                 },
                                                                             },
+                                                                            span: 12..13,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "a",
+                                                                                    mutable: false,
+                                                                                    span: 12..13,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 12,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 13,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 15,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 20,
-                                                                        },
+                                                                        init: None,
                                                                     },
-                                                                    span: 15..20,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "b",
-                                                                            mutable: true,
-                                                                            span: 15..20,
+                                                                ),
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -146,46 +132,46 @@ Ok(
                                                                                     column: 20,
                                                                                 },
                                                                             },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 29,
-                                                                        },
-                                                                    },
-                                                                    span: 22..29,
-                                                                    kind: Rest(
-                                                                        RestPat {
-                                                                            arg: Pattern {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 25,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 29,
+                                                                            span: 15..20,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "b",
+                                                                                    mutable: true,
+                                                                                    span: 15..20,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 15,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 20,
+                                                                                        },
                                                                                     },
                                                                                 },
-                                                                                span: 25..29,
-                                                                                kind: Ident(
-                                                                                    BindingIdent {
-                                                                                        name: "rest",
-                                                                                        mutable: false,
-                                                                                        span: 25..29,
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 22,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 29,
+                                                                                },
+                                                                            },
+                                                                            span: 22..29,
+                                                                            kind: Rest(
+                                                                                RestPat {
+                                                                                    arg: Pattern {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
@@ -196,40 +182,58 @@ Ok(
                                                                                                 column: 29,
                                                                                             },
                                                                                         },
+                                                                                        span: 25..29,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "rest",
+                                                                                                mutable: false,
+                                                                                                span: 25..29,
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 25,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 29,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 35..37,
+                                            stmts: [],
                                         },
-                                        type_ann: None,
-                                        optional: false,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
                                     },
-                                ],
-                                body: Block {
-                                    span: 35..37,
-                                    stmts: [],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-14.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-14.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let {x, mut y = 10} = point;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,138 +17,127 @@ Ok(
                     },
                 },
                 span: 0..28,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 19,
-                        },
-                    },
-                    span: 4..19,
-                    kind: Object(
-                        ObjectPat {
-                            props: [
-                                Shorthand(
-                                    ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 5..6,
-                                        ident: BindingIdent {
-                                            name: "x",
-                                            mutable: false,
-                                            span: 5..6,
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Shorthand(
-                                    ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 13,
-                                            },
-                                        },
-                                        span: 8..13,
-                                        ident: BindingIdent {
-                                            name: "y",
-                                            mutable: true,
-                                            span: 12..13,
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 13,
-                                                },
-                                            },
-                                        },
-                                        init: Some(
-                                            Expr {
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 19,
+                                },
+                            },
+                            span: 4..19,
+                            kind: Object(
+                                ObjectPat {
+                                    props: [
+                                        Shorthand(
+                                            ShorthandPatProp {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 16,
+                                                        column: 5,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 18,
+                                                        column: 6,
                                                     },
                                                 },
-                                                span: 16..18,
-                                                kind: Lit(
-                                                    Num(
-                                                        Num {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                            },
-                                                            span: 16..18,
-                                                            value: "10",
+                                                span: 5..6,
+                                                ident: BindingIdent {
+                                                    name: "x",
+                                                    mutable: false,
+                                                    span: 5..6,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 5,
                                                         },
-                                                    ),
-                                                ),
-                                                inferred_type: None,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 6,
+                                                        },
+                                                    },
+                                                },
+                                                init: None,
                                             },
                                         ),
-                                    },
-                                ),
-                            ],
-                            optional: false,
+                                        Shorthand(
+                                            ShorthandPatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 13,
+                                                    },
+                                                },
+                                                span: 8..13,
+                                                ident: BindingIdent {
+                                                    name: "y",
+                                                    mutable: true,
+                                                    span: 12..13,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 13,
+                                                        },
+                                                    },
+                                                },
+                                                init: Some(
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 16,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                        },
+                                                        span: 16..18,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 18,
+                                                                        },
+                                                                    },
+                                                                    span: 16..18,
+                                                                    value: "10",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 27,
-                            },
-                        },
-                        span: 22..27,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -160,13 +149,28 @@ Ok(
                                     },
                                 },
                                 span: 22..27,
-                                name: "point",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 22,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 27,
+                                            },
+                                        },
+                                        span: 22..27,
+                                        name: "point",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-15.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-15.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let [a, mut b = 98, ...rest] = letters;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,40 +17,26 @@ Ok(
                     },
                 },
                 span: 0..39,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 28,
-                        },
-                    },
-                    span: 4..28,
-                    kind: Array(
-                        ArrayPat {
-                            elems: [
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                            span: 5..6,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                    span: 5..6,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 28,
+                                },
+                            },
+                            span: 4..28,
+                            kind: Array(
+                                ArrayPat {
+                                    elems: [
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -61,32 +47,32 @@ Ok(
                                                             column: 6,
                                                         },
                                                     },
+                                                    span: 5..6,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                            span: 5..6,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 5,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 6,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 13,
-                                                },
+                                                init: None,
                                             },
-                                            span: 8..13,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: true,
-                                                    span: 8..13,
+                                        ),
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -97,79 +83,79 @@ Ok(
                                                             column: 13,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: Some(
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 18,
-                                                    },
-                                                },
-                                                span: 16..18,
-                                                kind: Lit(
-                                                    Num(
-                                                        Num {
+                                                    span: 8..13,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: true,
+                                                            span: 8..13,
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
-                                                                    column: 16,
+                                                                    column: 8,
                                                                 },
                                                                 end: Position {
                                                                     line: 0,
-                                                                    column: 18,
+                                                                    column: 13,
                                                                 },
                                                             },
-                                                            span: 16..18,
-                                                            value: "98",
                                                         },
                                                     ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        ),
-                                    },
-                                ),
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 20,
+                                                    inferred_type: None,
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 27,
-                                                },
-                                            },
-                                            span: 20..27,
-                                            kind: Rest(
-                                                RestPat {
-                                                    arg: Pattern {
+                                                init: Some(
+                                                    Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
-                                                                column: 23,
+                                                                column: 16,
                                                             },
                                                             end: Position {
                                                                 line: 0,
-                                                                column: 27,
+                                                                column: 18,
                                                             },
                                                         },
-                                                        span: 23..27,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "rest",
-                                                                mutable: false,
-                                                                span: 23..27,
+                                                        span: 16..18,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 18,
+                                                                        },
+                                                                    },
+                                                                    span: 16..18,
+                                                                    value: "98",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 20,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 27,
+                                                        },
+                                                    },
+                                                    span: 20..27,
+                                                    kind: Rest(
+                                                        RestPat {
+                                                            arg: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -180,39 +166,42 @@ Ok(
                                                                         column: 27,
                                                                     },
                                                                 },
+                                                                span: 23..27,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "rest",
+                                                                        mutable: false,
+                                                                        span: 23..27,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 23,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 27,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                            ],
-                            optional: false,
+                                                init: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 31,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 38,
-                            },
-                        },
-                        span: 31..38,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -224,13 +213,28 @@ Ok(
                                     },
                                 },
                                 span: 31..38,
-                                name: "letters",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 31,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 38,
+                                            },
+                                        },
+                                        span: 31..38,
+                                        name: "letters",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let {a, b, ...rest} = letters;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,102 +17,88 @@ Ok(
                     },
                 },
                 span: 0..30,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 19,
-                        },
-                    },
-                    span: 4..19,
-                    kind: Object(
-                        ObjectPat {
-                            props: [
-                                Shorthand(
-                                    ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 5..6,
-                                        ident: BindingIdent {
-                                            name: "a",
-                                            mutable: false,
-                                            span: 5..6,
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 19,
+                                },
+                            },
+                            span: 4..19,
+                            kind: Object(
+                                ObjectPat {
+                                    props: [
+                                        Shorthand(
+                                            ShorthandPatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 6,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Shorthand(
-                                    ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                        },
-                                        span: 8..9,
-                                        ident: BindingIdent {
-                                            name: "b",
-                                            mutable: false,
-                                            span: 8..9,
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                            },
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Rest(
-                                    RestPat {
-                                        arg: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                            },
-                                            span: 14..18,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "rest",
+                                                span: 5..6,
+                                                ident: BindingIdent {
+                                                    name: "a",
                                                     mutable: false,
-                                                    span: 14..18,
+                                                    span: 5..6,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 5,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 6,
+                                                        },
+                                                    },
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        Shorthand(
+                                            ShorthandPatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 9,
+                                                    },
+                                                },
+                                                span: 8..9,
+                                                ident: BindingIdent {
+                                                    name: "b",
+                                                    mutable: false,
+                                                    span: 8..9,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                    },
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        Rest(
+                                            RestPat {
+                                                arg: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -123,34 +109,37 @@ Ok(
                                                             column: 18,
                                                         },
                                                     },
+                                                    span: 14..18,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "rest",
+                                                            mutable: false,
+                                                            span: 14..18,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 14,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 18,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                            ],
-                            optional: false,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 29,
-                            },
-                        },
-                        span: 22..29,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -162,13 +151,28 @@ Ok(
                                     },
                                 },
                                 span: 22..29,
-                                name: "letters",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 22,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 29,
+                                            },
+                                        },
+                                        span: 22..29,
+                                        name: "letters",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let {p0: {x, y}, p1: {x, y}} = line;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,269 +17,258 @@ Ok(
                     },
                 },
                 span: 0..36,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 28,
-                        },
-                    },
-                    span: 4..28,
-                    kind: Object(
-                        ObjectPat {
-                            props: [
-                                KeyValue(
-                                    KeyValuePatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 15,
-                                            },
-                                        },
-                                        span: 5..15,
-                                        key: Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 7,
-                                                },
-                                            },
-                                            span: 5..7,
-                                            name: "p0",
-                                        },
-                                        value: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 15,
-                                                },
-                                            },
-                                            span: 9..15,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 10,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 11,
-                                                                    },
-                                                                },
-                                                                span: 10..11,
-                                                                ident: BindingIdent {
-                                                                    name: "x",
-                                                                    mutable: false,
-                                                                    span: 10..11,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 10,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 11,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 13,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 14,
-                                                                    },
-                                                                },
-                                                                span: 13..14,
-                                                                ident: BindingIdent {
-                                                                    name: "y",
-                                                                    mutable: false,
-                                                                    span: 13..14,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 13,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 14,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                KeyValue(
-                                    KeyValuePatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 27,
-                                            },
-                                        },
-                                        span: 17..27,
-                                        key: Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 17,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 19,
-                                                },
-                                            },
-                                            span: 17..19,
-                                            name: "p1",
-                                        },
-                                        value: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 27,
-                                                },
-                                            },
-                                            span: 21..27,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 22..23,
-                                                                ident: BindingIdent {
-                                                                    name: "x",
-                                                                    mutable: false,
-                                                                    span: 22..23,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 22,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 23,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 25,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 26,
-                                                                    },
-                                                                },
-                                                                span: 25..26,
-                                                                ident: BindingIdent {
-                                                                    name: "y",
-                                                                    mutable: false,
-                                                                    span: 25..26,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 25,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 26,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                            ],
-                            optional: false,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 31,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 28,
+                                },
                             },
-                            end: Position {
-                                line: 0,
-                                column: 35,
-                            },
+                            span: 4..28,
+                            kind: Object(
+                                ObjectPat {
+                                    props: [
+                                        KeyValue(
+                                            KeyValuePatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                },
+                                                span: 5..15,
+                                                key: Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 5,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 7,
+                                                        },
+                                                    },
+                                                    span: 5..7,
+                                                    name: "p0",
+                                                },
+                                                value: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 15,
+                                                        },
+                                                    },
+                                                    span: 9..15,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 10,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 11,
+                                                                            },
+                                                                        },
+                                                                        span: 10..11,
+                                                                        ident: BindingIdent {
+                                                                            name: "x",
+                                                                            mutable: false,
+                                                                            span: 10..11,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 10,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 11,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 13,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 14,
+                                                                            },
+                                                                        },
+                                                                        span: 13..14,
+                                                                        ident: BindingIdent {
+                                                                            name: "y",
+                                                                            mutable: false,
+                                                                            span: 13..14,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 13,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 14,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        KeyValue(
+                                            KeyValuePatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 17,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 27,
+                                                    },
+                                                },
+                                                span: 17..27,
+                                                key: Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 19,
+                                                        },
+                                                    },
+                                                    span: 17..19,
+                                                    name: "p1",
+                                                },
+                                                value: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 21,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 27,
+                                                        },
+                                                    },
+                                                    span: 21..27,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 22,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 23,
+                                                                            },
+                                                                        },
+                                                                        span: 22..23,
+                                                                        ident: BindingIdent {
+                                                                            name: "x",
+                                                                            mutable: false,
+                                                                            span: 22..23,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 22,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 25,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 26,
+                                                                            },
+                                                                        },
+                                                                        span: 25..26,
+                                                                        ident: BindingIdent {
+                                                                            name: "y",
+                                                                            mutable: false,
+                                                                            span: 25..26,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 25,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 26,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                        span: 31..35,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -291,13 +280,28 @@ Ok(
                                     },
                                 },
                                 span: 31..35,
-                                name: "line",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 31,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 35,
+                                            },
+                                        },
+                                        span: 31..35,
+                                        name: "line",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let [a, b, ...rest] = letters;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,40 +17,26 @@ Ok(
                     },
                 },
                 span: 0..30,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 19,
-                        },
-                    },
-                    span: 4..19,
-                    kind: Array(
-                        ArrayPat {
-                            elems: [
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                            span: 5..6,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                    span: 5..6,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 19,
+                                },
+                            },
+                            span: 4..19,
+                            kind: Array(
+                                ArrayPat {
+                                    elems: [
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -61,32 +47,32 @@ Ok(
                                                             column: 6,
                                                         },
                                                     },
+                                                    span: 5..6,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                            span: 5..6,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 5,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 6,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
+                                                init: None,
                                             },
-                                            span: 8..9,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: false,
-                                                    span: 8..9,
+                                        ),
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -97,46 +83,46 @@ Ok(
                                                             column: 9,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                            },
-                                            span: 11..18,
-                                            kind: Rest(
-                                                RestPat {
-                                                    arg: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 14,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 18,
+                                                    span: 8..9,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: false,
+                                                            span: 8..9,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 8,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 9,
+                                                                },
                                                             },
                                                         },
-                                                        span: 14..18,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "rest",
-                                                                mutable: false,
-                                                                span: 14..18,
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 18,
+                                                        },
+                                                    },
+                                                    span: 11..18,
+                                                    kind: Rest(
+                                                        RestPat {
+                                                            arg: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -147,39 +133,42 @@ Ok(
                                                                         column: 18,
                                                                     },
                                                                 },
+                                                                span: 14..18,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "rest",
+                                                                        mutable: false,
+                                                                        span: 14..18,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 14,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                            ],
-                            optional: false,
+                                                init: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 29,
-                            },
-                        },
-                        span: 22..29,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -191,13 +180,28 @@ Ok(
                                     },
                                 },
                                 span: 22..29,
-                                name: "letters",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 22,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 29,
+                                            },
+                                        },
+                                        span: 22..29,
+                                        name: "letters",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-5.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let [foo, ...[bar, ...rest]] = baz;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,40 +17,26 @@ Ok(
                     },
                 },
                 span: 0..35,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 28,
-                        },
-                    },
-                    span: 4..28,
-                    kind: Array(
-                        ArrayPat {
-                            elems: [
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                            },
-                                            span: 5..8,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "foo",
-                                                    mutable: false,
-                                                    span: 5..8,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 28,
+                                },
+                            },
+                            span: 4..28,
+                            kind: Array(
+                                ArrayPat {
+                                    elems: [
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -61,63 +47,63 @@ Ok(
                                                             column: 8,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Some(
-                                    ArrayPatElem {
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 27,
-                                                },
-                                            },
-                                            span: 10..27,
-                                            kind: Rest(
-                                                RestPat {
-                                                    arg: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 27,
+                                                    span: 5..8,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "foo",
+                                                            mutable: false,
+                                                            span: 5..8,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 5,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 8,
+                                                                },
                                                             },
                                                         },
-                                                        span: 13..27,
-                                                        kind: Array(
-                                                            ArrayPat {
-                                                                elems: [
-                                                                    Some(
-                                                                        ArrayPatElem {
-                                                                            pattern: Pattern {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 14,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 17,
-                                                                                    },
-                                                                                },
-                                                                                span: 14..17,
-                                                                                kind: Ident(
-                                                                                    BindingIdent {
-                                                                                        name: "bar",
-                                                                                        mutable: false,
-                                                                                        span: 14..17,
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        Some(
+                                            ArrayPatElem {
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 27,
+                                                        },
+                                                    },
+                                                    span: 10..27,
+                                                    kind: Rest(
+                                                        RestPat {
+                                                            arg: Pattern {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 13,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 27,
+                                                                    },
+                                                                },
+                                                                span: 13..27,
+                                                                kind: Array(
+                                                                    ArrayPat {
+                                                                        elems: [
+                                                                            Some(
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
@@ -128,46 +114,46 @@ Ok(
                                                                                                 column: 17,
                                                                                             },
                                                                                         },
-                                                                                    },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            init: None,
-                                                                        },
-                                                                    ),
-                                                                    Some(
-                                                                        ArrayPatElem {
-                                                                            pattern: Pattern {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 19,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 26,
-                                                                                    },
-                                                                                },
-                                                                                span: 19..26,
-                                                                                kind: Rest(
-                                                                                    RestPat {
-                                                                                        arg: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 22,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 26,
+                                                                                        span: 14..17,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "bar",
+                                                                                                mutable: false,
+                                                                                                span: 14..17,
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 14,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 17,
+                                                                                                    },
                                                                                                 },
                                                                                             },
-                                                                                            span: 22..26,
-                                                                                            kind: Ident(
-                                                                                                BindingIdent {
-                                                                                                    name: "rest",
-                                                                                                    mutable: false,
-                                                                                                    span: 22..26,
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    init: None,
+                                                                                },
+                                                                            ),
+                                                                            Some(
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 19,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 26,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 19..26,
+                                                                                        kind: Rest(
+                                                                                            RestPat {
+                                                                                                arg: Pattern {
                                                                                                     loc: SourceLocation {
                                                                                                         start: Position {
                                                                                                             line: 0,
@@ -178,52 +164,55 @@ Ok(
                                                                                                             column: 26,
                                                                                                         },
                                                                                                     },
+                                                                                                    span: 22..26,
+                                                                                                    kind: Ident(
+                                                                                                        BindingIdent {
+                                                                                                            name: "rest",
+                                                                                                            mutable: false,
+                                                                                                            span: 22..26,
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 22,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 26,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    inferred_type: None,
                                                                                                 },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            init: None,
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                                optional: false,
+                                                                                    init: None,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        optional: false,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                            ],
-                            optional: false,
+                                                init: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 31,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 34,
-                            },
-                        },
-                        span: 31..34,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -235,13 +224,28 @@ Ok(
                                     },
                                 },
                                 span: 31..34,
-                                name: "baz",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 31,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 34,
+                                            },
+                                        },
+                                        span: 31..34,
+                                        name: "baz",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-6.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = ([a, b]) => a;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..24,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,62 +30,62 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 23,
-                            },
-                        },
-                        span: 10..23,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 11..17,
-                                            kind: Array(
-                                                ArrayPat {
-                                                    elems: [
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 12,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 13,
-                                                                        },
-                                                                    },
-                                                                    span: 12..13,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "a",
-                                                                            mutable: false,
-                                                                            span: 12..13,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 23,
+                                    },
+                                },
+                                span: 10..23,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 11..17,
+                                                    kind: Array(
+                                                        ArrayPat {
+                                                            elems: [
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -110,32 +96,32 @@ Ok(
                                                                                     column: 13,
                                                                                 },
                                                                             },
+                                                                            span: 12..13,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "a",
+                                                                                    mutable: false,
+                                                                                    span: 12..13,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 12,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 13,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 15,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 16,
-                                                                        },
+                                                                        init: None,
                                                                     },
-                                                                    span: 15..16,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "b",
-                                                                            mutable: false,
-                                                                            span: 15..16,
+                                                                ),
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -146,40 +132,43 @@ Ok(
                                                                                     column: 16,
                                                                                 },
                                                                             },
+                                                                            span: 15..16,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "b",
+                                                                                    mutable: false,
+                                                                                    span: 15..16,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 15,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 16,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 22..23,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 23,
-                                                },
+                                                type_ann: None,
+                                                optional: false,
                                             },
+                                        ],
+                                        body: Block {
                                             span: 22..23,
-                                            kind: Ident(
-                                                Ident {
+                                            stmts: [
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -191,22 +180,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 22..23,
-                                                    name: "a",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                            },
+                                                            span: 22..23,
+                                                            name: "a",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-7.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = ([a, b]: [string, number]) => a;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..42,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,62 +30,62 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 41,
-                            },
-                        },
-                        span: 10..41,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 11..17,
-                                            kind: Array(
-                                                ArrayPat {
-                                                    elems: [
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 12,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 13,
-                                                                        },
-                                                                    },
-                                                                    span: 12..13,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "a",
-                                                                            mutable: false,
-                                                                            span: 12..13,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 41,
+                                    },
+                                },
+                                span: 10..41,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 11..17,
+                                                    kind: Array(
+                                                        ArrayPat {
+                                                            elems: [
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -110,32 +96,32 @@ Ok(
                                                                                     column: 13,
                                                                                 },
                                                                             },
+                                                                            span: 12..13,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "a",
+                                                                                    mutable: false,
+                                                                                    span: 12..13,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 12,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 13,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 15,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 16,
-                                                                        },
+                                                                        init: None,
                                                                     },
-                                                                    span: 15..16,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "b",
-                                                                            mutable: false,
-                                                                            span: 15..16,
+                                                                ),
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 0,
@@ -146,99 +132,102 @@ Ok(
                                                                                     column: 16,
                                                                                 },
                                                                             },
+                                                                            span: 15..16,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "b",
+                                                                                    mutable: false,
+                                                                                    span: 15..16,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 15,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 16,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: Some(
+                                                    TypeAnn {
+                                                        kind: Tuple(
+                                                            TupleType {
+                                                                types: [
+                                                                    TypeAnn {
+                                                                        kind: Keyword(
+                                                                            KeywordType {
+                                                                                keyword: String,
+                                                                            },
+                                                                        ),
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 20,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 26,
+                                                                            },
+                                                                        },
+                                                                        span: 20..26,
+                                                                        inferred_type: None,
+                                                                    },
+                                                                    TypeAnn {
+                                                                        kind: Keyword(
+                                                                            KeywordType {
+                                                                                keyword: Number,
+                                                                            },
+                                                                        ),
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 28,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 34,
+                                                                            },
+                                                                        },
+                                                                        span: 28..34,
+                                                                        inferred_type: None,
+                                                                    },
+                                                                ],
                                                             },
                                                         ),
-                                                    ],
-                                                    optional: false,
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: Some(
-                                            TypeAnn {
-                                                kind: Tuple(
-                                                    TupleType {
-                                                        types: [
-                                                            TypeAnn {
-                                                                kind: Keyword(
-                                                                    KeywordType {
-                                                                        keyword: String,
-                                                                    },
-                                                                ),
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 20,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 26,
-                                                                    },
-                                                                },
-                                                                span: 20..26,
-                                                                inferred_type: None,
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 19,
                                                             },
-                                                            TypeAnn {
-                                                                kind: Keyword(
-                                                                    KeywordType {
-                                                                        keyword: Number,
-                                                                    },
-                                                                ),
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 28,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 34,
-                                                                    },
-                                                                },
-                                                                span: 28..34,
-                                                                inferred_type: None,
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 35,
                                                             },
-                                                        ],
+                                                        },
+                                                        span: 19..35,
+                                                        inferred_type: None,
                                                     },
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 19,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 35,
-                                                    },
-                                                },
-                                                span: 19..35,
-                                                inferred_type: None,
+                                                optional: false,
                                             },
-                                        ),
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 40..41,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 40,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                            },
+                                        ],
+                                        body: Block {
                                             span: 40..41,
-                                            kind: Ident(
-                                                Ident {
+                                            stmts: [
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -250,22 +239,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 40..41,
-                                                    name: "a",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 40,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 41,
+                                                                },
+                                                            },
+                                                            span: 40..41,
+                                                            name: "a",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-8.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = ({a, b}) => b;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..24,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,132 +30,135 @@ Ok(
                                     column: 7,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 23,
-                            },
-                        },
-                        span: 10..23,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 11..17,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 12,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 13,
-                                                                    },
-                                                                },
-                                                                span: 12..13,
-                                                                ident: BindingIdent {
-                                                                    name: "a",
-                                                                    mutable: false,
-                                                                    span: 12..13,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 12,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 13,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 15,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 16,
-                                                                    },
-                                                                },
-                                                                span: 15..16,
-                                                                ident: BindingIdent {
-                                                                    name: "b",
-                                                                    mutable: false,
-                                                                    span: 15..16,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 15,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 16,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
-                                                },
-                                            ),
-                                            inferred_type: None,
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
                                         },
-                                        type_ann: None,
-                                        optional: false,
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
                                     },
-                                ],
-                                body: Block {
-                                    span: 22..23,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 22,
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 23,
+                                    },
+                                },
+                                span: 10..23,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 11..17,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 12,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 13,
+                                                                            },
+                                                                        },
+                                                                        span: 12..13,
+                                                                        ident: BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 12..13,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 12,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 13,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 15,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 16,
+                                                                            },
+                                                                        },
+                                                                        span: 15..16,
+                                                                        ident: BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                            span: 15..16,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 15,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 16,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 23,
-                                                },
+                                                type_ann: None,
+                                                optional: false,
                                             },
+                                        ],
+                                        body: Block {
                                             span: 22..23,
-                                            kind: Ident(
-                                                Ident {
+                                            stmts: [
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -181,22 +170,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 22..23,
-                                                    name: "b",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                            },
+                                                            span: 22..23,
+                                                            name: "b",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-9.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = ({a, b}: {a: string, b: number}) => b;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..48,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,227 +30,230 @@ Ok(
                                     column: 7,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 47,
-                            },
-                        },
-                        span: 10..47,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 11..17,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 12,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 13,
-                                                                    },
-                                                                },
-                                                                span: 12..13,
-                                                                ident: BindingIdent {
-                                                                    name: "a",
-                                                                    mutable: false,
-                                                                    span: 12..13,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 12,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 13,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 15,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 16,
-                                                                    },
-                                                                },
-                                                                span: 15..16,
-                                                                ident: BindingIdent {
-                                                                    name: "b",
-                                                                    mutable: false,
-                                                                    span: 15..16,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 15,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 16,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
-                                                },
-                                            ),
-                                            inferred_type: None,
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
                                         },
-                                        type_ann: Some(
-                                            TypeAnn {
-                                                kind: Object(
-                                                    ObjectType {
-                                                        elems: [
-                                                            Prop(
-                                                                TProp {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 20,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 29,
-                                                                        },
-                                                                    },
-                                                                    span: 20..29,
-                                                                    name: "a",
-                                                                    optional: false,
-                                                                    mutable: false,
-                                                                    type_ann: TypeAnn {
-                                                                        kind: Keyword(
-                                                                            KeywordType {
-                                                                                keyword: String,
-                                                                            },
-                                                                        ),
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 47,
+                                    },
+                                },
+                                span: 10..47,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 11..17,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
-                                                                                column: 23,
+                                                                                column: 12,
                                                                             },
                                                                             end: Position {
                                                                                 line: 0,
-                                                                                column: 29,
+                                                                                column: 13,
                                                                             },
                                                                         },
-                                                                        span: 23..29,
-                                                                        inferred_type: None,
-                                                                    },
-                                                                },
-                                                            ),
-                                                            Prop(
-                                                                TProp {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 31,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 40,
-                                                                        },
-                                                                    },
-                                                                    span: 31..40,
-                                                                    name: "b",
-                                                                    optional: false,
-                                                                    mutable: false,
-                                                                    type_ann: TypeAnn {
-                                                                        kind: Keyword(
-                                                                            KeywordType {
-                                                                                keyword: Number,
+                                                                        span: 12..13,
+                                                                        ident: BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 12..13,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 12,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 13,
+                                                                                },
                                                                             },
-                                                                        ),
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
-                                                                                column: 34,
+                                                                                column: 15,
                                                                             },
                                                                             end: Position {
                                                                                 line: 0,
-                                                                                column: 40,
+                                                                                column: 16,
                                                                             },
                                                                         },
-                                                                        span: 34..40,
-                                                                        inferred_type: None,
+                                                                        span: 15..16,
+                                                                        ident: BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                            span: 15..16,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 15,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 16,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
                                                                     },
-                                                                },
-                                                            ),
-                                                        ],
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: Some(
+                                                    TypeAnn {
+                                                        kind: Object(
+                                                            ObjectType {
+                                                                elems: [
+                                                                    Prop(
+                                                                        TProp {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 29,
+                                                                                },
+                                                                            },
+                                                                            span: 20..29,
+                                                                            name: "a",
+                                                                            optional: false,
+                                                                            mutable: false,
+                                                                            type_ann: TypeAnn {
+                                                                                kind: Keyword(
+                                                                                    KeywordType {
+                                                                                        keyword: String,
+                                                                                    },
+                                                                                ),
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 29,
+                                                                                    },
+                                                                                },
+                                                                                span: 23..29,
+                                                                                inferred_type: None,
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    Prop(
+                                                                        TProp {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 31,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 40,
+                                                                                },
+                                                                            },
+                                                                            span: 31..40,
+                                                                            name: "b",
+                                                                            optional: false,
+                                                                            mutable: false,
+                                                                            type_ann: TypeAnn {
+                                                                                kind: Keyword(
+                                                                                    KeywordType {
+                                                                                        keyword: Number,
+                                                                                    },
+                                                                                ),
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 34,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 40,
+                                                                                    },
+                                                                                },
+                                                                                span: 34..40,
+                                                                                inferred_type: None,
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                            },
+                                                        ),
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 19,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 41,
+                                                            },
+                                                        },
+                                                        span: 19..41,
+                                                        inferred_type: None,
                                                     },
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 19,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 41,
-                                                    },
-                                                },
-                                                span: 19..41,
-                                                inferred_type: None,
+                                                optional: false,
                                             },
-                                        ),
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 46..47,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 46,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 47,
-                                                },
-                                            },
+                                        ],
+                                        body: Block {
                                             span: 46..47,
-                                            kind: Ident(
-                                                Ident {
+                                            stmts: [
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -276,22 +265,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 46..47,
-                                                    name: "b",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 46,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 47,
+                                                                },
+                                                            },
+                                                            span: 46..47,
+                                                            name: "b",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let {x, y} = point;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,105 +17,94 @@ Ok(
                     },
                 },
                 span: 0..19,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 10,
-                        },
-                    },
-                    span: 4..10,
-                    kind: Object(
-                        ObjectPat {
-                            props: [
-                                Shorthand(
-                                    ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 5..6,
-                                        ident: BindingIdent {
-                                            name: "x",
-                                            mutable: false,
-                                            span: 5..6,
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                                Shorthand(
-                                    ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                        },
-                                        span: 8..9,
-                                        ident: BindingIdent {
-                                            name: "y",
-                                            mutable: false,
-                                            span: 8..9,
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                            },
-                                        },
-                                        init: None,
-                                    },
-                                ),
-                            ],
-                            optional: false,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 13,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 4,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 10,
+                                },
                             },
-                            end: Position {
-                                line: 0,
-                                column: 18,
-                            },
+                            span: 4..10,
+                            kind: Object(
+                                ObjectPat {
+                                    props: [
+                                        Shorthand(
+                                            ShorthandPatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 6,
+                                                    },
+                                                },
+                                                span: 5..6,
+                                                ident: BindingIdent {
+                                                    name: "x",
+                                                    mutable: false,
+                                                    span: 5..6,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 5,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 6,
+                                                        },
+                                                    },
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                        Shorthand(
+                                            ShorthandPatProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 9,
+                                                    },
+                                                },
+                                                span: 8..9,
+                                                ident: BindingIdent {
+                                                    name: "y",
+                                                    mutable: false,
+                                                    span: 8..9,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                    },
+                                                },
+                                                init: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                        span: 13..18,
-                        kind: Ident(
-                            Ident {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -127,13 +116,28 @@ Ok(
                                     },
                                 },
                                 span: 13..18,
-                                name: "point",
+                                kind: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 13,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 18,
+                                            },
+                                        },
+                                        span: 13..18,
+                                        name: "point",
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-2.snap
@@ -5,125 +5,138 @@ expression: "parse(\"foo(a, b);\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..9,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 3,
-                                            },
-                                        },
-                                        span: 0..3,
-                                        name: "foo",
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                        },
-                                        span: 4..5,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 4,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 5,
-                                                    },
-                                                },
-                                                span: 4..5,
-                                                name: "a",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 7,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                        },
-                                        span: 7..8,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 7,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 8,
-                                                    },
-                                                },
-                                                span: 7..8,
-                                                name: "b",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                            ],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 10,
+                    },
                 },
-            ),
+                span: 0..10,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 9,
+                            },
+                        },
+                        span: 0..9,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
+                                    },
+                                    span: 0..3,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 3,
+                                                },
+                                            },
+                                            span: 0..3,
+                                            name: "foo",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                            },
+                                            span: 4..5,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 4,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 5,
+                                                        },
+                                                    },
+                                                    span: 4..5,
+                                                    name: "a",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 7,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                            },
+                                            span: 7..8,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 7,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                    },
+                                                    span: 7..8,
+                                                    name: "b",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ],
+                                type_args: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-3.snap
@@ -5,129 +5,142 @@ expression: "parse(\"foo(10, \\\"hello\\\");\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 16,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..16,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 3,
-                                            },
-                                        },
-                                        span: 0..3,
-                                        name: "foo",
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 4..6,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 4,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 6,
-                                                        },
-                                                    },
-                                                    span: 4..6,
-                                                    value: "10",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 15,
-                                            },
-                                        },
-                                        span: 8..15,
-                                        kind: Lit(
-                                            Str(
-                                                Str {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 8,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 15,
-                                                        },
-                                                    },
-                                                    span: 8..15,
-                                                    value: "hello",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                            ],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 17,
+                    },
                 },
-            ),
+                span: 0..17,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 16,
+                            },
+                        },
+                        span: 0..16,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
+                                    },
+                                    span: 0..3,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 3,
+                                                },
+                                            },
+                                            span: 0..3,
+                                            name: "foo",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 6,
+                                                },
+                                            },
+                                            span: 4..6,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 4,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 6,
+                                                            },
+                                                        },
+                                                        span: 4..6,
+                                                        value: "10",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 15,
+                                                },
+                                            },
+                                            span: 8..15,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 8,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 15,
+                                                            },
+                                                        },
+                                                        span: 8..15,
+                                                        value: "hello",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ],
+                                type_args: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-4.snap
@@ -5,200 +5,213 @@ expression: "parse(\"f(x)(g(x));\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 10,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..10,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
+                    end: Position {
+                        line: 0,
+                        column: 11,
+                    },
+                },
+                span: 0..11,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 10,
+                            },
+                        },
+                        span: 0..10,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
+                                    span: 0..4,
+                                    kind: App(
+                                        App {
+                                            lam: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 1,
+                                                    },
+                                                },
+                                                span: 0..1,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 1,
+                                                            },
+                                                        },
+                                                        span: 0..1,
+                                                        name: "f",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            args: [
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 2,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 3,
+                                                            },
+                                                        },
+                                                        span: 2..3,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 2,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 3,
+                                                                    },
+                                                                },
+                                                                span: 2..3,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ],
+                                            type_args: None,
+                                        },
+                                    ),
+                                    inferred_type: None,
                                 },
-                                span: 0..4,
-                                kind: App(
-                                    App {
-                                        lam: Expr {
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 0,
+                                                    column: 5,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 1,
+                                                    column: 9,
                                                 },
                                             },
-                                            span: 0..1,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 0,
+                                            span: 5..9,
+                                            kind: App(
+                                                App {
+                                                    lam: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 5,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 6,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 1,
-                                                        },
+                                                        span: 5..6,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 5,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 6,
+                                                                    },
+                                                                },
+                                                                span: 5..6,
+                                                                name: "g",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                    span: 0..1,
-                                                    name: "f",
+                                                    args: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 7,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 8,
+                                                                    },
+                                                                },
+                                                                span: 7..8,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 7,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 8,
+                                                                            },
+                                                                        },
+                                                                        span: 7..8,
+                                                                        name: "x",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                    ],
+                                                    type_args: None,
                                                 },
                                             ),
                                             inferred_type: None,
                                         },
-                                        args: [
-                                            ExprOrSpread {
-                                                spread: None,
-                                                expr: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 2,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 3,
-                                                        },
-                                                    },
-                                                    span: 2..3,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 2,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 3,
-                                                                },
-                                                            },
-                                                            span: 2..3,
-                                                            name: "x",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ],
-                                        type_args: None,
                                     },
-                                ),
-                                inferred_type: None,
+                                ],
+                                type_args: None,
                             },
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                        },
-                                        span: 5..9,
-                                        kind: App(
-                                            App {
-                                                lam: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 5,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 6,
-                                                        },
-                                                    },
-                                                    span: 5..6,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 5,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 6,
-                                                                },
-                                                            },
-                                                            span: 5..6,
-                                                            name: "g",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                args: [
-                                                    ExprOrSpread {
-                                                        spread: None,
-                                                        expr: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 7,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 8,
-                                                                },
-                                                            },
-                                                            span: 7..8,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 7,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 8,
-                                                                        },
-                                                                    },
-                                                                    span: 7..8,
-                                                                    name: "x",
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ],
-                                                type_args: None,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                            ],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-5.snap
@@ -5,127 +5,140 @@ expression: "parse(\"foo(a, ...b);\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 12,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..12,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 3,
-                                            },
-                                        },
-                                        span: 0..3,
-                                        name: "foo",
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                        },
-                                        span: 4..5,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 4,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 5,
-                                                    },
-                                                },
-                                                span: 4..5,
-                                                name: "a",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                                ExprOrSpread {
-                                    spread: Some(
-                                        7..10,
-                                    ),
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 11,
-                                            },
-                                        },
-                                        span: 10..11,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 10,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 11,
-                                                    },
-                                                },
-                                                span: 10..11,
-                                                name: "b",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                            ],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 13,
+                    },
                 },
-            ),
+                span: 0..13,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 12,
+                            },
+                        },
+                        span: 0..12,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
+                                    },
+                                    span: 0..3,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 3,
+                                                },
+                                            },
+                                            span: 0..3,
+                                            name: "foo",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                            },
+                                            span: 4..5,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 4,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 5,
+                                                        },
+                                                    },
+                                                    span: 4..5,
+                                                    name: "a",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: Some(
+                                            7..10,
+                                        ),
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 10,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 11,
+                                                },
+                                            },
+                                            span: 10..11,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                    },
+                                                    span: 10..11,
+                                                    name: "b",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ],
+                                type_args: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-6.snap
@@ -5,7 +5,7 @@ expression: parse(src)
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 9..49,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                    },
-                    span: 13..14,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "S",
-                            mutable: false,
-                            span: 13..14,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,45 +30,45 @@ Ok(
                                     column: 13,
                                 },
                             },
+                            span: 13..14,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "S",
+                                    mutable: false,
+                                    span: 13..14,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 1,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 1,
+                                            column: 13,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 16,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 47,
-                            },
-                        },
-                        span: 17..48,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 17,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 18,
-                                                },
-                                            },
-                                            span: 18..19,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "f",
-                                                    mutable: false,
-                                                    span: 18..19,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 16,
+                                    },
+                                    end: Position {
+                                        line: 1,
+                                        column: 47,
+                                    },
+                                },
+                                span: 17..48,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 1,
@@ -93,50 +79,50 @@ Ok(
                                                             column: 18,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 24..48,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 23,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 47,
-                                                },
-                                            },
-                                            span: 24..48,
-                                            kind: Lambda(
-                                                Lambda {
-                                                    params: [
-                                                        EFnParam {
-                                                            pat: Pattern {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 24,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 25,
-                                                                    },
+                                                    span: 18..19,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "f",
+                                                            mutable: false,
+                                                            span: 18..19,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 1,
+                                                                    column: 17,
                                                                 },
-                                                                span: 25..26,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "g",
-                                                                        mutable: false,
-                                                                        span: 25..26,
+                                                                end: Position {
+                                                                    line: 1,
+                                                                    column: 18,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 24..48,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 1,
+                                                            column: 23,
+                                                        },
+                                                        end: Position {
+                                                            line: 1,
+                                                            column: 47,
+                                                        },
+                                                    },
+                                                    span: 24..48,
+                                                    kind: Lambda(
+                                                        Lambda {
+                                                            params: [
+                                                                EFnParam {
+                                                                    pat: Pattern {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 1,
@@ -147,50 +133,50 @@ Ok(
                                                                                 column: 25,
                                                                             },
                                                                         },
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            type_ann: None,
-                                                            optional: false,
-                                                        },
-                                                    ],
-                                                    body: Block {
-                                                        span: 31..48,
-                                                        stmts: [
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 30,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 47,
-                                                                    },
-                                                                },
-                                                                span: 31..48,
-                                                                kind: Lambda(
-                                                                    Lambda {
-                                                                        params: [
-                                                                            EFnParam {
-                                                                                pat: Pattern {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 1,
-                                                                                            column: 31,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 1,
-                                                                                            column: 32,
-                                                                                        },
+                                                                        span: 25..26,
+                                                                        kind: Ident(
+                                                                            BindingIdent {
+                                                                                name: "g",
+                                                                                mutable: false,
+                                                                                span: 25..26,
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 24,
                                                                                     },
-                                                                                    span: 32..33,
-                                                                                    kind: Ident(
-                                                                                        BindingIdent {
-                                                                                            name: "x",
-                                                                                            mutable: false,
-                                                                                            span: 32..33,
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 25,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                    type_ann: None,
+                                                                    optional: false,
+                                                                },
+                                                            ],
+                                                            body: Block {
+                                                                span: 31..48,
+                                                                stmts: [
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 1,
+                                                                                column: 30,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 1,
+                                                                                column: 47,
+                                                                            },
+                                                                        },
+                                                                        span: 31..48,
+                                                                        kind: Lambda(
+                                                                            Lambda {
+                                                                                params: [
+                                                                                    EFnParam {
+                                                                                        pat: Pattern {
                                                                                             loc: SourceLocation {
                                                                                                 start: Position {
                                                                                                     line: 1,
@@ -201,59 +187,62 @@ Ok(
                                                                                                     column: 32,
                                                                                                 },
                                                                                             },
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                                type_ann: None,
-                                                                                optional: false,
-                                                                            },
-                                                                        ],
-                                                                        body: Block {
-                                                                            span: 38..48,
-                                                                            stmts: [
-                                                                                Expr {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 1,
-                                                                                            column: 37,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 1,
-                                                                                            column: 47,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 38..48,
-                                                                                    kind: App(
-                                                                                        App {
-                                                                                            lam: Expr {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 1,
-                                                                                                        column: 37,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 1,
-                                                                                                        column: 41,
+                                                                                            span: 32..33,
+                                                                                            kind: Ident(
+                                                                                                BindingIdent {
+                                                                                                    name: "x",
+                                                                                                    mutable: false,
+                                                                                                    span: 32..33,
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 1,
+                                                                                                            column: 31,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 1,
+                                                                                                            column: 32,
+                                                                                                        },
                                                                                                     },
                                                                                                 },
-                                                                                                span: 38..42,
-                                                                                                kind: App(
-                                                                                                    App {
-                                                                                                        lam: Expr {
-                                                                                                            loc: SourceLocation {
-                                                                                                                start: Position {
-                                                                                                                    line: 1,
-                                                                                                                    column: 37,
-                                                                                                                },
-                                                                                                                end: Position {
-                                                                                                                    line: 1,
-                                                                                                                    column: 38,
-                                                                                                                },
+                                                                                            ),
+                                                                                            inferred_type: None,
+                                                                                        },
+                                                                                        type_ann: None,
+                                                                                        optional: false,
+                                                                                    },
+                                                                                ],
+                                                                                body: Block {
+                                                                                    span: 38..48,
+                                                                                    stmts: [
+                                                                                        Expr {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 37,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 47,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 38..48,
+                                                                                            kind: App(
+                                                                                                App {
+                                                                                                    lam: Expr {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 1,
+                                                                                                                column: 37,
                                                                                                             },
-                                                                                                            span: 38..39,
-                                                                                                            kind: Ident(
-                                                                                                                Ident {
+                                                                                                            end: Position {
+                                                                                                                line: 1,
+                                                                                                                column: 41,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 38..42,
+                                                                                                        kind: App(
+                                                                                                            App {
+                                                                                                                lam: Expr {
                                                                                                                     loc: SourceLocation {
                                                                                                                         start: Position {
                                                                                                                             line: 1,
@@ -265,94 +254,20 @@ Ok(
                                                                                                                         },
                                                                                                                     },
                                                                                                                     span: 38..39,
-                                                                                                                    name: "f",
-                                                                                                                },
-                                                                                                            ),
-                                                                                                            inferred_type: None,
-                                                                                                        },
-                                                                                                        args: [
-                                                                                                            ExprOrSpread {
-                                                                                                                spread: None,
-                                                                                                                expr: Expr {
-                                                                                                                    loc: SourceLocation {
-                                                                                                                        start: Position {
-                                                                                                                            line: 1,
-                                                                                                                            column: 39,
-                                                                                                                        },
-                                                                                                                        end: Position {
-                                                                                                                            line: 1,
-                                                                                                                            column: 40,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    span: 40..41,
                                                                                                                     kind: Ident(
                                                                                                                         Ident {
                                                                                                                             loc: SourceLocation {
                                                                                                                                 start: Position {
                                                                                                                                     line: 1,
-                                                                                                                                    column: 39,
+                                                                                                                                    column: 37,
                                                                                                                                 },
                                                                                                                                 end: Position {
                                                                                                                                     line: 1,
-                                                                                                                                    column: 40,
+                                                                                                                                    column: 38,
                                                                                                                                 },
                                                                                                                             },
-                                                                                                                            span: 40..41,
-                                                                                                                            name: "x",
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                    inferred_type: None,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        ],
-                                                                                                        type_args: None,
-                                                                                                    },
-                                                                                                ),
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            args: [
-                                                                                                ExprOrSpread {
-                                                                                                    spread: None,
-                                                                                                    expr: Expr {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 42,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 46,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 43..47,
-                                                                                                        kind: App(
-                                                                                                            App {
-                                                                                                                lam: Expr {
-                                                                                                                    loc: SourceLocation {
-                                                                                                                        start: Position {
-                                                                                                                            line: 1,
-                                                                                                                            column: 42,
-                                                                                                                        },
-                                                                                                                        end: Position {
-                                                                                                                            line: 1,
-                                                                                                                            column: 43,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    span: 43..44,
-                                                                                                                    kind: Ident(
-                                                                                                                        Ident {
-                                                                                                                            loc: SourceLocation {
-                                                                                                                                start: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 42,
-                                                                                                                                },
-                                                                                                                                end: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 43,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            span: 43..44,
-                                                                                                                            name: "g",
+                                                                                                                            span: 38..39,
+                                                                                                                            name: "f",
                                                                                                                         },
                                                                                                                     ),
                                                                                                                     inferred_type: None,
@@ -364,27 +279,27 @@ Ok(
                                                                                                                             loc: SourceLocation {
                                                                                                                                 start: Position {
                                                                                                                                     line: 1,
-                                                                                                                                    column: 44,
+                                                                                                                                    column: 39,
                                                                                                                                 },
                                                                                                                                 end: Position {
                                                                                                                                     line: 1,
-                                                                                                                                    column: 45,
+                                                                                                                                    column: 40,
                                                                                                                                 },
                                                                                                                             },
-                                                                                                                            span: 45..46,
+                                                                                                                            span: 40..41,
                                                                                                                             kind: Ident(
                                                                                                                                 Ident {
                                                                                                                                     loc: SourceLocation {
                                                                                                                                         start: Position {
                                                                                                                                             line: 1,
-                                                                                                                                            column: 44,
+                                                                                                                                            column: 39,
                                                                                                                                         },
                                                                                                                                         end: Position {
                                                                                                                                             line: 1,
-                                                                                                                                            column: 45,
+                                                                                                                                            column: 40,
                                                                                                                                         },
                                                                                                                                     },
-                                                                                                                                    span: 45..46,
+                                                                                                                                    span: 40..41,
                                                                                                                                     name: "x",
                                                                                                                                 },
                                                                                                                             ),
@@ -397,44 +312,133 @@ Ok(
                                                                                                         ),
                                                                                                         inferred_type: None,
                                                                                                     },
+                                                                                                    args: [
+                                                                                                        ExprOrSpread {
+                                                                                                            spread: None,
+                                                                                                            expr: Expr {
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 1,
+                                                                                                                        column: 42,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 1,
+                                                                                                                        column: 46,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                span: 43..47,
+                                                                                                                kind: App(
+                                                                                                                    App {
+                                                                                                                        lam: Expr {
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 42,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 1,
+                                                                                                                                    column: 43,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            span: 43..44,
+                                                                                                                            kind: Ident(
+                                                                                                                                Ident {
+                                                                                                                                    loc: SourceLocation {
+                                                                                                                                        start: Position {
+                                                                                                                                            line: 1,
+                                                                                                                                            column: 42,
+                                                                                                                                        },
+                                                                                                                                        end: Position {
+                                                                                                                                            line: 1,
+                                                                                                                                            column: 43,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    span: 43..44,
+                                                                                                                                    name: "g",
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                            inferred_type: None,
+                                                                                                                        },
+                                                                                                                        args: [
+                                                                                                                            ExprOrSpread {
+                                                                                                                                spread: None,
+                                                                                                                                expr: Expr {
+                                                                                                                                    loc: SourceLocation {
+                                                                                                                                        start: Position {
+                                                                                                                                            line: 1,
+                                                                                                                                            column: 44,
+                                                                                                                                        },
+                                                                                                                                        end: Position {
+                                                                                                                                            line: 1,
+                                                                                                                                            column: 45,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    span: 45..46,
+                                                                                                                                    kind: Ident(
+                                                                                                                                        Ident {
+                                                                                                                                            loc: SourceLocation {
+                                                                                                                                                start: Position {
+                                                                                                                                                    line: 1,
+                                                                                                                                                    column: 44,
+                                                                                                                                                },
+                                                                                                                                                end: Position {
+                                                                                                                                                    line: 1,
+                                                                                                                                                    column: 45,
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            span: 45..46,
+                                                                                                                                            name: "x",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                    inferred_type: None,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        type_args: None,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                inferred_type: None,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    type_args: None,
                                                                                                 },
-                                                                                            ],
-                                                                                            type_args: None,
+                                                                                            ),
+                                                                                            inferred_type: None,
                                                                                         },
-                                                                                    ),
-                                                                                    inferred_type: None,
+                                                                                    ],
                                                                                 },
-                                                                            ],
-                                                                        },
-                                                                        is_async: false,
-                                                                        return_type: None,
-                                                                        type_params: None,
+                                                                                is_async: false,
+                                                                                return_type: None,
+                                                                                type_params: None,
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
+                                                                ],
                                                             },
-                                                        ],
-                                                    },
-                                                    is_async: false,
-                                                    return_type: None,
-                                                    type_params: None,
+                                                            is_async: false,
+                                                            return_type: None,
+                                                            type_params: None,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 2,
@@ -446,23 +450,9 @@ Ok(
                     },
                 },
                 span: 58..82,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 2,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 2,
-                            column: 13,
-                        },
-                    },
-                    span: 62..63,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "K",
-                            mutable: false,
-                            span: 62..63,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 2,
@@ -473,45 +463,45 @@ Ok(
                                     column: 13,
                                 },
                             },
+                            span: 62..63,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "K",
+                                    mutable: false,
+                                    span: 62..63,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 2,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 2,
+                                            column: 13,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 2,
-                                column: 16,
-                            },
-                            end: Position {
-                                line: 2,
-                                column: 31,
-                            },
-                        },
-                        span: 66..81,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 17,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 18,
-                                                },
-                                            },
-                                            span: 67..68,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "x",
-                                                    mutable: false,
-                                                    span: 67..68,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 2,
+                                        column: 16,
+                                    },
+                                    end: Position {
+                                        line: 2,
+                                        column: 31,
+                                    },
+                                },
+                                span: 66..81,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -522,50 +512,50 @@ Ok(
                                                             column: 18,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 73..81,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 23,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 31,
-                                                },
-                                            },
-                                            span: 73..81,
-                                            kind: Lambda(
-                                                Lambda {
-                                                    params: [
-                                                        EFnParam {
-                                                            pat: Pattern {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 24,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 25,
-                                                                    },
+                                                    span: 67..68,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "x",
+                                                            mutable: false,
+                                                            span: 67..68,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 17,
                                                                 },
-                                                                span: 74..75,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "y",
-                                                                        mutable: false,
-                                                                        span: 74..75,
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 18,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 73..81,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 23,
+                                                        },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 31,
+                                                        },
+                                                    },
+                                                    span: 73..81,
+                                                    kind: Lambda(
+                                                        Lambda {
+                                                            params: [
+                                                                EFnParam {
+                                                                    pat: Pattern {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 2,
@@ -576,31 +566,34 @@ Ok(
                                                                                 column: 25,
                                                                             },
                                                                         },
+                                                                        span: 74..75,
+                                                                        kind: Ident(
+                                                                            BindingIdent {
+                                                                                name: "y",
+                                                                                mutable: false,
+                                                                                span: 74..75,
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 24,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 25,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            type_ann: None,
-                                                            optional: false,
-                                                        },
-                                                    ],
-                                                    body: Block {
-                                                        span: 80..81,
-                                                        stmts: [
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 30,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 31,
-                                                                    },
+                                                                    type_ann: None,
+                                                                    optional: false,
                                                                 },
+                                                            ],
+                                                            body: Block {
                                                                 span: 80..81,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                stmts: [
+                                                                    Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 2,
@@ -612,33 +605,48 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 80..81,
-                                                                        name: "x",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 30,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 31,
+                                                                                    },
+                                                                                },
+                                                                                span: 80..81,
+                                                                                name: "x",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
+                                                                ],
                                                             },
-                                                        ],
-                                                    },
-                                                    is_async: false,
-                                                    return_type: None,
-                                                    type_params: None,
+                                                            is_async: false,
+                                                            return_type: None,
+                                                            type_params: None,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 3,
@@ -650,23 +658,9 @@ Ok(
                     },
                 },
                 span: 91..107,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 13,
-                        },
-                    },
-                    span: 95..96,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "I",
-                            mutable: false,
-                            span: 95..96,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 3,
@@ -677,54 +671,57 @@ Ok(
                                     column: 13,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 3,
-                                column: 16,
-                            },
-                            end: Position {
-                                line: 3,
-                                column: 23,
-                            },
-                        },
-                        span: 99..106,
-                        kind: App(
-                            App {
-                                lam: Expr {
+                            span: 95..96,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "I",
+                                    mutable: false,
+                                    span: 95..96,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 3,
-                                            column: 16,
+                                            column: 12,
                                         },
                                         end: Position {
                                             line: 3,
-                                            column: 20,
+                                            column: 13,
                                         },
                                     },
-                                    span: 99..103,
-                                    kind: App(
-                                        App {
-                                            lam: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 17,
-                                                    },
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 3,
+                                        column: 16,
+                                    },
+                                    end: Position {
+                                        line: 3,
+                                        column: 23,
+                                    },
+                                },
+                                span: 99..106,
+                                kind: App(
+                                    App {
+                                        lam: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 3,
+                                                    column: 16,
                                                 },
-                                                span: 99..100,
-                                                kind: Ident(
-                                                    Ident {
+                                                end: Position {
+                                                    line: 3,
+                                                    column: 20,
+                                                },
+                                            },
+                                            span: 99..103,
+                                            kind: App(
+                                                App {
+                                                    lam: Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 3,
@@ -736,28 +733,28 @@ Ok(
                                                             },
                                                         },
                                                         span: 99..100,
-                                                        name: "S",
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            args: [
-                                                ExprOrSpread {
-                                                    spread: None,
-                                                    expr: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 3,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 3,
-                                                                column: 19,
-                                                            },
-                                                        },
-                                                        span: 101..102,
                                                         kind: Ident(
                                                             Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 16,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 17,
+                                                                    },
+                                                                },
+                                                                span: 99..100,
+                                                                name: "S",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    args: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 3,
@@ -769,35 +766,35 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 101..102,
-                                                                name: "K",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 19,
+                                                                            },
+                                                                        },
+                                                                        span: 101..102,
+                                                                        name: "K",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ],
+                                                    type_args: None,
                                                 },
-                                            ],
-                                            type_args: None,
+                                            ),
+                                            inferred_type: None,
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                args: [
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 21,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 22,
-                                                },
-                                            },
-                                            span: 104..105,
-                                            kind: Ident(
-                                                Ident {
+                                        args: [
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 3,
@@ -809,20 +806,35 @@ Ok(
                                                         },
                                                     },
                                                     span: 104..105,
-                                                    name: "K",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 22,
+                                                                },
+                                                            },
+                                                            span: 104..105,
+                                                            name: "K",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                            },
+                                        ],
+                                        type_args: None,
                                     },
-                                ],
-                                type_args: None,
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application.snap
@@ -5,58 +5,71 @@ expression: "parse(\"foo();\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..5,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 3,
-                                            },
-                                        },
-                                        span: 0..3,
-                                        name: "foo",
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            args: [],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 6,
+                    },
                 },
-            ),
+                span: 0..6,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 5,
+                            },
+                        },
+                        span: 0..5,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
+                                    },
+                                    span: 0..3,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 3,
+                                                },
+                                            },
+                                            span: 0..3,
+                                            name: "foo",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [],
+                                type_args: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
@@ -5,67 +5,80 @@ expression: "parse(\"() => 10;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..8,
-                    kind: Lambda(
-                        Lambda {
-                            params: [],
-                            body: Block {
-                                span: 6..8,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                        },
-                                        span: 6..8,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 6,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 8,
-                                                        },
-                                                    },
-                                                    span: 6..8,
-                                                    value: "10",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
-                            },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 9,
+                    },
                 },
-            ),
+                span: 0..9,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 8,
+                            },
+                        },
+                        span: 0..8,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Block {
+                                    span: 6..8,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 6,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                            },
+                                            span: 6..8,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 6,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 8,
+                                                            },
+                                                        },
+                                                        span: 6..8,
+                                                        value: "10",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
@@ -5,103 +5,116 @@ expression: "parse(\"(a) => \\\"hello\\\";\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 14,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..14,
-                    kind: Lambda(
-                        Lambda {
-                            params: [
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 2,
-                                            },
-                                        },
-                                        span: 1..2,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
-                                                span: 1..2,
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 1,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 2,
-                                                    },
+                    end: Position {
+                        line: 0,
+                        column: 15,
+                    },
+                },
+                span: 0..15,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 14,
+                            },
+                        },
+                        span: 0..14,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 2,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                            ],
-                            body: Block {
-                                span: 7..14,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 7,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 14,
-                                            },
-                                        },
-                                        span: 7..14,
-                                        kind: Lit(
-                                            Str(
-                                                Str {
+                                            span: 1..2,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "a",
+                                                    mutable: false,
+                                                    span: 1..2,
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 7,
+                                                            column: 1,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 14,
+                                                            column: 2,
                                                         },
                                                     },
-                                                    span: 7..14,
-                                                    value: "hello",
                                                 },
                                             ),
-                                        ),
-                                        inferred_type: None,
+                                            inferred_type: None,
+                                        },
+                                        type_ann: None,
+                                        optional: false,
                                     },
                                 ],
+                                body: Block {
+                                    span: 7..14,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 7,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                            },
+                                            span: 7..14,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 7,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                        },
+                                                        span: 7..14,
+                                                        value: "hello",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
                             },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
@@ -5,156 +5,169 @@ expression: "parse(\"(a, ...b) => true;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 17,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..17,
-                    kind: Lambda(
-                        Lambda {
-                            params: [
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 2,
-                                            },
-                                        },
-                                        span: 1..2,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
-                                                span: 1..2,
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 1,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 2,
-                                                    },
+                    end: Position {
+                        line: 0,
+                        column: 18,
+                    },
+                },
+                span: 0..18,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 17,
+                            },
+                        },
+                        span: 0..17,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 2,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                        },
-                                        span: 4..8,
-                                        kind: Rest(
-                                            RestPat {
-                                                arg: Pattern {
+                                            span: 1..2,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "a",
+                                                    mutable: false,
+                                                    span: 1..2,
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 7,
+                                                            column: 1,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 8,
+                                                            column: 2,
                                                         },
                                                     },
-                                                    span: 7..8,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "b",
-                                                            mutable: false,
-                                                            span: 7..8,
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 7,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 8,
-                                                                },
-                                                            },
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                            ],
-                            body: Block {
-                                span: 13..17,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 13,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
-                                        },
-                                        span: 13..17,
-                                        kind: Lit(
-                                            Bool(
-                                                Bool {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 13,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                    },
-                                                    span: 13..17,
-                                                    value: true,
                                                 },
                                             ),
-                                        ),
-                                        inferred_type: None,
+                                            inferred_type: None,
+                                        },
+                                        type_ann: None,
+                                        optional: false,
+                                    },
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                            },
+                                            span: 4..8,
+                                            kind: Rest(
+                                                RestPat {
+                                                    arg: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 7,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 8,
+                                                            },
+                                                        },
+                                                        span: 7..8,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "b",
+                                                                mutable: false,
+                                                                span: 7..8,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 7,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 8,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        type_ann: None,
+                                        optional: false,
                                     },
                                 ],
+                                body: Block {
+                                    span: 13..17,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 13,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 17,
+                                                },
+                                            },
+                                            span: 13..17,
+                                            kind: Lit(
+                                                Bool(
+                                                    Bool {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 13,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                        },
+                                                        span: 13..17,
+                                                        value: true,
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
                             },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
@@ -5,55 +5,52 @@ expression: "parse(\"({x, y}) => x + y;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 17,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..17,
-                    kind: Lambda(
-                        Lambda {
-                            params: [
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 1,
+                    end: Position {
+                        line: 0,
+                        column: 18,
+                    },
+                },
+                span: 0..18,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 17,
+                            },
+                        },
+                        span: 0..17,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 7,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 7,
-                                            },
-                                        },
-                                        span: 1..7,
-                                        kind: Object(
-                                            ObjectPat {
-                                                props: [
-                                                    Shorthand(
-                                                        ShorthandPatProp {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 2,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 3,
-                                                                },
-                                                            },
-                                                            span: 2..3,
-                                                            ident: BindingIdent {
-                                                                name: "x",
-                                                                mutable: false,
-                                                                span: 2..3,
+                                            span: 1..7,
+                                            kind: Object(
+                                                ObjectPat {
+                                                    props: [
+                                                        Shorthand(
+                                                            ShorthandPatProp {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -64,27 +61,27 @@ Ok(
                                                                         column: 3,
                                                                     },
                                                                 },
-                                                            },
-                                                            init: None,
-                                                        },
-                                                    ),
-                                                    Shorthand(
-                                                        ShorthandPatProp {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 5,
+                                                                span: 2..3,
+                                                                ident: BindingIdent {
+                                                                    name: "x",
+                                                                    mutable: false,
+                                                                    span: 2..3,
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 2,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 3,
+                                                                        },
+                                                                    },
                                                                 },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 6,
-                                                                },
+                                                                init: None,
                                                             },
-                                                            span: 5..6,
-                                                            ident: BindingIdent {
-                                                                name: "y",
-                                                                mutable: false,
-                                                                span: 5..6,
+                                                        ),
+                                                        Shorthand(
+                                                            ShorthandPatProp {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -95,112 +92,128 @@ Ok(
                                                                         column: 6,
                                                                     },
                                                                 },
+                                                                span: 5..6,
+                                                                ident: BindingIdent {
+                                                                    name: "y",
+                                                                    mutable: false,
+                                                                    span: 5..6,
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 5,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 6,
+                                                                        },
+                                                                    },
+                                                                },
+                                                                init: None,
                                                             },
-                                                            init: None,
-                                                        },
-                                                    ),
-                                                ],
-                                                optional: false,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                            ],
-                            body: Block {
-                                span: 12..17,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 12,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
+                                                        ),
+                                                    ],
+                                                    optional: false,
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 12..17,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 12,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 13,
-                                                        },
-                                                    },
-                                                    span: 12..13,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 12,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 13,
-                                                                },
-                                                            },
-                                                            span: 12..13,
-                                                            name: "x",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 16,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                    },
-                                                    span: 16..17,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 17,
-                                                                },
-                                                            },
-                                                            span: 16..17,
-                                                            name: "y",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                        type_ann: None,
+                                        optional: false,
                                     },
                                 ],
+                                body: Block {
+                                    span: 12..17,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 12,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 17,
+                                                },
+                                            },
+                                            span: 12..17,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 13,
+                                                            },
+                                                        },
+                                                        span: 12..13,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 13,
+                                                                    },
+                                                                },
+                                                                span: 12..13,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 16,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                        },
+                                                        span: 16..17,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 16,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 17,
+                                                                    },
+                                                                },
+                                                                span: 16..17,
+                                                                name: "y",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
                             },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
@@ -5,52 +5,52 @@ expression: "parse(\"({x: p, y: q}) => p + q;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 23,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..23,
-                    kind: Lambda(
-                        Lambda {
-                            params: [
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 1,
+                    end: Position {
+                        line: 0,
+                        column: 24,
+                    },
+                },
+                span: 0..24,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 23,
+                            },
+                        },
+                        span: 0..23,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 13,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 13,
-                                            },
-                                        },
-                                        span: 1..13,
-                                        kind: Object(
-                                            ObjectPat {
-                                                props: [
-                                                    KeyValue(
-                                                        KeyValuePatProp {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 2,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 6,
-                                                                },
-                                                            },
-                                                            span: 2..6,
-                                                            key: Ident {
+                                            span: 1..13,
+                                            kind: Object(
+                                                ObjectPat {
+                                                    props: [
+                                                        KeyValue(
+                                                            KeyValuePatProp {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -58,60 +58,60 @@ Ok(
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 3,
-                                                                    },
-                                                                },
-                                                                span: 2..3,
-                                                                name: "x",
-                                                            },
-                                                            value: Pattern {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 5,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
                                                                         column: 6,
                                                                     },
                                                                 },
-                                                                span: 5..6,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "p",
-                                                                        mutable: false,
-                                                                        span: 5..6,
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 5,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 6,
-                                                                            },
+                                                                span: 2..6,
+                                                                key: Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 2,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 3,
                                                                         },
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            init: None,
-                                                        },
-                                                    ),
-                                                    KeyValue(
-                                                        KeyValuePatProp {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 8,
+                                                                    span: 2..3,
+                                                                    name: "x",
                                                                 },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 12,
+                                                                value: Pattern {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 5,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 6,
+                                                                        },
+                                                                    },
+                                                                    span: 5..6,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "p",
+                                                                            mutable: false,
+                                                                            span: 5..6,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 5,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 6,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
+                                                                init: None,
                                                             },
-                                                            span: 8..12,
-                                                            key: Ident {
+                                                        ),
+                                                        KeyValue(
+                                                            KeyValuePatProp {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -119,148 +119,161 @@ Ok(
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 9,
-                                                                    },
-                                                                },
-                                                                span: 8..9,
-                                                                name: "y",
-                                                            },
-                                                            value: Pattern {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 11,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
                                                                         column: 12,
                                                                     },
                                                                 },
-                                                                span: 11..12,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "q",
-                                                                        mutable: false,
-                                                                        span: 11..12,
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 11,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 12,
-                                                                            },
+                                                                span: 8..12,
+                                                                key: Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 8,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 9,
                                                                         },
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
+                                                                    span: 8..9,
+                                                                    name: "y",
+                                                                },
+                                                                value: Pattern {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 11,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 12,
+                                                                        },
+                                                                    },
+                                                                    span: 11..12,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "q",
+                                                                            mutable: false,
+                                                                            span: 11..12,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 11,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 12,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
                                                             },
-                                                            init: None,
-                                                        },
-                                                    ),
-                                                ],
-                                                optional: false,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                            ],
-                            body: Block {
-                                span: 18..23,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 18,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 23,
-                                            },
+                                                        ),
+                                                    ],
+                                                    optional: false,
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                        span: 18..23,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Add,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                    },
-                                                    span: 18..19,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
-                                                            },
-                                                            span: 18..19,
-                                                            name: "p",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 22,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 23,
-                                                                },
-                                                            },
-                                                            span: 22..23,
-                                                            name: "q",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                        type_ann: None,
+                                        optional: false,
                                     },
                                 ],
+                                body: Block {
+                                    span: 18..23,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
+                                            },
+                                            span: 18..23,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 19,
+                                                            },
+                                                        },
+                                                        span: 18..19,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 18,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 19,
+                                                                    },
+                                                                },
+                                                                span: 18..19,
+                                                                name: "p",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                        },
+                                                        span: 22..23,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 23,
+                                                                    },
+                                                                },
+                                                                span: 22..23,
+                                                                name: "q",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
                             },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
@@ -5,156 +5,169 @@ expression: "parse(\"(a?: boolean, b?) => c;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 22,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..22,
-                    kind: Lambda(
-                        Lambda {
-                            params: [
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 2,
-                                            },
-                                        },
-                                        span: 1..2,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
-                                                span: 1..2,
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 1,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 2,
-                                                    },
-                                                },
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    type_ann: Some(
-                                        TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: Boolean,
-                                                },
-                                            ),
+                    end: Position {
+                        line: 0,
+                        column: 23,
+                    },
+                },
+                span: 0..23,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 22,
+                            },
+                        },
+                        span: 0..22,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Pattern {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 5,
+                                                    column: 1,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 12,
+                                                    column: 2,
                                                 },
                                             },
-                                            span: 5..12,
+                                            span: 1..2,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "a",
+                                                    mutable: false,
+                                                    span: 1..2,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 1,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 2,
+                                                        },
+                                                    },
+                                                },
+                                            ),
                                             inferred_type: None,
                                         },
-                                    ),
-                                    optional: true,
-                                },
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 15,
-                                            },
-                                        },
-                                        span: 14..15,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "b",
-                                                mutable: false,
-                                                span: 14..15,
+                                        type_ann: Some(
+                                            TypeAnn {
+                                                kind: Keyword(
+                                                    KeywordType {
+                                                        keyword: Boolean,
+                                                    },
+                                                ),
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 14,
+                                                        column: 5,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 15,
+                                                        column: 12,
                                                     },
                                                 },
+                                                span: 5..12,
+                                                inferred_type: None,
                                             },
                                         ),
-                                        inferred_type: None,
+                                        optional: true,
                                     },
-                                    type_ann: None,
-                                    optional: true,
-                                },
-                            ],
-                            body: Block {
-                                span: 21..22,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 21,
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 15,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 22,
-                                            },
-                                        },
-                                        span: 21..22,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 22,
+                                            span: 14..15,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "b",
+                                                    mutable: false,
+                                                    span: 14..15,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 15,
+                                                        },
                                                     },
                                                 },
-                                                span: 21..22,
-                                                name: "c",
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        type_ann: None,
+                                        optional: true,
                                     },
                                 ],
+                                body: Block {
+                                    span: 21..22,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 21,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
+                                            },
+                                            span: 21..22,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 21,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 22,
+                                                        },
+                                                    },
+                                                    span: 21..22,
+                                                    name: "c",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
                             },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
@@ -5,136 +5,149 @@ expression: "parse(\"(a, b) => c;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..11,
-                    kind: Lambda(
-                        Lambda {
-                            params: [
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 2,
-                                            },
-                                        },
-                                        span: 1..2,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
-                                                span: 1..2,
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 1,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 2,
-                                                    },
+                    end: Position {
+                        line: 0,
+                        column: 12,
+                    },
+                },
+                span: 0..12,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 11,
+                            },
+                        },
+                        span: 0..11,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 2,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
+                                            span: 1..2,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "a",
+                                                    mutable: false,
+                                                    span: 1..2,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 1,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 2,
+                                                        },
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        type_ann: None,
+                                        optional: false,
                                     },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                                EFnParam {
-                                    pat: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                        },
-                                        span: 4..5,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "b",
-                                                mutable: false,
-                                                span: 4..5,
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 4,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 5,
-                                                    },
+                                    EFnParam {
+                                        pat: Pattern {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 5,
                                                 },
                                             },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    type_ann: None,
-                                    optional: false,
-                                },
-                            ],
-                            body: Block {
-                                span: 10..11,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 11,
-                                            },
-                                        },
-                                        span: 10..11,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 10,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 11,
+                                            span: 4..5,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "b",
+                                                    mutable: false,
+                                                    span: 4..5,
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 4,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 5,
+                                                        },
                                                     },
                                                 },
-                                                span: 10..11,
-                                                name: "c",
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        type_ann: None,
+                                        optional: false,
                                     },
                                 ],
+                                body: Block {
+                                    span: 10..11,
+                                    stmts: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 10,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 11,
+                                                },
+                                            },
+                                            span: 10..11,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                    },
+                                                    span: 10..11,
+                                                    name: "c",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
                             },
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
@@ -5,204 +5,178 @@ expression: "parse(\"if (a) { 5 } else if (b) { 10 } else { 20 };\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 43,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..43,
-                    kind: IfElse(
-                        IfElse {
-                            cond: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                },
-                                span: 4..5,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                        },
-                                        span: 4..5,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 44,
+                    },
+                },
+                span: 0..44,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            consequent: Block {
-                                span: 7..12,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
+                            end: Position {
+                                line: 0,
+                                column: 43,
+                            },
+                        },
+                        span: 0..43,
+                        kind: IfElse(
+                            IfElse {
+                                cond: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
                                         },
-                                        span: 9..10,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 9,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 10,
-                                                        },
-                                                    },
-                                                    span: 9..10,
-                                                    value: "5",
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                    span: 4..5,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
                                                 },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
-                            },
-                            alternate: Some(
-                                Block {
-                                    span: 18..43,
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                            },
+                                            span: 4..5,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                consequent: Block {
+                                    span: 7..12,
                                     stmts: [
                                         Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 18,
+                                                    column: 9,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 43,
+                                                    column: 10,
                                                 },
                                             },
-                                            span: 18..43,
-                                            kind: IfElse(
-                                                IfElse {
-                                                    cond: Expr {
+                                            span: 9..10,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
-                                                                column: 22,
+                                                                column: 9,
                                                             },
                                                             end: Position {
                                                                 line: 0,
-                                                                column: 23,
+                                                                column: 10,
                                                             },
                                                         },
-                                                        span: 22..23,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 22..23,
-                                                                name: "b",
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
+                                                        span: 9..10,
+                                                        value: "5",
                                                     },
-                                                    consequent: Block {
-                                                        span: 25..31,
-                                                        stmts: [
-                                                            Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 27,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 29,
-                                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                                alternate: Some(
+                                    Block {
+                                        span: 18..43,
+                                        stmts: [
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 18,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 43,
+                                                    },
+                                                },
+                                                span: 18..43,
+                                                kind: IfElse(
+                                                    IfElse {
+                                                        cond: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
                                                                 },
-                                                                span: 27..29,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 27,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 29,
-                                                                                },
-                                                                            },
-                                                                            span: 27..29,
-                                                                            value: "10",
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                            },
+                                                            span: 22..23,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
                                                                         },
-                                                                    ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        ],
-                                                    },
-                                                    alternate: Some(
-                                                        Block {
-                                                            span: 37..43,
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    name: "b",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        consequent: Block {
+                                                            span: 25..31,
                                                             stmts: [
                                                                 Expr {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
-                                                                            column: 39,
+                                                                            column: 27,
                                                                         },
                                                                         end: Position {
                                                                             line: 0,
-                                                                            column: 41,
+                                                                            column: 29,
                                                                         },
                                                                     },
-                                                                    span: 39..41,
+                                                                    span: 27..29,
                                                                     kind: Lit(
                                                                         Num(
                                                                             Num {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
-                                                                                        column: 39,
+                                                                                        column: 27,
                                                                                     },
                                                                                     end: Position {
                                                                                         line: 0,
-                                                                                        column: 41,
+                                                                                        column: 29,
                                                                                     },
                                                                                 },
-                                                                                span: 39..41,
-                                                                                value: "20",
+                                                                                span: 27..29,
+                                                                                value: "10",
                                                                             },
                                                                         ),
                                                                     ),
@@ -210,19 +184,58 @@ Ok(
                                                                 },
                                                             ],
                                                         },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                                        alternate: Some(
+                                                            Block {
+                                                                span: 37..43,
+                                                                stmts: [
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 39,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 41,
+                                                                            },
+                                                                        },
+                                                                        span: 39..41,
+                                                                        kind: Lit(
+                                                                            Num(
+                                                                                Num {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 39,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 41,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 39..41,
+                                                                                    value: "20",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ],
+                                    },
+                                ),
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
@@ -5,121 +5,95 @@ expression: "parse(\"if (true) { 5 } else { 10 };\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 27,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..27,
-                    kind: IfElse(
-                        IfElse {
-                            cond: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 8,
-                                    },
-                                },
-                                span: 4..8,
-                                kind: Lit(
-                                    Bool(
-                                        Bool {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 4,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                            },
-                                            span: 4..8,
-                                            value: true,
-                                        },
-                                    ),
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 28,
+                    },
+                },
+                span: 0..28,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            consequent: Block {
-                                span: 10..15,
-                                stmts: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 12,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 13,
-                                            },
+                            end: Position {
+                                line: 0,
+                                column: 27,
+                            },
+                        },
+                        span: 0..27,
+                        kind: IfElse(
+                            IfElse {
+                                cond: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
                                         },
-                                        span: 12..13,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 12,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 13,
-                                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 8,
+                                        },
+                                    },
+                                    span: 4..8,
+                                    kind: Lit(
+                                        Bool(
+                                            Bool {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 4,
                                                     },
-                                                    span: 12..13,
-                                                    value: "5",
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
                                                 },
-                                            ),
+                                                span: 4..8,
+                                                value: true,
+                                            },
                                         ),
-                                        inferred_type: None,
-                                    },
-                                ],
-                            },
-                            alternate: Some(
-                                Block {
-                                    span: 21..27,
+                                    ),
+                                    inferred_type: None,
+                                },
+                                consequent: Block {
+                                    span: 10..15,
                                     stmts: [
                                         Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 23,
+                                                    column: 12,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 25,
+                                                    column: 13,
                                                 },
                                             },
-                                            span: 23..25,
+                                            span: 12..13,
                                             kind: Lit(
                                                 Num(
                                                     Num {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
-                                                                column: 23,
+                                                                column: 12,
                                                             },
                                                             end: Position {
                                                                 line: 0,
-                                                                column: 25,
+                                                                column: 13,
                                                             },
                                                         },
-                                                        span: 23..25,
-                                                        value: "10",
+                                                        span: 12..13,
+                                                        value: "5",
                                                     },
                                                 ),
                                             ),
@@ -127,12 +101,51 @@ Ok(
                                         },
                                     ],
                                 },
-                            ),
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                alternate: Some(
+                                    Block {
+                                        span: 21..27,
+                                        stmts: [
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 23,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 25,
+                                                    },
+                                                },
+                                                span: 23..25,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 23..25,
+                                                            value: "10",
+                                                        },
+                                                    ),
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ],
+                                    },
+                                ),
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let-2.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"\n            let bar = if (let {x: x is string} = foo) {
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 13..226,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
-                    span: 17..20,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "bar",
-                            mutable: false,
-                            span: 17..20,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,152 +30,155 @@ Ok(
                                     column: 19,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 7,
-                                column: 13,
-                            },
-                        },
-                        span: 23..225,
-                        kind: IfElse(
-                            IfElse {
-                                cond: Expr {
+                            span: 17..20,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "bar",
+                                    mutable: false,
+                                    span: 17..20,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 1,
-                                            column: 26,
+                                            column: 16,
                                         },
                                         end: Position {
                                             line: 1,
-                                            column: 52,
+                                            column: 19,
                                         },
                                     },
-                                    span: 27..53,
-                                    kind: LetExpr(
-                                        LetExpr {
-                                            pat: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 30,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 46,
-                                                    },
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 7,
+                                        column: 13,
+                                    },
+                                },
+                                span: 23..225,
+                                kind: IfElse(
+                                    IfElse {
+                                        cond: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 1,
+                                                    column: 26,
                                                 },
-                                                span: 31..47,
-                                                kind: Object(
-                                                    ObjectPat {
-                                                        props: [
-                                                            KeyValue(
-                                                                KeyValuePatProp {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 1,
-                                                                            column: 31,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 1,
-                                                                            column: 45,
-                                                                        },
-                                                                    },
-                                                                    span: 32..46,
-                                                                    key: Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 31,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 32,
-                                                                            },
-                                                                        },
-                                                                        span: 32..33,
-                                                                        name: "x",
-                                                                    },
-                                                                    value: Pattern {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 34,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 45,
-                                                                            },
-                                                                        },
-                                                                        span: 35..46,
-                                                                        kind: Is(
-                                                                            IsPat {
-                                                                                ident: BindingIdent {
-                                                                                    name: "x",
-                                                                                    mutable: false,
-                                                                                    span: 35..36,
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 1,
-                                                                                            column: 34,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 1,
-                                                                                            column: 35,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                is_id: Ident {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 1,
-                                                                                            column: 39,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 1,
-                                                                                            column: 45,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 40..46,
-                                                                                    name: "string",
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    init: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                        optional: false,
-                                                    },
-                                                ),
-                                                inferred_type: None,
+                                                end: Position {
+                                                    line: 1,
+                                                    column: 52,
+                                                },
                                             },
-                                            expr: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 49,
+                                            span: 27..53,
+                                            kind: LetExpr(
+                                                LetExpr {
+                                                    pat: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 1,
+                                                                column: 30,
+                                                            },
+                                                            end: Position {
+                                                                line: 1,
+                                                                column: 46,
+                                                            },
+                                                        },
+                                                        span: 31..47,
+                                                        kind: Object(
+                                                            ObjectPat {
+                                                                props: [
+                                                                    KeyValue(
+                                                                        KeyValuePatProp {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 1,
+                                                                                    column: 31,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 1,
+                                                                                    column: 45,
+                                                                                },
+                                                                            },
+                                                                            span: 32..46,
+                                                                            key: Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 31,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 32,
+                                                                                    },
+                                                                                },
+                                                                                span: 32..33,
+                                                                                name: "x",
+                                                                            },
+                                                                            value: Pattern {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 34,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 45,
+                                                                                    },
+                                                                                },
+                                                                                span: 35..46,
+                                                                                kind: Is(
+                                                                                    IsPat {
+                                                                                        ident: BindingIdent {
+                                                                                            name: "x",
+                                                                                            mutable: false,
+                                                                                            span: 35..36,
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 34,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 35,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        is_id: Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 39,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 1,
+                                                                                                    column: 45,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 40..46,
+                                                                                            name: "string",
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                            init: None,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                optional: false,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 52,
-                                                    },
-                                                },
-                                                span: 50..53,
-                                                kind: Ident(
-                                                    Ident {
+                                                    expr: Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 1,
@@ -201,204 +190,201 @@ Ok(
                                                             },
                                                         },
                                                         span: 50..53,
-                                                        name: "foo",
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                consequent: Block {
-                                    span: 55..95,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 73..81,
-                                            kind: Lit(
-                                                Str(
-                                                    Str {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 16,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 1,
+                                                                        column: 49,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 1,
+                                                                        column: 52,
+                                                                    },
+                                                                },
+                                                                span: 50..53,
+                                                                name: "foo",
                                                             },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 24,
-                                                            },
-                                                        },
-                                                        span: 73..81,
-                                                        value: "object",
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
+                                                },
                                             ),
                                             inferred_type: None,
                                         },
-                                    ],
-                                },
-                                alternate: Some(
-                                    Block {
-                                        span: 101..225,
-                                        stmts: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 19,
+                                        consequent: Block {
+                                            span: 55..95,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 24,
+                                                        },
                                                     },
-                                                    end: Position {
-                                                        line: 7,
-                                                        column: 13,
-                                                    },
-                                                },
-                                                span: 101..225,
-                                                kind: IfElse(
-                                                    IfElse {
-                                                        cond: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 23,
+                                                    span: 73..81,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 16,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 24,
+                                                                    },
                                                                 },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 57,
-                                                                },
+                                                                span: 73..81,
+                                                                value: "object",
                                                             },
-                                                            span: 105..139,
-                                                            kind: LetExpr(
-                                                                LetExpr {
-                                                                    pat: Pattern {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 27,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 51,
-                                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
+                                        alternate: Some(
+                                            Block {
+                                                span: 101..225,
+                                                stmts: [
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 3,
+                                                                column: 19,
+                                                            },
+                                                            end: Position {
+                                                                line: 7,
+                                                                column: 13,
+                                                            },
+                                                        },
+                                                        span: 101..225,
+                                                        kind: IfElse(
+                                                            IfElse {
+                                                                cond: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 23,
                                                                         },
-                                                                        span: 109..133,
-                                                                        kind: Array(
-                                                                            ArrayPat {
-                                                                                elems: [
-                                                                                    Some(
-                                                                                        ArrayPatElem {
-                                                                                            pattern: Pattern {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 28,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 38,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 110..120,
-                                                                                                kind: Is(
-                                                                                                    IsPat {
-                                                                                                        ident: BindingIdent {
-                                                                                                            name: "a",
-                                                                                                            mutable: false,
-                                                                                                            span: 110..111,
-                                                                                                            loc: SourceLocation {
-                                                                                                                start: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 28,
-                                                                                                                },
-                                                                                                                end: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 29,
-                                                                                                                },
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 57,
+                                                                        },
+                                                                    },
+                                                                    span: 105..139,
+                                                                    kind: LetExpr(
+                                                                        LetExpr {
+                                                                            pat: Pattern {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 27,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 51,
+                                                                                    },
+                                                                                },
+                                                                                span: 109..133,
+                                                                                kind: Array(
+                                                                                    ArrayPat {
+                                                                                        elems: [
+                                                                                            Some(
+                                                                                                ArrayPatElem {
+                                                                                                    pattern: Pattern {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 28,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 38,
                                                                                                             },
                                                                                                         },
-                                                                                                        is_id: Ident {
-                                                                                                            loc: SourceLocation {
-                                                                                                                start: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 33,
-                                                                                                                },
-                                                                                                                end: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 38,
-                                                                                                                },
-                                                                                                            },
-                                                                                                            span: 115..120,
-                                                                                                            name: "Array",
-                                                                                                        },
-                                                                                                    },
-                                                                                                ),
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            init: None,
-                                                                                        },
-                                                                                    ),
-                                                                                    Some(
-                                                                                        ArrayPatElem {
-                                                                                            pattern: Pattern {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 40,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 41,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 122..123,
-                                                                                                kind: Wildcard,
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            init: None,
-                                                                                        },
-                                                                                    ),
-                                                                                    Some(
-                                                                                        ArrayPatElem {
-                                                                                            pattern: Pattern {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 43,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 50,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 125..132,
-                                                                                                kind: Rest(
-                                                                                                    RestPat {
-                                                                                                        arg: Pattern {
-                                                                                                            loc: SourceLocation {
-                                                                                                                start: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 46,
-                                                                                                                },
-                                                                                                                end: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 50,
-                                                                                                                },
-                                                                                                            },
-                                                                                                            span: 128..132,
-                                                                                                            kind: Ident(
-                                                                                                                BindingIdent {
-                                                                                                                    name: "rest",
+                                                                                                        span: 110..120,
+                                                                                                        kind: Is(
+                                                                                                            IsPat {
+                                                                                                                ident: BindingIdent {
+                                                                                                                    name: "a",
                                                                                                                     mutable: false,
-                                                                                                                    span: 128..132,
+                                                                                                                    span: 110..111,
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 28,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 29,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                is_id: Ident {
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 33,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 3,
+                                                                                                                            column: 38,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    span: 115..120,
+                                                                                                                    name: "Array",
+                                                                                                                },
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        inferred_type: None,
+                                                                                                    },
+                                                                                                    init: None,
+                                                                                                },
+                                                                                            ),
+                                                                                            Some(
+                                                                                                ArrayPatElem {
+                                                                                                    pattern: Pattern {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 40,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 41,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 122..123,
+                                                                                                        kind: Wildcard,
+                                                                                                        inferred_type: None,
+                                                                                                    },
+                                                                                                    init: None,
+                                                                                                },
+                                                                                            ),
+                                                                                            Some(
+                                                                                                ArrayPatElem {
+                                                                                                    pattern: Pattern {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 43,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 50,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 125..132,
+                                                                                                        kind: Rest(
+                                                                                                            RestPat {
+                                                                                                                arg: Pattern {
                                                                                                                     loc: SourceLocation {
                                                                                                                         start: Position {
                                                                                                                             line: 3,
@@ -409,37 +395,40 @@ Ok(
                                                                                                                             column: 50,
                                                                                                                         },
                                                                                                                     },
+                                                                                                                    span: 128..132,
+                                                                                                                    kind: Ident(
+                                                                                                                        BindingIdent {
+                                                                                                                            name: "rest",
+                                                                                                                            mutable: false,
+                                                                                                                            span: 128..132,
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 46,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 50,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    inferred_type: None,
                                                                                                                 },
-                                                                                                            ),
-                                                                                                            inferred_type: None,
-                                                                                                        },
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        inferred_type: None,
                                                                                                     },
-                                                                                                ),
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            init: None,
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                optional: false,
+                                                                                                    init: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ],
+                                                                                        optional: false,
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    expr: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 54,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 57,
-                                                                            },
-                                                                        },
-                                                                        span: 136..139,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                            expr: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 3,
@@ -451,104 +440,119 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 136..139,
-                                                                                name: "foo",
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        consequent: Block {
-                                                            span: 141..180,
-                                                            stmts: [
-                                                                Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 4,
-                                                                            column: 16,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 4,
-                                                                            column: 23,
-                                                                        },
-                                                                    },
-                                                                    span: 159..166,
-                                                                    kind: Lit(
-                                                                        Str(
-                                                                            Str {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 4,
-                                                                                        column: 16,
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 3,
+                                                                                                column: 54,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 3,
+                                                                                                column: 57,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 136..139,
+                                                                                        name: "foo",
                                                                                     },
-                                                                                    end: Position {
-                                                                                        line: 4,
-                                                                                        column: 23,
-                                                                                    },
-                                                                                },
-                                                                                span: 159..166,
-                                                                                value: "array",
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
+                                                                        },
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
-                                                            ],
-                                                        },
-                                                        alternate: Some(
-                                                            Block {
-                                                                span: 186..225,
-                                                                stmts: [
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 6,
-                                                                                column: 16,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 6,
-                                                                                column: 23,
-                                                                            },
-                                                                        },
-                                                                        span: 204..211,
-                                                                        kind: Lit(
-                                                                            Str(
-                                                                                Str {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 6,
-                                                                                            column: 16,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 6,
-                                                                                            column: 23,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 204..211,
-                                                                                    value: "other",
+                                                                consequent: Block {
+                                                                    span: 141..180,
+                                                                    stmts: [
+                                                                        Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 4,
+                                                                                    column: 16,
                                                                                 },
+                                                                                end: Position {
+                                                                                    line: 4,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                            span: 159..166,
+                                                                            kind: Lit(
+                                                                                Str(
+                                                                                    Str {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 4,
+                                                                                                column: 16,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 4,
+                                                                                                column: 23,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 159..166,
+                                                                                        value: "array",
+                                                                                    },
+                                                                                ),
                                                                             ),
-                                                                        ),
-                                                                        inferred_type: None,
+                                                                            inferred_type: None,
+                                                                        },
+                                                                    ],
+                                                                },
+                                                                alternate: Some(
+                                                                    Block {
+                                                                        span: 186..225,
+                                                                        stmts: [
+                                                                            Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 6,
+                                                                                        column: 16,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 6,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 204..211,
+                                                                                kind: Lit(
+                                                                                    Str(
+                                                                                        Str {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 6,
+                                                                                                    column: 16,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 6,
+                                                                                                    column: 23,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 204..211,
+                                                                                            value: "other",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                        ],
                                                                     },
-                                                                ],
+                                                                ),
                                                             },
                                                         ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                ],
                                             },
-                                        ],
+                                        ),
                                     },
                                 ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"\n            let bar = if (let {x, y: b, ...rest} = foo)
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 13..219,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
-                    span: 17..20,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "bar",
-                            mutable: false,
-                            span: 17..20,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,130 +30,130 @@ Ok(
                                     column: 19,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 7,
-                                column: 13,
-                            },
-                        },
-                        span: 23..218,
-                        kind: IfElse(
-                            IfElse {
-                                cond: Expr {
+                            span: 17..20,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "bar",
+                                    mutable: false,
+                                    span: 17..20,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 1,
-                                            column: 26,
+                                            column: 16,
                                         },
                                         end: Position {
                                             line: 1,
-                                            column: 54,
+                                            column: 19,
                                         },
                                     },
-                                    span: 27..55,
-                                    kind: LetExpr(
-                                        LetExpr {
-                                            pat: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 30,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 48,
-                                                    },
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 7,
+                                        column: 13,
+                                    },
+                                },
+                                span: 23..218,
+                                kind: IfElse(
+                                    IfElse {
+                                        cond: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 1,
+                                                    column: 26,
                                                 },
-                                                span: 31..49,
-                                                kind: Object(
-                                                    ObjectPat {
-                                                        props: [
-                                                            Shorthand(
-                                                                ShorthandPatProp {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 1,
-                                                                            column: 31,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 1,
-                                                                            column: 32,
-                                                                        },
-                                                                    },
-                                                                    span: 32..33,
-                                                                    ident: BindingIdent {
-                                                                        name: "x",
-                                                                        mutable: false,
-                                                                        span: 32..33,
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 31,
+                                                end: Position {
+                                                    line: 1,
+                                                    column: 54,
+                                                },
+                                            },
+                                            span: 27..55,
+                                            kind: LetExpr(
+                                                LetExpr {
+                                                    pat: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 1,
+                                                                column: 30,
+                                                            },
+                                                            end: Position {
+                                                                line: 1,
+                                                                column: 48,
+                                                            },
+                                                        },
+                                                        span: 31..49,
+                                                        kind: Object(
+                                                            ObjectPat {
+                                                                props: [
+                                                                    Shorthand(
+                                                                        ShorthandPatProp {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 1,
+                                                                                    column: 31,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 1,
+                                                                                    column: 32,
+                                                                                },
                                                                             },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 32,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    init: None,
-                                                                },
-                                                            ),
-                                                            KeyValue(
-                                                                KeyValuePatProp {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 1,
-                                                                            column: 34,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 1,
-                                                                            column: 38,
-                                                                        },
-                                                                    },
-                                                                    span: 35..39,
-                                                                    key: Ident {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 34,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 35,
-                                                                            },
-                                                                        },
-                                                                        span: 35..36,
-                                                                        name: "y",
-                                                                    },
-                                                                    value: Pattern {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 37,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 38,
-                                                                            },
-                                                                        },
-                                                                        span: 38..39,
-                                                                        kind: Ident(
-                                                                            BindingIdent {
-                                                                                name: "b",
+                                                                            span: 32..33,
+                                                                            ident: BindingIdent {
+                                                                                name: "x",
                                                                                 mutable: false,
-                                                                                span: 38..39,
+                                                                                span: 32..33,
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 31,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 32,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            init: None,
+                                                                        },
+                                                                    ),
+                                                                    KeyValue(
+                                                                        KeyValuePatProp {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 1,
+                                                                                    column: 34,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 1,
+                                                                                    column: 38,
+                                                                                },
+                                                                            },
+                                                                            span: 35..39,
+                                                                            key: Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 34,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 35,
+                                                                                    },
+                                                                                },
+                                                                                span: 35..36,
+                                                                                name: "y",
+                                                                            },
+                                                                            value: Pattern {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 1,
@@ -178,32 +164,32 @@ Ok(
                                                                                         column: 38,
                                                                                     },
                                                                                 },
+                                                                                span: 38..39,
+                                                                                kind: Ident(
+                                                                                    BindingIdent {
+                                                                                        name: "b",
+                                                                                        mutable: false,
+                                                                                        span: 38..39,
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 1,
+                                                                                                column: 37,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 1,
+                                                                                                column: 38,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    init: None,
-                                                                },
-                                                            ),
-                                                            Rest(
-                                                                RestPat {
-                                                                    arg: Pattern {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 43,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 47,
-                                                                            },
+                                                                            init: None,
                                                                         },
-                                                                        span: 44..48,
-                                                                        kind: Ident(
-                                                                            BindingIdent {
-                                                                                name: "rest",
-                                                                                mutable: false,
-                                                                                span: 44..48,
+                                                                    ),
+                                                                    Rest(
+                                                                        RestPat {
+                                                                            arg: Pattern {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 1,
@@ -214,32 +200,35 @@ Ok(
                                                                                         column: 47,
                                                                                     },
                                                                                 },
+                                                                                span: 44..48,
+                                                                                kind: Ident(
+                                                                                    BindingIdent {
+                                                                                        name: "rest",
+                                                                                        mutable: false,
+                                                                                        span: 44..48,
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 1,
+                                                                                                column: 43,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 1,
+                                                                                                column: 47,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                },
-                                                            ),
-                                                        ],
-                                                        optional: false,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                optional: false,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                            expr: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 51,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 54,
-                                                    },
-                                                },
-                                                span: 52..55,
-                                                kind: Ident(
-                                                    Ident {
+                                                    expr: Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 1,
@@ -251,118 +240,115 @@ Ok(
                                                             },
                                                         },
                                                         span: 52..55,
-                                                        name: "foo",
-                                                    },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                consequent: Block {
-                                    span: 57..97,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 75..83,
-                                            kind: Lit(
-                                                Str(
-                                                    Str {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 16,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 1,
+                                                                        column: 51,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 1,
+                                                                        column: 54,
+                                                                    },
+                                                                },
+                                                                span: 52..55,
+                                                                name: "foo",
                                                             },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 24,
-                                                            },
-                                                        },
-                                                        span: 75..83,
-                                                        value: "object",
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
+                                                },
                                             ),
                                             inferred_type: None,
                                         },
-                                    ],
-                                },
-                                alternate: Some(
-                                    Block {
-                                        span: 103..218,
-                                        stmts: [
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 19,
+                                        consequent: Block {
+                                            span: 57..97,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 24,
+                                                        },
                                                     },
-                                                    end: Position {
-                                                        line: 7,
-                                                        column: 13,
-                                                    },
-                                                },
-                                                span: 103..218,
-                                                kind: IfElse(
-                                                    IfElse {
-                                                        cond: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 23,
+                                                    span: 75..83,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 16,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 24,
+                                                                    },
                                                                 },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 48,
-                                                                },
+                                                                span: 75..83,
+                                                                value: "object",
                                                             },
-                                                            span: 107..132,
-                                                            kind: LetExpr(
-                                                                LetExpr {
-                                                                    pat: Pattern {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 27,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 42,
-                                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
+                                        alternate: Some(
+                                            Block {
+                                                span: 103..218,
+                                                stmts: [
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 3,
+                                                                column: 19,
+                                                            },
+                                                            end: Position {
+                                                                line: 7,
+                                                                column: 13,
+                                                            },
+                                                        },
+                                                        span: 103..218,
+                                                        kind: IfElse(
+                                                            IfElse {
+                                                                cond: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 23,
                                                                         },
-                                                                        span: 111..126,
-                                                                        kind: Array(
-                                                                            ArrayPat {
-                                                                                elems: [
-                                                                                    Some(
-                                                                                        ArrayPatElem {
-                                                                                            pattern: Pattern {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 28,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 29,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 112..113,
-                                                                                                kind: Ident(
-                                                                                                    BindingIdent {
-                                                                                                        name: "a",
-                                                                                                        mutable: false,
-                                                                                                        span: 112..113,
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 48,
+                                                                        },
+                                                                    },
+                                                                    span: 107..132,
+                                                                    kind: LetExpr(
+                                                                        LetExpr {
+                                                                            pat: Pattern {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 27,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 42,
+                                                                                    },
+                                                                                },
+                                                                                span: 111..126,
+                                                                                kind: Array(
+                                                                                    ArrayPat {
+                                                                                        elems: [
+                                                                                            Some(
+                                                                                                ArrayPatElem {
+                                                                                                    pattern: Pattern {
                                                                                                         loc: SourceLocation {
                                                                                                             start: Position {
                                                                                                                 line: 3,
@@ -373,66 +359,66 @@ Ok(
                                                                                                                 column: 29,
                                                                                                             },
                                                                                                         },
-                                                                                                    },
-                                                                                                ),
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            init: None,
-                                                                                        },
-                                                                                    ),
-                                                                                    Some(
-                                                                                        ArrayPatElem {
-                                                                                            pattern: Pattern {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 31,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 32,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 115..116,
-                                                                                                kind: Wildcard,
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            init: None,
-                                                                                        },
-                                                                                    ),
-                                                                                    Some(
-                                                                                        ArrayPatElem {
-                                                                                            pattern: Pattern {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 34,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 3,
-                                                                                                        column: 41,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 118..125,
-                                                                                                kind: Rest(
-                                                                                                    RestPat {
-                                                                                                        arg: Pattern {
-                                                                                                            loc: SourceLocation {
-                                                                                                                start: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 37,
-                                                                                                                },
-                                                                                                                end: Position {
-                                                                                                                    line: 3,
-                                                                                                                    column: 41,
+                                                                                                        span: 112..113,
+                                                                                                        kind: Ident(
+                                                                                                            BindingIdent {
+                                                                                                                name: "a",
+                                                                                                                mutable: false,
+                                                                                                                span: 112..113,
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 28,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 29,
+                                                                                                                    },
                                                                                                                 },
                                                                                                             },
-                                                                                                            span: 121..125,
-                                                                                                            kind: Ident(
-                                                                                                                BindingIdent {
-                                                                                                                    name: "rest",
-                                                                                                                    mutable: false,
-                                                                                                                    span: 121..125,
+                                                                                                        ),
+                                                                                                        inferred_type: None,
+                                                                                                    },
+                                                                                                    init: None,
+                                                                                                },
+                                                                                            ),
+                                                                                            Some(
+                                                                                                ArrayPatElem {
+                                                                                                    pattern: Pattern {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 31,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 32,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 115..116,
+                                                                                                        kind: Wildcard,
+                                                                                                        inferred_type: None,
+                                                                                                    },
+                                                                                                    init: None,
+                                                                                                },
+                                                                                            ),
+                                                                                            Some(
+                                                                                                ArrayPatElem {
+                                                                                                    pattern: Pattern {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 34,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 3,
+                                                                                                                column: 41,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 118..125,
+                                                                                                        kind: Rest(
+                                                                                                            RestPat {
+                                                                                                                arg: Pattern {
                                                                                                                     loc: SourceLocation {
                                                                                                                         start: Position {
                                                                                                                             line: 3,
@@ -443,37 +429,40 @@ Ok(
                                                                                                                             column: 41,
                                                                                                                         },
                                                                                                                     },
+                                                                                                                    span: 121..125,
+                                                                                                                    kind: Ident(
+                                                                                                                        BindingIdent {
+                                                                                                                            name: "rest",
+                                                                                                                            mutable: false,
+                                                                                                                            span: 121..125,
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 37,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 41,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    inferred_type: None,
                                                                                                                 },
-                                                                                                            ),
-                                                                                                            inferred_type: None,
-                                                                                                        },
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        inferred_type: None,
                                                                                                     },
-                                                                                                ),
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            init: None,
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                optional: false,
+                                                                                                    init: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ],
+                                                                                        optional: false,
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    expr: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 45,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 48,
-                                                                            },
-                                                                        },
-                                                                        span: 129..132,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                            expr: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 3,
@@ -485,104 +474,119 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 129..132,
-                                                                                name: "foo",
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        consequent: Block {
-                                                            span: 134..173,
-                                                            stmts: [
-                                                                Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 4,
-                                                                            column: 16,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 4,
-                                                                            column: 23,
-                                                                        },
-                                                                    },
-                                                                    span: 152..159,
-                                                                    kind: Lit(
-                                                                        Str(
-                                                                            Str {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 4,
-                                                                                        column: 16,
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 3,
+                                                                                                column: 45,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 3,
+                                                                                                column: 48,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 129..132,
+                                                                                        name: "foo",
                                                                                     },
-                                                                                    end: Position {
-                                                                                        line: 4,
-                                                                                        column: 23,
-                                                                                    },
-                                                                                },
-                                                                                span: 152..159,
-                                                                                value: "array",
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
+                                                                        },
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
-                                                            ],
-                                                        },
-                                                        alternate: Some(
-                                                            Block {
-                                                                span: 179..218,
-                                                                stmts: [
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 6,
-                                                                                column: 16,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 6,
-                                                                                column: 23,
-                                                                            },
-                                                                        },
-                                                                        span: 197..204,
-                                                                        kind: Lit(
-                                                                            Str(
-                                                                                Str {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 6,
-                                                                                            column: 16,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 6,
-                                                                                            column: 23,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 197..204,
-                                                                                    value: "other",
+                                                                consequent: Block {
+                                                                    span: 134..173,
+                                                                    stmts: [
+                                                                        Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 4,
+                                                                                    column: 16,
                                                                                 },
+                                                                                end: Position {
+                                                                                    line: 4,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                            span: 152..159,
+                                                                            kind: Lit(
+                                                                                Str(
+                                                                                    Str {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 4,
+                                                                                                column: 16,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 4,
+                                                                                                column: 23,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 152..159,
+                                                                                        value: "array",
+                                                                                    },
+                                                                                ),
                                                                             ),
-                                                                        ),
-                                                                        inferred_type: None,
+                                                                            inferred_type: None,
+                                                                        },
+                                                                    ],
+                                                                },
+                                                                alternate: Some(
+                                                                    Block {
+                                                                        span: 179..218,
+                                                                        stmts: [
+                                                                            Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 6,
+                                                                                        column: 16,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 6,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 197..204,
+                                                                                kind: Lit(
+                                                                                    Str(
+                                                                                        Str {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 6,
+                                                                                                    column: 16,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 6,
+                                                                                                    column: 23,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 197..204,
+                                                                                            value: "other",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                        ],
                                                                     },
-                                                                ],
+                                                                ),
                                                             },
                                                         ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                ],
                                             },
-                                        ],
+                                        ),
                                     },
                                 ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__it_works.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__it_works.snap
@@ -5,7 +5,7 @@ expression: parse(src)
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 9..35,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 15,
-                        },
-                    },
-                    span: 13..16,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "add",
-                            mutable: false,
-                            span: 13..16,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,45 +30,45 @@ Ok(
                                     column: 15,
                                 },
                             },
+                            span: 13..16,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "add",
+                                    mutable: false,
+                                    span: 13..16,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 1,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 1,
+                                            column: 15,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 18,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 33,
-                            },
-                        },
-                        span: 19..34,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 19,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 20,
-                                                },
-                                            },
-                                            span: 20..21,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                    span: 20..21,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 18,
+                                    },
+                                    end: Position {
+                                        line: 1,
+                                        column: 33,
+                                    },
+                                },
+                                span: 19..34,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 1,
@@ -93,31 +79,31 @@ Ok(
                                                             column: 20,
                                                         },
                                                     },
+                                                    span: 20..21,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                            span: 20..21,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 1,
+                                                                    column: 19,
+                                                                },
+                                                                end: Position {
+                                                                    line: 1,
+                                                                    column: 20,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 23,
-                                                },
+                                                type_ann: None,
+                                                optional: false,
                                             },
-                                            span: 23..24,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: false,
-                                                    span: 23..24,
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 1,
@@ -128,46 +114,49 @@ Ok(
                                                             column: 23,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 29..34,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 28,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 33,
-                                                },
-                                            },
-                                            span: 29..34,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 28,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 29,
+                                                    span: 23..24,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: false,
+                                                            span: 23..24,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 1,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 1,
+                                                                    column: 23,
+                                                                },
                                                             },
                                                         },
-                                                        span: 29..30,
-                                                        kind: Ident(
-                                                            Ident {
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 29..34,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 1,
+                                                            column: 28,
+                                                        },
+                                                        end: Position {
+                                                            line: 1,
+                                                            column: 33,
+                                                        },
+                                                    },
+                                                    span: 29..34,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 1,
@@ -179,25 +168,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 29..30,
-                                                                name: "a",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 1,
+                                                                                column: 28,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 1,
+                                                                                column: 29,
+                                                                            },
+                                                                        },
+                                                                        span: 29..30,
+                                                                        name: "a",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 32,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 33,
-                                                            },
-                                                        },
-                                                        span: 33..34,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 1,
@@ -209,28 +198,43 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 33..34,
-                                                                name: "b",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 1,
+                                                                                column: 32,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 1,
+                                                                                column: 33,
+                                                                            },
+                                                                        },
+                                                                        span: 33..34,
+                                                                        name: "b",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 2,
@@ -242,23 +246,9 @@ Ok(
                     },
                 },
                 span: 44..70,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 2,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 2,
-                            column: 15,
-                        },
-                    },
-                    span: 48..51,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "sub",
-                            mutable: false,
-                            span: 48..51,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 2,
@@ -269,45 +259,45 @@ Ok(
                                     column: 15,
                                 },
                             },
+                            span: 48..51,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "sub",
+                                    mutable: false,
+                                    span: 48..51,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 2,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 2,
+                                            column: 15,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 2,
-                                column: 18,
-                            },
-                            end: Position {
-                                line: 2,
-                                column: 33,
-                            },
-                        },
-                        span: 54..69,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 19,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 20,
-                                                },
-                                            },
-                                            span: 55..56,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                    span: 55..56,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 2,
+                                        column: 18,
+                                    },
+                                    end: Position {
+                                        line: 2,
+                                        column: 33,
+                                    },
+                                },
+                                span: 54..69,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -318,31 +308,31 @@ Ok(
                                                             column: 20,
                                                         },
                                                     },
+                                                    span: 55..56,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                            span: 55..56,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 19,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 20,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 23,
-                                                },
+                                                type_ann: None,
+                                                optional: false,
                                             },
-                                            span: 58..59,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: false,
-                                                    span: 58..59,
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -353,46 +343,49 @@ Ok(
                                                             column: 23,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: None,
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 64..69,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 28,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 33,
-                                                },
-                                            },
-                                            span: 64..69,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Sub,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 28,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 29,
+                                                    span: 58..59,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: false,
+                                                            span: 58..59,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 23,
+                                                                },
                                                             },
                                                         },
-                                                        span: 64..65,
-                                                        kind: Ident(
-                                                            Ident {
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: None,
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 64..69,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 28,
+                                                        },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 33,
+                                                        },
+                                                    },
+                                                    span: 64..69,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Sub,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 2,
@@ -404,25 +397,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 64..65,
-                                                                name: "a",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 28,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 29,
+                                                                            },
+                                                                        },
+                                                                        span: 64..65,
+                                                                        name: "a",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 32,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 33,
-                                                            },
-                                                        },
-                                                        span: 68..69,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 2,
@@ -434,28 +427,43 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 68..69,
-                                                                name: "b",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 32,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 33,
+                                                                            },
+                                                                        },
+                                                                        span: 68..69,
+                                                                        name: "b",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 3,
@@ -467,23 +475,9 @@ Ok(
                     },
                 },
                 span: 79..100,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 15,
-                        },
-                    },
-                    span: 83..86,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "sum",
-                            mutable: false,
-                            span: 83..86,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 3,
@@ -494,40 +488,43 @@ Ok(
                                     column: 15,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 3,
-                                column: 18,
-                            },
-                            end: Position {
-                                line: 3,
-                                column: 28,
-                            },
-                        },
-                        span: 89..99,
-                        kind: App(
-                            App {
-                                lam: Expr {
+                            span: 83..86,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "sum",
+                                    mutable: false,
+                                    span: 83..86,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 3,
-                                            column: 18,
+                                            column: 12,
                                         },
                                         end: Position {
                                             line: 3,
-                                            column: 21,
+                                            column: 15,
                                         },
                                     },
-                                    span: 89..92,
-                                    kind: Ident(
-                                        Ident {
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 3,
+                                        column: 18,
+                                    },
+                                    end: Position {
+                                        line: 3,
+                                        column: 28,
+                                    },
+                                },
+                                span: 89..99,
+                                kind: App(
+                                    App {
+                                        lam: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 3,
@@ -539,90 +536,105 @@ Ok(
                                                 },
                                             },
                                             span: 89..92,
-                                            name: "add",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                args: [
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 23,
-                                                },
-                                            },
-                                            span: 93..94,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 3,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 3,
-                                                                column: 23,
-                                                            },
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 18,
                                                         },
-                                                        span: 93..94,
-                                                        value: "5",
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 21,
+                                                        },
                                                     },
-                                                ),
+                                                    span: 89..92,
+                                                    name: "add",
+                                                },
                                             ),
                                             inferred_type: None,
                                         },
-                                    },
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 27,
+                                        args: [
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 22,
+                                                        },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 23,
+                                                        },
+                                                    },
+                                                    span: 93..94,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 22,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 23,
+                                                                    },
+                                                                },
+                                                                span: 93..94,
+                                                                value: "5",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 96..98,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 3,
-                                                                column: 25,
-                                                            },
-                                                            end: Position {
-                                                                line: 3,
-                                                                column: 27,
-                                                            },
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 25,
                                                         },
-                                                        span: 96..98,
-                                                        value: "10",
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 27,
+                                                        },
                                                     },
-                                                ),
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                                    span: 96..98,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 25,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 27,
+                                                                    },
+                                                                },
+                                                                span: 96..98,
+                                                                value: "10",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ],
+                                        type_args: None,
                                     },
-                                ],
-                                type_args: None,
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-10.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-10.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let elem = <div point={point} id=\\\"point\\\">Hello, {msg}
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..60,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                    },
-                    span: 4..8,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "elem",
-                            mutable: false,
-                            span: 4..8,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,26 +30,29 @@ Ok(
                                     column: 8,
                                 },
                             },
+                            span: 4..8,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "elem",
+                                    mutable: false,
+                                    span: 4..8,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 8,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 11,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 59,
-                            },
-                        },
-                        span: 11..59,
-                        kind: JSXElement(
-                            JSXElement {
+                        type_ann: None,
+                        init: Some(
+                            Expr {
                                 loc: SourceLocation {
                                     start: Position {
                                         line: 0,
@@ -75,61 +64,61 @@ Ok(
                                     },
                                 },
                                 span: 11..59,
-                                name: "div",
-                                attrs: [
-                                    JSXAttr {
+                                kind: JSXElement(
+                                    JSXElement {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 16,
+                                                column: 11,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 29,
+                                                column: 59,
                                             },
                                         },
-                                        span: 16..29,
-                                        ident: Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                            },
-                                            span: 16..21,
-                                            name: "point",
-                                        },
-                                        value: JSXExprContainer(
-                                            JSXExprContainer {
+                                        span: 11..59,
+                                        name: "div",
+                                        attrs: [
+                                            JSXAttr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 22,
+                                                        column: 16,
                                                     },
                                                     end: Position {
                                                         line: 0,
                                                         column: 29,
                                                     },
                                                 },
-                                                span: 22..29,
-                                                expr: Expr {
+                                                span: 16..29,
+                                                ident: Ident {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 23,
+                                                            column: 16,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 28,
+                                                            column: 21,
                                                         },
                                                     },
-                                                    span: 23..28,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    span: 16..21,
+                                                    name: "point",
+                                                },
+                                                value: JSXExprContainer(
+                                                    JSXExprContainer {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 29,
+                                                            },
+                                                        },
+                                                        span: 22..29,
+                                                        expr: Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -141,104 +130,104 @@ Ok(
                                                                 },
                                                             },
                                                             span: 23..28,
-                                                            name: "point",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                    },
-                                    JSXAttr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 30,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 40,
-                                            },
-                                        },
-                                        span: 30..40,
-                                        ident: Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 30,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 32,
-                                                },
-                                            },
-                                            span: 30..32,
-                                            name: "id",
-                                        },
-                                        value: Lit(
-                                            Str(
-                                                Str {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 33,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 40,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 28,
+                                                                        },
+                                                                    },
+                                                                    span: 23..28,
+                                                                    name: "point",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     },
-                                                    span: 33..40,
-                                                    value: "point",
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ],
-                                children: [
-                                    JSXText(
-                                        JSXText {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 48,
-                                                },
+                                                ),
                                             },
-                                            span: 41..48,
-                                            value: "Hello, ",
-                                        },
-                                    ),
-                                    JSXExprContainer(
-                                        JSXExprContainer {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 48,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 53,
-                                                },
-                                            },
-                                            span: 48..53,
-                                            expr: Expr {
+                                            JSXAttr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 49,
+                                                        column: 30,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 52,
+                                                        column: 40,
                                                     },
                                                 },
-                                                span: 49..52,
-                                                kind: Ident(
-                                                    Ident {
+                                                span: 30..40,
+                                                ident: Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 30,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 30..32,
+                                                    name: "id",
+                                                },
+                                                value: Lit(
+                                                    Str(
+                                                        Str {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 33,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 40,
+                                                                },
+                                                            },
+                                                            span: 33..40,
+                                                            value: "point",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        children: [
+                                            JSXText(
+                                                JSXText {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 48,
+                                                        },
+                                                    },
+                                                    span: 41..48,
+                                                    value: "Hello, ",
+                                                },
+                                            ),
+                                            JSXExprContainer(
+                                                JSXExprContainer {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 48,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 53,
+                                                        },
+                                                    },
+                                                    span: 48..53,
+                                                    expr: Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
@@ -250,20 +239,35 @@ Ok(
                                                             },
                                                         },
                                                         span: 49..52,
-                                                        name: "msg",
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 49,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 52,
+                                                                    },
+                                                                },
+                                                                span: 49..52,
+                                                                name: "msg",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                ],
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-2.snap
@@ -5,86 +5,99 @@ expression: "parse(\"<Foo>{bar}</Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 16,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..16,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 16,
-                                },
+                    end: Position {
+                        line: 0,
+                        column: 16,
+                    },
+                },
+                span: 0..16,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            span: 0..16,
-                            name: "Foo",
-                            attrs: [],
-                            children: [
-                                JSXExprContainer(
-                                    JSXExprContainer {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                        },
-                                        span: 5..10,
-                                        expr: Expr {
+                            end: Position {
+                                line: 0,
+                                column: 16,
+                            },
+                        },
+                        span: 0..16,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 16,
+                                    },
+                                },
+                                span: 0..16,
+                                name: "Foo",
+                                attrs: [],
+                                children: [
+                                    JSXExprContainer(
+                                        JSXExprContainer {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 6,
+                                                    column: 5,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 9,
+                                                    column: 10,
                                                 },
                                             },
-                                            span: 6..9,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 6,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 9,
-                                                        },
+                                            span: 5..10,
+                                            expr: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 6,
                                                     },
-                                                    span: 6..9,
-                                                    name: "bar",
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 9,
+                                                    },
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                                span: 6..9,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 6,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 9,
+                                                            },
+                                                        },
+                                                        span: 6..9,
+                                                        name: "bar",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
                                         },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                    ),
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-3.snap
@@ -5,118 +5,131 @@ expression: "parse(\"<Foo>Hello {world}!</Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 25,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..25,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 25,
-                                },
+                    end: Position {
+                        line: 0,
+                        column: 25,
+                    },
+                },
+                span: 0..25,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            span: 0..25,
-                            name: "Foo",
-                            attrs: [],
-                            children: [
-                                JSXText(
-                                    JSXText {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 11,
-                                            },
-                                        },
-                                        span: 5..11,
-                                        value: "Hello ",
+                            end: Position {
+                                line: 0,
+                                column: 25,
+                            },
+                        },
+                        span: 0..25,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
                                     },
-                                ),
-                                JSXExprContainer(
-                                    JSXExprContainer {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 11,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 18,
-                                            },
-                                        },
-                                        span: 11..18,
-                                        expr: Expr {
+                                    end: Position {
+                                        line: 0,
+                                        column: 25,
+                                    },
+                                },
+                                span: 0..25,
+                                name: "Foo",
+                                attrs: [],
+                                children: [
+                                    JSXText(
+                                        JSXText {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 12,
+                                                    column: 5,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 17,
+                                                    column: 11,
                                                 },
                                             },
-                                            span: 12..17,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 12,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
+                                            span: 5..11,
+                                            value: "Hello ",
+                                        },
+                                    ),
+                                    JSXExprContainer(
+                                        JSXExprContainer {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 11,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                            },
+                                            span: 11..18,
+                                            expr: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 12,
                                                     },
-                                                    span: 12..17,
-                                                    name: "world",
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 17,
+                                                    },
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                JSXText(
-                                    JSXText {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 18,
+                                                span: 12..17,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                        },
+                                                        span: 12..17,
+                                                        name: "world",
+                                                    },
+                                                ),
+                                                inferred_type: None,
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 19,
-                                            },
                                         },
-                                        span: 18..19,
-                                        value: "!",
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                    ),
+                                    JSXText(
+                                        JSXText {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 19,
+                                                },
+                                            },
+                                            span: 18..19,
+                                            value: "!",
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-4.snap
@@ -5,134 +5,147 @@ expression: "parse(\"<Foo>{<Bar>{baz}</Bar>}</Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 29,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..29,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 29,
-                                },
+                    end: Position {
+                        line: 0,
+                        column: 29,
+                    },
+                },
+                span: 0..29,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            span: 0..29,
-                            name: "Foo",
-                            attrs: [],
-                            children: [
-                                JSXExprContainer(
-                                    JSXExprContainer {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 23,
-                                            },
-                                        },
-                                        span: 5..23,
-                                        expr: Expr {
+                            end: Position {
+                                line: 0,
+                                column: 29,
+                            },
+                        },
+                        span: 0..29,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 29,
+                                    },
+                                },
+                                span: 0..29,
+                                name: "Foo",
+                                attrs: [],
+                                children: [
+                                    JSXExprContainer(
+                                        JSXExprContainer {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 6,
+                                                    column: 5,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 22,
+                                                    column: 23,
                                                 },
                                             },
-                                            span: 6..22,
-                                            kind: JSXElement(
-                                                JSXElement {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 6,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
+                                            span: 5..23,
+                                            expr: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 6,
                                                     },
-                                                    span: 6..22,
-                                                    name: "Bar",
-                                                    attrs: [],
-                                                    children: [
-                                                        JSXExprContainer(
-                                                            JSXExprContainer {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 11,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 16,
-                                                                    },
-                                                                },
-                                                                span: 11..16,
-                                                                expr: Expr {
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 22,
+                                                    },
+                                                },
+                                                span: 6..22,
+                                                kind: JSXElement(
+                                                    JSXElement {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 6,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                        },
+                                                        span: 6..22,
+                                                        name: "Bar",
+                                                        attrs: [],
+                                                        children: [
+                                                            JSXExprContainer(
+                                                                JSXExprContainer {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
-                                                                            column: 12,
+                                                                            column: 11,
                                                                         },
                                                                         end: Position {
                                                                             line: 0,
-                                                                            column: 15,
+                                                                            column: 16,
                                                                         },
                                                                     },
-                                                                    span: 12..15,
-                                                                    kind: Ident(
-                                                                        Ident {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 12,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 15,
-                                                                                },
+                                                                    span: 11..16,
+                                                                    expr: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 12,
                                                                             },
-                                                                            span: 12..15,
-                                                                            name: "baz",
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 15,
+                                                                            },
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
+                                                                        span: 12..15,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 12,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 15,
+                                                                                    },
+                                                                                },
+                                                                                span: 12..15,
+                                                                                name: "baz",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
                                                                 },
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                            inferred_type: None,
+                                                            ),
+                                                        ],
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
                                         },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                    ),
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-5.snap
@@ -5,40 +5,53 @@ expression: "parse(\"<Foo></Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..11,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 11,
-                                },
-                            },
-                            span: 0..11,
-                            name: "Foo",
-                            attrs: [],
-                            children: [],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 11,
+                    },
                 },
-            ),
+                span: 0..11,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 11,
+                            },
+                        },
+                        span: 0..11,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 11,
+                                    },
+                                },
+                                span: 0..11,
+                                name: "Foo",
+                                attrs: [],
+                                children: [],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-6.snap
@@ -5,47 +5,47 @@ expression: "parse(\"<Foo bar={baz} />\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 17,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..17,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 17,
-                                },
+                    end: Position {
+                        line: 0,
+                        column: 17,
+                    },
+                },
+                span: 0..17,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            span: 0..17,
-                            name: "Foo",
-                            attrs: [
-                                JSXAttr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 5,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 14,
-                                        },
+                            end: Position {
+                                line: 0,
+                                column: 17,
+                            },
+                        },
+                        span: 0..17,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
                                     },
-                                    span: 5..14,
-                                    ident: Ident {
+                                    end: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                },
+                                span: 0..17,
+                                name: "Foo",
+                                attrs: [
+                                    JSXAttr {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
@@ -53,65 +53,78 @@ Ok(
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 8,
+                                                column: 14,
                                             },
                                         },
-                                        span: 5..8,
-                                        name: "bar",
-                                    },
-                                    value: JSXExprContainer(
-                                        JSXExprContainer {
+                                        span: 5..14,
+                                        ident: Ident {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 9,
+                                                    column: 5,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 14,
+                                                    column: 8,
                                                 },
                                             },
-                                            span: 9..14,
-                                            expr: Expr {
+                                            span: 5..8,
+                                            name: "bar",
+                                        },
+                                        value: JSXExprContainer(
+                                            JSXExprContainer {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 10,
+                                                        column: 9,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 13,
+                                                        column: 14,
                                                     },
                                                 },
-                                                span: 10..13,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 10,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
+                                                span: 9..14,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 10,
                                                         },
-                                                        span: 10..13,
-                                                        name: "baz",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 13,
+                                                        },
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                    span: 10..13,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 10,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 13,
+                                                                },
+                                                            },
+                                                            span: 10..13,
+                                                            name: "baz",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             },
-                                        },
-                                    ),
-                                },
-                            ],
-                            children: [],
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                        ),
+                                    },
+                                ],
+                                children: [],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-7.snap
@@ -5,47 +5,47 @@ expression: "parse(\"<Foo msg=\\\"hello\\\" bar={baz}></Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 33,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..33,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 33,
-                                },
+                    end: Position {
+                        line: 0,
+                        column: 33,
+                    },
+                },
+                span: 0..33,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            span: 0..33,
-                            name: "Foo",
-                            attrs: [
-                                JSXAttr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 5,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
+                            end: Position {
+                                line: 0,
+                                column: 33,
+                            },
+                        },
+                        span: 0..33,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
                                     },
-                                    span: 5..16,
-                                    ident: Ident {
+                                    end: Position {
+                                        line: 0,
+                                        column: 33,
+                                    },
+                                },
+                                span: 0..33,
+                                name: "Foo",
+                                attrs: [
+                                    JSXAttr {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
@@ -53,44 +53,44 @@ Ok(
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 8,
+                                                column: 16,
                                             },
                                         },
-                                        span: 5..8,
-                                        name: "msg",
-                                    },
-                                    value: Lit(
-                                        Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 9,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 16,
-                                                    },
+                                        span: 5..16,
+                                        ident: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 5,
                                                 },
-                                                span: 9..16,
-                                                value: "hello",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
                                             },
+                                            span: 5..8,
+                                            name: "msg",
+                                        },
+                                        value: Lit(
+                                            Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 16,
+                                                        },
+                                                    },
+                                                    span: 9..16,
+                                                    value: "hello",
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                },
-                                JSXAttr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 26,
-                                        },
                                     },
-                                    span: 17..26,
-                                    ident: Ident {
+                                    JSXAttr {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
@@ -98,65 +98,78 @@ Ok(
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 20,
+                                                column: 26,
                                             },
                                         },
-                                        span: 17..20,
-                                        name: "bar",
-                                    },
-                                    value: JSXExprContainer(
-                                        JSXExprContainer {
+                                        span: 17..26,
+                                        ident: Ident {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 21,
+                                                    column: 17,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 26,
+                                                    column: 20,
                                                 },
                                             },
-                                            span: 21..26,
-                                            expr: Expr {
+                                            span: 17..20,
+                                            name: "bar",
+                                        },
+                                        value: JSXExprContainer(
+                                            JSXExprContainer {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 22,
+                                                        column: 21,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 25,
+                                                        column: 26,
                                                     },
                                                 },
-                                                span: 22..25,
-                                                kind: Ident(
-                                                    Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 25,
-                                                            },
+                                                span: 21..26,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 22,
                                                         },
-                                                        span: 22..25,
-                                                        name: "baz",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                    span: 22..25,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 22..25,
+                                                            name: "baz",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             },
-                                        },
-                                    ),
-                                },
-                            ],
-                            children: [],
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                        ),
+                                    },
+                                ],
+                                children: [],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-8.snap
@@ -5,105 +5,118 @@ expression: "parse(\"<Foo><Bar>{baz}</Bar></Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 27,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..27,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 27,
-                                },
+                    end: Position {
+                        line: 0,
+                        column: 27,
+                    },
+                },
+                span: 0..27,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            span: 0..27,
-                            name: "Foo",
-                            attrs: [],
-                            children: [
-                                JSXElement(
-                                    JSXElement {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
+                            end: Position {
+                                line: 0,
+                                column: 27,
+                            },
+                        },
+                        span: 0..27,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 27,
+                                    },
+                                },
+                                span: 0..27,
+                                name: "Foo",
+                                attrs: [],
+                                children: [
+                                    JSXElement(
+                                        JSXElement {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 21,
+                                                },
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 21,
-                                            },
-                                        },
-                                        span: 5..21,
-                                        name: "Bar",
-                                        attrs: [],
-                                        children: [
-                                            JSXExprContainer(
-                                                JSXExprContainer {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 10,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 15,
-                                                        },
-                                                    },
-                                                    span: 10..15,
-                                                    expr: Expr {
+                                            span: 5..21,
+                                            name: "Bar",
+                                            attrs: [],
+                                            children: [
+                                                JSXExprContainer(
+                                                    JSXExprContainer {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
-                                                                column: 11,
+                                                                column: 10,
                                                             },
                                                             end: Position {
                                                                 line: 0,
-                                                                column: 14,
+                                                                column: 15,
                                                             },
                                                         },
-                                                        span: 11..14,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 11,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 14,
-                                                                    },
+                                                        span: 10..15,
+                                                        expr: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 11,
                                                                 },
-                                                                span: 11..14,
-                                                                name: "baz",
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 14,
+                                                                },
                                                             },
-                                                        ),
-                                                        inferred_type: None,
+                                                            span: 11..14,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 11,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 14,
+                                                                        },
+                                                                    },
+                                                                    span: 11..14,
+                                                                    name: "baz",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
                                                     },
-                                                },
-                                            ),
-                                        ],
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx-9.snap
@@ -5,138 +5,151 @@ expression: "parse(\"<Foo>hello<Bar/>{world}<Baz/></Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 35,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..35,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 35,
-                                },
+                    end: Position {
+                        line: 0,
+                        column: 35,
+                    },
+                },
+                span: 0..35,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            span: 0..35,
-                            name: "Foo",
-                            attrs: [],
-                            children: [
-                                JSXText(
-                                    JSXText {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                        },
-                                        span: 5..10,
-                                        value: "hello",
+                            end: Position {
+                                line: 0,
+                                column: 35,
+                            },
+                        },
+                        span: 0..35,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
                                     },
-                                ),
-                                JSXElement(
-                                    JSXElement {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 16,
-                                            },
-                                        },
-                                        span: 10..16,
-                                        name: "Bar",
-                                        attrs: [],
-                                        children: [],
+                                    end: Position {
+                                        line: 0,
+                                        column: 35,
                                     },
-                                ),
-                                JSXExprContainer(
-                                    JSXExprContainer {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 23,
-                                            },
-                                        },
-                                        span: 16..23,
-                                        expr: Expr {
+                                },
+                                span: 0..35,
+                                name: "Foo",
+                                attrs: [],
+                                children: [
+                                    JSXText(
+                                        JSXText {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 17,
+                                                    column: 5,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 22,
+                                                    column: 10,
                                                 },
                                             },
-                                            span: 17..22,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
+                                            span: 5..10,
+                                            value: "hello",
+                                        },
+                                    ),
+                                    JSXElement(
+                                        JSXElement {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 10,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                            },
+                                            span: 10..16,
+                                            name: "Bar",
+                                            attrs: [],
+                                            children: [],
+                                        },
+                                    ),
+                                    JSXExprContainer(
+                                        JSXExprContainer {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
+                                            },
+                                            span: 16..23,
+                                            expr: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 17,
                                                     },
-                                                    span: 17..22,
-                                                    name: "world",
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 22,
+                                                    },
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                JSXElement(
-                                    JSXElement {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 23,
+                                                span: 17..22,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                        },
+                                                        span: 17..22,
+                                                        name: "world",
+                                                    },
+                                                ),
+                                                inferred_type: None,
                                             },
-                                            end: Position {
-                                                line: 0,
-                                                column: 29,
-                                            },
                                         },
-                                        span: 23..29,
-                                        name: "Baz",
-                                        attrs: [],
-                                        children: [],
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                    ),
+                                    JSXElement(
+                                        JSXElement {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 29,
+                                                },
+                                            },
+                                            span: 23..29,
+                                            name: "Baz",
+                                            attrs: [],
+                                            children: [],
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__jsx.snap
@@ -5,57 +5,70 @@ expression: "parse(\"<Foo>Hello</Foo>\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 16,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..16,
-                    kind: JSXElement(
-                        JSXElement {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 0,
-                                    column: 0,
-                                },
-                                end: Position {
-                                    line: 0,
-                                    column: 16,
-                                },
-                            },
-                            span: 0..16,
-                            name: "Foo",
-                            attrs: [],
-                            children: [
-                                JSXText(
-                                    JSXText {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                        },
-                                        span: 5..10,
-                                        value: "Hello",
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 16,
+                    },
                 },
-            ),
+                span: 0..16,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 16,
+                            },
+                        },
+                        span: 0..16,
+                        kind: JSXElement(
+                            JSXElement {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 0,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 16,
+                                    },
+                                },
+                                span: 0..16,
+                                name: "Foo",
+                                attrs: [],
+                                children: [
+                                    JSXText(
+                                        JSXText {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 10,
+                                                },
+                                            },
+                                            span: 5..10,
+                                            value: "Hello",
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-2.snap
@@ -5,92 +5,105 @@ expression: "parse(\"foo.bar();\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..9,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
+                    end: Position {
+                        line: 0,
+                        column: 10,
+                    },
+                },
+                span: 0..10,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 9,
+                            },
+                        },
+                        span: 0..9,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 7,
-                                    },
-                                },
-                                span: 0..7,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
+                                    span: 0..7,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 3,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 3,
-                                                },
+                                                span: 0..3,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 3,
+                                                            },
+                                                        },
+                                                        span: 0..3,
+                                                        name: "foo",
+                                                    },
+                                                ),
+                                                inferred_type: None,
                                             },
-                                            span: 0..3,
-                                            kind: Ident(
+                                            prop: Ident(
                                                 Ident {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 0,
+                                                            column: 4,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 3,
+                                                            column: 7,
                                                         },
                                                     },
-                                                    span: 0..3,
-                                                    name: "foo",
+                                                    span: 4..7,
+                                                    name: "bar",
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
-                                        prop: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 4,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 7,
-                                                    },
-                                                },
-                                                span: 4..7,
-                                                name: "bar",
-                                            },
-                                        ),
-                                    },
-                                ),
-                                inferred_type: None,
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [],
+                                type_args: None,
                             },
-                            args: [],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-3.snap
@@ -5,321 +5,334 @@ expression: "parse(\"p.x * p.x + p.y * p.y;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 21,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..21,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: Add,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                },
-                                span: 0..9,
-                                kind: BinaryExpr(
-                                    BinaryExpr {
-                                        op: Mul,
-                                        left: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 3,
-                                                },
-                                            },
-                                            span: 0..3,
-                                            kind: Member(
-                                                Member {
-                                                    obj: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 0,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 1,
-                                                            },
-                                                        },
-                                                        span: 0..1,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 0,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 1,
-                                                                    },
-                                                                },
-                                                                span: 0..1,
-                                                                name: "p",
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    prop: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 2,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 3,
-                                                                },
-                                                            },
-                                                            span: 2..3,
-                                                            name: "x",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        right: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                            },
-                                            span: 6..9,
-                                            kind: Member(
-                                                Member {
-                                                    obj: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 6,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 7,
-                                                            },
-                                                        },
-                                                        span: 6..7,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 6,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 7,
-                                                                    },
-                                                                },
-                                                                span: 6..7,
-                                                                name: "p",
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    prop: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 8,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 9,
-                                                                },
-                                                            },
-                                                            span: 8..9,
-                                                            name: "x",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 22,
+                    },
+                },
+                span: 0..22,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 12,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 21,
-                                    },
-                                },
-                                span: 12..21,
-                                kind: BinaryExpr(
-                                    BinaryExpr {
-                                        op: Mul,
-                                        left: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 15,
-                                                },
-                                            },
-                                            span: 12..15,
-                                            kind: Member(
-                                                Member {
-                                                    obj: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
-                                                        },
-                                                        span: 12..13,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 12,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 13,
-                                                                    },
-                                                                },
-                                                                span: 12..13,
-                                                                name: "p",
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    prop: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 14,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 15,
-                                                                },
-                                                            },
-                                                            span: 14..15,
-                                                            name: "y",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        right: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                            },
-                                            span: 18..21,
-                                            kind: Member(
-                                                Member {
-                                                    obj: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
-                                                        },
-                                                        span: 18..19,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 18,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 19,
-                                                                    },
-                                                                },
-                                                                span: 18..19,
-                                                                name: "p",
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    prop: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 20,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 21,
-                                                                },
-                                                            },
-                                                            span: 20..21,
-                                                            name: "y",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 21,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..21,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: Add,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                    span: 0..9,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Mul,
+                                            left: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 3,
+                                                    },
+                                                },
+                                                span: 0..3,
+                                                kind: Member(
+                                                    Member {
+                                                        obj: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 0,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 1,
+                                                                },
+                                                            },
+                                                            span: 0..1,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 0,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 1,
+                                                                        },
+                                                                    },
+                                                                    span: 0..1,
+                                                                    name: "p",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        prop: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 2,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 3,
+                                                                    },
+                                                                },
+                                                                span: 2..3,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            right: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 6,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 9,
+                                                    },
+                                                },
+                                                span: 6..9,
+                                                kind: Member(
+                                                    Member {
+                                                        obj: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 6,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 7,
+                                                                },
+                                                            },
+                                                            span: 6..7,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 6,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 7,
+                                                                        },
+                                                                    },
+                                                                    span: 6..7,
+                                                                    name: "p",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        prop: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 8,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 9,
+                                                                    },
+                                                                },
+                                                                span: 8..9,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 21,
+                                        },
+                                    },
+                                    span: 12..21,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Mul,
+                                            left: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 12,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                },
+                                                span: 12..15,
+                                                kind: Member(
+                                                    Member {
+                                                        obj: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 12,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 13,
+                                                                },
+                                                            },
+                                                            span: 12..13,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 12,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 13,
+                                                                        },
+                                                                    },
+                                                                    span: 12..13,
+                                                                    name: "p",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        prop: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 15,
+                                                                    },
+                                                                },
+                                                                span: 14..15,
+                                                                name: "y",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            right: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 18,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                },
+                                                span: 18..21,
+                                                kind: Member(
+                                                    Member {
+                                                        obj: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 18,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 19,
+                                                                },
+                                                            },
+                                                            span: 18..19,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 18,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 19,
+                                                                        },
+                                                                    },
+                                                                    span: 18..19,
+                                                                    name: "p",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        prop: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 20,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 21,
+                                                                    },
+                                                                },
+                                                                span: 20..21,
+                                                                name: "y",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-4.snap
@@ -5,112 +5,125 @@ expression: "parse(\"foo().bar();\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..11,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                },
-                                span: 0..9,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                            },
-                                            span: 0..5,
-                                            kind: App(
-                                                App {
-                                                    lam: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 0,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 3,
-                                                            },
-                                                        },
-                                                        span: 0..3,
-                                                        kind: Ident(
-                                                            Ident {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 0,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 3,
-                                                                    },
-                                                                },
-                                                                span: 0..3,
-                                                                name: "foo",
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    args: [],
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 12,
+                    },
+                },
+                span: 0..12,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 11,
+                            },
+                        },
+                        span: 0..11,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
                                         },
-                                        prop: Ident(
-                                            Ident {
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                    span: 0..9,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 6,
+                                                        column: 0,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 9,
+                                                        column: 5,
                                                     },
                                                 },
-                                                span: 6..9,
-                                                name: "bar",
+                                                span: 0..5,
+                                                kind: App(
+                                                    App {
+                                                        lam: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 0,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 3,
+                                                                },
+                                                            },
+                                                            span: 0..3,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 0,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 3,
+                                                                        },
+                                                                    },
+                                                                    span: 0..3,
+                                                                    name: "foo",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                        args: [],
+                                                        type_args: None,
+                                                    },
+                                                ),
+                                                inferred_type: None,
                                             },
-                                        ),
-                                    },
-                                ),
-                                inferred_type: None,
+                                            prop: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 6,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                    },
+                                                    span: 6..9,
+                                                    name: "bar",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [],
+                                type_args: None,
                             },
-                            args: [],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-5.snap
@@ -5,79 +5,79 @@ expression: "parse(\"arr[0][1];\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..9,
-                    kind: Member(
-                        Member {
-                            obj: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 0..6,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 3,
-                                                },
-                                            },
-                                            span: 0..3,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 0,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 3,
-                                                        },
-                                                    },
-                                                    span: 0..3,
-                                                    name: "arr",
-                                                },
-                                            ),
-                                            inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 10,
+                    },
+                },
+                span: 0..10,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 9,
+                            },
+                        },
+                        span: 0..9,
+                        kind: Member(
+                            Member {
+                                obj: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
                                         },
-                                        prop: Computed(
-                                            ComputedPropName {
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 0..6,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 4,
+                                                        column: 0,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 5,
+                                                        column: 3,
                                                     },
                                                 },
-                                                span: 4..5,
-                                                expr: Expr {
+                                                span: 0..3,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 3,
+                                                            },
+                                                        },
+                                                        span: 0..3,
+                                                        name: "arr",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            prop: Computed(
+                                                ComputedPropName {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -89,46 +89,46 @@ Ok(
                                                         },
                                                     },
                                                     span: 4..5,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 4,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 5,
-                                                                    },
-                                                                },
-                                                                span: 4..5,
-                                                                value: "0",
+                                                    expr: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 4,
                                                             },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 5,
+                                                            },
+                                                        },
+                                                        span: 4..5,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 4,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 5,
+                                                                        },
+                                                                    },
+                                                                    span: 4..5,
+                                                                    value: "0",
+                                                                },
+                                                            ),
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            prop: Computed(
-                                ComputedPropName {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 7,
+                                            ),
                                         },
-                                        end: Position {
-                                            line: 0,
-                                            column: 8,
-                                        },
-                                    },
-                                    span: 7..8,
-                                    expr: Expr {
+                                    ),
+                                    inferred_type: None,
+                                },
+                                prop: Computed(
+                                    ComputedPropName {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
@@ -140,33 +140,46 @@ Ok(
                                             },
                                         },
                                         span: 7..8,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 7,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 8,
-                                                        },
-                                                    },
-                                                    span: 7..8,
-                                                    value: "1",
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 7,
                                                 },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                            },
+                                            span: 7..8,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 7,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 8,
+                                                            },
+                                                        },
+                                                        span: 7..8,
+                                                        value: "1",
+                                                    },
+                                                ),
                                             ),
-                                        ),
-                                        inferred_type: None,
+                                            inferred_type: None,
+                                        },
                                     },
-                                },
-                            ),
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                ),
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-6.snap
@@ -5,79 +5,79 @@ expression: "parse(\"arr[x](y);\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..9,
-                    kind: App(
-                        App {
-                            lam: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 0..6,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 3,
-                                                },
-                                            },
-                                            span: 0..3,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 0,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 3,
-                                                        },
-                                                    },
-                                                    span: 0..3,
-                                                    name: "arr",
-                                                },
-                                            ),
-                                            inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 10,
+                    },
+                },
+                span: 0..10,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 9,
+                            },
+                        },
+                        span: 0..9,
+                        kind: App(
+                            App {
+                                lam: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
                                         },
-                                        prop: Computed(
-                                            ComputedPropName {
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 0..6,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 4,
+                                                        column: 0,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 5,
+                                                        column: 3,
                                                     },
                                                 },
-                                                span: 4..5,
-                                                expr: Expr {
+                                                span: 0..3,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 3,
+                                                            },
+                                                        },
+                                                        span: 0..3,
+                                                        name: "arr",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            prop: Computed(
+                                                ComputedPropName {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -89,71 +89,84 @@ Ok(
                                                         },
                                                     },
                                                     span: 4..5,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 4,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 5,
-                                                                },
+                                                    expr: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 4,
                                                             },
-                                                            span: 4..5,
-                                                            name: "x",
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 5,
+                                                            },
                                                         },
-                                                    ),
-                                                    inferred_type: None,
+                                                        span: 4..5,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 4,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 5,
+                                                                    },
+                                                                },
+                                                                span: 4..5,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 7,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
+                                            ),
                                         },
-                                        span: 7..8,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 7,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 8,
-                                                    },
-                                                },
-                                                span: 7..8,
-                                                name: "y",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
+                                    ),
+                                    inferred_type: None,
                                 },
-                            ],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 7,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                            },
+                                            span: 7..8,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 7,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                    },
+                                                    span: 7..8,
+                                                    name: "y",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ],
+                                type_args: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-7.snap
@@ -5,65 +5,65 @@ expression: "parse(\"arr[arr.length - 1];\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 19,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..19,
-                    kind: Member(
-                        Member {
-                            obj: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 3,
-                                            },
-                                        },
-                                        span: 0..3,
-                                        name: "arr",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 20,
+                    },
+                },
+                span: 0..20,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            prop: Computed(
-                                ComputedPropName {
+                            end: Position {
+                                line: 0,
+                                column: 19,
+                            },
+                        },
+                        span: 0..19,
+                        kind: Member(
+                            Member {
+                                obj: Expr {
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 4,
+                                            column: 0,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 18,
+                                            column: 3,
                                         },
                                     },
-                                    span: 4..18,
-                                    expr: Expr {
+                                    span: 0..3,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 3,
+                                                },
+                                            },
+                                            span: 0..3,
+                                            name: "arr",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                prop: Computed(
+                                    ComputedPropName {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
@@ -75,116 +75,129 @@ Ok(
                                             },
                                         },
                                         span: 4..18,
-                                        kind: BinaryExpr(
-                                            BinaryExpr {
-                                                op: Sub,
-                                                left: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 4,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                            },
+                                            span: 4..18,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Sub,
+                                                    left: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 4,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
                                                         },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 14,
-                                                        },
-                                                    },
-                                                    span: 4..14,
-                                                    kind: Member(
-                                                        Member {
-                                                            obj: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 4,
+                                                        span: 4..14,
+                                                        kind: Member(
+                                                            Member {
+                                                                obj: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 4,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 7,
+                                                                        },
                                                                     },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 7,
-                                                                    },
+                                                                    span: 4..7,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 4,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 7,
+                                                                                },
+                                                                            },
+                                                                            span: 4..7,
+                                                                            name: "arr",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                                span: 4..7,
-                                                                kind: Ident(
+                                                                prop: Ident(
                                                                     Ident {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
-                                                                                column: 4,
+                                                                                column: 8,
                                                                             },
                                                                             end: Position {
                                                                                 line: 0,
-                                                                                column: 7,
+                                                                                column: 14,
                                                                             },
                                                                         },
-                                                                        span: 4..7,
-                                                                        name: "arr",
+                                                                        span: 8..14,
+                                                                        name: "length",
                                                                     },
                                                                 ),
-                                                                inferred_type: None,
                                                             },
-                                                            prop: Ident(
-                                                                Ident {
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    right: Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                        },
+                                                        span: 17..18,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
-                                                                            column: 8,
+                                                                            column: 17,
                                                                         },
                                                                         end: Position {
                                                                             line: 0,
-                                                                            column: 14,
+                                                                            column: 18,
                                                                         },
                                                                     },
-                                                                    span: 8..14,
-                                                                    name: "length",
+                                                                    span: 17..18,
+                                                                    value: "1",
                                                                 },
                                                             ),
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                                right: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                    },
-                                                    span: 17..18,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 17,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 18,
-                                                                    },
-                                                                },
-                                                                span: 17..18,
-                                                                value: "1",
-                                                            },
                                                         ),
-                                                    ),
-                                                    inferred_type: None,
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                            ),
+                                            inferred_type: None,
+                                        },
                                     },
-                                },
-                            ),
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                ),
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access-8.snap
@@ -5,65 +5,65 @@ expression: "parse(\"foo[bar[-1]];\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 12,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..12,
-                    kind: Member(
-                        Member {
-                            obj: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 3,
-                                            },
-                                        },
-                                        span: 0..3,
-                                        name: "foo",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 13,
+                    },
+                },
+                span: 0..13,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            prop: Computed(
-                                ComputedPropName {
+                            end: Position {
+                                line: 0,
+                                column: 12,
+                            },
+                        },
+                        span: 0..12,
+                        kind: Member(
+                            Member {
+                                obj: Expr {
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 4,
+                                            column: 0,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 11,
+                                            column: 3,
                                         },
                                     },
-                                    span: 4..11,
-                                    expr: Expr {
+                                    span: 0..3,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 3,
+                                                },
+                                            },
+                                            span: 0..3,
+                                            name: "foo",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                prop: Computed(
+                                    ComputedPropName {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
@@ -75,52 +75,52 @@ Ok(
                                             },
                                         },
                                         span: 4..11,
-                                        kind: Member(
-                                            Member {
-                                                obj: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 4,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 7,
-                                                        },
-                                                    },
-                                                    span: 4..7,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 4,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 7,
-                                                                },
-                                                            },
-                                                            span: 4..7,
-                                                            name: "bar",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
                                                 },
-                                                prop: Computed(
-                                                    ComputedPropName {
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 11,
+                                                },
+                                            },
+                                            span: 4..11,
+                                            kind: Member(
+                                                Member {
+                                                    obj: Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
-                                                                column: 8,
+                                                                column: 4,
                                                             },
                                                             end: Position {
                                                                 line: 0,
-                                                                column: 10,
+                                                                column: 7,
                                                             },
                                                         },
-                                                        span: 8..10,
-                                                        expr: Expr {
+                                                        span: 4..7,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 4,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 7,
+                                                                    },
+                                                                },
+                                                                span: 4..7,
+                                                                name: "bar",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                    prop: Computed(
+                                                        ComputedPropName {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -132,58 +132,71 @@ Ok(
                                                                 },
                                                             },
                                                             span: 8..10,
-                                                            kind: UnaryExpr(
-                                                                UnaryExpr {
-                                                                    op: Minus,
-                                                                    arg: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 9,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 10,
-                                                                            },
-                                                                        },
-                                                                        span: 9..10,
-                                                                        kind: Lit(
-                                                                            Num(
-                                                                                Num {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 9,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 10,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 9..10,
-                                                                                    value: "1",
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        inferred_type: None,
+                                                            expr: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 8,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 10,
                                                                     },
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
+                                                                span: 8..10,
+                                                                kind: UnaryExpr(
+                                                                    UnaryExpr {
+                                                                        op: Minus,
+                                                                        arg: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 9,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 10,
+                                                                                },
+                                                                            },
+                                                                            span: 9..10,
+                                                                            kind: Lit(
+                                                                                Num(
+                                                                                    Num {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 9,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 10,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 9..10,
+                                                                                        value: "1",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
                                                         },
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                                    ),
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
                                     },
-                                },
-                            ),
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                                ),
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__member_access.snap
@@ -5,106 +5,119 @@ expression: "parse(\"a.b.c;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..5,
-                    kind: Member(
-                        Member {
-                            obj: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
+                    end: Position {
+                        line: 0,
+                        column: 6,
+                    },
+                },
+                span: 0..6,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 5,
+                            },
+                        },
+                        span: 0..5,
+                        kind: Member(
+                            Member {
+                                obj: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
+                                    span: 0..3,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 1,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
+                                                span: 0..1,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 1,
+                                                            },
+                                                        },
+                                                        span: 0..1,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                                inferred_type: None,
                                             },
-                                            span: 0..1,
-                                            kind: Ident(
+                                            prop: Ident(
                                                 Ident {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 0,
+                                                            column: 2,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 1,
+                                                            column: 3,
                                                         },
                                                     },
-                                                    span: 0..1,
-                                                    name: "a",
+                                                    span: 2..3,
+                                                    name: "b",
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
-                                        prop: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 2,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 3,
-                                                    },
-                                                },
-                                                span: 2..3,
-                                                name: "b",
+                                    ),
+                                    inferred_type: None,
+                                },
+                                prop: Ident(
+                                    Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 4,
                                             },
-                                        ),
+                                            end: Position {
+                                                line: 0,
+                                                column: 5,
+                                            },
+                                        },
+                                        span: 4..5,
+                                        name: "c",
                                     },
                                 ),
-                                inferred_type: None,
                             },
-                            prop: Ident(
-                                Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 5,
-                                        },
-                                    },
-                                    span: 4..5,
-                                    name: "c",
-                                },
-                            ),
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression-2.snap
@@ -5,164 +5,177 @@ expression: "parse(\"new Array(1, 2, 3);\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 18,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..18,
-                    kind: New(
-                        New {
-                            expr: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                },
-                                span: 4..9,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                        },
-                                        span: 4..9,
-                                        name: "Array",
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 11,
-                                            },
-                                        },
-                                        span: 10..11,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 10,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 11,
-                                                        },
-                                                    },
-                                                    span: 10..11,
-                                                    value: "1",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 13,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 14,
-                                            },
-                                        },
-                                        span: 13..14,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 13,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 14,
-                                                        },
-                                                    },
-                                                    span: 13..14,
-                                                    value: "2",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
-                                        },
-                                        span: 16..17,
-                                        kind: Lit(
-                                            Num(
-                                                Num {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 16,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                    },
-                                                    span: 16..17,
-                                                    value: "3",
-                                                },
-                                            ),
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                },
-                            ],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 19,
+                    },
                 },
-            ),
+                span: 0..19,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 18,
+                            },
+                        },
+                        span: 0..18,
+                        kind: New(
+                            New {
+                                expr: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                    span: 4..9,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 9,
+                                                },
+                                            },
+                                            span: 4..9,
+                                            name: "Array",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 10,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 11,
+                                                },
+                                            },
+                                            span: 10..11,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 10,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 11,
+                                                            },
+                                                        },
+                                                        span: 10..11,
+                                                        value: "1",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 13,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                            },
+                                            span: 13..14,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 13,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                        },
+                                                        span: 13..14,
+                                                        value: "2",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 17,
+                                                },
+                                            },
+                                            span: 16..17,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 16,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                        },
+                                                        span: 16..17,
+                                                        value: "3",
+                                                    },
+                                                ),
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ],
+                                type_args: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__new_expression.snap
@@ -5,58 +5,71 @@ expression: "parse(\"new Array();\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..11,
-                    kind: New(
-                        New {
-                            expr: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                },
-                                span: 4..9,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                        },
-                                        span: 4..9,
-                                        name: "Array",
-                                    },
-                                ),
-                                inferred_type: None,
-                            },
-                            args: [],
-                            type_args: None,
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 12,
+                    },
                 },
-            ),
+                span: 0..12,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 11,
+                            },
+                        },
+                        span: 0..11,
+                        kind: New(
+                            New {
+                                expr: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                    span: 4..9,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 9,
+                                                },
+                                            },
+                                            span: 4..9,
+                                            name: "Array",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                args: [],
+                                type_args: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-2.snap
@@ -5,40 +5,53 @@ expression: "parse(\"1.23;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 4,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..4,
-                    kind: Lit(
-                        Num(
-                            Num {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                },
-                                span: 0..4,
-                                value: "1.23",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 5,
+                    },
                 },
-            ),
+                span: 0..5,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 4,
+                            },
+                        },
+                        span: 0..4,
+                        kind: Lit(
+                            Num(
+                                Num {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                    },
+                                    span: 0..4,
+                                    value: "1.23",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers-3.snap
@@ -5,59 +5,72 @@ expression: "parse(\"-10;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 3,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..3,
-                    kind: UnaryExpr(
-                        UnaryExpr {
-                            op: Minus,
-                            arg: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 1..3,
-                                kind: Lit(
-                                    Num(
-                                        Num {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 3,
-                                                },
-                                            },
-                                            span: 1..3,
-                                            value: "10",
-                                        },
-                                    ),
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 4,
+                    },
+                },
+                span: 0..4,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 3,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..3,
+                        kind: UnaryExpr(
+                            UnaryExpr {
+                                op: Minus,
+                                arg: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
+                                    },
+                                    span: 1..3,
+                                    kind: Lit(
+                                        Num(
+                                            Num {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 1,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 3,
+                                                    },
+                                                },
+                                                span: 1..3,
+                                                value: "10",
+                                            },
+                                        ),
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__numbers.snap
@@ -5,40 +5,53 @@ expression: "parse(\"10;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 2,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..2,
-                    kind: Lit(
-                        Num(
-                            Num {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 2,
-                                    },
-                                },
-                                span: 0..2,
-                                value: "10",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 3,
+                    },
                 },
-            ),
+                span: 0..3,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 2,
+                            },
+                        },
+                        span: 0..2,
+                        kind: Lit(
+                            Num(
+                                Num {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 2,
+                                        },
+                                    },
+                                    span: 0..2,
+                                    value: "10",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Foo<T> = {mut [P in keyof T]?: T[P]};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,45 +17,100 @@ Ok(
                     },
                 },
                 span: 0..42,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                    },
-                    span: 5..8,
-                    name: "Foo",
-                },
-                type_ann: TypeAnn {
-                    kind: Mapped(
-                        MappedType {
-                            type_param: TypeParam {
-                                span: 20..32,
-                                name: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 20,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 21,
-                                        },
-                                    },
-                                    span: 20..21,
-                                    name: "P",
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                constraint: Some(
-                                    TypeAnn {
-                                        kind: KeyOf(
-                                            KeyOfType {
-                                                type_ann: TypeAnn {
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Foo",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Mapped(
+                                MappedType {
+                                    type_param: TypeParam {
+                                        span: 20..32,
+                                        name: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 20,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 21,
+                                                },
+                                            },
+                                            span: 20..21,
+                                            name: "P",
+                                        },
+                                        constraint: Some(
+                                            TypeAnn {
+                                                kind: KeyOf(
+                                                    KeyOfType {
+                                                        type_ann: TypeAnn {
+                                                            kind: TypeRef(
+                                                                TypeRef {
+                                                                    name: "T",
+                                                                    type_args: None,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 31,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 32,
+                                                                },
+                                                            },
+                                                            span: 31..32,
+                                                            inferred_type: None,
+                                                        },
+                                                    },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 25,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 32,
+                                                    },
+                                                },
+                                                span: 25..32,
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        default: None,
+                                    },
+                                    optional: Some(
+                                        TMappedTypeChange {
+                                            span: 33..34,
+                                            change: Plus,
+                                        },
+                                    ),
+                                    mutable: Some(
+                                        TMappedTypeChange {
+                                            span: 15..18,
+                                            change: Plus,
+                                        },
+                                    ),
+                                    type_ann: TypeAnn {
+                                        kind: IndexedAccess(
+                                            IndexedAccessType {
+                                                obj_type: TypeAnn {
                                                     kind: TypeRef(
                                                         TypeRef {
                                                             name: "T",
@@ -65,14 +120,34 @@ Ok(
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 31,
+                                                            column: 36,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 32,
+                                                            column: 37,
                                                         },
                                                     },
-                                                    span: 31..32,
+                                                    span: 36..37,
+                                                    inferred_type: None,
+                                                },
+                                                index_type: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "P",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 38,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 39,
+                                                        },
+                                                    },
+                                                    span: 38..39,
                                                     inferred_type: None,
                                                 },
                                             },
@@ -80,126 +155,55 @@ Ok(
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 25,
+                                                column: 36,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 32,
+                                                column: 40,
                                             },
                                         },
-                                        span: 25..32,
+                                        span: 36..40,
                                         inferred_type: None,
                                     },
-                                ),
-                                default: None,
-                            },
-                            optional: Some(
-                                TMappedTypeChange {
-                                    span: 33..34,
-                                    change: Plus,
                                 },
                             ),
-                            mutable: Some(
-                                TMappedTypeChange {
-                                    span: 15..18,
-                                    change: Plus,
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 14,
                                 },
-                            ),
-                            type_ann: TypeAnn {
-                                kind: IndexedAccess(
-                                    IndexedAccessType {
-                                        obj_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 36,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 37,
-                                                },
-                                            },
-                                            span: 36..37,
-                                            inferred_type: None,
-                                        },
-                                        index_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "P",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 38,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 39,
-                                                },
-                                            },
-                                            span: 38..39,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 36,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 40,
-                                    },
+                                end: Position {
+                                    line: 0,
+                                    column: 41,
                                 },
-                                span: 36..40,
-                                inferred_type: None,
                             },
+                            span: 14..41,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 14,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 41,
-                        },
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 9..10,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 9,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 10,
+                                            },
+                                        },
+                                        span: 9..10,
+                                        name: "T",
+                                    },
+                                    constraint: None,
+                                    default: None,
+                                },
+                            ],
+                        ),
                     },
-                    span: 14..41,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 9..10,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                },
-                                span: 9..10,
-                                name: "T",
-                            },
-                            constraint: None,
-                            default: None,
-                        },
-                    ],
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Bar<T> = {+mut [P in keyof T]+?: T[P]};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,45 +17,100 @@ Ok(
                     },
                 },
                 span: 0..44,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                    },
-                    span: 5..8,
-                    name: "Bar",
-                },
-                type_ann: TypeAnn {
-                    kind: Mapped(
-                        MappedType {
-                            type_param: TypeParam {
-                                span: 21..33,
-                                name: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 21,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 22,
-                                        },
-                                    },
-                                    span: 21..22,
-                                    name: "P",
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                constraint: Some(
-                                    TypeAnn {
-                                        kind: KeyOf(
-                                            KeyOfType {
-                                                type_ann: TypeAnn {
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Bar",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Mapped(
+                                MappedType {
+                                    type_param: TypeParam {
+                                        span: 21..33,
+                                        name: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 21,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
+                                            },
+                                            span: 21..22,
+                                            name: "P",
+                                        },
+                                        constraint: Some(
+                                            TypeAnn {
+                                                kind: KeyOf(
+                                                    KeyOfType {
+                                                        type_ann: TypeAnn {
+                                                            kind: TypeRef(
+                                                                TypeRef {
+                                                                    name: "T",
+                                                                    type_args: None,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 32,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 33,
+                                                                },
+                                                            },
+                                                            span: 32..33,
+                                                            inferred_type: None,
+                                                        },
+                                                    },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 26,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 33,
+                                                    },
+                                                },
+                                                span: 26..33,
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        default: None,
+                                    },
+                                    optional: Some(
+                                        TMappedTypeChange {
+                                            span: 35..36,
+                                            change: Plus,
+                                        },
+                                    ),
+                                    mutable: Some(
+                                        TMappedTypeChange {
+                                            span: 16..19,
+                                            change: Plus,
+                                        },
+                                    ),
+                                    type_ann: TypeAnn {
+                                        kind: IndexedAccess(
+                                            IndexedAccessType {
+                                                obj_type: TypeAnn {
                                                     kind: TypeRef(
                                                         TypeRef {
                                                             name: "T",
@@ -65,14 +120,34 @@ Ok(
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 32,
+                                                            column: 38,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 33,
+                                                            column: 39,
                                                         },
                                                     },
-                                                    span: 32..33,
+                                                    span: 38..39,
+                                                    inferred_type: None,
+                                                },
+                                                index_type: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "P",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 40,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                    },
+                                                    span: 40..41,
                                                     inferred_type: None,
                                                 },
                                             },
@@ -80,126 +155,55 @@ Ok(
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 26,
+                                                column: 38,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 33,
+                                                column: 42,
                                             },
                                         },
-                                        span: 26..33,
+                                        span: 38..42,
                                         inferred_type: None,
                                     },
-                                ),
-                                default: None,
-                            },
-                            optional: Some(
-                                TMappedTypeChange {
-                                    span: 35..36,
-                                    change: Plus,
                                 },
                             ),
-                            mutable: Some(
-                                TMappedTypeChange {
-                                    span: 16..19,
-                                    change: Plus,
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 14,
                                 },
-                            ),
-                            type_ann: TypeAnn {
-                                kind: IndexedAccess(
-                                    IndexedAccessType {
-                                        obj_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 38,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 39,
-                                                },
-                                            },
-                                            span: 38..39,
-                                            inferred_type: None,
-                                        },
-                                        index_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "P",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 40,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                            },
-                                            span: 40..41,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 38,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 42,
-                                    },
+                                end: Position {
+                                    line: 0,
+                                    column: 43,
                                 },
-                                span: 38..42,
-                                inferred_type: None,
                             },
+                            span: 14..43,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 14,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 43,
-                        },
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 9..10,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 9,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 10,
+                                            },
+                                        },
+                                        span: 9..10,
+                                        name: "T",
+                                    },
+                                    constraint: None,
+                                    default: None,
+                                },
+                            ],
+                        ),
                     },
-                    span: 14..43,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 9..10,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                },
-                                span: 9..10,
-                                name: "T",
-                            },
-                            constraint: None,
-                            default: None,
-                        },
-                    ],
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Baz<T> = {-mut [P in keyof T]-?: T[P]};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,45 +17,100 @@ Ok(
                     },
                 },
                 span: 0..44,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                    },
-                    span: 5..8,
-                    name: "Baz",
-                },
-                type_ann: TypeAnn {
-                    kind: Mapped(
-                        MappedType {
-                            type_param: TypeParam {
-                                span: 21..33,
-                                name: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 21,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 22,
-                                        },
-                                    },
-                                    span: 21..22,
-                                    name: "P",
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                constraint: Some(
-                                    TypeAnn {
-                                        kind: KeyOf(
-                                            KeyOfType {
-                                                type_ann: TypeAnn {
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Baz",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Mapped(
+                                MappedType {
+                                    type_param: TypeParam {
+                                        span: 21..33,
+                                        name: Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 21,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
+                                            },
+                                            span: 21..22,
+                                            name: "P",
+                                        },
+                                        constraint: Some(
+                                            TypeAnn {
+                                                kind: KeyOf(
+                                                    KeyOfType {
+                                                        type_ann: TypeAnn {
+                                                            kind: TypeRef(
+                                                                TypeRef {
+                                                                    name: "T",
+                                                                    type_args: None,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 32,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 33,
+                                                                },
+                                                            },
+                                                            span: 32..33,
+                                                            inferred_type: None,
+                                                        },
+                                                    },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 26,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 33,
+                                                    },
+                                                },
+                                                span: 26..33,
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        default: None,
+                                    },
+                                    optional: Some(
+                                        TMappedTypeChange {
+                                            span: 35..36,
+                                            change: Minus,
+                                        },
+                                    ),
+                                    mutable: Some(
+                                        TMappedTypeChange {
+                                            span: 16..19,
+                                            change: Minus,
+                                        },
+                                    ),
+                                    type_ann: TypeAnn {
+                                        kind: IndexedAccess(
+                                            IndexedAccessType {
+                                                obj_type: TypeAnn {
                                                     kind: TypeRef(
                                                         TypeRef {
                                                             name: "T",
@@ -65,14 +120,34 @@ Ok(
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
-                                                            column: 32,
+                                                            column: 38,
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 33,
+                                                            column: 39,
                                                         },
                                                     },
-                                                    span: 32..33,
+                                                    span: 38..39,
+                                                    inferred_type: None,
+                                                },
+                                                index_type: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "P",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 40,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                    },
+                                                    span: 40..41,
                                                     inferred_type: None,
                                                 },
                                             },
@@ -80,126 +155,55 @@ Ok(
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 26,
+                                                column: 38,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 33,
+                                                column: 42,
                                             },
                                         },
-                                        span: 26..33,
+                                        span: 38..42,
                                         inferred_type: None,
                                     },
-                                ),
-                                default: None,
-                            },
-                            optional: Some(
-                                TMappedTypeChange {
-                                    span: 35..36,
-                                    change: Minus,
                                 },
                             ),
-                            mutable: Some(
-                                TMappedTypeChange {
-                                    span: 16..19,
-                                    change: Minus,
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 14,
                                 },
-                            ),
-                            type_ann: TypeAnn {
-                                kind: IndexedAccess(
-                                    IndexedAccessType {
-                                        obj_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 38,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 39,
-                                                },
-                                            },
-                                            span: 38..39,
-                                            inferred_type: None,
-                                        },
-                                        index_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "P",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 40,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                            },
-                                            span: 40..41,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 38,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 42,
-                                    },
+                                end: Position {
+                                    line: 0,
+                                    column: 43,
                                 },
-                                span: 38..42,
-                                inferred_type: None,
                             },
+                            span: 14..43,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 14,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 43,
-                        },
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 9..10,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 9,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 10,
+                                            },
+                                        },
+                                        span: 9..10,
+                                        name: "T",
+                                    },
+                                    constraint: None,
+                                    default: None,
+                                },
+                            ],
+                        ),
                     },
-                    span: 14..43,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 9..10,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                },
-                                span: 9..10,
-                                name: "T",
-                            },
-                            constraint: None,
-                            default: None,
-                        },
-                    ],
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__object_types.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Pick<T, K extends keyof T> = {[P in K]: T[P]};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,219 +17,223 @@ Ok(
                     },
                 },
                 span: 0..51,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                    },
-                    span: 5..9,
-                    name: "Pick",
-                },
-                type_ann: TypeAnn {
-                    kind: Mapped(
-                        MappedType {
-                            type_param: TypeParam {
-                                span: 36..42,
-                                name: Ident {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 36,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 37,
-                                        },
-                                    },
-                                    span: 36..37,
-                                    name: "P",
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                constraint: Some(
-                                    TypeAnn {
-                                        kind: TypeRef(
-                                            TypeRef {
-                                                name: "K",
-                                                type_args: None,
-                                            },
-                                        ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 41,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 42,
-                                            },
-                                        },
-                                        span: 41..42,
-                                        inferred_type: None,
-                                    },
-                                ),
-                                default: None,
+                                end: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
                             },
-                            optional: None,
-                            mutable: None,
-                            type_ann: TypeAnn {
-                                kind: IndexedAccess(
-                                    IndexedAccessType {
-                                        obj_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
-                                                },
-                                            ),
+                            span: 5..9,
+                            name: "Pick",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Mapped(
+                                MappedType {
+                                    type_param: TypeParam {
+                                        span: 36..42,
+                                        name: Ident {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 45,
+                                                    column: 36,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 46,
+                                                    column: 37,
                                                 },
                                             },
-                                            span: 45..46,
-                                            inferred_type: None,
+                                            span: 36..37,
+                                            name: "P",
                                         },
-                                        index_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "P",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 47,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 48,
-                                                },
-                                            },
-                                            span: 47..48,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 45,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 49,
-                                    },
-                                },
-                                span: 45..49,
-                                inferred_type: None,
-                            },
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 34,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 50,
-                        },
-                    },
-                    span: 34..50,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 10..11,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 11,
-                                    },
-                                },
-                                span: 10..11,
-                                name: "T",
-                            },
-                            constraint: None,
-                            default: None,
-                        },
-                        TypeParam {
-                            span: 13..30,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 13,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 14,
-                                    },
-                                },
-                                span: 13..14,
-                                name: "K",
-                            },
-                            constraint: Some(
-                                TypeAnn {
-                                    kind: KeyOf(
-                                        KeyOfType {
-                                            type_ann: TypeAnn {
+                                        constraint: Some(
+                                            TypeAnn {
                                                 kind: TypeRef(
                                                     TypeRef {
-                                                        name: "T",
+                                                        name: "K",
                                                         type_args: None,
                                                     },
                                                 ),
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 29,
+                                                        column: 41,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 30,
+                                                        column: 42,
                                                     },
                                                 },
-                                                span: 29..30,
+                                                span: 41..42,
                                                 inferred_type: None,
                                             },
-                                        },
-                                    ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 23,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 30,
-                                        },
+                                        ),
+                                        default: None,
                                     },
-                                    span: 23..30,
-                                    inferred_type: None,
+                                    optional: None,
+                                    mutable: None,
+                                    type_ann: TypeAnn {
+                                        kind: IndexedAccess(
+                                            IndexedAccessType {
+                                                obj_type: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "T",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 45,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 46,
+                                                        },
+                                                    },
+                                                    span: 45..46,
+                                                    inferred_type: None,
+                                                },
+                                                index_type: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "P",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 47,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 48,
+                                                        },
+                                                    },
+                                                    span: 47..48,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 45,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 49,
+                                            },
+                                        },
+                                        span: 45..49,
+                                        inferred_type: None,
+                                    },
                                 },
                             ),
-                            default: None,
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 34,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 50,
+                                },
+                            },
+                            span: 34..50,
+                            inferred_type: None,
                         },
-                    ],
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 10..11,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 10,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 11,
+                                            },
+                                        },
+                                        span: 10..11,
+                                        name: "T",
+                                    },
+                                    constraint: None,
+                                    default: None,
+                                },
+                                TypeParam {
+                                    span: 13..30,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 13,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 14,
+                                            },
+                                        },
+                                        span: 13..14,
+                                        name: "K",
+                                    },
+                                    constraint: Some(
+                                        TypeAnn {
+                                            kind: KeyOf(
+                                                KeyOfType {
+                                                    type_ann: TypeAnn {
+                                                        kind: TypeRef(
+                                                            TypeRef {
+                                                                name: "T",
+                                                                type_args: None,
+                                                            },
+                                                        ),
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 29,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 30,
+                                                            },
+                                                        },
+                                                        span: 29..30,
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 23,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 30,
+                                                },
+                                            },
+                                            span: 23..30,
+                                            inferred_type: None,
+                                        },
+                                    ),
+                                    default: None,
+                                },
+                            ],
+                        ),
+                    },
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let obj = {x, y};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..17,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "obj",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,70 +30,88 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "obj",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 16,
-                            },
-                        },
-                        span: 10..16,
-                        kind: Obj(
-                            Obj {
-                                props: [
-                                    Prop(
-                                        Shorthand(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 11,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 16,
+                                    },
+                                },
+                                span: 10..16,
+                                kind: Obj(
+                                    Obj {
+                                        props: [
+                                            Prop(
+                                                Shorthand(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 11,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                        },
+                                                        span: 11..12,
+                                                        name: "x",
                                                     },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 12,
+                                                ),
+                                            ),
+                                            Prop(
+                                                Shorthand(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 15,
+                                                            },
+                                                        },
+                                                        span: 14..15,
+                                                        name: "y",
                                                     },
-                                                },
-                                                span: 11..12,
-                                                name: "x",
-                                            },
-                                        ),
-                                    ),
-                                    Prop(
-                                        Shorthand(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 14,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 15,
-                                                    },
-                                                },
-                                                span: 14..15,
-                                                name: "y",
-                                            },
-                                        ),
-                                    ),
-                                ],
+                                                ),
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let obj = {a, b, ...others};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..28,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "obj",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,79 +30,82 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "obj",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 27,
-                            },
-                        },
-                        span: 10..27,
-                        kind: Obj(
-                            Obj {
-                                props: [
-                                    Prop(
-                                        Shorthand(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 11,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 12,
-                                                    },
-                                                },
-                                                span: 11..12,
-                                                name: "a",
-                                            },
-                                        ),
-                                    ),
-                                    Prop(
-                                        Shorthand(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 14,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 15,
-                                                    },
-                                                },
-                                                span: 14..15,
-                                                name: "b",
-                                            },
-                                        ),
-                                    ),
-                                    Spread(
-                                        SpreadElement {
-                                            expr: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 20,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 26,
-                                                    },
-                                                },
-                                                span: 20..26,
-                                                kind: Ident(
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 27,
+                                    },
+                                },
+                                span: 10..27,
+                                kind: Obj(
+                                    Obj {
+                                        props: [
+                                            Prop(
+                                                Shorthand(
                                                     Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 11,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                        },
+                                                        span: 11..12,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                            ),
+                                            Prop(
+                                                Shorthand(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 15,
+                                                            },
+                                                        },
+                                                        span: 14..15,
+                                                        name: "b",
+                                                    },
+                                                ),
+                                            ),
+                                            Spread(
+                                                SpreadElement {
+                                                    expr: Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
@@ -128,20 +117,35 @@ Ok(
                                                             },
                                                         },
                                                         span: 20..26,
-                                                        name: "others",
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 20,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 26,
+                                                                    },
+                                                                },
+                                                                span: 20..26,
+                                                                name: "others",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                ],
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__objects.snap
@@ -5,132 +5,145 @@ expression: "parse(\"{x: 5, y: 10};\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 13,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..13,
-                    kind: Obj(
-                        Obj {
-                            props: [
-                                Prop(
-                                    KeyValue(
-                                        KeyValueProp {
-                                            key: Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 1,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 2,
-                                                    },
-                                                },
-                                                span: 1..2,
-                                                name: "x",
-                                            },
-                                            value: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 4,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 5,
-                                                    },
-                                                },
-                                                span: 4..5,
-                                                kind: Lit(
-                                                    Num(
-                                                        Num {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 4,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 5,
-                                                                },
-                                                            },
-                                                            span: 4..5,
-                                                            value: "5",
-                                                        },
-                                                    ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                ),
-                                Prop(
-                                    KeyValue(
-                                        KeyValueProp {
-                                            key: Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 7,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 8,
-                                                    },
-                                                },
-                                                span: 7..8,
-                                                name: "y",
-                                            },
-                                            value: Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 10,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 12,
-                                                    },
-                                                },
-                                                span: 10..12,
-                                                kind: Lit(
-                                                    Num(
-                                                        Num {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 10,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 12,
-                                                                },
-                                                            },
-                                                            span: 10..12,
-                                                            value: "10",
-                                                        },
-                                                    ),
-                                                ),
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
-                                ),
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 14,
+                    },
                 },
-            ),
+                span: 0..14,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 13,
+                            },
+                        },
+                        span: 0..13,
+                        kind: Obj(
+                            Obj {
+                                props: [
+                                    Prop(
+                                        KeyValue(
+                                            KeyValueProp {
+                                                key: Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 1,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 2,
+                                                        },
+                                                    },
+                                                    span: 1..2,
+                                                    name: "x",
+                                                },
+                                                value: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 4,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 5,
+                                                        },
+                                                    },
+                                                    span: 4..5,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 4,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 5,
+                                                                    },
+                                                                },
+                                                                span: 4..5,
+                                                                value: "5",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                    Prop(
+                                        KeyValue(
+                                            KeyValueProp {
+                                                key: Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 7,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
+                                                    },
+                                                    span: 7..8,
+                                                    name: "y",
+                                                },
+                                                value: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                    },
+                                                    span: 10..12,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 10,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                },
+                                                                span: 10..12,
+                                                                value: "10",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-10.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-10.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let cond = a != b;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..18,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                    },
-                    span: 4..8,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "cond",
-                            mutable: false,
-                            span: 4..8,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,41 +30,44 @@ Ok(
                                     column: 8,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 11,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 17,
-                            },
-                        },
-                        span: 11..17,
-                        kind: BinaryExpr(
-                            BinaryExpr {
-                                op: NotEq,
-                                left: Expr {
+                            span: 4..8,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "cond",
+                                    mutable: false,
+                                    span: 4..8,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 11,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 12,
+                                            column: 8,
                                         },
                                     },
-                                    span: 11..12,
-                                    kind: Ident(
-                                        Ident {
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 11,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                },
+                                span: 11..17,
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: NotEq,
+                                        left: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -90,25 +79,25 @@ Ok(
                                                 },
                                             },
                                             span: 11..12,
-                                            name: "a",
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                    },
+                                                    span: 11..12,
+                                                    name: "a",
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                right: Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
-                                    },
-                                    span: 16..17,
-                                    kind: Ident(
-                                        Ident {
+                                        right: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -120,17 +109,32 @@ Ok(
                                                 },
                                             },
                                             span: 16..17,
-                                            name: "b",
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 16..17,
+                                                    name: "b",
+                                                },
+                                            ),
+                                            inferred_type: None,
                                         },
-                                    ),
-                                    inferred_type: None,
-                                },
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-11.snap
@@ -5,57 +5,70 @@ expression: "parse(\"-a;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 2,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..2,
-                    kind: UnaryExpr(
-                        UnaryExpr {
-                            op: Minus,
-                            arg: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 2,
-                                    },
-                                },
-                                span: 1..2,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 2,
-                                            },
-                                        },
-                                        span: 1..2,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 3,
+                    },
+                },
+                span: 0..3,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 2,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..2,
+                        kind: UnaryExpr(
+                            UnaryExpr {
+                                op: Minus,
+                                arg: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 2,
+                                        },
+                                    },
+                                    span: 1..2,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 2,
+                                                },
+                                            },
+                                            span: 1..2,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-12.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-12.snap
@@ -5,106 +5,119 @@ expression: "parse(\"-(a + b);\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..8,
-                    kind: UnaryExpr(
-                        UnaryExpr {
-                            op: Minus,
-                            arg: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 2,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 7,
-                                    },
-                                },
-                                span: 2..7,
-                                kind: BinaryExpr(
-                                    BinaryExpr {
-                                        op: Add,
-                                        left: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 2,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 3,
-                                                },
-                                            },
-                                            span: 2..3,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 2,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 3,
-                                                        },
-                                                    },
-                                                    span: 2..3,
-                                                    name: "a",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        right: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 7,
-                                                },
-                                            },
-                                            span: 6..7,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 6,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 7,
-                                                        },
-                                                    },
-                                                    span: 6..7,
-                                                    name: "b",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 9,
+                    },
+                },
+                span: 0..9,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 8,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..8,
+                        kind: UnaryExpr(
+                            UnaryExpr {
+                                op: Minus,
+                                arg: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 2,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                    span: 2..7,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Add,
+                                            left: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 2,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 3,
+                                                    },
+                                                },
+                                                span: 2..3,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 2,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 3,
+                                                            },
+                                                        },
+                                                        span: 2..3,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            right: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 6,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 7,
+                                                    },
+                                                },
+                                                span: 6..7,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 6,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 7,
+                                                            },
+                                                        },
+                                                        span: 6..7,
+                                                        name: "b",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-2.snap
@@ -5,136 +5,149 @@ expression: "parse(\"x * y / z;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..9,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: Div,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                },
-                                span: 0..5,
-                                kind: BinaryExpr(
-                                    BinaryExpr {
-                                        op: Mul,
-                                        left: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
-                                            },
-                                            span: 0..1,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 0,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 1,
-                                                        },
-                                                    },
-                                                    span: 0..1,
-                                                    name: "x",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        right: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 4,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                            },
-                                            span: 4..5,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 4,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 5,
-                                                        },
-                                                    },
-                                                    span: 4..5,
-                                                    name: "y",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 10,
+                    },
+                },
+                span: 0..10,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 8,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                },
-                                span: 8..9,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 8,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                        },
-                                        span: 8..9,
-                                        name: "z",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 9,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..9,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: Div,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                    span: 0..5,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Mul,
+                                            left: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 1,
+                                                    },
+                                                },
+                                                span: 0..1,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 0,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 1,
+                                                            },
+                                                        },
+                                                        span: 0..1,
+                                                        name: "x",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            right: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 4,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                },
+                                                span: 4..5,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 4,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 5,
+                                                            },
+                                                        },
+                                                        span: 4..5,
+                                                        name: "y",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 8,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                    span: 8..9,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 8,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 9,
+                                                },
+                                            },
+                                            span: 8..9,
+                                            name: "z",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-3.snap
@@ -5,136 +5,149 @@ expression: "parse(\"(a + b) * c;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..11,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: Mul,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 1..6,
-                                kind: BinaryExpr(
-                                    BinaryExpr {
-                                        op: Add,
-                                        left: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 2,
-                                                },
-                                            },
-                                            span: 1..2,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 1,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 2,
-                                                        },
-                                                    },
-                                                    span: 1..2,
-                                                    name: "a",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        right: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                            span: 5..6,
-                                            kind: Ident(
-                                                Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 5,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 6,
-                                                        },
-                                                    },
-                                                    span: 5..6,
-                                                    name: "b",
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 12,
+                    },
+                },
+                span: 0..12,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 11,
-                                    },
-                                },
-                                span: 10..11,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 10,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 11,
-                                            },
-                                        },
-                                        span: 10..11,
-                                        name: "c",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 11,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..11,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: Mul,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 1..6,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Add,
+                                            left: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 1,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 2,
+                                                    },
+                                                },
+                                                span: 1..2,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 1,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 2,
+                                                            },
+                                                        },
+                                                        span: 1..2,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                            right: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 6,
+                                                    },
+                                                },
+                                                span: 5..6,
+                                                kind: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 5,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 6,
+                                                            },
+                                                        },
+                                                        span: 5..6,
+                                                        name: "b",
+                                                    },
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 10,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 11,
+                                        },
+                                    },
+                                    span: 10..11,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 10,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 11,
+                                                },
+                                            },
+                                            span: 10..11,
+                                            name: "c",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-4.snap
@@ -5,87 +5,100 @@ expression: "parse(\"a == b;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 6,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..6,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: EqEq,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 7,
+                    },
+                },
+                span: 0..7,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 5..6,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 5..6,
-                                        name: "b",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 6,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..6,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: EqEq,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                    },
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                            },
+                                            span: 0..1,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 5..6,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 6,
+                                                },
+                                            },
+                                            span: 5..6,
+                                            name: "b",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-5.snap
@@ -5,87 +5,100 @@ expression: "parse(\"a != b;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 6,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..6,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: NotEq,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 7,
+                    },
+                },
+                span: 0..7,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 5..6,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 5..6,
-                                        name: "b",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 6,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..6,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: NotEq,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                    },
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                            },
+                                            span: 0..1,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 5..6,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 6,
+                                                },
+                                            },
+                                            span: 5..6,
+                                            name: "b",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-6.snap
@@ -5,87 +5,100 @@ expression: "parse(\"a > b;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..5,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: Gt,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 6,
+                    },
+                },
+                span: 0..6,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                },
-                                span: 4..5,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                        },
-                                        span: 4..5,
-                                        name: "b",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 5,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..5,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: Gt,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                    },
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                            },
+                                            span: 0..1,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                    span: 4..5,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                            },
+                                            span: 4..5,
+                                            name: "b",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-7.snap
@@ -5,87 +5,100 @@ expression: "parse(\"a >= b;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 6,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..6,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: GtEq,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 7,
+                    },
+                },
+                span: 0..7,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 5..6,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 5..6,
-                                        name: "b",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 6,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..6,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: GtEq,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                    },
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                            },
+                                            span: 0..1,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 5..6,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 6,
+                                                },
+                                            },
+                                            span: 5..6,
+                                            name: "b",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-8.snap
@@ -5,87 +5,100 @@ expression: "parse(\"a < b;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..5,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: Lt,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 6,
+                    },
+                },
+                span: 0..6,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                },
-                                span: 4..5,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                        },
-                                        span: 4..5,
-                                        name: "b",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 5,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..5,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: Lt,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                    },
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                            },
+                                            span: 0..1,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                    span: 4..5,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                            },
+                                            span: 4..5,
+                                            name: "b",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations-9.snap
@@ -5,87 +5,100 @@ expression: "parse(\"a <= b;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 6,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..6,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: LtEq,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 7,
+                    },
+                },
+                span: 0..7,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 6,
-                                    },
-                                },
-                                span: 5..6,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 6,
-                                            },
-                                        },
-                                        span: 5..6,
-                                        name: "b",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 6,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..6,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: LtEq,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                    },
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                            },
+                                            span: 0..1,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 6,
+                                        },
+                                    },
+                                    span: 5..6,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 6,
+                                                },
+                                            },
+                                            span: 5..6,
+                                            name: "b",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__operations.snap
@@ -5,142 +5,155 @@ expression: "parse(\"1 + 2 - 3;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 9,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..9,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: Sub,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                },
-                                span: 0..5,
-                                kind: BinaryExpr(
-                                    BinaryExpr {
-                                        op: Add,
-                                        left: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 1,
-                                                },
-                                            },
-                                            span: 0..1,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 0,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 1,
-                                                            },
-                                                        },
-                                                        span: 0..1,
-                                                        value: "1",
-                                                    },
-                                                ),
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        right: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 4,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                            },
-                                            span: 4..5,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 4,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 5,
-                                                            },
-                                                        },
-                                                        span: 4..5,
-                                                        value: "2",
-                                                    },
-                                                ),
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 10,
+                    },
+                },
+                span: 0..10,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 8,
+                            end: Position {
+                                line: 0,
+                                column: 9,
+                            },
+                        },
+                        span: 0..9,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: Sub,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
                                     },
-                                    end: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                },
-                                span: 8..9,
-                                kind: Lit(
-                                    Num(
-                                        Num {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
+                                    span: 0..5,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Add,
+                                            left: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 1,
+                                                    },
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
+                                                span: 0..1,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 0,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 1,
+                                                                },
+                                                            },
+                                                            span: 0..1,
+                                                            value: "1",
+                                                        },
+                                                    ),
+                                                ),
+                                                inferred_type: None,
                                             },
-                                            span: 8..9,
-                                            value: "3",
+                                            right: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 4,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                },
+                                                span: 4..5,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 4,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 5,
+                                                                },
+                                                            },
+                                                            span: 4..5,
+                                                            value: "2",
+                                                        },
+                                                    ),
+                                                ),
+                                                inferred_type: None,
+                                            },
                                         },
                                     ),
-                                ),
-                                inferred_type: None,
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 8,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 9,
+                                        },
+                                    },
+                                    span: 8..9,
+                                    kind: Lit(
+                                        Num(
+                                            Num {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 9,
+                                                    },
+                                                },
+                                                span: 8..9,
+                                                value: "3",
+                                            },
+                                        ),
+                                    ),
+                                    inferred_type: None,
+                                },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-2.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"\n            let bar = match (foo) {\n                {a
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 13..129,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
-                    span: 17..20,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "bar",
-                            mutable: false,
-                            span: 17..20,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,40 +30,43 @@ Ok(
                                     column: 19,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 4,
-                                column: 13,
-                            },
-                        },
-                        span: 23..128,
-                        kind: Match(
-                            Match {
-                                expr: Expr {
+                            span: 17..20,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "bar",
+                                    mutable: false,
+                                    span: 17..20,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 1,
-                                            column: 29,
+                                            column: 16,
                                         },
                                         end: Position {
                                             line: 1,
-                                            column: 32,
+                                            column: 19,
                                         },
                                     },
-                                    span: 30..33,
-                                    kind: Ident(
-                                        Ident {
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 4,
+                                        column: 13,
+                                    },
+                                },
+                                span: 23..128,
+                                kind: Match(
+                                    Match {
+                                        expr: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 1,
@@ -89,290 +78,305 @@ Ok(
                                                 },
                                             },
                                             span: 30..33,
-                                            name: "foo",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                arms: [
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 2,
-                                                column: 41,
-                                            },
-                                        },
-                                        span: 53..78,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 29,
-                                                },
-                                            },
-                                            span: 53..66,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        KeyValue(
-                                                            KeyValuePatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 17,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 28,
-                                                                    },
-                                                                },
-                                                                span: 54..65,
-                                                                key: Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 17,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 18,
-                                                                        },
-                                                                    },
-                                                                    span: 54..55,
-                                                                    name: "a",
-                                                                },
-                                                                value: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 20,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 28,
-                                                                        },
-                                                                    },
-                                                                    span: 57..65,
-                                                                    kind: Object(
-                                                                        ObjectPat {
-                                                                            props: [
-                                                                                KeyValue(
-                                                                                    KeyValuePatProp {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 2,
-                                                                                                column: 21,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 2,
-                                                                                                column: 27,
-                                                                                            },
-                                                                                        },
-                                                                                        span: 58..64,
-                                                                                        key: Ident {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 2,
-                                                                                                    column: 21,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 2,
-                                                                                                    column: 22,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 58..59,
-                                                                                            name: "b",
-                                                                                        },
-                                                                                        value: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 2,
-                                                                                                    column: 24,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 2,
-                                                                                                    column: 27,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 61..64,
-                                                                                            kind: Object(
-                                                                                                ObjectPat {
-                                                                                                    props: [
-                                                                                                        Shorthand(
-                                                                                                            ShorthandPatProp {
-                                                                                                                loc: SourceLocation {
-                                                                                                                    start: Position {
-                                                                                                                        line: 2,
-                                                                                                                        column: 25,
-                                                                                                                    },
-                                                                                                                    end: Position {
-                                                                                                                        line: 2,
-                                                                                                                        column: 26,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                span: 62..63,
-                                                                                                                ident: BindingIdent {
-                                                                                                                    name: "c",
-                                                                                                                    mutable: false,
-                                                                                                                    span: 62..63,
-                                                                                                                    loc: SourceLocation {
-                                                                                                                        start: Position {
-                                                                                                                            line: 2,
-                                                                                                                            column: 25,
-                                                                                                                        },
-                                                                                                                        end: Position {
-                                                                                                                            line: 2,
-                                                                                                                            column: 26,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                init: None,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ],
-                                                                                                    optional: false,
-                                                                                                },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                        init: None,
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                            optional: false,
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 1,
+                                                            column: 29,
+                                                        },
+                                                        end: Position {
+                                                            line: 1,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 30..33,
+                                                    name: "foo",
                                                 },
                                             ),
                                             inferred_type: None,
                                         },
-                                        guard: None,
-                                        body: Block {
-                                            span: 70..78,
-                                            stmts: [
-                                                Expr {
+                                        arms: [
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 2,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 2,
+                                                        column: 41,
+                                                    },
+                                                },
+                                                span: 53..78,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
-                                                            column: 33,
+                                                            column: 16,
                                                         },
                                                         end: Position {
                                                             line: 2,
-                                                            column: 41,
+                                                            column: 29,
                                                         },
                                                     },
+                                                    span: 53..66,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                KeyValue(
+                                                                    KeyValuePatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 17,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 28,
+                                                                            },
+                                                                        },
+                                                                        span: 54..65,
+                                                                        key: Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 2,
+                                                                                    column: 17,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 2,
+                                                                                    column: 18,
+                                                                                },
+                                                                            },
+                                                                            span: 54..55,
+                                                                            name: "a",
+                                                                        },
+                                                                        value: Pattern {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 2,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 2,
+                                                                                    column: 28,
+                                                                                },
+                                                                            },
+                                                                            span: 57..65,
+                                                                            kind: Object(
+                                                                                ObjectPat {
+                                                                                    props: [
+                                                                                        KeyValue(
+                                                                                            KeyValuePatProp {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 2,
+                                                                                                        column: 21,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 2,
+                                                                                                        column: 27,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 58..64,
+                                                                                                key: Ident {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 2,
+                                                                                                            column: 21,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 2,
+                                                                                                            column: 22,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 58..59,
+                                                                                                    name: "b",
+                                                                                                },
+                                                                                                value: Pattern {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 2,
+                                                                                                            column: 24,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 2,
+                                                                                                            column: 27,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 61..64,
+                                                                                                    kind: Object(
+                                                                                                        ObjectPat {
+                                                                                                            props: [
+                                                                                                                Shorthand(
+                                                                                                                    ShorthandPatProp {
+                                                                                                                        loc: SourceLocation {
+                                                                                                                            start: Position {
+                                                                                                                                line: 2,
+                                                                                                                                column: 25,
+                                                                                                                            },
+                                                                                                                            end: Position {
+                                                                                                                                line: 2,
+                                                                                                                                column: 26,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        span: 62..63,
+                                                                                                                        ident: BindingIdent {
+                                                                                                                            name: "c",
+                                                                                                                            mutable: false,
+                                                                                                                            span: 62..63,
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 2,
+                                                                                                                                    column: 25,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 2,
+                                                                                                                                    column: 26,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        init: None,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ],
+                                                                                                            optional: false,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    inferred_type: None,
+                                                                                                },
+                                                                                                init: None,
+                                                                                            },
+                                                                                        ),
+                                                                                    ],
+                                                                                    optional: false,
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                guard: None,
+                                                body: Block {
                                                     span: 70..78,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 33,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 41,
-                                                                    },
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 33,
                                                                 },
-                                                                span: 70..78,
-                                                                value: "object",
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 41,
+                                                                },
                                                             },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 3,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 3,
-                                                column: 34,
-                                            },
-                                        },
-                                        span: 96..114,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 17,
+                                                            span: 70..78,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 33,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 41,
+                                                                            },
+                                                                        },
+                                                                        span: 70..78,
+                                                                        value: "object",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
                                                 },
                                             },
-                                            span: 96..97,
-                                            kind: Wildcard,
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 101..114,
-                                            stmts: [
-                                                Expr {
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 3,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 3,
+                                                        column: 34,
+                                                    },
+                                                },
+                                                span: 96..114,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 3,
-                                                            column: 21,
+                                                            column: 16,
                                                         },
                                                         end: Position {
                                                             line: 3,
-                                                            column: 34,
+                                                            column: 17,
                                                         },
                                                     },
-                                                    span: 101..114,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 3,
-                                                                        column: 21,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 34,
-                                                                    },
-                                                                },
-                                                                span: 101..114,
-                                                                value: "fallthrough",
-                                                            },
-                                                        ),
-                                                    ),
+                                                    span: 96..97,
+                                                    kind: Wildcard,
                                                     inferred_type: None,
                                                 },
-                                            ],
-                                        },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 101..114,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 34,
+                                                                },
+                                                            },
+                                                            span: 101..114,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 21,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 34,
+                                                                            },
+                                                                        },
+                                                                        span: 101..114,
+                                                                        value: "fallthrough",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-3.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"\n            let bar = match (foo) {\n                n 
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 13..171,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
-                    span: 17..20,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "bar",
-                            mutable: false,
-                            span: 17..20,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,40 +30,43 @@ Ok(
                                     column: 19,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 5,
-                                column: 13,
-                            },
-                        },
-                        span: 23..170,
-                        kind: Match(
-                            Match {
-                                expr: Expr {
+                            span: 17..20,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "bar",
+                                    mutable: false,
+                                    span: 17..20,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 1,
-                                            column: 29,
+                                            column: 16,
                                         },
                                         end: Position {
                                             line: 1,
-                                            column: 32,
+                                            column: 19,
                                         },
                                     },
-                                    span: 30..33,
-                                    kind: Ident(
-                                        Ident {
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 5,
+                                        column: 13,
+                                    },
+                                },
+                                span: 23..170,
+                                kind: Match(
+                                    Match {
+                                        expr: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 1,
@@ -89,332 +78,347 @@ Ok(
                                                 },
                                             },
                                             span: 30..33,
-                                            name: "foo",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                arms: [
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 2,
-                                                column: 39,
-                                            },
-                                        },
-                                        span: 53..76,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 27,
-                                                },
-                                            },
-                                            span: 53..64,
-                                            kind: Is(
-                                                IsPat {
-                                                    ident: BindingIdent {
-                                                        name: "n",
-                                                        mutable: false,
-                                                        span: 53..54,
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 16,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 17,
-                                                            },
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 1,
+                                                            column: 29,
+                                                        },
+                                                        end: Position {
+                                                            line: 1,
+                                                            column: 32,
                                                         },
                                                     },
-                                                    is_id: Ident {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 21,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 27,
-                                                            },
-                                                        },
-                                                        span: 58..64,
-                                                        name: "number",
-                                                    },
+                                                    span: 30..33,
+                                                    name: "foo",
                                                 },
                                             ),
                                             inferred_type: None,
                                         },
-                                        guard: None,
-                                        body: Block {
-                                            span: 68..76,
-                                            stmts: [
-                                                Expr {
+                                        arms: [
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 2,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 2,
+                                                        column: 39,
+                                                    },
+                                                },
+                                                span: 53..76,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
-                                                            column: 31,
+                                                            column: 16,
                                                         },
                                                         end: Position {
                                                             line: 2,
-                                                            column: 39,
+                                                            column: 27,
                                                         },
                                                     },
-                                                    span: 68..76,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
+                                                    span: 53..64,
+                                                    kind: Is(
+                                                        IsPat {
+                                                            ident: BindingIdent {
+                                                                name: "n",
+                                                                mutable: false,
+                                                                span: 53..54,
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 2,
-                                                                        column: 31,
+                                                                        column: 16,
                                                                     },
                                                                     end: Position {
                                                                         line: 2,
-                                                                        column: 39,
-                                                                    },
-                                                                },
-                                                                span: 68..76,
-                                                                value: "number",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 3,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 3,
-                                                column: 42,
-                                            },
-                                        },
-                                        span: 94..120,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 31,
-                                                },
-                                            },
-                                            span: 94..109,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        KeyValue(
-                                                            KeyValuePatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 3,
                                                                         column: 17,
                                                                     },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 30,
-                                                                    },
                                                                 },
-                                                                span: 95..108,
-                                                                key: Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 17,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 18,
-                                                                        },
-                                                                    },
-                                                                    span: 95..96,
-                                                                    name: "a",
-                                                                },
-                                                                value: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 20,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 30,
-                                                                        },
-                                                                    },
-                                                                    span: 98..108,
-                                                                    kind: Is(
-                                                                        IsPat {
-                                                                            ident: BindingIdent {
-                                                                                name: "a",
-                                                                                mutable: false,
-                                                                                span: 98..99,
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 20,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 21,
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            is_id: Ident {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 25,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 30,
-                                                                                    },
-                                                                                },
-                                                                                span: 103..108,
-                                                                                name: "Array",
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
                                                             },
-                                                        ),
-                                                    ],
-                                                    optional: false,
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 113..120,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 3,
-                                                            column: 35,
-                                                        },
-                                                        end: Position {
-                                                            line: 3,
-                                                            column: 42,
-                                                        },
-                                                    },
-                                                    span: 113..120,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
+                                                            is_id: Ident {
                                                                 loc: SourceLocation {
                                                                     start: Position {
-                                                                        line: 3,
-                                                                        column: 35,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 42,
-                                                                    },
-                                                                },
-                                                                span: 113..120,
-                                                                value: "Array",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 4,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 4,
-                                                column: 34,
-                                            },
-                                        },
-                                        span: 138..156,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 4,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 4,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 138..139,
-                                            kind: Wildcard,
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 143..156,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 4,
-                                                            column: 21,
-                                                        },
-                                                        end: Position {
-                                                            line: 4,
-                                                            column: 34,
-                                                        },
-                                                    },
-                                                    span: 143..156,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 4,
+                                                                        line: 2,
                                                                         column: 21,
                                                                     },
                                                                     end: Position {
-                                                                        line: 4,
-                                                                        column: 34,
+                                                                        line: 2,
+                                                                        column: 27,
                                                                     },
                                                                 },
-                                                                span: 143..156,
-                                                                value: "fallthrough",
+                                                                span: 58..64,
+                                                                name: "number",
                                                             },
-                                                        ),
+                                                        },
                                                     ),
                                                     inferred_type: None,
                                                 },
-                                            ],
-                                        },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 68..76,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 31,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 39,
+                                                                },
+                                                            },
+                                                            span: 68..76,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 31,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 39,
+                                                                            },
+                                                                        },
+                                                                        span: 68..76,
+                                                                        value: "number",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 3,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 3,
+                                                        column: 42,
+                                                    },
+                                                },
+                                                span: 94..120,
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 31,
+                                                        },
+                                                    },
+                                                    span: 94..109,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                KeyValue(
+                                                                    KeyValuePatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 17,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 30,
+                                                                            },
+                                                                        },
+                                                                        span: 95..108,
+                                                                        key: Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 3,
+                                                                                    column: 17,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 3,
+                                                                                    column: 18,
+                                                                                },
+                                                                            },
+                                                                            span: 95..96,
+                                                                            name: "a",
+                                                                        },
+                                                                        value: Pattern {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 3,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 3,
+                                                                                    column: 30,
+                                                                                },
+                                                                            },
+                                                                            span: 98..108,
+                                                                            kind: Is(
+                                                                                IsPat {
+                                                                                    ident: BindingIdent {
+                                                                                        name: "a",
+                                                                                        mutable: false,
+                                                                                        span: 98..99,
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 3,
+                                                                                                column: 20,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 3,
+                                                                                                column: 21,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    is_id: Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 3,
+                                                                                                column: 25,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 3,
+                                                                                                column: 30,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 103..108,
+                                                                                        name: "Array",
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 113..120,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 35,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 42,
+                                                                },
+                                                            },
+                                                            span: 113..120,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 35,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 42,
+                                                                            },
+                                                                        },
+                                                                        span: 113..120,
+                                                                        value: "Array",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 4,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 4,
+                                                        column: 34,
+                                                    },
+                                                },
+                                                span: 138..156,
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 4,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 4,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 138..139,
+                                                    kind: Wildcard,
+                                                    inferred_type: None,
+                                                },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 143..156,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 4,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 4,
+                                                                    column: 34,
+                                                                },
+                                                            },
+                                                            span: 143..156,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 4,
+                                                                                column: 21,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 4,
+                                                                                column: 34,
+                                                                            },
+                                                                        },
+                                                                        span: 143..156,
+                                                                        value: "fallthrough",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-4.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"\n            let bar = match (foo) {\n                1 
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 13..174,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
-                    span: 17..20,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "bar",
-                            mutable: false,
-                            span: 17..20,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,40 +30,43 @@ Ok(
                                     column: 19,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 6,
-                                column: 13,
-                            },
-                        },
-                        span: 23..173,
-                        kind: Match(
-                            Match {
-                                expr: Expr {
+                            span: 17..20,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "bar",
+                                    mutable: false,
+                                    span: 17..20,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 1,
-                                            column: 29,
+                                            column: 16,
                                         },
                                         end: Position {
                                             line: 1,
-                                            column: 32,
+                                            column: 19,
                                         },
                                     },
-                                    span: 30..33,
-                                    kind: Ident(
-                                        Ident {
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        column: 13,
+                                    },
+                                },
+                                span: 23..173,
+                                kind: Match(
+                                    Match {
+                                        expr: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 1,
@@ -89,211 +78,208 @@ Ok(
                                                 },
                                             },
                                             span: 30..33,
-                                            name: "foo",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                arms: [
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 2,
-                                                column: 26,
-                                            },
-                                        },
-                                        span: 53..63,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 53..54,
-                                            kind: Lit(
-                                                LitPat {
-                                                    lit: Num(
-                                                        Num {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 17,
-                                                                },
-                                                            },
-                                                            span: 53..54,
-                                                            value: "1",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 58..63,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 21,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 26,
-                                                        },
-                                                    },
-                                                    span: 58..63,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 21,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 26,
-                                                                    },
-                                                                },
-                                                                span: 58..63,
-                                                                value: "one",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 3,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 3,
-                                                column: 26,
-                                            },
-                                        },
-                                        span: 81..91,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 81..82,
-                                            kind: Lit(
-                                                LitPat {
-                                                    lit: Num(
-                                                        Num {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 17,
-                                                                },
-                                                            },
-                                                            span: 81..82,
-                                                            value: "2",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 86..91,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 3,
-                                                            column: 21,
-                                                        },
-                                                        end: Position {
-                                                            line: 3,
-                                                            column: 26,
-                                                        },
-                                                    },
-                                                    span: 86..91,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 3,
-                                                                        column: 21,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 26,
-                                                                    },
-                                                                },
-                                                                span: 86..91,
-                                                                value: "two",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 4,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 4,
-                                                column: 37,
-                                            },
-                                        },
-                                        span: 109..130,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 4,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 4,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 109..110,
                                             kind: Ident(
-                                                BindingIdent {
-                                                    name: "n",
-                                                    mutable: false,
-                                                    span: 109..110,
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 1,
+                                                            column: 29,
+                                                        },
+                                                        end: Position {
+                                                            line: 1,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 30..33,
+                                                    name: "foo",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        arms: [
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 2,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 2,
+                                                        column: 26,
+                                                    },
+                                                },
+                                                span: 53..63,
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 53..54,
+                                                    kind: Lit(
+                                                        LitPat {
+                                                            lit: Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 17,
+                                                                        },
+                                                                    },
+                                                                    span: 53..54,
+                                                                    value: "1",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 58..63,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 26,
+                                                                },
+                                                            },
+                                                            span: 58..63,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 21,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 26,
+                                                                            },
+                                                                        },
+                                                                        span: 58..63,
+                                                                        value: "one",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 3,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 3,
+                                                        column: 26,
+                                                    },
+                                                },
+                                                span: 81..91,
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 81..82,
+                                                    kind: Lit(
+                                                        LitPat {
+                                                            lit: Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 17,
+                                                                        },
+                                                                    },
+                                                                    span: 81..82,
+                                                                    value: "2",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 86..91,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 26,
+                                                                },
+                                                            },
+                                                            span: 86..91,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 21,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 26,
+                                                                            },
+                                                                        },
+                                                                        span: 86..91,
+                                                                        value: "two",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 4,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 4,
+                                                        column: 37,
+                                                    },
+                                                },
+                                                span: 109..130,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 4,
@@ -304,40 +290,43 @@ Ok(
                                                             column: 17,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: Some(
-                                            Expr {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 4,
-                                                        column: 22,
-                                                    },
-                                                    end: Position {
-                                                        line: 4,
-                                                        column: 27,
-                                                    },
-                                                },
-                                                span: 115..120,
-                                                kind: BinaryExpr(
-                                                    BinaryExpr {
-                                                        op: Lt,
-                                                        left: Expr {
+                                                    span: 109..110,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "n",
+                                                            mutable: false,
+                                                            span: 109..110,
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 4,
-                                                                    column: 22,
+                                                                    column: 16,
                                                                 },
                                                                 end: Position {
                                                                     line: 4,
-                                                                    column: 23,
+                                                                    column: 17,
                                                                 },
                                                             },
-                                                            span: 115..116,
-                                                            kind: Ident(
-                                                                Ident {
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                guard: Some(
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 4,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 4,
+                                                                column: 27,
+                                                            },
+                                                        },
+                                                        span: 115..120,
+                                                        kind: BinaryExpr(
+                                                            BinaryExpr {
+                                                                op: Lt,
+                                                                left: Expr {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 4,
@@ -349,159 +338,174 @@ Ok(
                                                                         },
                                                                     },
                                                                     span: 115..116,
-                                                                    name: "n",
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 4,
+                                                                                    column: 22,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 4,
+                                                                                    column: 23,
+                                                                                },
+                                                                            },
+                                                                            span: 115..116,
+                                                                            name: "n",
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        right: Expr {
+                                                                right: Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 4,
+                                                                            column: 26,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 4,
+                                                                            column: 27,
+                                                                        },
+                                                                    },
+                                                                    span: 119..120,
+                                                                    kind: Lit(
+                                                                        Num(
+                                                                            Num {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 4,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 4,
+                                                                                        column: 27,
+                                                                                    },
+                                                                                },
+                                                                                span: 119..120,
+                                                                                value: "5",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                ),
+                                                body: Block {
+                                                    span: 125..130,
+                                                    stmts: [
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 4,
-                                                                    column: 26,
+                                                                    column: 32,
                                                                 },
                                                                 end: Position {
                                                                     line: 4,
-                                                                    column: 27,
+                                                                    column: 37,
                                                                 },
                                                             },
-                                                            span: 119..120,
+                                                            span: 125..130,
                                                             kind: Lit(
-                                                                Num(
-                                                                    Num {
+                                                                Str(
+                                                                    Str {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 4,
-                                                                                column: 26,
+                                                                                column: 32,
                                                                             },
                                                                             end: Position {
                                                                                 line: 4,
-                                                                                column: 27,
+                                                                                column: 37,
                                                                             },
                                                                         },
-                                                                        span: 119..120,
-                                                                        value: "5",
+                                                                        span: 125..130,
+                                                                        value: "few",
                                                                     },
                                                                 ),
                                                             ),
                                                             inferred_type: None,
                                                         },
-                                                    },
-                                                ),
-                                                inferred_type: None,
+                                                    ],
+                                                },
                                             },
-                                        ),
-                                        body: Block {
-                                            span: 125..130,
-                                            stmts: [
-                                                Expr {
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 5,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 5,
+                                                        column: 27,
+                                                    },
+                                                },
+                                                span: 148..159,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
-                                                            line: 4,
-                                                            column: 32,
+                                                            line: 5,
+                                                            column: 16,
                                                         },
                                                         end: Position {
-                                                            line: 4,
-                                                            column: 37,
+                                                            line: 5,
+                                                            column: 17,
                                                         },
                                                     },
-                                                    span: 125..130,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 4,
-                                                                        column: 32,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 4,
-                                                                        column: 37,
-                                                                    },
-                                                                },
-                                                                span: 125..130,
-                                                                value: "few",
-                                                            },
-                                                        ),
-                                                    ),
+                                                    span: 148..149,
+                                                    kind: Wildcard,
                                                     inferred_type: None,
                                                 },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 5,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 5,
-                                                column: 27,
-                                            },
-                                        },
-                                        span: 148..159,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 5,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 5,
-                                                    column: 17,
-                                                },
-                                            },
-                                            span: 148..149,
-                                            kind: Wildcard,
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 153..159,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
-                                                            column: 21,
-                                                        },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 27,
-                                                        },
-                                                    },
+                                                guard: None,
+                                                body: Block {
                                                     span: 153..159,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 5,
-                                                                        column: 21,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 5,
-                                                                        column: 27,
-                                                                    },
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 5,
+                                                                    column: 21,
                                                                 },
-                                                                span: 153..159,
-                                                                value: "many",
+                                                                end: Position {
+                                                                    line: 5,
+                                                                    column: 27,
+                                                                },
                                                             },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
+                                                            span: 153..159,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 5,
+                                                                                column: 21,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 5,
+                                                                                column: 27,
+                                                                            },
+                                                                        },
+                                                                        span: 153..159,
+                                                                        value: "many",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
                                                 },
-                                            ],
-                                        },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"\n            let bar = match (foo) {\n                {x
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 13..318,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
-                    span: 17..20,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "bar",
-                            mutable: false,
-                            span: 17..20,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 1,
@@ -44,40 +30,43 @@ Ok(
                                     column: 19,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 9,
-                                column: 13,
-                            },
-                        },
-                        span: 23..317,
-                        kind: Match(
-                            Match {
-                                expr: Expr {
+                            span: 17..20,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "bar",
+                                    mutable: false,
+                                    span: 17..20,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 1,
-                                            column: 29,
+                                            column: 16,
                                         },
                                         end: Position {
                                             line: 1,
-                                            column: 32,
+                                            column: 19,
                                         },
                                     },
-                                    span: 30..33,
-                                    kind: Ident(
-                                        Ident {
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 22,
+                                    },
+                                    end: Position {
+                                        line: 9,
+                                        column: 13,
+                                    },
+                                },
+                                span: 23..317,
+                                kind: Match(
+                                    Match {
+                                        expr: Expr {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 1,
@@ -89,114 +78,111 @@ Ok(
                                                 },
                                             },
                                             span: 30..33,
-                                            name: "foo",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                arms: [
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 2,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 2,
-                                                column: 52,
-                                            },
-                                        },
-                                        span: 53..89,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 2,
-                                                    column: 16,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 1,
+                                                            column: 29,
+                                                        },
+                                                        end: Position {
+                                                            line: 1,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 30..33,
+                                                    name: "foo",
                                                 },
-                                                end: Position {
-                                                    line: 2,
-                                                    column: 40,
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        arms: [
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 2,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 2,
+                                                        column: 52,
+                                                    },
                                                 },
-                                            },
-                                            span: 53..77,
-                                            kind: Object(
-                                                ObjectPat {
-                                                    props: [
-                                                        Shorthand(
-                                                            ShorthandPatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 17,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 18,
-                                                                    },
-                                                                },
-                                                                span: 54..55,
-                                                                ident: BindingIdent {
-                                                                    name: "x",
-                                                                    mutable: false,
-                                                                    span: 54..55,
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 17,
+                                                span: 53..89,
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 2,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 2,
+                                                            column: 40,
+                                                        },
+                                                    },
+                                                    span: 53..77,
+                                                    kind: Object(
+                                                        ObjectPat {
+                                                            props: [
+                                                                Shorthand(
+                                                                    ShorthandPatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 17,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 18,
+                                                                            },
                                                                         },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 18,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        KeyValue(
-                                                            KeyValuePatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 20,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 24,
-                                                                    },
-                                                                },
-                                                                span: 57..61,
-                                                                key: Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 20,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 21,
-                                                                        },
-                                                                    },
-                                                                    span: 57..58,
-                                                                    name: "y",
-                                                                },
-                                                                value: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 23,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 24,
-                                                                        },
-                                                                    },
-                                                                    span: 60..61,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "b",
+                                                                        span: 54..55,
+                                                                        ident: BindingIdent {
+                                                                            name: "x",
                                                                             mutable: false,
-                                                                            span: 60..61,
+                                                                            span: 54..55,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 2,
+                                                                                    column: 17,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 2,
+                                                                                    column: 18,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                KeyValue(
+                                                                    KeyValuePatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 20,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 24,
+                                                                            },
+                                                                        },
+                                                                        span: 57..61,
+                                                                        key: Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 2,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 2,
+                                                                                    column: 21,
+                                                                                },
+                                                                            },
+                                                                            span: 57..58,
+                                                                            name: "y",
+                                                                        },
+                                                                        value: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 2,
@@ -207,96 +193,96 @@ Ok(
                                                                                     column: 24,
                                                                                 },
                                                                             },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        KeyValue(
-                                                            KeyValuePatProp {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 26,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 30,
-                                                                    },
-                                                                },
-                                                                span: 63..67,
-                                                                key: Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 26,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 27,
-                                                                        },
-                                                                    },
-                                                                    span: 63..64,
-                                                                    name: "z",
-                                                                },
-                                                                value: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 29,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 30,
-                                                                        },
-                                                                    },
-                                                                    span: 66..67,
-                                                                    kind: Lit(
-                                                                        LitPat {
-                                                                            lit: Num(
-                                                                                Num {
+                                                                            span: 60..61,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "b",
+                                                                                    mutable: false,
+                                                                                    span: 60..61,
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 2,
-                                                                                            column: 29,
+                                                                                            column: 23,
                                                                                         },
                                                                                         end: Position {
                                                                                             line: 2,
-                                                                                            column: 30,
+                                                                                            column: 24,
                                                                                         },
                                                                                     },
-                                                                                    span: 66..67,
-                                                                                    value: "5",
                                                                                 },
                                                                             ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Rest(
-                                                            RestPat {
-                                                                arg: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 2,
-                                                                            column: 35,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 2,
-                                                                            column: 39,
-                                                                        },
+                                                                        init: None,
                                                                     },
-                                                                    span: 72..76,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "rest",
-                                                                            mutable: false,
-                                                                            span: 72..76,
+                                                                ),
+                                                                KeyValue(
+                                                                    KeyValuePatProp {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 26,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 30,
+                                                                            },
+                                                                        },
+                                                                        span: 63..67,
+                                                                        key: Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 2,
+                                                                                    column: 26,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 2,
+                                                                                    column: 27,
+                                                                                },
+                                                                            },
+                                                                            span: 63..64,
+                                                                            name: "z",
+                                                                        },
+                                                                        value: Pattern {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 2,
+                                                                                    column: 29,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 2,
+                                                                                    column: 30,
+                                                                                },
+                                                                            },
+                                                                            span: 66..67,
+                                                                            kind: Lit(
+                                                                                LitPat {
+                                                                                    lit: Num(
+                                                                                        Num {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 2,
+                                                                                                    column: 29,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 2,
+                                                                                                    column: 30,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 66..67,
+                                                                                            value: "5",
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Rest(
+                                                                    RestPat {
+                                                                        arg: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 2,
@@ -307,103 +293,103 @@ Ok(
                                                                                     column: 39,
                                                                                 },
                                                                             },
+                                                                            span: 72..76,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "rest",
+                                                                                    mutable: false,
+                                                                                    span: 72..76,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 2,
+                                                                                            column: 35,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 2,
+                                                                                            column: 39,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                            },
-                                                        ),
-                                                    ],
-                                                    optional: false,
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 81..89,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 2,
-                                                            column: 44,
-                                                        },
-                                                        end: Position {
-                                                            line: 2,
-                                                            column: 52,
-                                                        },
-                                                    },
-                                                    span: 81..89,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 44,
                                                                     },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 52,
-                                                                    },
-                                                                },
-                                                                span: 81..89,
-                                                                value: "object",
-                                                            },
-                                                        ),
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
                                                     ),
                                                     inferred_type: None,
                                                 },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 3,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 3,
-                                                column: 42,
-                                            },
-                                        },
-                                        span: 107..133,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 3,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 3,
-                                                    column: 31,
-                                                },
-                                            },
-                                            span: 107..122,
-                                            kind: Array(
-                                                ArrayPat {
-                                                    elems: [
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 17,
+                                                guard: None,
+                                                body: Block {
+                                                    span: 81..89,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 44,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 52,
+                                                                },
+                                                            },
+                                                            span: 81..89,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 44,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 52,
+                                                                            },
                                                                         },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 18,
-                                                                        },
+                                                                        span: 81..89,
+                                                                        value: "object",
                                                                     },
-                                                                    span: 108..109,
-                                                                    kind: Ident(
-                                                                        BindingIdent {
-                                                                            name: "a",
-                                                                            mutable: false,
-                                                                            span: 108..109,
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 3,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 3,
+                                                        column: 42,
+                                                    },
+                                                },
+                                                span: 107..133,
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 3,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 3,
+                                                            column: 31,
+                                                        },
+                                                    },
+                                                    span: 107..122,
+                                                    kind: Array(
+                                                        ArrayPat {
+                                                            elems: [
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 3,
@@ -414,66 +400,66 @@ Ok(
                                                                                     column: 18,
                                                                                 },
                                                                             },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 20,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 21,
-                                                                        },
-                                                                    },
-                                                                    span: 111..112,
-                                                                    kind: Wildcard,
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            ArrayPatElem {
-                                                                pattern: Pattern {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 23,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 30,
-                                                                        },
-                                                                    },
-                                                                    span: 114..121,
-                                                                    kind: Rest(
-                                                                        RestPat {
-                                                                            arg: Pattern {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 26,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 30,
+                                                                            span: 108..109,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "a",
+                                                                                    mutable: false,
+                                                                                    span: 108..109,
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 3,
+                                                                                            column: 17,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 3,
+                                                                                            column: 18,
+                                                                                        },
                                                                                     },
                                                                                 },
-                                                                                span: 117..121,
-                                                                                kind: Ident(
-                                                                                    BindingIdent {
-                                                                                        name: "rest",
-                                                                                        mutable: false,
-                                                                                        span: 117..121,
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 3,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 3,
+                                                                                    column: 21,
+                                                                                },
+                                                                            },
+                                                                            span: 111..112,
+                                                                            kind: Wildcard,
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                                Some(
+                                                                    ArrayPatElem {
+                                                                        pattern: Pattern {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 3,
+                                                                                    column: 23,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 3,
+                                                                                    column: 30,
+                                                                                },
+                                                                            },
+                                                                            span: 114..121,
+                                                                            kind: Rest(
+                                                                                RestPat {
+                                                                                    arg: Pattern {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 3,
@@ -484,346 +470,346 @@ Ok(
                                                                                                 column: 30,
                                                                                             },
                                                                                         },
+                                                                                        span: 117..121,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "rest",
+                                                                                                mutable: false,
+                                                                                                span: 117..121,
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 26,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 30,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                        init: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            optional: false,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 126..133,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 35,
+                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 42,
+                                                                },
+                                                            },
+                                                            span: 126..133,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 35,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 42,
                                                                             },
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                init: None,
-                                                            },
-                                                        ),
+                                                                        span: 126..133,
+                                                                        value: "array",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
                                                     ],
-                                                    optional: false,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 126..133,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 3,
-                                                            column: 35,
-                                                        },
-                                                        end: Position {
-                                                            line: 3,
-                                                            column: 42,
-                                                        },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 4,
+                                                        column: 16,
                                                     },
-                                                    span: 126..133,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 3,
-                                                                        column: 35,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 42,
-                                                                    },
-                                                                },
-                                                                span: 126..133,
-                                                                value: "array",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
+                                                    end: Position {
+                                                        line: 4,
+                                                        column: 36,
+                                                    },
                                                 },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 4,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 4,
-                                                column: 36,
-                                            },
-                                        },
-                                        span: 151..171,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 4,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 4,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 151..159,
-                                            kind: Lit(
-                                                LitPat {
-                                                    lit: Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 4,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 4,
-                                                                    column: 24,
-                                                                },
-                                                            },
-                                                            span: 151..159,
-                                                            value: "string",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 163..171,
-                                            stmts: [
-                                                Expr {
+                                                span: 151..171,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 4,
-                                                            column: 28,
+                                                            column: 16,
                                                         },
                                                         end: Position {
                                                             line: 4,
-                                                            column: 36,
-                                                        },
-                                                    },
-                                                    span: 163..171,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 4,
-                                                                        column: 28,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 4,
-                                                                        column: 36,
-                                                                    },
-                                                                },
-                                                                span: 163..171,
-                                                                value: "string",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 5,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 5,
-                                                column: 30,
-                                            },
-                                        },
-                                        span: 189..203,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 5,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 5,
-                                                    column: 20,
-                                                },
-                                            },
-                                            span: 189..193,
-                                            kind: Lit(
-                                                LitPat {
-                                                    lit: Bool(
-                                                        Bool {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 5,
-                                                                    column: 16,
-                                                                },
-                                                                end: Position {
-                                                                    line: 5,
-                                                                    column: 20,
-                                                                },
-                                                            },
-                                                            span: 189..193,
-                                                            value: true,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 197..203,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
                                                             column: 24,
                                                         },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 30,
-                                                        },
                                                     },
-                                                    span: 197..203,
+                                                    span: 151..159,
                                                     kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 5,
-                                                                        column: 24,
+                                                        LitPat {
+                                                            lit: Str(
+                                                                Str {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 4,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 4,
+                                                                            column: 24,
+                                                                        },
                                                                     },
-                                                                    end: Position {
-                                                                        line: 5,
-                                                                        column: 30,
-                                                                    },
+                                                                    span: 151..159,
+                                                                    value: "string",
                                                                 },
-                                                                span: 197..203,
-                                                                value: "true",
-                                                            },
-                                                        ),
+                                                            ),
+                                                        },
                                                     ),
                                                     inferred_type: None,
                                                 },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 6,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 6,
-                                                column: 32,
-                                            },
-                                        },
-                                        span: 221..237,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 6,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 6,
-                                                    column: 21,
-                                                },
-                                            },
-                                            span: 221..226,
-                                            kind: Lit(
-                                                LitPat {
-                                                    lit: Bool(
-                                                        Bool {
+                                                guard: None,
+                                                body: Block {
+                                                    span: 163..171,
+                                                    stmts: [
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
-                                                                    line: 6,
-                                                                    column: 16,
+                                                                    line: 4,
+                                                                    column: 28,
                                                                 },
                                                                 end: Position {
-                                                                    line: 6,
-                                                                    column: 21,
+                                                                    line: 4,
+                                                                    column: 36,
                                                                 },
                                                             },
-                                                            span: 221..226,
-                                                            value: false,
+                                                            span: 163..171,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 4,
+                                                                                column: 28,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 4,
+                                                                                column: 36,
+                                                                            },
+                                                                        },
+                                                                        span: 163..171,
+                                                                        value: "string",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 5,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 5,
+                                                        column: 30,
+                                                    },
+                                                },
+                                                span: 189..203,
+                                                pattern: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 5,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 5,
+                                                            column: 20,
+                                                        },
+                                                    },
+                                                    span: 189..193,
+                                                    kind: Lit(
+                                                        LitPat {
+                                                            lit: Bool(
+                                                                Bool {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 5,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 5,
+                                                                            column: 20,
+                                                                        },
+                                                                    },
+                                                                    span: 189..193,
+                                                                    value: true,
+                                                                },
+                                                            ),
                                                         },
                                                     ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 230..237,
-                                            stmts: [
-                                                Expr {
+                                                guard: None,
+                                                body: Block {
+                                                    span: 197..203,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 5,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 5,
+                                                                    column: 30,
+                                                                },
+                                                            },
+                                                            span: 197..203,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 5,
+                                                                                column: 24,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 5,
+                                                                                column: 30,
+                                                                            },
+                                                                        },
+                                                                        span: 197..203,
+                                                                        value: "true",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 6,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 6,
+                                                        column: 32,
+                                                    },
+                                                },
+                                                span: 221..237,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 6,
-                                                            column: 25,
+                                                            column: 16,
                                                         },
                                                         end: Position {
                                                             line: 6,
-                                                            column: 32,
+                                                            column: 21,
                                                         },
                                                     },
-                                                    span: 230..237,
+                                                    span: 221..226,
                                                     kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 6,
-                                                                        column: 25,
+                                                        LitPat {
+                                                            lit: Bool(
+                                                                Bool {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 6,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 6,
+                                                                            column: 21,
+                                                                        },
                                                                     },
-                                                                    end: Position {
-                                                                        line: 6,
-                                                                        column: 32,
-                                                                    },
+                                                                    span: 221..226,
+                                                                    value: false,
                                                                 },
-                                                                span: 230..237,
-                                                                value: "false",
-                                                            },
-                                                        ),
+                                                            ),
+                                                        },
                                                     ),
                                                     inferred_type: None,
                                                 },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 7,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 7,
-                                                column: 31,
-                                            },
-                                        },
-                                        span: 255..270,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 7,
-                                                    column: 16,
+                                                guard: None,
+                                                body: Block {
+                                                    span: 230..237,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 6,
+                                                                    column: 25,
+                                                                },
+                                                                end: Position {
+                                                                    line: 6,
+                                                                    column: 32,
+                                                                },
+                                                            },
+                                                            span: 230..237,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 6,
+                                                                                column: 25,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 6,
+                                                                                column: 32,
+                                                                            },
+                                                                        },
+                                                                        span: 230..237,
+                                                                        value: "false",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
                                                 },
-                                                end: Position {
-                                                    line: 7,
-                                                    column: 17,
-                                                },
                                             },
-                                            span: 255..256,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "n",
-                                                    mutable: false,
-                                                    span: 255..256,
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 7,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 7,
+                                                        column: 31,
+                                                    },
+                                                },
+                                                span: 255..270,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 7,
@@ -834,122 +820,140 @@ Ok(
                                                             column: 17,
                                                         },
                                                     },
+                                                    span: 255..256,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "n",
+                                                            mutable: false,
+                                                            span: 255..256,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 7,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 7,
+                                                                    column: 17,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 260..270,
-                                            stmts: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 7,
-                                                            column: 21,
-                                                        },
-                                                        end: Position {
-                                                            line: 7,
-                                                            column: 31,
-                                                        },
-                                                    },
+                                                guard: None,
+                                                body: Block {
                                                     span: 260..270,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 7,
-                                                                        column: 21,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 7,
-                                                                        column: 31,
-                                                                    },
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 7,
+                                                                    column: 21,
                                                                 },
-                                                                span: 260..270,
-                                                                value: "variable",
+                                                                end: Position {
+                                                                    line: 7,
+                                                                    column: 31,
+                                                                },
                                                             },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                        },
-                                    },
-                                    Arm {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 8,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 8,
-                                                column: 31,
-                                            },
-                                        },
-                                        span: 288..303,
-                                        pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 8,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 8,
-                                                    column: 17,
+                                                            span: 260..270,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 7,
+                                                                                column: 21,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 7,
+                                                                                column: 31,
+                                                                            },
+                                                                        },
+                                                                        span: 260..270,
+                                                                        value: "variable",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
                                                 },
                                             },
-                                            span: 288..289,
-                                            kind: Wildcard,
-                                            inferred_type: None,
-                                        },
-                                        guard: None,
-                                        body: Block {
-                                            span: 293..303,
-                                            stmts: [
-                                                Expr {
+                                            Arm {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 8,
+                                                        column: 16,
+                                                    },
+                                                    end: Position {
+                                                        line: 8,
+                                                        column: 31,
+                                                    },
+                                                },
+                                                span: 288..303,
+                                                pattern: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 8,
-                                                            column: 21,
+                                                            column: 16,
                                                         },
                                                         end: Position {
                                                             line: 8,
-                                                            column: 31,
+                                                            column: 17,
                                                         },
                                                     },
-                                                    span: 293..303,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 8,
-                                                                        column: 21,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 8,
-                                                                        column: 31,
-                                                                    },
-                                                                },
-                                                                span: 293..303,
-                                                                value: "wildcard",
-                                                            },
-                                                        ),
-                                                    ),
+                                                    span: 288..289,
+                                                    kind: Wildcard,
                                                     inferred_type: None,
                                                 },
-                                            ],
-                                        },
+                                                guard: None,
+                                                body: Block {
+                                                    span: 293..303,
+                                                    stmts: [
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 8,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 8,
+                                                                    column: 31,
+                                                                },
+                                                            },
+                                                            span: 293..303,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 8,
+                                                                                column: 21,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 8,
+                                                                                column: 31,
+                                                                            },
+                                                                        },
+                                                                        span: 293..303,
+                                                                        value: "wildcard",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let bar = () => { let x = Math.random(); x; };\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..46,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "bar",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,61 +30,61 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "bar",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 45,
-                            },
-                        },
-                        span: 10..45,
-                        kind: Lambda(
-                            Lambda {
-                                params: [],
-                                body: Block {
-                                    span: 16..45,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 40,
-                                                },
-                                            },
-                                            span: 18..40,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 45,
+                                    },
+                                },
+                                span: 10..45,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [],
+                                        body: Block {
+                                            span: 16..45,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 18,
                                                         },
-                                                        span: 22..23,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "x",
-                                                                mutable: false,
-                                                                span: 22..23,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 40,
+                                                        },
+                                                    },
+                                                    span: 18..40,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -109,53 +95,56 @@ Ok(
                                                                         column: 23,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 26,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 39,
-                                                            },
-                                                        },
-                                                        span: 26..39,
-                                                        kind: App(
-                                                            App {
-                                                                lam: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 26,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 37,
+                                                                span: 22..23,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "x",
+                                                                        mutable: false,
+                                                                        span: 22..23,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 22,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 23,
+                                                                            },
                                                                         },
                                                                     },
-                                                                    span: 26..37,
-                                                                    kind: Member(
-                                                                        Member {
-                                                                            obj: Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 26,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 30,
-                                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            type_ann: None,
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 26,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 39,
+                                                                    },
+                                                                },
+                                                                span: 26..39,
+                                                                kind: App(
+                                                                    App {
+                                                                        lam: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 26,
                                                                                 },
-                                                                                span: 26..30,
-                                                                                kind: Ident(
-                                                                                    Ident {
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 37,
+                                                                                },
+                                                                            },
+                                                                            span: 26..37,
+                                                                            kind: Member(
+                                                                                Member {
+                                                                                    obj: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
@@ -167,55 +156,55 @@ Ok(
                                                                                             },
                                                                                         },
                                                                                         span: 26..30,
-                                                                                        name: "Math",
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 26,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 30,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 26..30,
+                                                                                                name: "Math",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            prop: Ident(
-                                                                                Ident {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 31,
+                                                                                    prop: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 31,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 37,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 31..37,
+                                                                                            name: "random",
                                                                                         },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 37,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 31..37,
-                                                                                    name: "random",
+                                                                                    ),
                                                                                 },
                                                                             ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                args: [],
-                                                                type_args: None,
+                                                                        args: [],
+                                                                        type_args: None,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 42,
-                                                },
-                                            },
-                                            span: 41..42,
-                                            kind: Ident(
-                                                Ident {
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -227,22 +216,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 41..42,
-                                                    name: "x",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 41,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 42,
+                                                                },
+                                                            },
+                                                            span: 41..42,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = () => { let x = Math.random(); x };\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..45,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,61 +30,61 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 44,
-                            },
-                        },
-                        span: 10..44,
-                        kind: Lambda(
-                            Lambda {
-                                params: [],
-                                body: Block {
-                                    span: 16..44,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 40,
-                                                },
-                                            },
-                                            span: 18..40,
-                                            kind: LetDecl(
-                                                LetDecl {
-                                                    pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 44,
+                                    },
+                                },
+                                span: 10..44,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [],
+                                        body: Block {
+                                            span: 16..44,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 18,
                                                         },
-                                                        span: 22..23,
-                                                        kind: Ident(
-                                                            BindingIdent {
-                                                                name: "x",
-                                                                mutable: false,
-                                                                span: 22..23,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 40,
+                                                        },
+                                                    },
+                                                    span: 18..40,
+                                                    kind: LetDecl(
+                                                        LetDecl {
+                                                            pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -109,53 +95,56 @@ Ok(
                                                                         column: 23,
                                                                     },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 26,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 39,
-                                                            },
-                                                        },
-                                                        span: 26..39,
-                                                        kind: App(
-                                                            App {
-                                                                lam: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 26,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 37,
+                                                                span: 22..23,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "x",
+                                                                        mutable: false,
+                                                                        span: 22..23,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 22,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 23,
+                                                                            },
                                                                         },
                                                                     },
-                                                                    span: 26..37,
-                                                                    kind: Member(
-                                                                        Member {
-                                                                            obj: Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 26,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 30,
-                                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                            type_ann: None,
+                                                            init: Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 26,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 39,
+                                                                    },
+                                                                },
+                                                                span: 26..39,
+                                                                kind: App(
+                                                                    App {
+                                                                        lam: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 26,
                                                                                 },
-                                                                                span: 26..30,
-                                                                                kind: Ident(
-                                                                                    Ident {
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 37,
+                                                                                },
+                                                                            },
+                                                                            span: 26..37,
+                                                                            kind: Member(
+                                                                                Member {
+                                                                                    obj: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
@@ -167,55 +156,55 @@ Ok(
                                                                                             },
                                                                                         },
                                                                                         span: 26..30,
-                                                                                        name: "Math",
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 26,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 30,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 26..30,
+                                                                                                name: "Math",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            prop: Ident(
-                                                                                Ident {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 31,
+                                                                                    prop: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 31,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 37,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 31..37,
+                                                                                            name: "random",
                                                                                         },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 37,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 31..37,
-                                                                                    name: "random",
+                                                                                    ),
                                                                                 },
                                                                             ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                args: [],
-                                                                type_args: None,
+                                                                        args: [],
+                                                                        type_args: None,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 42,
-                                                },
-                                            },
-                                            span: 41..42,
-                                            kind: Ident(
-                                                Ident {
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -227,22 +216,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 41..42,
-                                                    name: "x",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 41,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 42,
+                                                                },
+                                                            },
+                                                            span: 41..42,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-2.snap
@@ -5,40 +5,53 @@ expression: "parse(r#\"\"hello\";\"#)"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..7,
-                    kind: Lit(
-                        Str(
-                            Str {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 7,
-                                    },
-                                },
-                                span: 0..7,
-                                value: "hello",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 8,
+                    },
                 },
-            ),
+                span: 0..8,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 7,
+                            },
+                        },
+                        span: 0..7,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                    span: 0..7,
+                                    value: "hello",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-3.snap
@@ -5,40 +5,53 @@ expression: "parse(\"\\\"line 1\\\\nline 2\\\\nline 3\\\";\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 24,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..24,
-                    kind: Lit(
-                        Str(
-                            Str {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 24,
-                                    },
-                                },
-                                span: 0..24,
-                                value: "line 1\nline 2\nline 3",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 25,
+                    },
                 },
-            ),
+                span: 0..25,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 24,
+                            },
+                        },
+                        span: 0..24,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 24,
+                                        },
+                                    },
+                                    span: 0..24,
+                                    value: "line 1\nline 2\nline 3",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-4.snap
@@ -5,40 +5,53 @@ expression: "parse(\"\\\"a \\\\u2212 b\\\";\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 12,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..12,
-                    kind: Lit(
-                        Str(
-                            Str {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 12,
-                                    },
-                                },
-                                span: 0..12,
-                                value: "a − b",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 13,
+                    },
                 },
-            ),
+                span: 0..13,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 12,
+                            },
+                        },
+                        span: 0..12,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 12,
+                                        },
+                                    },
+                                    span: 0..12,
+                                    value: "a − b",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings-5.snap
@@ -5,40 +5,53 @@ expression: "parse(\"\\\"hello, \\\\\\\"world\\\\\\\"!\\\";\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 19,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..19,
-                    kind: Lit(
-                        Str(
-                            Str {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 19,
-                                    },
-                                },
-                                span: 0..19,
-                                value: "hello, \"world\"!",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 20,
+                    },
                 },
-            ),
+                span: 0..20,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 19,
+                            },
+                        },
+                        span: 0..19,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 19,
+                                        },
+                                    },
+                                    span: 0..19,
+                                    value: "hello, \"world\"!",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__strings.snap
@@ -5,40 +5,53 @@ expression: "parse(r#\"\"\";\"#)"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 2,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..2,
-                    kind: Lit(
-                        Str(
-                            Str {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 2,
-                                    },
-                                },
-                                span: 0..2,
-                                value: "",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 3,
+                    },
                 },
-            ),
+                span: 0..3,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 2,
+                            },
+                        },
+                        span: 0..2,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 2,
+                                        },
+                                    },
+                                    span: 0..2,
+                                    value: "",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tagged_template_literals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tagged_template_literals.snap
@@ -5,241 +5,254 @@ expression: "parse(\"sql`SELECT * FROM ${table} WHERE id = ${id}`\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 44,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..44,
-                    kind: TaggedTemplateLiteral(
-                        TaggedTemplateLiteral {
-                            tag: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                name: "sql",
+                    end: Position {
+                        line: 0,
+                        column: 44,
+                    },
+                },
+                span: 0..44,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            template: TemplateLiteral {
-                                exprs: [
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 20,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                        },
-                                        span: 20..25,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 20,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 25,
-                                                    },
-                                                },
-                                                span: 20..25,
-                                                name: "table",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                    Expr {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 40,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 42,
-                                            },
-                                        },
-                                        span: 40..42,
-                                        kind: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 40,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 42,
-                                                    },
-                                                },
-                                                span: 40..42,
-                                                name: "id",
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ],
-                                quasis: [
-                                    TemplateElem {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 18,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 26,
-                                            },
-                                        },
-                                        span: 4..18,
-                                        raw: Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 18,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 26,
-                                                    },
-                                                },
-                                                span: 4..18,
-                                                value: "SELECT * FROM ",
-                                            },
-                                        ),
-                                        cooked: Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 18,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 26,
-                                                    },
-                                                },
-                                                span: 4..18,
-                                                value: "SELECT * FROM ",
-                                            },
-                                        ),
-                                    },
-                                    TemplateElem {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 38,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 43,
-                                            },
-                                        },
-                                        span: 26..38,
-                                        raw: Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 38,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 43,
-                                                    },
-                                                },
-                                                span: 26..38,
-                                                value: " WHERE id = ",
-                                            },
-                                        ),
-                                        cooked: Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 38,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 43,
-                                                    },
-                                                },
-                                                span: 26..38,
-                                                value: " WHERE id = ",
-                                            },
-                                        ),
-                                    },
-                                    TemplateElem {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 3,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 44,
-                                            },
-                                        },
-                                        span: 43..43,
-                                        raw: Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 3,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 44,
-                                                    },
-                                                },
-                                                span: 43..43,
-                                                value: "",
-                                            },
-                                        ),
-                                        cooked: Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 3,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 44,
-                                                    },
-                                                },
-                                                span: 43..43,
-                                                value: "",
-                                            },
-                                        ),
-                                    },
-                                ],
+                            end: Position {
+                                line: 0,
+                                column: 44,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..44,
+                        kind: TaggedTemplateLiteral(
+                            TaggedTemplateLiteral {
+                                tag: Ident {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
+                                    },
+                                    span: 0..3,
+                                    name: "sql",
+                                },
+                                template: TemplateLiteral {
+                                    exprs: [
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 20,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 25,
+                                                },
+                                            },
+                                            span: 20..25,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 20,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 25,
+                                                        },
+                                                    },
+                                                    span: 20..25,
+                                                    name: "table",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        Expr {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 40,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 42,
+                                                },
+                                            },
+                                            span: 40..42,
+                                            kind: Ident(
+                                                Ident {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 40,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 42,
+                                                        },
+                                                    },
+                                                    span: 40..42,
+                                                    name: "id",
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                    quasis: [
+                                        TemplateElem {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 26,
+                                                },
+                                            },
+                                            span: 4..18,
+                                            raw: Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 18,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 26,
+                                                        },
+                                                    },
+                                                    span: 4..18,
+                                                    value: "SELECT * FROM ",
+                                                },
+                                            ),
+                                            cooked: Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 18,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 26,
+                                                        },
+                                                    },
+                                                    span: 4..18,
+                                                    value: "SELECT * FROM ",
+                                                },
+                                            ),
+                                        },
+                                        TemplateElem {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 38,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 43,
+                                                },
+                                            },
+                                            span: 26..38,
+                                            raw: Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 38,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 43,
+                                                        },
+                                                    },
+                                                    span: 26..38,
+                                                    value: " WHERE id = ",
+                                                },
+                                            ),
+                                            cooked: Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 38,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 43,
+                                                        },
+                                                    },
+                                                    span: 26..38,
+                                                    value: " WHERE id = ",
+                                                },
+                                            ),
+                                        },
+                                        TemplateElem {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 3,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 44,
+                                                },
+                                            },
+                                            span: 43..43,
+                                            raw: Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 3,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 44,
+                                                        },
+                                                    },
+                                                    span: 43..43,
+                                                    value: "",
+                                                },
+                                            ),
+                                            cooked: Str(
+                                                Str {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 3,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 44,
+                                                        },
+                                                    },
+                                                    span: 43..43,
+                                                    value: "",
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-2.snap
@@ -5,150 +5,163 @@ expression: "parse(\"`Hello, ${name}`\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 16,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..16,
-                    kind: TemplateLiteral(
-                        TemplateLiteral {
-                            exprs: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 10,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 14,
-                                        },
-                                    },
-                                    span: 10..14,
-                                    kind: Ident(
-                                        Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                            },
-                                            span: 10..14,
-                                            name: "name",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
-                            quasis: [
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 8,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 15,
-                                        },
-                                    },
-                                    span: 1..8,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 15,
-                                                },
-                                            },
-                                            span: 1..8,
-                                            value: "Hello, ",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 15,
-                                                },
-                                            },
-                                            span: 1..8,
-                                            value: "Hello, ",
-                                        },
-                                    ),
-                                },
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
-                                    },
-                                    span: 15..15,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 16,
-                                                },
-                                            },
-                                            span: 15..15,
-                                            value: "",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 16,
-                                                },
-                                            },
-                                            span: 15..15,
-                                            value: "",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 16,
+                    },
                 },
-            ),
+                span: 0..16,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 16,
+                            },
+                        },
+                        span: 0..16,
+                        kind: TemplateLiteral(
+                            TemplateLiteral {
+                                exprs: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 10,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 14,
+                                            },
+                                        },
+                                        span: 10..14,
+                                        kind: Ident(
+                                            Ident {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 10,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 14,
+                                                    },
+                                                },
+                                                span: 10..14,
+                                                name: "name",
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ],
+                                quasis: [
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 8,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 15,
+                                            },
+                                        },
+                                        span: 1..8,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                },
+                                                span: 1..8,
+                                                value: "Hello, ",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                },
+                                                span: 1..8,
+                                                value: "Hello, ",
+                                            },
+                                        ),
+                                    },
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 0,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 16,
+                                            },
+                                        },
+                                        span: 15..15,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 16,
+                                                    },
+                                                },
+                                                span: 15..15,
+                                                value: "",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 16,
+                                                    },
+                                                },
+                                                span: 15..15,
+                                                value: "",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-3.snap
@@ -5,225 +5,238 @@ expression: "parse(\"`(${x}, ${y})`\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 14,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..14,
-                    kind: TemplateLiteral(
-                        TemplateLiteral {
-                            exprs: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 5,
-                                        },
-                                    },
-                                    span: 4..5,
-                                    kind: Ident(
-                                        Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 4,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                            },
-                                            span: 4..5,
-                                            name: "x",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 10,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 11,
-                                        },
-                                    },
-                                    span: 10..11,
-                                    kind: Ident(
-                                        Ident {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                            },
-                                            span: 10..11,
-                                            name: "y",
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
-                            quasis: [
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 2,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 6,
-                                        },
-                                    },
-                                    span: 1..2,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 2,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                            span: 1..2,
-                                            value: "(",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 2,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 6,
-                                                },
-                                            },
-                                            span: 1..2,
-                                            value: "(",
-                                        },
-                                    ),
-                                },
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 8,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                    },
-                                    span: 6..8,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                            },
-                                            span: 6..8,
-                                            value: ", ",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 8,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                            },
-                                            span: 6..8,
-                                            value: ", ",
-                                        },
-                                    ),
-                                },
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 14,
-                                        },
-                                    },
-                                    span: 12..13,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                            },
-                                            span: 12..13,
-                                            value: ")",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                            },
-                                            span: 12..13,
-                                            value: ")",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 14,
+                    },
                 },
-            ),
+                span: 0..14,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 14,
+                            },
+                        },
+                        span: 0..14,
+                        kind: TemplateLiteral(
+                            TemplateLiteral {
+                                exprs: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 4,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 5,
+                                            },
+                                        },
+                                        span: 4..5,
+                                        kind: Ident(
+                                            Ident {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 4,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                },
+                                                span: 4..5,
+                                                name: "x",
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 10,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 11,
+                                            },
+                                        },
+                                        span: 10..11,
+                                        kind: Ident(
+                                            Ident {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 10,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 11,
+                                                    },
+                                                },
+                                                span: 10..11,
+                                                name: "y",
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ],
+                                quasis: [
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 2,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 6,
+                                            },
+                                        },
+                                        span: 1..2,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 2,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 6,
+                                                    },
+                                                },
+                                                span: 1..2,
+                                                value: "(",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 2,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 6,
+                                                    },
+                                                },
+                                                span: 1..2,
+                                                value: "(",
+                                            },
+                                        ),
+                                    },
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 8,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 12,
+                                            },
+                                        },
+                                        span: 6..8,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 12,
+                                                    },
+                                                },
+                                                span: 6..8,
+                                                value: ", ",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 8,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 12,
+                                                    },
+                                                },
+                                                span: 6..8,
+                                                value: ", ",
+                                            },
+                                        ),
+                                    },
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 0,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 14,
+                                            },
+                                        },
+                                        span: 12..13,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 14,
+                                                    },
+                                                },
+                                                span: 12..13,
+                                                value: ")",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 14,
+                                                    },
+                                                },
+                                                span: 12..13,
+                                                value: ")",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-4.snap
@@ -5,74 +5,87 @@ expression: "parse(r#\"`Hello, \"world\"`\"#)"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 16,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..16,
-                    kind: TemplateLiteral(
-                        TemplateLiteral {
-                            exprs: [],
-                            quasis: [
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
-                                    },
-                                    span: 1..15,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 16,
-                                                },
-                                            },
-                                            span: 1..15,
-                                            value: "Hello, \"world\"",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 16,
-                                                },
-                                            },
-                                            span: 1..15,
-                                            value: "Hello, \"world\"",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 16,
+                    },
                 },
-            ),
+                span: 0..16,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 16,
+                            },
+                        },
+                        span: 0..16,
+                        kind: TemplateLiteral(
+                            TemplateLiteral {
+                                exprs: [],
+                                quasis: [
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 0,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 16,
+                                            },
+                                        },
+                                        span: 1..15,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 16,
+                                                    },
+                                                },
+                                                span: 1..15,
+                                                value: "Hello, \"world\"",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 16,
+                                                    },
+                                                },
+                                                span: 1..15,
+                                                value: "Hello, \"world\"",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-5.snap
@@ -5,262 +5,275 @@ expression: "parse(\"`foo ${`bar ${baz}`}`\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 21,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..21,
-                    kind: TemplateLiteral(
-                        TemplateLiteral {
-                            exprs: [
-                                Expr {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 7,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 19,
-                                        },
-                                    },
-                                    span: 7..19,
-                                    kind: TemplateLiteral(
-                                        TemplateLiteral {
-                                            exprs: [
-                                                Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 14,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                    },
-                                                    span: 14..17,
-                                                    kind: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 14,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 17,
-                                                                },
-                                                            },
-                                                            span: 14..17,
-                                                            name: "baz",
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            ],
-                                            quasis: [
-                                                TemplateElem {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 12,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 18,
-                                                        },
-                                                    },
-                                                    span: 8..12,
-                                                    raw: Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 12,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                            },
-                                                            span: 8..12,
-                                                            value: "bar ",
-                                                        },
-                                                    ),
-                                                    cooked: Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 12,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 18,
-                                                                },
-                                                            },
-                                                            span: 8..12,
-                                                            value: "bar ",
-                                                        },
-                                                    ),
-                                                },
-                                                TemplateElem {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 7,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                    },
-                                                    span: 18..18,
-                                                    raw: Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 7,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
-                                                            },
-                                                            span: 18..18,
-                                                            value: "",
-                                                        },
-                                                    ),
-                                                    cooked: Str(
-                                                        Str {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 7,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
-                                                            },
-                                                            span: 18..18,
-                                                            value: "",
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                    inferred_type: None,
-                                },
-                            ],
-                            quasis: [
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 5,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 20,
-                                        },
-                                    },
-                                    span: 1..5,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 20,
-                                                },
-                                            },
-                                            span: 1..5,
-                                            value: "foo ",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 5,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 20,
-                                                },
-                                            },
-                                            span: 1..5,
-                                            value: "foo ",
-                                        },
-                                    ),
-                                },
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 21,
-                                        },
-                                    },
-                                    span: 20..20,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                            },
-                                            span: 20..20,
-                                            value: "",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                            },
-                                            span: 20..20,
-                                            value: "",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 21,
+                    },
                 },
-            ),
+                span: 0..21,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 21,
+                            },
+                        },
+                        span: 0..21,
+                        kind: TemplateLiteral(
+                            TemplateLiteral {
+                                exprs: [
+                                    Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 7,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 19,
+                                            },
+                                        },
+                                        span: 7..19,
+                                        kind: TemplateLiteral(
+                                            TemplateLiteral {
+                                                exprs: [
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                        },
+                                                        span: 14..17,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 17,
+                                                                    },
+                                                                },
+                                                                span: 14..17,
+                                                                name: "baz",
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                ],
+                                                quasis: [
+                                                    TemplateElem {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                        },
+                                                        span: 8..12,
+                                                        raw: Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 18,
+                                                                    },
+                                                                },
+                                                                span: 8..12,
+                                                                value: "bar ",
+                                                            },
+                                                        ),
+                                                        cooked: Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 18,
+                                                                    },
+                                                                },
+                                                                span: 8..12,
+                                                                value: "bar ",
+                                                            },
+                                                        ),
+                                                    },
+                                                    TemplateElem {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 7,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 19,
+                                                            },
+                                                        },
+                                                        span: 18..18,
+                                                        raw: Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 7,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 19,
+                                                                    },
+                                                                },
+                                                                span: 18..18,
+                                                                value: "",
+                                                            },
+                                                        ),
+                                                        cooked: Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 7,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 19,
+                                                                    },
+                                                                },
+                                                                span: 18..18,
+                                                                value: "",
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ],
+                                quasis: [
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 5,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 20,
+                                            },
+                                        },
+                                        span: 1..5,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 20,
+                                                    },
+                                                },
+                                                span: 1..5,
+                                                value: "foo ",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 5,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 20,
+                                                    },
+                                                },
+                                                span: 1..5,
+                                                value: "foo ",
+                                            },
+                                        ),
+                                    },
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 0,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 21,
+                                            },
+                                        },
+                                        span: 20..20,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                },
+                                                span: 20..20,
+                                                value: "",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                },
+                                                span: 20..20,
+                                                value: "",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-6.snap
@@ -5,74 +5,87 @@ expression: "parse(\"`line 1\\\\nline 2\\\\nline 3`\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 24,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..24,
-                    kind: TemplateLiteral(
-                        TemplateLiteral {
-                            exprs: [],
-                            quasis: [
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 24,
-                                        },
-                                    },
-                                    span: 1..23,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 1..23,
-                                            value: "line 1\\nline 2\\nline 3",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                            },
-                                            span: 1..23,
-                                            value: "line 1\nline 2\nline 3",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 24,
+                    },
                 },
-            ),
+                span: 0..24,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 24,
+                            },
+                        },
+                        span: 0..24,
+                        kind: TemplateLiteral(
+                            TemplateLiteral {
+                                exprs: [],
+                                quasis: [
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 0,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 24,
+                                            },
+                                        },
+                                        span: 1..23,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 24,
+                                                    },
+                                                },
+                                                span: 1..23,
+                                                value: "line 1\\nline 2\\nline 3",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 24,
+                                                    },
+                                                },
+                                                span: 1..23,
+                                                value: "line 1\nline 2\nline 3",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals-7.snap
@@ -5,74 +5,87 @@ expression: "parse(\"`a \\\\u2212 b`\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 12,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..12,
-                    kind: TemplateLiteral(
-                        TemplateLiteral {
-                            exprs: [],
-                            quasis: [
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 12,
-                                        },
-                                    },
-                                    span: 1..11,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                            },
-                                            span: 1..11,
-                                            value: "a \\u2212 b",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                            },
-                                            span: 1..11,
-                                            value: "a − b",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 12,
+                    },
                 },
-            ),
+                span: 0..12,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 12,
+                            },
+                        },
+                        span: 0..12,
+                        kind: TemplateLiteral(
+                            TemplateLiteral {
+                                exprs: [],
+                                quasis: [
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 0,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 12,
+                                            },
+                                        },
+                                        span: 1..11,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 12,
+                                                    },
+                                                },
+                                                span: 1..11,
+                                                value: "a \\u2212 b",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 12,
+                                                    },
+                                                },
+                                                span: 1..11,
+                                                value: "a − b",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__template_literals.snap
@@ -5,74 +5,87 @@ expression: "parse(\"`Hello, world`\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 14,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..14,
-                    kind: TemplateLiteral(
-                        TemplateLiteral {
-                            exprs: [],
-                            quasis: [
-                                TemplateElem {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 14,
-                                        },
-                                    },
-                                    span: 1..13,
-                                    raw: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                            },
-                                            span: 1..13,
-                                            value: "Hello, world",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 0,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
-                                                },
-                                            },
-                                            span: 1..13,
-                                            value: "Hello, world",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                    inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 14,
+                    },
                 },
-            ),
+                span: 0..14,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 14,
+                            },
+                        },
+                        span: 0..14,
+                        kind: TemplateLiteral(
+                            TemplateLiteral {
+                                exprs: [],
+                                quasis: [
+                                    TemplateElem {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 0,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 14,
+                                            },
+                                        },
+                                        span: 1..13,
+                                        raw: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 14,
+                                                    },
+                                                },
+                                                span: 1..13,
+                                                value: "Hello, world",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 0,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 14,
+                                                    },
+                                                },
+                                                span: 1..13,
+                                                value: "Hello, world",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions-2.snap
@@ -5,74 +5,100 @@ expression: "parse(\"123;\\n\\\"hello\\\";\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 3,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..3,
-                    kind: Lit(
-                        Num(
-                            Num {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 3,
-                                    },
-                                },
-                                span: 0..3,
-                                value: "123",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
-                },
-            ),
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 7,
-                        },
+                    end: Position {
+                        line: 0,
+                        column: 4,
                     },
-                    span: 5..12,
-                    kind: Lit(
-                        Str(
-                            Str {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 7,
-                                    },
-                                },
-                                span: 5..12,
-                                value: "hello",
-                            },
-                        ),
-                    ),
-                    inferred_type: None,
                 },
-            ),
+                span: 0..4,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 0,
+                                column: 3,
+                            },
+                        },
+                        span: 0..3,
+                        kind: Lit(
+                            Num(
+                                Num {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 3,
+                                        },
+                                    },
+                                    span: 0..3,
+                                    value: "123",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 1,
+                        column: 0,
+                    },
+                    end: Position {
+                        line: 1,
+                        column: 8,
+                    },
+                },
+                span: 5..13,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 1,
+                                column: 0,
+                            },
+                            end: Position {
+                                line: 1,
+                                column: 7,
+                            },
+                        },
+                        span: 5..12,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 1,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 1,
+                                            column: 7,
+                                        },
+                                    },
+                                    span: 5..12,
+                                    value: "hello",
+                                },
+                            ),
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__top_level_expressions.snap
@@ -5,87 +5,100 @@ expression: "parse(\"a + b;\")"
 Ok(
     Program {
         body: [
-            ExprStmt(
-                Expr {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
+            Statement {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
                     },
-                    span: 0..5,
-                    kind: BinaryExpr(
-                        BinaryExpr {
-                            op: Add,
-                            left: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 0,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 1,
-                                    },
-                                },
-                                span: 0..1,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 0,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 1,
-                                            },
-                                        },
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                inferred_type: None,
+                    end: Position {
+                        line: 0,
+                        column: 6,
+                    },
+                },
+                span: 0..6,
+                kind: ExprStmt(
+                    Expr {
+                        loc: SourceLocation {
+                            start: Position {
+                                line: 0,
+                                column: 0,
                             },
-                            right: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 4,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 5,
-                                    },
-                                },
-                                span: 4..5,
-                                kind: Ident(
-                                    Ident {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 4,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 5,
-                                            },
-                                        },
-                                        span: 4..5,
-                                        name: "b",
-                                    },
-                                ),
-                                inferred_type: None,
+                            end: Position {
+                                line: 0,
+                                column: 5,
                             },
                         },
-                    ),
-                    inferred_type: None,
-                },
-            ),
+                        span: 0..5,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: Add,
+                                left: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 1,
+                                        },
+                                    },
+                                    span: 0..1,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 0,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 1,
+                                                },
+                                            },
+                                            span: 0..1,
+                                            name: "a",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                                right: Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                    span: 4..5,
+                                    kind: Ident(
+                                        Ident {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 4,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 5,
+                                                },
+                                            },
+                                            span: 4..5,
+                                            name: "b",
+                                        },
+                                    ),
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+            },
         ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let x = [1, 2, 3];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..18,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,139 +30,157 @@ Ok(
                                     column: 5,
                                 },
                             },
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 4..5,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 17,
-                            },
-                        },
-                        span: 8..17,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 10,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 8,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                },
+                                span: 8..17,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
+                                                    },
+                                                    span: 9..10,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 9,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 10,
+                                                                    },
+                                                                },
+                                                                span: 9..10,
+                                                                value: "1",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 9..10,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 9,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 10,
-                                                            },
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
                                                         },
-                                                        span: 9..10,
-                                                        value: "1",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 13,
+                                                        },
                                                     },
-                                                ),
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 13,
+                                                    span: 12..13,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 13,
+                                                                    },
+                                                                },
+                                                                span: 12..13,
+                                                                value: "2",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 12..13,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 15,
                                                         },
-                                                        span: 12..13,
-                                                        value: "2",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 16,
+                                                        },
                                                     },
-                                                ),
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    },
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 15,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 16,
+                                                    span: 15..16,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 15,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 16,
+                                                                    },
+                                                                },
+                                                                span: 15..16,
+                                                                value: "3",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 15..16,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 15,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 16,
-                                                            },
-                                                        },
-                                                        span: 15..16,
-                                                        value: "3",
-                                                    },
-                                                ),
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let x = [1, [a, b]];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..20,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,95 +30,98 @@ Ok(
                                     column: 5,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 19,
-                            },
-                        },
-                        span: 8..19,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                            },
-                                            span: 9..10,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 9,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 10,
-                                                            },
-                                                        },
-                                                        span: 9..10,
-                                                        value: "1",
-                                                    },
-                                                ),
-                                            ),
-                                            inferred_type: None,
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 4..5,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
                                         },
                                     },
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                            },
-                                            span: 12..18,
-                                            kind: Tuple(
-                                                Tuple {
-                                                    elems: [
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
+                                },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 8,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 19,
+                                    },
+                                },
+                                span: 8..19,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
+                                                    },
+                                                    span: 9..10,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
-                                                                        column: 13,
+                                                                        column: 9,
                                                                     },
                                                                     end: Position {
                                                                         line: 0,
-                                                                        column: 14,
+                                                                        column: 10,
                                                                     },
                                                                 },
-                                                                span: 13..14,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                span: 9..10,
+                                                                value: "1",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 18,
+                                                        },
+                                                    },
+                                                    span: 12..18,
+                                                    kind: Tuple(
+                                                        Tuple {
+                                                            elems: [
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -144,28 +133,28 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 13..14,
-                                                                        name: "a",
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        },
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 16,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 17,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 13,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 14,
+                                                                                    },
+                                                                                },
+                                                                                span: 13..14,
+                                                                                name: "a",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
                                                                 },
-                                                                span: 16..17,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -177,25 +166,40 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 16..17,
-                                                                        name: "b",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 16,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 17,
+                                                                                    },
+                                                                                },
+                                                                                span: 16..17,
+                                                                                name: "b",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ],
                                                         },
-                                                    ],
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                            },
+                                        ],
                                     },
-                                ],
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let foo = () => [a, b];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..23,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "foo",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,61 +30,64 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "foo",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 22,
-                            },
-                        },
-                        span: 10..22,
-                        kind: Lambda(
-                            Lambda {
-                                params: [],
-                                body: Block {
-                                    span: 16..22,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 16,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
-                                            },
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 22,
+                                    },
+                                },
+                                span: 10..22,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [],
+                                        body: Block {
                                             span: 16..22,
-                                            kind: Tuple(
-                                                Tuple {
-                                                    elems: [
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 17,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 18,
-                                                                    },
-                                                                },
-                                                                span: 17..18,
-                                                                kind: Ident(
-                                                                    Ident {
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 16,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 22,
+                                                        },
+                                                    },
+                                                    span: 16..22,
+                                                    kind: Tuple(
+                                                        Tuple {
+                                                            elems: [
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -110,28 +99,28 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 17..18,
-                                                                        name: "a",
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        },
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 20,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 21,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 17,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 18,
+                                                                                    },
+                                                                                },
+                                                                                span: 17..18,
+                                                                                name: "a",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
                                                                 },
-                                                                span: 20..21,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -143,28 +132,43 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 20..21,
-                                                                        name: "b",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 20,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                },
+                                                                                span: 20..21,
+                                                                                name: "b",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ],
                                                         },
-                                                    ],
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: None,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: None,
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let x = [];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..11,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,33 +30,51 @@ Ok(
                                     column: 5,
                                 },
                             },
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 4..5,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                        },
-                        span: 8..10,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [],
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 8,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                },
+                                span: 8..10,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let msg: string = \\\"hello\\\";\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..26,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "msg",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,66 +30,84 @@ Ok(
                                     column: 7,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Keyword(
-                            KeywordType {
-                                keyword: String,
-                            },
-                        ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 15,
-                            },
-                        },
-                        span: 9..15,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 18,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 25,
-                            },
-                        },
-                        span: 18..25,
-                        kind: Lit(
-                            Str(
-                                Str {
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "msg",
+                                    mutable: false,
+                                    span: 4..7,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 18,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 25,
+                                            column: 7,
                                         },
                                     },
-                                    span: 18..25,
-                                    value: "hello",
                                 },
                             ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Keyword(
+                                    KeywordType {
+                                        keyword: String,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 15,
+                                    },
+                                },
+                                span: 9..15,
+                                inferred_type: None,
+                            },
                         ),
-                        inferred_type: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 18,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 25,
+                                    },
+                                },
+                                span: 18..25,
+                                kind: Lit(
+                                    Str(
+                                        Str {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 18,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 25,
+                                                },
+                                            },
+                                            span: 18..25,
+                                            value: "hello",
+                                        },
+                                    ),
+                                ),
+                                inferred_type: None,
+                            },
+                        ),
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let add = (a: number, b: number): number => a + b;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..50,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "add",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,45 +30,45 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "add",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 49,
-                            },
-                        },
-                        span: 10..49,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 12,
-                                                },
-                                            },
-                                            span: 11..12,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "a",
-                                                    mutable: false,
-                                                    span: 11..12,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 10,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 49,
+                                    },
+                                },
+                                span: 10..49,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -93,51 +79,51 @@ Ok(
                                                             column: 12,
                                                         },
                                                     },
+                                                    span: 11..12,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "a",
+                                                            mutable: false,
+                                                            span: 11..12,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 11,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 12,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: Some(
-                                            TypeAnn {
-                                                kind: Keyword(
-                                                    KeywordType {
-                                                        keyword: Number,
+                                                type_ann: Some(
+                                                    TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                keyword: Number,
+                                                            },
+                                                        ),
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 20,
+                                                            },
+                                                        },
+                                                        span: 14..20,
+                                                        inferred_type: None,
                                                     },
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 14,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 20,
-                                                    },
-                                                },
-                                                span: 14..20,
-                                                inferred_type: None,
+                                                optional: false,
                                             },
-                                        ),
-                                        optional: false,
-                                    },
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 23,
-                                                },
-                                            },
-                                            span: 22..23,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "b",
-                                                    mutable: false,
-                                                    span: 22..23,
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -148,66 +134,69 @@ Ok(
                                                             column: 23,
                                                         },
                                                     },
+                                                    span: 22..23,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "b",
+                                                            mutable: false,
+                                                            span: 22..23,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: Some(
-                                            TypeAnn {
-                                                kind: Keyword(
-                                                    KeywordType {
-                                                        keyword: Number,
-                                                    },
-                                                ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 25,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 31,
-                                                    },
-                                                },
-                                                span: 25..31,
-                                                inferred_type: None,
-                                            },
-                                        ),
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 44..49,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 44,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 49,
-                                                },
-                                            },
-                                            span: 44..49,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
+                                                type_ann: Some(
+                                                    TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                keyword: Number,
+                                                            },
+                                                        ),
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
-                                                                column: 44,
+                                                                column: 25,
                                                             },
                                                             end: Position {
                                                                 line: 0,
-                                                                column: 45,
+                                                                column: 31,
                                                             },
                                                         },
-                                                        span: 44..45,
-                                                        kind: Ident(
-                                                            Ident {
+                                                        span: 25..31,
+                                                        inferred_type: None,
+                                                    },
+                                                ),
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 44..49,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 44,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 49,
+                                                        },
+                                                    },
+                                                    span: 44..49,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -219,25 +208,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 44..45,
-                                                                name: "a",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 44,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 45,
+                                                                            },
+                                                                        },
+                                                                        span: 44..45,
+                                                                        name: "a",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 48,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 49,
-                                                            },
-                                                        },
-                                                        span: 48..49,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -249,46 +238,61 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 48..49,
-                                                                name: "b",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 48,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 49,
+                                                                            },
+                                                                        },
+                                                                        span: 48..49,
+                                                                        name: "b",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        },
+                                        is_async: false,
+                                        return_type: Some(
+                                            TypeAnn {
+                                                kind: Keyword(
+                                                    KeywordType {
+                                                        keyword: Number,
+                                                    },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 34,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 40,
                                                     },
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: Some(
-                                    TypeAnn {
-                                        kind: Keyword(
-                                            KeywordType {
-                                                keyword: Number,
+                                                span: 34..40,
+                                                inferred_type: None,
                                             },
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 34,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 40,
-                                            },
-                                        },
-                                        span: 34..40,
-                                        inferred_type: None,
+                                        type_params: None,
                                     },
                                 ),
-                                type_params: None,
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let p: Point = {x: 5, y: 10};\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..29,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "p",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,159 +30,177 @@ Ok(
                                     column: 5,
                                 },
                             },
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "p",
+                                    mutable: false,
+                                    span: 4..5,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 5,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: TypeRef(
-                            TypeRef {
-                                name: "Point",
-                                type_args: None,
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Point",
+                                        type_args: None,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 7,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 12,
+                                    },
+                                },
+                                span: 7..12,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 7,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 12,
-                            },
-                        },
-                        span: 7..12,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 15,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 28,
-                            },
-                        },
-                        span: 15..28,
-                        kind: Obj(
-                            Obj {
-                                props: [
-                                    Prop(
-                                        KeyValue(
-                                            KeyValueProp {
-                                                key: Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 16,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 17,
-                                                        },
-                                                    },
-                                                    span: 16..17,
-                                                    name: "x",
-                                                },
-                                                value: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 19,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 20,
-                                                        },
-                                                    },
-                                                    span: 19..20,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 19,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 20,
-                                                                    },
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 15,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 28,
+                                    },
+                                },
+                                span: 15..28,
+                                kind: Obj(
+                                    Obj {
+                                        props: [
+                                            Prop(
+                                                KeyValue(
+                                                    KeyValueProp {
+                                                        key: Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 16,
                                                                 },
-                                                                span: 19..20,
-                                                                value: "5",
-                                                            },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                    ),
-                                    Prop(
-                                        KeyValue(
-                                            KeyValueProp {
-                                                key: Ident {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 22,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 23,
-                                                        },
-                                                    },
-                                                    span: 22..23,
-                                                    name: "y",
-                                                },
-                                                value: Expr {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 25,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 27,
-                                                        },
-                                                    },
-                                                    span: 25..27,
-                                                    kind: Lit(
-                                                        Num(
-                                                            Num {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 25,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 27,
-                                                                    },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 17,
                                                                 },
-                                                                span: 25..27,
-                                                                value: "10",
                                                             },
-                                                        ),
-                                                    ),
-                                                    inferred_type: None,
-                                                },
-                                            },
-                                        ),
-                                    ),
-                                ],
+                                                            span: 16..17,
+                                                            name: "x",
+                                                        },
+                                                        value: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 19,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                            },
+                                                            span: 19..20,
+                                                            kind: Lit(
+                                                                Num(
+                                                                    Num {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 20,
+                                                                            },
+                                                                        },
+                                                                        span: 19..20,
+                                                                        value: "5",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    },
+                                                ),
+                                            ),
+                                            Prop(
+                                                KeyValue(
+                                                    KeyValueProp {
+                                                        key: Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                            },
+                                                            span: 22..23,
+                                                            name: "y",
+                                                        },
+                                                        value: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 27,
+                                                                },
+                                                            },
+                                                            span: 25..27,
+                                                            kind: Lit(
+                                                                Num(
+                                                                    Num {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 25,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 27,
+                                                                            },
+                                                                        },
+                                                                        span: 25..27,
+                                                                        value: "10",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    },
+                                                ),
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-5.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let FOO: \\\"foo\\\" = \\\"foo\\\";\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..23,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "FOO",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,79 +30,97 @@ Ok(
                                     column: 7,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Lit(
-                            Str(
-                                Str {
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "FOO",
+                                    mutable: false,
+                                    span: 4..7,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 9,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 14,
+                                            column: 7,
                                         },
                                     },
-                                    span: 9..14,
-                                    value: "foo",
                                 },
                             ),
-                        ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 14,
-                            },
+                            inferred_type: None,
                         },
-                        span: 9..14,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 17,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 22,
-                            },
-                        },
-                        span: 17..22,
-                        kind: Lit(
-                            Str(
-                                Str {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 17,
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Lit(
+                                    Str(
+                                        Str {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 9,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 14,
+                                                },
+                                            },
+                                            span: 9..14,
+                                            value: "foo",
                                         },
-                                        end: Position {
-                                            line: 0,
-                                            column: 22,
-                                        },
+                                    ),
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 9,
                                     },
-                                    span: 17..22,
-                                    value: "foo",
+                                    end: Position {
+                                        line: 0,
+                                        column: 14,
+                                    },
                                 },
-                            ),
+                                span: 9..14,
+                                inferred_type: None,
+                            },
                         ),
-                        inferred_type: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 22,
+                                    },
+                                },
+                                span: 17..22,
+                                kind: Lit(
+                                    Str(
+                                        Str {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 17,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 22,
+                                                },
+                                            },
+                                            span: 17..22,
+                                            value: "foo",
+                                        },
+                                    ),
+                                ),
+                                inferred_type: None,
+                            },
+                        ),
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let x: number = 5;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..18,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                    },
-                    span: 4..5,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "x",
-                            mutable: false,
-                            span: 4..5,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,66 +30,84 @@ Ok(
                                     column: 5,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Keyword(
-                            KeywordType {
-                                keyword: Number,
-                            },
-                        ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 7,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 13,
-                            },
-                        },
-                        span: 7..13,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 16,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 17,
-                            },
-                        },
-                        span: 16..17,
-                        kind: Lit(
-                            Num(
-                                Num {
+                            span: 4..5,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "x",
+                                    mutable: false,
+                                    span: 4..5,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 16,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 17,
+                                            column: 5,
                                         },
                                     },
-                                    span: 16..17,
-                                    value: "5",
                                 },
                             ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Keyword(
+                                    KeywordType {
+                                        keyword: Number,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 7,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 13,
+                                    },
+                                },
+                                span: 7..13,
+                                inferred_type: None,
+                            },
                         ),
-                        inferred_type: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 16,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                },
+                                span: 16..17,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 17,
+                                                },
+                                            },
+                                            span: 16..17,
+                                            value: "5",
+                                        },
+                                    ),
+                                ),
+                                inferred_type: None,
+                            },
+                        ),
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-10.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-10.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"type C = A[\"b\"][C_Key];\"#)"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,130 +17,134 @@ Ok(
                     },
                 },
                 span: 0..23,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 6,
+                                },
+                            },
+                            span: 5..6,
+                            name: "C",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 6,
-                        },
-                    },
-                    span: 5..6,
-                    name: "C",
-                },
-                type_ann: TypeAnn {
-                    kind: IndexedAccess(
-                        IndexedAccessType {
-                            obj_type: TypeAnn {
-                                kind: IndexedAccess(
-                                    IndexedAccessType {
-                                        obj_type: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "A",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 10,
-                                                },
-                                            },
-                                            span: 9..10,
-                                            inferred_type: None,
-                                        },
-                                        index_type: TypeAnn {
-                                            kind: Lit(
-                                                Str(
-                                                    Str {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 11,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 14,
-                                                            },
+                        type_ann: TypeAnn {
+                            kind: IndexedAccess(
+                                IndexedAccessType {
+                                    obj_type: TypeAnn {
+                                        kind: IndexedAccess(
+                                            IndexedAccessType {
+                                                obj_type: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "A",
+                                                            type_args: None,
                                                         },
-                                                        span: 11..14,
-                                                        value: "b",
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 9,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
                                                     },
-                                                ),
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 11,
+                                                    span: 9..10,
+                                                    inferred_type: None,
                                                 },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 14,
+                                                index_type: TypeAnn {
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 11,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                },
+                                                                span: 11..14,
+                                                                value: "b",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 11,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
+                                                    },
+                                                    span: 11..14,
+                                                    inferred_type: None,
                                                 },
                                             },
-                                            span: 11..14,
-                                            inferred_type: None,
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 9,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 15,
+                                            },
                                         },
+                                        span: 9..15,
+                                        inferred_type: None,
                                     },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 15,
-                                    },
-                                },
-                                span: 9..15,
-                                inferred_type: None,
-                            },
-                            index_type: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "C_Key",
-                                        type_args: None,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 16,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 21,
+                                    index_type: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "C_Key",
+                                                type_args: None,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 16,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 21,
+                                            },
+                                        },
+                                        span: 16..21,
+                                        inferred_type: None,
                                     },
                                 },
-                                span: 16..21,
-                                inferred_type: None,
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 9,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 22,
+                                },
                             },
+                            span: 9..22,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 9,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 22,
-                        },
+                        type_params: None,
                     },
-                    span: 9..22,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-11.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Array<T> = {[key: number]: T};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,56 +17,42 @@ Ok(
                     },
                 },
                 span: 0..35,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 10,
+                                },
+                            },
+                            span: 5..10,
+                            name: "Array",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 10,
-                        },
-                    },
-                    span: 5..10,
-                    name: "Array",
-                },
-                type_ann: TypeAnn {
-                    kind: Object(
-                        ObjectType {
-                            elems: [
-                                Index(
-                                    TIndex {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 33,
-                                            },
-                                        },
-                                        span: 17..33,
-                                        key: TypeAnnFnParam {
-                                            pat: Pattern {
+                        type_ann: TypeAnn {
+                            kind: Object(
+                                ObjectType {
+                                    elems: [
+                                        Index(
+                                            TIndex {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
-                                                        column: 18,
+                                                        column: 17,
                                                     },
                                                     end: Position {
                                                         line: 0,
-                                                        column: 21,
+                                                        column: 33,
                                                     },
                                                 },
-                                                span: 18..21,
-                                                kind: Ident(
-                                                    BindingIdent {
-                                                        name: "key",
-                                                        mutable: false,
-                                                        span: 18..21,
+                                                span: 17..33,
+                                                key: TypeAnnFnParam {
+                                                    pat: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
@@ -77,92 +63,110 @@ Ok(
                                                                 column: 21,
                                                             },
                                                         },
+                                                        span: 18..21,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "key",
+                                                                mutable: false,
+                                                                span: 18..21,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 18,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 21,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
                                                     },
-                                                ),
-                                                inferred_type: None,
+                                                    type_ann: TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                keyword: Number,
+                                                            },
+                                                        ),
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 29,
+                                                            },
+                                                        },
+                                                        span: 23..29,
+                                                        inferred_type: None,
+                                                    },
+                                                    optional: false,
+                                                },
+                                                mutable: false,
+                                                type_ann: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "T",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 32,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 33,
+                                                        },
+                                                    },
+                                                    span: 32..33,
+                                                    inferred_type: None,
+                                                },
                                             },
-                                            type_ann: TypeAnn {
-                                                kind: Keyword(
-                                                    KeywordType {
-                                                        keyword: Number,
-                                                    },
-                                                ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 23,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 29,
-                                                    },
-                                                },
-                                                span: 23..29,
-                                                inferred_type: None,
-                                            },
-                                            optional: false,
-                                        },
-                                        mutable: false,
-                                        type_ann: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 32,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 33,
-                                                },
-                                            },
-                                            span: 32..33,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 34,
-                        },
-                    },
-                    span: 16..34,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 11..12,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 11,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 12,
-                                    },
+                                        ),
+                                    ],
                                 },
-                                span: 11..12,
-                                name: "T",
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 16,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 34,
+                                },
                             },
-                            constraint: None,
-                            default: None,
+                            span: 16..34,
+                            inferred_type: None,
                         },
-                    ],
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 11..12,
+                                    name: Ident {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 11,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 12,
+                                            },
+                                        },
+                                        span: 11..12,
+                                        name: "T",
+                                    },
+                                    constraint: None,
+                                    default: None,
+                                },
+                            ],
+                        ),
+                    },
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-12.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-12.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type MutPoint = mut {x: number, y: number};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,134 +17,138 @@ Ok(
                     },
                 },
                 span: 0..43,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 13,
+                                },
+                            },
+                            span: 5..13,
+                            name: "MutPoint",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 13,
-                        },
-                    },
-                    span: 5..13,
-                    name: "MutPoint",
-                },
-                type_ann: TypeAnn {
-                    kind: Mutable(
-                        MutableType {
-                            type_ann: TypeAnn {
-                                kind: Object(
-                                    ObjectType {
-                                        elems: [
-                                            Prop(
-                                                TProp {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 21,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 30,
-                                                        },
-                                                    },
-                                                    span: 21..30,
-                                                    name: "x",
-                                                    optional: false,
-                                                    mutable: false,
-                                                    type_ann: TypeAnn {
-                                                        kind: Keyword(
-                                                            KeywordType {
-                                                                keyword: Number,
+                        type_ann: TypeAnn {
+                            kind: Mutable(
+                                MutableType {
+                                    type_ann: TypeAnn {
+                                        kind: Object(
+                                            ObjectType {
+                                                elems: [
+                                                    Prop(
+                                                        TProp {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 30,
+                                                                },
                                                             },
-                                                        ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 24,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 30,
+                                                            span: 21..30,
+                                                            name: "x",
+                                                            optional: false,
+                                                            mutable: false,
+                                                            type_ann: TypeAnn {
+                                                                kind: Keyword(
+                                                                    KeywordType {
+                                                                        keyword: Number,
+                                                                    },
+                                                                ),
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 24,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 30,
+                                                                    },
+                                                                },
+                                                                span: 24..30,
+                                                                inferred_type: None,
                                                             },
                                                         },
-                                                        span: 24..30,
-                                                        inferred_type: None,
-                                                    },
-                                                },
-                                            ),
-                                            Prop(
-                                                TProp {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 32,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 41,
-                                                        },
-                                                    },
-                                                    span: 32..41,
-                                                    name: "y",
-                                                    optional: false,
-                                                    mutable: false,
-                                                    type_ann: TypeAnn {
-                                                        kind: Keyword(
-                                                            KeywordType {
-                                                                keyword: Number,
+                                                    ),
+                                                    Prop(
+                                                        TProp {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 32,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 41,
+                                                                },
                                                             },
-                                                        ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 35,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 41,
+                                                            span: 32..41,
+                                                            name: "y",
+                                                            optional: false,
+                                                            mutable: false,
+                                                            type_ann: TypeAnn {
+                                                                kind: Keyword(
+                                                                    KeywordType {
+                                                                        keyword: Number,
+                                                                    },
+                                                                ),
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 35,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 41,
+                                                                    },
+                                                                },
+                                                                span: 35..41,
+                                                                inferred_type: None,
                                                             },
                                                         },
-                                                        span: 35..41,
-                                                        inferred_type: None,
-                                                    },
-                                                },
-                                            ),
-                                        ],
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 20,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 42,
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 20,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 42,
+                                            },
+                                        },
+                                        span: 20..42,
+                                        inferred_type: None,
                                     },
                                 },
-                                span: 20..42,
-                                inferred_type: None,
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 16,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 42,
+                                },
                             },
+                            span: 16..42,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 42,
-                        },
+                        type_params: None,
                     },
-                    span: 16..42,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-13.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-13.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type MutPoint = {mut x: number, mut y: number};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,116 +17,120 @@ Ok(
                     },
                 },
                 span: 0..47,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 13,
+                                },
+                            },
+                            span: 5..13,
+                            name: "MutPoint",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 13,
+                        type_ann: TypeAnn {
+                            kind: Object(
+                                ObjectType {
+                                    elems: [
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 17,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 30,
+                                                    },
+                                                },
+                                                span: 17..30,
+                                                name: "x",
+                                                optional: false,
+                                                mutable: true,
+                                                type_ann: TypeAnn {
+                                                    kind: Keyword(
+                                                        KeywordType {
+                                                            keyword: Number,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 24,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 30,
+                                                        },
+                                                    },
+                                                    span: 24..30,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 32,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 45,
+                                                    },
+                                                },
+                                                span: 32..45,
+                                                name: "y",
+                                                optional: false,
+                                                mutable: true,
+                                                type_ann: TypeAnn {
+                                                    kind: Keyword(
+                                                        KeywordType {
+                                                            keyword: Number,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 39,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 45,
+                                                        },
+                                                    },
+                                                    span: 39..45,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 16,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 46,
+                                },
+                            },
+                            span: 16..46,
+                            inferred_type: None,
                         },
+                        type_params: None,
                     },
-                    span: 5..13,
-                    name: "MutPoint",
-                },
-                type_ann: TypeAnn {
-                    kind: Object(
-                        ObjectType {
-                            elems: [
-                                Prop(
-                                    TProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 30,
-                                            },
-                                        },
-                                        span: 17..30,
-                                        name: "x",
-                                        optional: false,
-                                        mutable: true,
-                                        type_ann: TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: Number,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 30,
-                                                },
-                                            },
-                                            span: 24..30,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                Prop(
-                                    TProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 32,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 45,
-                                            },
-                                        },
-                                        span: 32..45,
-                                        name: "y",
-                                        optional: false,
-                                        mutable: true,
-                                        type_ann: TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: Number,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 39,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 45,
-                                                },
-                                            },
-                                            span: 39..45,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 46,
-                        },
-                    },
-                    span: 16..46,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Point = {x: number, y: number};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,116 +17,120 @@ Ok(
                     },
                 },
                 span: 0..36,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 10,
+                                },
+                            },
+                            span: 5..10,
+                            name: "Point",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 10,
+                        type_ann: TypeAnn {
+                            kind: Object(
+                                ObjectType {
+                                    elems: [
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 14,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 23,
+                                                    },
+                                                },
+                                                span: 14..23,
+                                                name: "x",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: TypeAnn {
+                                                    kind: Keyword(
+                                                        KeywordType {
+                                                            keyword: Number,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 23,
+                                                        },
+                                                    },
+                                                    span: 17..23,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 25,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 34,
+                                                    },
+                                                },
+                                                span: 25..34,
+                                                name: "y",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: TypeAnn {
+                                                    kind: Keyword(
+                                                        KeywordType {
+                                                            keyword: Number,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 28,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 34,
+                                                        },
+                                                    },
+                                                    span: 28..34,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 13,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 35,
+                                },
+                            },
+                            span: 13..35,
+                            inferred_type: None,
                         },
+                        type_params: None,
                     },
-                    span: 5..10,
-                    name: "Point",
-                },
-                type_ann: TypeAnn {
-                    kind: Object(
-                        ObjectType {
-                            elems: [
-                                Prop(
-                                    TProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 14,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 23,
-                                            },
-                                        },
-                                        span: 14..23,
-                                        name: "x",
-                                        optional: false,
-                                        mutable: false,
-                                        type_ann: TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: Number,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 17,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 23,
-                                                },
-                                            },
-                                            span: 17..23,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                                Prop(
-                                    TProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 25,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 34,
-                                            },
-                                        },
-                                        span: 25..34,
-                                        name: "y",
-                                        optional: false,
-                                        mutable: false,
-                                        type_ann: TypeAnn {
-                                            kind: Keyword(
-                                                KeywordType {
-                                                    keyword: Number,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 28,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 34,
-                                                },
-                                            },
-                                            span: 28..34,
-                                            inferred_type: None,
-                                        },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 13,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 35,
-                        },
-                    },
-                    span: 13..35,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Foo<T> = {bar: T};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,101 +17,105 @@ Ok(
                     },
                 },
                 span: 0..23,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Foo",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 8,
+                        type_ann: TypeAnn {
+                            kind: Object(
+                                ObjectType {
+                                    elems: [
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 15,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                },
+                                                span: 15..21,
+                                                name: "bar",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "T",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 20,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 21,
+                                                        },
+                                                    },
+                                                    span: 20..21,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 14,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 22,
+                                },
+                            },
+                            span: 14..22,
+                            inferred_type: None,
                         },
-                    },
-                    span: 5..8,
-                    name: "Foo",
-                },
-                type_ann: TypeAnn {
-                    kind: Object(
-                        ObjectType {
-                            elems: [
-                                Prop(
-                                    TProp {
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 9..10,
+                                    name: Ident {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 15,
+                                                column: 9,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 21,
+                                                column: 10,
                                             },
                                         },
-                                        span: 15..21,
-                                        name: "bar",
-                                        optional: false,
-                                        mutable: false,
-                                        type_ann: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
-                                                },
-                                            ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 20,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                            },
-                                            span: 20..21,
-                                            inferred_type: None,
-                                        },
+                                        span: 9..10,
+                                        name: "T",
                                     },
-                                ),
-                            ],
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 14,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 22,
-                        },
-                    },
-                    span: 14..22,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 9..10,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
+                                    constraint: None,
+                                    default: None,
                                 },
-                                span: 9..10,
-                                name: "T",
-                            },
-                            constraint: None,
-                            default: None,
-                        },
-                    ],
+                            ],
+                        ),
+                    },
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Foo<T extends string> = {bar: T};\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,121 +17,125 @@ Ok(
                     },
                 },
                 span: 0..38,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Foo",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 8,
+                        type_ann: TypeAnn {
+                            kind: Object(
+                                ObjectType {
+                                    elems: [
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 30,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 36,
+                                                    },
+                                                },
+                                                span: 30..36,
+                                                name: "bar",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "T",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 35,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 36,
+                                                        },
+                                                    },
+                                                    span: 35..36,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 29,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 37,
+                                },
+                            },
+                            span: 29..37,
+                            inferred_type: None,
                         },
-                    },
-                    span: 5..8,
-                    name: "Foo",
-                },
-                type_ann: TypeAnn {
-                    kind: Object(
-                        ObjectType {
-                            elems: [
-                                Prop(
-                                    TProp {
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 9..25,
+                                    name: Ident {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 30,
+                                                column: 9,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 36,
+                                                column: 10,
                                             },
                                         },
-                                        span: 30..36,
-                                        name: "bar",
-                                        optional: false,
-                                        mutable: false,
-                                        type_ann: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
+                                        span: 9..10,
+                                        name: "T",
+                                    },
+                                    constraint: Some(
+                                        TypeAnn {
+                                            kind: Keyword(
+                                                KeywordType {
+                                                    keyword: String,
                                                 },
                                             ),
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 35,
+                                                    column: 19,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 36,
+                                                    column: 25,
                                                 },
                                             },
-                                            span: 35..36,
+                                            span: 19..25,
                                             inferred_type: None,
                                         },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 29,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 37,
-                        },
-                    },
-                    span: 29..37,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 9..25,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                },
-                                span: 9..10,
-                                name: "T",
-                            },
-                            constraint: Some(
-                                TypeAnn {
-                                    kind: Keyword(
-                                        KeywordType {
-                                            keyword: String,
-                                        },
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 19,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 25,
-                                        },
-                                    },
-                                    span: 19..25,
-                                    inferred_type: None,
+                                    default: None,
                                 },
-                            ),
-                            default: None,
-                        },
-                    ],
+                            ],
+                        ),
+                    },
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-5.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"type Foo<T = \"foo\"> = {bar: T};\"#)"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,134 +17,138 @@ Ok(
                     },
                 },
                 span: 0..31,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Foo",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 8,
+                        type_ann: TypeAnn {
+                            kind: Object(
+                                ObjectType {
+                                    elems: [
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 23,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 29,
+                                                    },
+                                                },
+                                                span: 23..29,
+                                                name: "bar",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "T",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 28,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 29,
+                                                        },
+                                                    },
+                                                    span: 28..29,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 22,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 30,
+                                },
+                            },
+                            span: 22..30,
+                            inferred_type: None,
                         },
-                    },
-                    span: 5..8,
-                    name: "Foo",
-                },
-                type_ann: TypeAnn {
-                    kind: Object(
-                        ObjectType {
-                            elems: [
-                                Prop(
-                                    TProp {
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 9..18,
+                                    name: Ident {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 23,
+                                                column: 9,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 29,
+                                                column: 10,
                                             },
                                         },
-                                        span: 23..29,
-                                        name: "bar",
-                                        optional: false,
-                                        mutable: false,
-                                        type_ann: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
-                                                },
+                                        span: 9..10,
+                                        name: "T",
+                                    },
+                                    constraint: None,
+                                    default: Some(
+                                        TypeAnn {
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 13,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 18,
+                                                            },
+                                                        },
+                                                        span: 13..18,
+                                                        value: "foo",
+                                                    },
+                                                ),
                                             ),
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 28,
+                                                    column: 13,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 29,
+                                                    column: 18,
                                                 },
                                             },
-                                            span: 28..29,
+                                            span: 13..18,
                                             inferred_type: None,
                                         },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 22,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 30,
-                        },
-                    },
-                    span: 22..30,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 9..18,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                },
-                                span: 9..10,
-                                name: "T",
-                            },
-                            constraint: None,
-                            default: Some(
-                                TypeAnn {
-                                    kind: Lit(
-                                        Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 13,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 18,
-                                                    },
-                                                },
-                                                span: 13..18,
-                                                value: "foo",
-                                            },
-                                        ),
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 13,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 18,
-                                        },
-                                    },
-                                    span: 13..18,
-                                    inferred_type: None,
                                 },
-                            ),
-                        },
-                    ],
+                            ],
+                        ),
+                    },
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-6.snap
@@ -5,7 +5,7 @@ expression: "parse(r#\"type Foo<T extends string = \"foo\"> = {bar: T};\"#)"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,154 +17,158 @@ Ok(
                     },
                 },
                 span: 0..46,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Foo",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 8,
+                        type_ann: TypeAnn {
+                            kind: Object(
+                                ObjectType {
+                                    elems: [
+                                        Prop(
+                                            TProp {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 38,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 44,
+                                                    },
+                                                },
+                                                span: 38..44,
+                                                name: "bar",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "T",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 43,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 44,
+                                                        },
+                                                    },
+                                                    span: 43..44,
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 37,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 45,
+                                },
+                            },
+                            span: 37..45,
+                            inferred_type: None,
                         },
-                    },
-                    span: 5..8,
-                    name: "Foo",
-                },
-                type_ann: TypeAnn {
-                    kind: Object(
-                        ObjectType {
-                            elems: [
-                                Prop(
-                                    TProp {
+                        type_params: Some(
+                            [
+                                TypeParam {
+                                    span: 9..33,
+                                    name: Ident {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
-                                                column: 38,
+                                                column: 9,
                                             },
                                             end: Position {
                                                 line: 0,
-                                                column: 44,
+                                                column: 10,
                                             },
                                         },
-                                        span: 38..44,
-                                        name: "bar",
-                                        optional: false,
-                                        mutable: false,
-                                        type_ann: TypeAnn {
-                                            kind: TypeRef(
-                                                TypeRef {
-                                                    name: "T",
-                                                    type_args: None,
+                                        span: 9..10,
+                                        name: "T",
+                                    },
+                                    constraint: Some(
+                                        TypeAnn {
+                                            kind: Keyword(
+                                                KeywordType {
+                                                    keyword: String,
                                                 },
                                             ),
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 43,
+                                                    column: 19,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 44,
+                                                    column: 25,
                                                 },
                                             },
-                                            span: 43..44,
+                                            span: 19..25,
                                             inferred_type: None,
                                         },
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 37,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 45,
-                        },
-                    },
-                    span: 37..45,
-                    inferred_type: None,
-                },
-                type_params: Some(
-                    [
-                        TypeParam {
-                            span: 9..33,
-                            name: Ident {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 10,
-                                    },
-                                },
-                                span: 9..10,
-                                name: "T",
-                            },
-                            constraint: Some(
-                                TypeAnn {
-                                    kind: Keyword(
-                                        KeywordType {
-                                            keyword: String,
-                                        },
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 19,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 25,
-                                        },
-                                    },
-                                    span: 19..25,
-                                    inferred_type: None,
-                                },
-                            ),
-                            default: Some(
-                                TypeAnn {
-                                    kind: Lit(
-                                        Str(
-                                            Str {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 28,
+                                    default: Some(
+                                        TypeAnn {
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 28,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 33,
+                                                            },
+                                                        },
+                                                        span: 28..33,
+                                                        value: "foo",
                                                     },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 33,
-                                                    },
+                                                ),
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 28,
                                                 },
-                                                span: 28..33,
-                                                value: "foo",
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 33,
+                                                },
                                             },
-                                        ),
+                                            span: 28..33,
+                                            inferred_type: None,
+                                        },
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 28,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 33,
-                                        },
-                                    },
-                                    span: 28..33,
-                                    inferred_type: None,
                                 },
-                            ),
-                        },
-                    ],
+                            ],
+                        ),
+                    },
                 ),
             },
         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-7.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type CoordNames = keyof Point;\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,60 +17,64 @@ Ok(
                     },
                 },
                 span: 0..30,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 15,
+                                },
+                            },
+                            span: 5..15,
+                            name: "CoordNames",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 15,
-                        },
-                    },
-                    span: 5..15,
-                    name: "CoordNames",
-                },
-                type_ann: TypeAnn {
-                    kind: KeyOf(
-                        KeyOfType {
-                            type_ann: TypeAnn {
-                                kind: TypeRef(
-                                    TypeRef {
-                                        name: "Point",
-                                        type_args: None,
-                                    },
-                                ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 24,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 29,
+                        type_ann: TypeAnn {
+                            kind: KeyOf(
+                                KeyOfType {
+                                    type_ann: TypeAnn {
+                                        kind: TypeRef(
+                                            TypeRef {
+                                                name: "Point",
+                                                type_args: None,
+                                            },
+                                        ),
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 24,
+                                            },
+                                            end: Position {
+                                                line: 0,
+                                                column: 29,
+                                            },
+                                        },
+                                        span: 24..29,
+                                        inferred_type: None,
                                     },
                                 },
-                                span: 24..29,
-                                inferred_type: None,
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 18,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 29,
+                                },
                             },
+                            span: 18..29,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 18,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 29,
-                        },
+                        type_params: None,
                     },
-                    span: 18..29,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-8.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Foo = typeof foo;\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,38 +17,27 @@ Ok(
                     },
                 },
                 span: 0..22,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 8,
-                        },
-                    },
-                    span: 5..8,
-                    name: "Foo",
-                },
-                type_ann: TypeAnn {
-                    kind: Query(
-                        QueryType {
-                            expr: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 18,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 21,
-                                    },
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                span: 18..21,
-                                kind: Ident(
-                                    Ident {
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Foo",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Query(
+                                QueryType {
+                                    expr: Expr {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 0,
@@ -60,27 +49,42 @@ Ok(
                                             },
                                         },
                                         span: 18..21,
-                                        name: "foo",
+                                        kind: Ident(
+                                            Ident {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 18,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 21,
+                                                    },
+                                                },
+                                                span: 18..21,
+                                                name: "foo",
+                                            },
+                                        ),
+                                        inferred_type: None,
                                     },
-                                ),
-                                inferred_type: None,
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 11,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 21,
+                                },
                             },
+                            span: 11..21,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 11,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 21,
-                        },
+                        type_params: None,
                     },
-                    span: 11..21,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls-9.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type FooBar = typeof foo.bar;\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,52 +17,41 @@ Ok(
                     },
                 },
                 span: 0..29,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
-                    },
-                    span: 5..11,
-                    name: "FooBar",
-                },
-                type_ann: TypeAnn {
-                    kind: Query(
-                        QueryType {
-                            expr: Expr {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 0,
-                                        column: 21,
-                                    },
-                                    end: Position {
-                                        line: 0,
-                                        column: 28,
-                                    },
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
                                 },
-                                span: 21..28,
-                                kind: Member(
-                                    Member {
-                                        obj: Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 24,
-                                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 11,
+                                },
+                            },
+                            span: 5..11,
+                            name: "FooBar",
+                        },
+                        type_ann: TypeAnn {
+                            kind: Query(
+                                QueryType {
+                                    expr: Expr {
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 0,
+                                                column: 21,
                                             },
-                                            span: 21..24,
-                                            kind: Ident(
-                                                Ident {
+                                            end: Position {
+                                                line: 0,
+                                                column: 28,
+                                            },
+                                        },
+                                        span: 21..28,
+                                        kind: Member(
+                                            Member {
+                                                obj: Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -74,47 +63,62 @@ Ok(
                                                         },
                                                     },
                                                     span: 21..24,
-                                                    name: "foo",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                            },
+                                                            span: 21..24,
+                                                            name: "foo",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        prop: Ident(
-                                            Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 25,
+                                                prop: Ident(
+                                                    Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 28,
+                                                            },
+                                                        },
+                                                        span: 25..28,
+                                                        name: "bar",
                                                     },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 28,
-                                                    },
-                                                },
-                                                span: 25..28,
-                                                name: "bar",
+                                                ),
                                             },
                                         ),
+                                        inferred_type: None,
                                     },
-                                ),
-                                inferred_type: None,
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 14,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 28,
+                                },
                             },
+                            span: 14..28,
+                            inferred_type: None,
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 14,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 28,
-                        },
+                        type_params: None,
                     },
-                    span: 14..28,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_decls.snap
@@ -5,7 +5,7 @@ expression: "parse(\"type Num = number;\")"
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,41 +17,45 @@ Ok(
                     },
                 },
                 span: 0..18,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 5,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 8,
+                                },
+                            },
+                            span: 5..8,
+                            name: "Num",
                         },
-                        end: Position {
-                            line: 0,
-                            column: 8,
+                        type_ann: TypeAnn {
+                            kind: Keyword(
+                                KeywordType {
+                                    keyword: Number,
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 0,
+                                    column: 11,
+                                },
+                                end: Position {
+                                    line: 0,
+                                    column: 17,
+                                },
+                            },
+                            span: 11..17,
+                            inferred_type: None,
                         },
+                        type_params: None,
                     },
-                    span: 5..8,
-                    name: "Num",
-                },
-                type_ann: TypeAnn {
-                    kind: Keyword(
-                        KeywordType {
-                            keyword: Number,
-                        },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 11,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 17,
-                        },
-                    },
-                    span: 11..17,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-2.snap
@@ -5,7 +5,7 @@ expression: "parse(\"declare let get_bar: (foo: Foo) => T;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 8..37,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 19,
-                        },
-                    },
-                    span: 12..19,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "get_bar",
-                            mutable: false,
-                            span: 12..19,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,33 +30,33 @@ Ok(
                                     column: 19,
                                 },
                             },
+                            span: 12..19,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "get_bar",
+                                    mutable: false,
+                                    span: 12..19,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 19,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Lam(
-                            LamType {
-                                params: [
-                                    TypeAnnFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 22,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 25,
-                                                },
-                                            },
-                                            span: 22..25,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "foo",
-                                                    mutable: false,
-                                                    span: 22..25,
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Lam(
+                                    LamType {
+                                        params: [
+                                            TypeAnnFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -81,72 +67,90 @@ Ok(
                                                             column: 25,
                                                         },
                                                     },
+                                                    span: 22..25,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "foo",
+                                                            mutable: false,
+                                                            span: 22..25,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: TypeAnn {
+                                                type_ann: TypeAnn {
+                                                    kind: TypeRef(
+                                                        TypeRef {
+                                                            name: "Foo",
+                                                            type_args: None,
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 27,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 30,
+                                                        },
+                                                    },
+                                                    span: 27..30,
+                                                    inferred_type: None,
+                                                },
+                                                optional: false,
+                                            },
+                                        ],
+                                        ret: TypeAnn {
                                             kind: TypeRef(
                                                 TypeRef {
-                                                    name: "Foo",
+                                                    name: "T",
                                                     type_args: None,
                                                 },
                                             ),
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
-                                                    column: 27,
+                                                    column: 35,
                                                 },
                                                 end: Position {
                                                     line: 0,
-                                                    column: 30,
+                                                    column: 36,
                                                 },
                                             },
-                                            span: 27..30,
+                                            span: 35..36,
                                             inferred_type: None,
                                         },
-                                        optional: false,
+                                        type_params: None,
                                     },
-                                ],
-                                ret: TypeAnn {
-                                    kind: TypeRef(
-                                        TypeRef {
-                                            name: "T",
-                                            type_args: None,
-                                        },
-                                    ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 0,
-                                            column: 35,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 36,
-                                        },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 21,
                                     },
-                                    span: 35..36,
-                                    inferred_type: None,
+                                    end: Position {
+                                        line: 0,
+                                        column: 36,
+                                    },
                                 },
-                                type_params: None,
+                                span: 21..36,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 21,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 36,
-                            },
-                        },
-                        span: 21..36,
-                        inferred_type: None,
+                        init: None,
+                        declare: true,
                     },
                 ),
-                init: None,
-                declare: true,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-3.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let str_arr: string[] = [];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..27,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
-                    },
-                    span: 4..11,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "str_arr",
-                            mutable: false,
-                            span: 4..11,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,71 +30,89 @@ Ok(
                                     column: 11,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Array(
-                            ArrayType {
-                                elem_type: TypeAnn {
-                                    kind: Keyword(
-                                        KeywordType {
-                                            keyword: String,
-                                        },
-                                    ),
+                            span: 4..11,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "str_arr",
+                                    mutable: false,
+                                    span: 4..11,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 13,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 19,
+                                            column: 11,
                                         },
                                     },
-                                    span: 13..19,
-                                    inferred_type: None,
                                 },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Array(
+                                    ArrayType {
+                                        elem_type: TypeAnn {
+                                            kind: Keyword(
+                                                KeywordType {
+                                                    keyword: String,
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 13,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 19,
+                                                },
+                                            },
+                                            span: 13..19,
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 13,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 21,
+                                    },
+                                },
+                                span: 13..21,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 13,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 21,
-                            },
-                        },
-                        span: 13..21,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 24,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 26,
-                            },
-                        },
-                        span: 24..26,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [],
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 24,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 26,
+                                    },
+                                },
+                                span: 24..26,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-4.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let thunk_arr: (() => undefined)[] = [];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..40,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 13,
-                        },
-                    },
-                    span: 4..13,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "thunk_arr",
-                            mutable: false,
-                            span: 4..13,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,91 +30,109 @@ Ok(
                                     column: 13,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Array(
-                            ArrayType {
-                                elem_type: TypeAnn {
-                                    kind: Lam(
-                                        LamType {
-                                            params: [],
-                                            ret: TypeAnn {
-                                                kind: Keyword(
-                                                    KeywordType {
-                                                        keyword: Undefined,
-                                                    },
-                                                ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 22,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 31,
-                                                    },
-                                                },
-                                                span: 22..31,
-                                                inferred_type: None,
-                                            },
-                                            type_params: None,
-                                        },
-                                    ),
+                            span: 4..13,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "thunk_arr",
+                                    mutable: false,
+                                    span: 4..13,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 16,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 31,
+                                            column: 13,
                                         },
                                     },
-                                    span: 16..31,
-                                    inferred_type: None,
                                 },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Array(
+                                    ArrayType {
+                                        elem_type: TypeAnn {
+                                            kind: Lam(
+                                                LamType {
+                                                    params: [],
+                                                    ret: TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                keyword: Undefined,
+                                                            },
+                                                        ),
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 31,
+                                                            },
+                                                        },
+                                                        span: 22..31,
+                                                        inferred_type: None,
+                                                    },
+                                                    type_params: None,
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 31,
+                                                },
+                                            },
+                                            span: 16..31,
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 15,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 34,
+                                    },
+                                },
+                                span: 15..34,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 15,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 34,
-                            },
-                        },
-                        span: 15..34,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 37,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 39,
-                            },
-                        },
-                        span: 37..39,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [],
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 37,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 39,
+                                    },
+                                },
+                                span: 37..39,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-5.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let arr: string[] | number[] = [];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..34,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 7,
-                        },
-                    },
-                    span: 4..7,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "arr",
-                            mutable: false,
-                            span: 4..7,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,128 +30,146 @@ Ok(
                                     column: 7,
                                 },
                             },
+                            span: 4..7,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "arr",
+                                    mutable: false,
+                                    span: 4..7,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 7,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Union(
-                            UnionType {
-                                types: [
-                                    TypeAnn {
-                                        kind: Array(
-                                            ArrayType {
-                                                elem_type: TypeAnn {
-                                                    kind: Keyword(
-                                                        KeywordType {
-                                                            keyword: String,
-                                                        },
-                                                    ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 9,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 15,
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Union(
+                                    UnionType {
+                                        types: [
+                                            TypeAnn {
+                                                kind: Array(
+                                                    ArrayType {
+                                                        elem_type: TypeAnn {
+                                                            kind: Keyword(
+                                                                KeywordType {
+                                                                    keyword: String,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 9,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 15,
+                                                                },
+                                                            },
+                                                            span: 9..15,
+                                                            inferred_type: None,
                                                         },
                                                     },
-                                                    span: 9..15,
-                                                    inferred_type: None,
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 9,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 17,
+                                                    },
                                                 },
+                                                span: 9..17,
+                                                inferred_type: None,
                                             },
-                                        ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 17,
-                                            },
-                                        },
-                                        span: 9..17,
-                                        inferred_type: None,
-                                    },
-                                    TypeAnn {
-                                        kind: Array(
-                                            ArrayType {
-                                                elem_type: TypeAnn {
-                                                    kind: Keyword(
-                                                        KeywordType {
-                                                            keyword: Number,
-                                                        },
-                                                    ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 20,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 26,
+                                            TypeAnn {
+                                                kind: Array(
+                                                    ArrayType {
+                                                        elem_type: TypeAnn {
+                                                            kind: Keyword(
+                                                                KeywordType {
+                                                                    keyword: Number,
+                                                                },
+                                                            ),
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 26,
+                                                                },
+                                                            },
+                                                            span: 20..26,
+                                                            inferred_type: None,
                                                         },
                                                     },
-                                                    span: 20..26,
-                                                    inferred_type: None,
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 20,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 28,
+                                                    },
                                                 },
+                                                span: 20..28,
+                                                inferred_type: None,
                                             },
-                                        ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 20,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 28,
-                                            },
-                                        },
-                                        span: 20..28,
-                                        inferred_type: None,
+                                        ],
                                     },
-                                ],
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 9,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 28,
+                                    },
+                                },
+                                span: 9..28,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 9,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 28,
-                            },
-                        },
-                        span: 9..28,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 31,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 33,
-                            },
-                        },
-                        span: 31..33,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [],
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 31,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 33,
+                                    },
+                                },
+                                span: 31..33,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-6.snap
@@ -5,7 +5,7 @@ expression: "parse(\"declare let add: ((a: number, b: number) => number) & (a: s
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 8..87,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 15,
-                        },
-                    },
-                    span: 12..15,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "add",
-                            mutable: false,
-                            span: 12..15,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,37 +30,37 @@ Ok(
                                     column: 15,
                                 },
                             },
+                            span: 12..15,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "add",
+                                    mutable: false,
+                                    span: 12..15,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 15,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Intersection(
-                            IntersectionType {
-                                types: [
-                                    TypeAnn {
-                                        kind: Lam(
-                                            LamType {
-                                                params: [
-                                                    TypeAnnFnParam {
-                                                        pat: Pattern {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 19,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 20,
-                                                                },
-                                                            },
-                                                            span: 19..20,
-                                                            kind: Ident(
-                                                                BindingIdent {
-                                                                    name: "a",
-                                                                    mutable: false,
-                                                                    span: 19..20,
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Intersection(
+                                    IntersectionType {
+                                        types: [
+                                            TypeAnn {
+                                                kind: Lam(
+                                                    LamType {
+                                                        params: [
+                                                            TypeAnnFnParam {
+                                                                pat: Pattern {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -85,49 +71,49 @@ Ok(
                                                                             column: 20,
                                                                         },
                                                                     },
+                                                                    span: 19..20,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 19..20,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 19,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 20,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        type_ann: TypeAnn {
-                                                            kind: Keyword(
-                                                                KeywordType {
-                                                                    keyword: Number,
+                                                                type_ann: TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: Number,
+                                                                        },
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 28,
+                                                                        },
+                                                                    },
+                                                                    span: 22..28,
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 22,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 28,
-                                                                },
+                                                                optional: false,
                                                             },
-                                                            span: 22..28,
-                                                            inferred_type: None,
-                                                        },
-                                                        optional: false,
-                                                    },
-                                                    TypeAnnFnParam {
-                                                        pat: Pattern {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 30,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 31,
-                                                                },
-                                                            },
-                                                            span: 30..31,
-                                                            kind: Ident(
-                                                                BindingIdent {
-                                                                    name: "b",
-                                                                    mutable: false,
-                                                                    span: 30..31,
+                                                            TypeAnnFnParam {
+                                                                pat: Pattern {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -138,11 +124,49 @@ Ok(
                                                                             column: 31,
                                                                         },
                                                                     },
+                                                                    span: 30..31,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                            span: 30..31,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 30,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 31,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        type_ann: TypeAnn {
+                                                                type_ann: TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: Number,
+                                                                        },
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 33,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 39,
+                                                                        },
+                                                                    },
+                                                                    span: 33..39,
+                                                                    inferred_type: None,
+                                                                },
+                                                                optional: false,
+                                                            },
+                                                        ],
+                                                        ret: TypeAnn {
                                                             kind: Keyword(
                                                                 KeywordType {
                                                                     keyword: Number,
@@ -151,76 +175,38 @@ Ok(
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
-                                                                    column: 33,
+                                                                    column: 44,
                                                                 },
                                                                 end: Position {
                                                                     line: 0,
-                                                                    column: 39,
+                                                                    column: 50,
                                                                 },
                                                             },
-                                                            span: 33..39,
+                                                            span: 44..50,
                                                             inferred_type: None,
                                                         },
-                                                        optional: false,
+                                                        type_params: None,
                                                     },
-                                                ],
-                                                ret: TypeAnn {
-                                                    kind: Keyword(
-                                                        KeywordType {
-                                                            keyword: Number,
-                                                        },
-                                                    ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 44,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 50,
-                                                        },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 18,
                                                     },
-                                                    span: 44..50,
-                                                    inferred_type: None,
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 50,
+                                                    },
                                                 },
-                                                type_params: None,
+                                                span: 18..50,
+                                                inferred_type: None,
                                             },
-                                        ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 18,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 50,
-                                            },
-                                        },
-                                        span: 18..50,
-                                        inferred_type: None,
-                                    },
-                                    TypeAnn {
-                                        kind: Lam(
-                                            LamType {
-                                                params: [
-                                                    TypeAnnFnParam {
-                                                        pat: Pattern {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 55,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 56,
-                                                                },
-                                                            },
-                                                            span: 55..56,
-                                                            kind: Ident(
-                                                                BindingIdent {
-                                                                    name: "a",
-                                                                    mutable: false,
-                                                                    span: 55..56,
+                                            TypeAnn {
+                                                kind: Lam(
+                                                    LamType {
+                                                        params: [
+                                                            TypeAnnFnParam {
+                                                                pat: Pattern {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -231,49 +217,49 @@ Ok(
                                                                             column: 56,
                                                                         },
                                                                     },
+                                                                    span: 55..56,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 55..56,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 55,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 56,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        type_ann: TypeAnn {
-                                                            kind: Keyword(
-                                                                KeywordType {
-                                                                    keyword: String,
+                                                                type_ann: TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: String,
+                                                                        },
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 58,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 64,
+                                                                        },
+                                                                    },
+                                                                    span: 58..64,
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 58,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 64,
-                                                                },
+                                                                optional: false,
                                                             },
-                                                            span: 58..64,
-                                                            inferred_type: None,
-                                                        },
-                                                        optional: false,
-                                                    },
-                                                    TypeAnnFnParam {
-                                                        pat: Pattern {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 66,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 67,
-                                                                },
-                                                            },
-                                                            span: 66..67,
-                                                            kind: Ident(
-                                                                BindingIdent {
-                                                                    name: "b",
-                                                                    mutable: false,
-                                                                    span: 66..67,
+                                                            TypeAnnFnParam {
+                                                                pat: Pattern {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -284,11 +270,49 @@ Ok(
                                                                             column: 67,
                                                                         },
                                                                     },
+                                                                    span: 66..67,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                            span: 66..67,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 66,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 67,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
                                                                 },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        type_ann: TypeAnn {
+                                                                type_ann: TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: String,
+                                                                        },
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 69,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 75,
+                                                                        },
+                                                                    },
+                                                                    span: 69..75,
+                                                                    inferred_type: None,
+                                                                },
+                                                                optional: false,
+                                                            },
+                                                        ],
+                                                        ret: TypeAnn {
                                                             kind: Keyword(
                                                                 KeywordType {
                                                                     keyword: String,
@@ -297,73 +321,53 @@ Ok(
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
-                                                                    column: 69,
+                                                                    column: 80,
                                                                 },
                                                                 end: Position {
                                                                     line: 0,
-                                                                    column: 75,
+                                                                    column: 86,
                                                                 },
                                                             },
-                                                            span: 69..75,
+                                                            span: 80..86,
                                                             inferred_type: None,
                                                         },
-                                                        optional: false,
+                                                        type_params: None,
                                                     },
-                                                ],
-                                                ret: TypeAnn {
-                                                    kind: Keyword(
-                                                        KeywordType {
-                                                            keyword: String,
-                                                        },
-                                                    ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 0,
-                                                            column: 80,
-                                                        },
-                                                        end: Position {
-                                                            line: 0,
-                                                            column: 86,
-                                                        },
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 54,
                                                     },
-                                                    span: 80..86,
-                                                    inferred_type: None,
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 86,
+                                                    },
                                                 },
-                                                type_params: None,
+                                                span: 54..86,
+                                                inferred_type: None,
                                             },
-                                        ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 0,
-                                                column: 54,
-                                            },
-                                            end: Position {
-                                                line: 0,
-                                                column: 86,
-                                            },
-                                        },
-                                        span: 54..86,
-                                        inferred_type: None,
+                                        ],
                                     },
-                                ],
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 86,
+                                    },
+                                },
+                                span: 17..86,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 17,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 86,
-                            },
-                        },
-                        span: 17..86,
-                        inferred_type: None,
+                        init: None,
+                        declare: true,
                     },
                 ),
-                init: None,
-                declare: true,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-7.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let nested_arr: string[][] = [];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..32,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 14,
-                        },
-                    },
-                    span: 4..14,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "nested_arr",
-                            mutable: false,
-                            span: 4..14,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,89 +30,107 @@ Ok(
                                     column: 14,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Array(
-                            ArrayType {
-                                elem_type: TypeAnn {
-                                    kind: Array(
-                                        ArrayType {
-                                            elem_type: TypeAnn {
-                                                kind: Keyword(
-                                                    KeywordType {
-                                                        keyword: String,
-                                                    },
-                                                ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 22,
-                                                    },
-                                                },
-                                                span: 16..22,
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
+                            span: 4..14,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "nested_arr",
+                                    mutable: false,
+                                    span: 4..14,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 16,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 24,
+                                            column: 14,
                                         },
                                     },
-                                    span: 16..24,
-                                    inferred_type: None,
                                 },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Array(
+                                    ArrayType {
+                                        elem_type: TypeAnn {
+                                            kind: Array(
+                                                ArrayType {
+                                                    elem_type: TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                keyword: String,
+                                                            },
+                                                        ),
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 16,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 22,
+                                                            },
+                                                        },
+                                                        span: 16..22,
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 16,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 24,
+                                                },
+                                            },
+                                            span: 16..24,
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 16,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 26,
+                                    },
+                                },
+                                span: 16..26,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 16,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 26,
-                            },
-                        },
-                        span: 16..26,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 29,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 31,
-                            },
-                        },
-                        span: 29..31,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [],
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 29,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 31,
+                                    },
+                                },
+                                span: 29..31,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-8.snap
@@ -5,7 +5,7 @@ expression: parse(src)
 Ok(
     Program {
         body: [
-            TypeDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 1,
@@ -17,293 +17,297 @@ Ok(
                     },
                 },
                 span: 9..120,
-                declare: false,
-                id: Ident {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 18,
-                        },
-                    },
-                    span: 14..19,
-                    name: "Event",
-                },
-                type_ann: TypeAnn {
-                    kind: Union(
-                        UnionType {
-                            types: [
-                                TypeAnn {
-                                    kind: Object(
-                                        ObjectType {
-                                            elems: [
-                                                Prop(
-                                                    TProp {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 13,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 30,
-                                                            },
-                                                        },
-                                                        span: 36..53,
-                                                        name: "type",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: TypeAnn {
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 2,
-                                                                                column: 19,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 2,
-                                                                                column: 30,
-                                                                            },
-                                                                        },
-                                                                        span: 42..53,
-                                                                        value: "mousedown",
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 19,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 30,
-                                                                },
-                                                            },
-                                                            span: 42..53,
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ),
-                                                Prop(
-                                                    TProp {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 32,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 41,
-                                                            },
-                                                        },
-                                                        span: 55..64,
-                                                        name: "x",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: TypeAnn {
-                                                            kind: Keyword(
-                                                                KeywordType {
-                                                                    keyword: Number,
-                                                                },
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 35,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 41,
-                                                                },
-                                                            },
-                                                            span: 58..64,
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ),
-                                                Prop(
-                                                    TProp {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 2,
-                                                                column: 43,
-                                                            },
-                                                            end: Position {
-                                                                line: 2,
-                                                                column: 52,
-                                                            },
-                                                        },
-                                                        span: 66..75,
-                                                        name: "y",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: TypeAnn {
-                                                            kind: Keyword(
-                                                                KeywordType {
-                                                                    keyword: Number,
-                                                                },
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 2,
-                                                                    column: 46,
-                                                                },
-                                                                end: Position {
-                                                                    line: 2,
-                                                                    column: 52,
-                                                                },
-                                                            },
-                                                            span: 69..75,
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ),
-                                            ],
-                                        },
-                                    ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 53,
-                                        },
-                                    },
-                                    span: 35..76,
-                                    inferred_type: None,
+                kind: TypeDecl(
+                    TypeDecl {
+                        declare: false,
+                        id: Ident {
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 1,
+                                    column: 13,
                                 },
-                                TypeAnn {
-                                    kind: Object(
-                                        ObjectType {
-                                            elems: [
-                                                Prop(
-                                                    TProp {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 3,
-                                                                column: 13,
-                                                            },
-                                                            end: Position {
-                                                                line: 3,
-                                                                column: 28,
-                                                            },
-                                                        },
-                                                        span: 90..105,
-                                                        name: "type",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: TypeAnn {
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 19,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 28,
-                                                                            },
-                                                                        },
-                                                                        span: 96..105,
-                                                                        value: "keydown",
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 19,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 28,
-                                                                },
-                                                            },
-                                                            span: 96..105,
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ),
-                                                Prop(
-                                                    TProp {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 3,
-                                                                column: 30,
-                                                            },
-                                                            end: Position {
-                                                                line: 3,
-                                                                column: 41,
-                                                            },
-                                                        },
-                                                        span: 107..118,
-                                                        name: "key",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: TypeAnn {
-                                                            kind: Keyword(
-                                                                KeywordType {
-                                                                    keyword: String,
-                                                                },
-                                                            ),
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 3,
-                                                                    column: 35,
-                                                                },
-                                                                end: Position {
-                                                                    line: 3,
-                                                                    column: 41,
-                                                                },
-                                                            },
-                                                            span: 112..118,
-                                                            inferred_type: None,
-                                                        },
-                                                    },
-                                                ),
-                                            ],
-                                        },
-                                    ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 3,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 3,
-                                            column: 42,
-                                        },
-                                    },
-                                    span: 89..119,
-                                    inferred_type: None,
+                                end: Position {
+                                    line: 1,
+                                    column: 18,
                                 },
-                            ],
+                            },
+                            span: 14..19,
+                            name: "Event",
                         },
-                    ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 2,
-                            column: 10,
+                        type_ann: TypeAnn {
+                            kind: Union(
+                                UnionType {
+                                    types: [
+                                        TypeAnn {
+                                            kind: Object(
+                                                ObjectType {
+                                                    elems: [
+                                                        Prop(
+                                                            TProp {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 13,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 30,
+                                                                    },
+                                                                },
+                                                                span: 36..53,
+                                                                name: "type",
+                                                                optional: false,
+                                                                mutable: false,
+                                                                type_ann: TypeAnn {
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 19,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 30,
+                                                                                    },
+                                                                                },
+                                                                                span: 42..53,
+                                                                                value: "mousedown",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 19,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 30,
+                                                                        },
+                                                                    },
+                                                                    span: 42..53,
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                        Prop(
+                                                            TProp {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 32,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 41,
+                                                                    },
+                                                                },
+                                                                span: 55..64,
+                                                                name: "x",
+                                                                optional: false,
+                                                                mutable: false,
+                                                                type_ann: TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: Number,
+                                                                        },
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 35,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 41,
+                                                                        },
+                                                                    },
+                                                                    span: 58..64,
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                        Prop(
+                                                            TProp {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 2,
+                                                                        column: 43,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 2,
+                                                                        column: 52,
+                                                                    },
+                                                                },
+                                                                span: 66..75,
+                                                                name: "y",
+                                                                optional: false,
+                                                                mutable: false,
+                                                                type_ann: TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: Number,
+                                                                        },
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 46,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 52,
+                                                                        },
+                                                                    },
+                                                                    span: 69..75,
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 2,
+                                                    column: 12,
+                                                },
+                                                end: Position {
+                                                    line: 2,
+                                                    column: 53,
+                                                },
+                                            },
+                                            span: 35..76,
+                                            inferred_type: None,
+                                        },
+                                        TypeAnn {
+                                            kind: Object(
+                                                ObjectType {
+                                                    elems: [
+                                                        Prop(
+                                                            TProp {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 13,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 28,
+                                                                    },
+                                                                },
+                                                                span: 90..105,
+                                                                name: "type",
+                                                                optional: false,
+                                                                mutable: false,
+                                                                type_ann: TypeAnn {
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 19,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 28,
+                                                                                    },
+                                                                                },
+                                                                                span: 96..105,
+                                                                                value: "keydown",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 19,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 28,
+                                                                        },
+                                                                    },
+                                                                    span: 96..105,
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                        Prop(
+                                                            TProp {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 30,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 3,
+                                                                        column: 41,
+                                                                    },
+                                                                },
+                                                                span: 107..118,
+                                                                name: "key",
+                                                                optional: false,
+                                                                mutable: false,
+                                                                type_ann: TypeAnn {
+                                                                    kind: Keyword(
+                                                                        KeywordType {
+                                                                            keyword: String,
+                                                                        },
+                                                                    ),
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 35,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 41,
+                                                                        },
+                                                                    },
+                                                                    span: 112..118,
+                                                                    inferred_type: None,
+                                                                },
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 3,
+                                                    column: 12,
+                                                },
+                                                end: Position {
+                                                    line: 3,
+                                                    column: 42,
+                                                },
+                                            },
+                                            span: 89..119,
+                                            inferred_type: None,
+                                        },
+                                    ],
+                                },
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 2,
+                                    column: 10,
+                                },
+                                end: Position {
+                                    line: 3,
+                                    column: 42,
+                                },
+                            },
+                            span: 33..119,
+                            inferred_type: None,
                         },
-                        end: Position {
-                            line: 3,
-                            column: 42,
-                        },
+                        type_params: None,
                     },
-                    span: 33..119,
-                    inferred_type: None,
-                },
-                type_params: None,
+                ),
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types-9.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let mut_arr: mut string[] = [];\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..31,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
-                    },
-                    span: 4..11,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "mut_arr",
-                            mutable: false,
-                            span: 4..11,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,89 +30,107 @@ Ok(
                                     column: 11,
                                 },
                             },
-                        },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: Some(
-                    TypeAnn {
-                        kind: Mutable(
-                            MutableType {
-                                type_ann: TypeAnn {
-                                    kind: Array(
-                                        ArrayType {
-                                            elem_type: TypeAnn {
-                                                kind: Keyword(
-                                                    KeywordType {
-                                                        keyword: String,
-                                                    },
-                                                ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 17,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 23,
-                                                    },
-                                                },
-                                                span: 17..23,
-                                                inferred_type: None,
-                                            },
-                                        },
-                                    ),
+                            span: 4..11,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "mut_arr",
+                                    mutable: false,
+                                    span: 4..11,
                                     loc: SourceLocation {
                                         start: Position {
                                             line: 0,
-                                            column: 17,
+                                            column: 4,
                                         },
                                         end: Position {
                                             line: 0,
-                                            column: 25,
+                                            column: 11,
                                         },
                                     },
-                                    span: 17..25,
-                                    inferred_type: None,
                                 },
+                            ),
+                            inferred_type: None,
+                        },
+                        type_ann: Some(
+                            TypeAnn {
+                                kind: Mutable(
+                                    MutableType {
+                                        type_ann: TypeAnn {
+                                            kind: Array(
+                                                ArrayType {
+                                                    elem_type: TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                keyword: String,
+                                                            },
+                                                        ),
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 17,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 23,
+                                                            },
+                                                        },
+                                                        span: 17..23,
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 17,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 25,
+                                                },
+                                            },
+                                            span: 17..25,
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 13,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 25,
+                                    },
+                                },
+                                span: 13..25,
+                                inferred_type: None,
                             },
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 13,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 25,
-                            },
-                        },
-                        span: 13..25,
-                        inferred_type: None,
-                    },
-                ),
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 28,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 30,
-                            },
-                        },
-                        span: 28..30,
-                        kind: Tuple(
-                            Tuple {
-                                elems: [],
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 28,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 30,
+                                    },
+                                },
+                                span: 28..30,
+                                kind: Tuple(
+                                    Tuple {
+                                        elems: [],
+                                    },
+                                ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types.snap
@@ -5,7 +5,7 @@ expression: "parse(\"let get_bar = <T>(foo: Foo<T>) => foo.bar;\")"
 Ok(
     Program {
         body: [
-            VarDecl {
+            Statement {
                 loc: SourceLocation {
                     start: Position {
                         line: 0,
@@ -17,23 +17,9 @@ Ok(
                     },
                 },
                 span: 0..42,
-                pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 0,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 0,
-                            column: 11,
-                        },
-                    },
-                    span: 4..11,
-                    kind: Ident(
-                        BindingIdent {
-                            name: "get_bar",
-                            mutable: false,
-                            span: 4..11,
+                kind: VarDecl(
+                    VarDecl {
+                        pattern: Pattern {
                             loc: SourceLocation {
                                 start: Position {
                                     line: 0,
@@ -44,45 +30,45 @@ Ok(
                                     column: 11,
                                 },
                             },
+                            span: 4..11,
+                            kind: Ident(
+                                BindingIdent {
+                                    name: "get_bar",
+                                    mutable: false,
+                                    span: 4..11,
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 4,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 11,
+                                        },
+                                    },
+                                },
+                            ),
+                            inferred_type: None,
                         },
-                    ),
-                    inferred_type: None,
-                },
-                type_ann: None,
-                init: Some(
-                    Expr {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 0,
-                                column: 14,
-                            },
-                            end: Position {
-                                line: 0,
-                                column: 41,
-                            },
-                        },
-                        span: 14..41,
-                        kind: Lambda(
-                            Lambda {
-                                params: [
-                                    EFnParam {
-                                        pat: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 18,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 21,
-                                                },
-                                            },
-                                            span: 18..21,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "foo",
-                                                    mutable: false,
-                                                    span: 18..21,
+                        type_ann: None,
+                        init: Some(
+                            Expr {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 14,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 41,
+                                    },
+                                },
+                                span: 14..41,
+                                kind: Lambda(
+                                    Lambda {
+                                        params: [
+                                            EFnParam {
+                                                pat: Pattern {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -93,89 +79,92 @@ Ok(
                                                             column: 21,
                                                         },
                                                     },
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
-                                        type_ann: Some(
-                                            TypeAnn {
-                                                kind: TypeRef(
-                                                    TypeRef {
-                                                        name: "Foo",
-                                                        type_args: Some(
-                                                            [
-                                                                TypeAnn {
-                                                                    kind: TypeRef(
-                                                                        TypeRef {
-                                                                            name: "T",
-                                                                            type_args: None,
-                                                                        },
-                                                                    ),
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 27,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 28,
-                                                                        },
-                                                                    },
-                                                                    span: 27..28,
-                                                                    inferred_type: None,
+                                                    span: 18..21,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "foo",
+                                                            mutable: false,
+                                                            span: 18..21,
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 18,
                                                                 },
-                                                            ],
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: Some(
+                                                    TypeAnn {
+                                                        kind: TypeRef(
+                                                            TypeRef {
+                                                                name: "Foo",
+                                                                type_args: Some(
+                                                                    [
+                                                                        TypeAnn {
+                                                                            kind: TypeRef(
+                                                                                TypeRef {
+                                                                                    name: "T",
+                                                                                    type_args: None,
+                                                                                },
+                                                                            ),
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 27,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 28,
+                                                                                },
+                                                                            },
+                                                                            span: 27..28,
+                                                                            inferred_type: None,
+                                                                        },
+                                                                    ],
+                                                                ),
+                                                            },
                                                         ),
-                                                    },
-                                                ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 23,
-                                                    },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 29,
-                                                    },
-                                                },
-                                                span: 23..29,
-                                                inferred_type: None,
-                                            },
-                                        ),
-                                        optional: false,
-                                    },
-                                ],
-                                body: Block {
-                                    span: 34..41,
-                                    stmts: [
-                                        Expr {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 0,
-                                                    column: 34,
-                                                },
-                                                end: Position {
-                                                    line: 0,
-                                                    column: 41,
-                                                },
-                                            },
-                                            span: 34..41,
-                                            kind: Member(
-                                                Member {
-                                                    obj: Expr {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 0,
-                                                                column: 34,
+                                                                column: 23,
                                                             },
                                                             end: Position {
                                                                 line: 0,
-                                                                column: 37,
+                                                                column: 29,
                                                             },
                                                         },
-                                                        span: 34..37,
-                                                        kind: Ident(
-                                                            Ident {
+                                                        span: 23..29,
+                                                        inferred_type: None,
+                                                    },
+                                                ),
+                                                optional: false,
+                                            },
+                                        ],
+                                        body: Block {
+                                            span: 34..41,
+                                            stmts: [
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 34,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                    },
+                                                    span: 34..41,
+                                                    kind: Member(
+                                                        Member {
+                                                            obj: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -187,64 +176,79 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 34..37,
-                                                                name: "foo",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 34,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 37,
+                                                                            },
+                                                                        },
+                                                                        span: 34..37,
+                                                                        name: "foo",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    prop: Ident(
-                                                        Ident {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 38,
+                                                            prop: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 38,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 41,
+                                                                        },
+                                                                    },
+                                                                    span: 38..41,
+                                                                    name: "bar",
                                                                 },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 41,
-                                                                },
-                                                            },
-                                                            span: 38..41,
-                                                            name: "bar",
+                                                            ),
                                                         },
                                                     ),
+                                                    inferred_type: None,
                                                 },
-                                            ),
-                                            inferred_type: None,
+                                            ],
                                         },
-                                    ],
-                                },
-                                is_async: false,
-                                return_type: None,
-                                type_params: Some(
-                                    [
-                                        TypeParam {
-                                            span: 15..16,
-                                            name: Ident {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 0,
-                                                        column: 15,
+                                        is_async: false,
+                                        return_type: None,
+                                        type_params: Some(
+                                            [
+                                                TypeParam {
+                                                    span: 15..16,
+                                                    name: Ident {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 15,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 16,
+                                                            },
+                                                        },
+                                                        span: 15..16,
+                                                        name: "T",
                                                     },
-                                                    end: Position {
-                                                        line: 0,
-                                                        column: 16,
-                                                    },
+                                                    constraint: None,
+                                                    default: None,
                                                 },
-                                                span: 15..16,
-                                                name: "T",
-                                            },
-                                            constraint: None,
-                                            default: None,
-                                        },
-                                    ],
+                                            ],
+                                        ),
+                                    },
                                 ),
+                                inferred_type: None,
                             },
                         ),
-                        inferred_type: None,
+                        declare: false,
                     },
                 ),
-                declare: false,
             },
         ],
     },


### PR DESCRIPTION
This will make the switch from `Expr` to `Statement` in the `Block` struct easier.