### PR TITLE
Update Block to contain Statements instead of Exprs

### DIFF
--- a/crates/escalier_ast/src/values/expr.rs
+++ b/crates/escalier_ast/src/values/expr.rs
@@ -20,7 +20,7 @@ pub struct Program {
 pub struct Block {
     #[drive(skip)]
     pub span: Span,
-    pub stmts: Vec<Expr>,
+    pub stmts: Vec<Statement>,
 }
 
 #[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]

--- a/crates/escalier_ast/src/values/expr.rs
+++ b/crates/escalier_ast/src/values/expr.rs
@@ -265,16 +265,6 @@ pub struct DoExpr {
     pub body: Block,
 }
 
-// Later on we can make this a real decl.  For now, it's here to ease the move
-// to deferring lambda-ization.
-#[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
-pub struct LetDecl {
-    pub pattern: Pattern,
-    #[drive(skip)]
-    pub type_ann: Option<TypeAnn>,
-    pub init: Box<Expr>,
-}
-
 #[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]
 pub enum ExprKind {
     App(App),
@@ -303,7 +293,6 @@ pub enum ExprKind {
     Class(Class),
     Regex(Regex),
     DoExpr(DoExpr),
-    LetDecl(LetDecl),
 }
 
 #[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq)]

--- a/crates/escalier_codegen/src/js.rs
+++ b/crates/escalier_codegen/src/js.rs
@@ -702,10 +702,6 @@ fn build_expr(expr: &values::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> 
 
             Expr::Ident(temp_id)
         }
-        values::ExprKind::LetDecl(_) => {
-            // NOTE: This should always be handled by the DoExpr arm
-            todo!();
-        }
     }
 }
 

--- a/crates/escalier_infer/src/infer.rs
+++ b/crates/escalier_infer/src/infer.rs
@@ -41,7 +41,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
 
     // TODO: figure out how report multiple errors
     for stmt in &mut prog.body {
-        match infer_stmt(stmt, ctx) {
+        match infer_stmt(stmt, ctx, true) {
             Ok(_) => (),
             Err(mut errors) => reports.append(&mut errors),
         }

--- a/crates/escalier_infer/src/infer_expr.rs
+++ b/crates/escalier_infer/src/infer_expr.rs
@@ -826,28 +826,6 @@ pub fn infer_expr(
         // seems like a bad idea.
         ExprKind::Class(_) => todo!(),
         ExprKind::DoExpr(DoExpr { body }) => infer_block(body, ctx),
-        ExprKind::LetDecl(LetDecl {
-            pattern,
-            type_ann,
-            init,
-        }) => {
-            let (pa, s1) =
-                infer_pattern_and_init(pattern, type_ann, init, ctx, &PatternUsage::Assign)?;
-
-            // Inserts the new variables from infer_pattern_and_init() into the
-            // current context.
-            // TODO: have infer_pattern_and_init do this
-            for (name, binding) in pa {
-                ctx.insert_binding(name.to_owned(), binding.to_owned());
-            }
-
-            let s = s1;
-            let t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
-
-            update_pattern(pattern, &s);
-
-            Ok((s, t))
-        }
     };
 
     let (s, mut t) = result?;

--- a/crates/escalier_infer/src/infer_expr.rs
+++ b/crates/escalier_infer/src/infer_expr.rs
@@ -11,6 +11,7 @@ use crate::context::Context;
 use crate::expand_type::get_obj_type;
 use crate::infer_fn_param::infer_fn_param;
 use crate::infer_pattern::*;
+use crate::infer_stmt::infer_stmt;
 use crate::infer_type_ann::*;
 use crate::scheme::get_type_param_map;
 use crate::substitutable::{Subst, Substitutable};
@@ -865,9 +866,9 @@ pub fn infer_block(body: &mut Block, ctx: &mut Context) -> Result<(Subst, Type),
     let mut t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
     let mut s = Subst::new();
 
-    for expr in &mut body.stmts {
+    for stmt in &mut body.stmts {
         new_ctx = new_ctx.clone();
-        let (new_s, new_t) = infer_expr(&mut new_ctx, expr, false)?;
+        let (new_s, new_t) = infer_stmt(stmt, &mut new_ctx, false)?;
 
         t = new_t.apply(&s);
         s = compose_subs(&new_s, &s);

--- a/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
@@ -437,7 +437,7 @@ Program {
                                                     body: Block {
                                                         span: 20..25,
                                                         stmts: [
-                                                            Expr {
+                                                            Statement {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -449,23 +449,23 @@ Program {
                                                                     },
                                                                 },
                                                                 span: 20..25,
-                                                                kind: BinaryExpr(
-                                                                    BinaryExpr {
-                                                                        op: Add,
-                                                                        left: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 20,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 21,
-                                                                                },
+                                                                kind: ExprStmt(
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 20,
                                                                             },
-                                                                            span: 20..21,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 25,
+                                                                            },
+                                                                        },
+                                                                        span: 20..25,
+                                                                        kind: BinaryExpr(
+                                                                            BinaryExpr {
+                                                                                op: Add,
+                                                                                left: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -477,36 +477,46 @@ Program {
                                                                                         },
                                                                                     },
                                                                                     span: 20..21,
-                                                                                    name: "a",
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: Some(
-                                                                                Type {
-                                                                                    kind: Var(
-                                                                                        TVar {
-                                                                                            id: 2,
-                                                                                            constraint: None,
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 20,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 21,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 20..21,
+                                                                                            name: "a",
                                                                                         },
                                                                                     ),
-                                                                                    mutable: false,
-                                                                                    provenance: None,
+                                                                                    inferred_type: Some(
+                                                                                        Type {
+                                                                                            kind: Keyword(
+                                                                                                Number,
+                                                                                            ),
+                                                                                            mutable: false,
+                                                                                            provenance: Some(
+                                                                                                Type(
+                                                                                                    Type {
+                                                                                                        kind: Var(
+                                                                                                            TVar {
+                                                                                                                id: 2,
+                                                                                                                constraint: None,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        mutable: false,
+                                                                                                        provenance: None,
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            ),
-                                                                        },
-                                                                        right: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 24,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 25,
-                                                                                },
-                                                                            },
-                                                                            span: 24..25,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                                right: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -518,31 +528,56 @@ Program {
                                                                                         },
                                                                                     },
                                                                                     span: 24..25,
-                                                                                    name: "b",
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: Some(
-                                                                                Type {
-                                                                                    kind: Var(
-                                                                                        TVar {
-                                                                                            id: 3,
-                                                                                            constraint: None,
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 24,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 25,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 24..25,
+                                                                                            name: "b",
                                                                                         },
                                                                                     ),
-                                                                                    mutable: false,
-                                                                                    provenance: None,
+                                                                                    inferred_type: Some(
+                                                                                        Type {
+                                                                                            kind: Keyword(
+                                                                                                Number,
+                                                                                            ),
+                                                                                            mutable: false,
+                                                                                            provenance: Some(
+                                                                                                Type(
+                                                                                                    Type {
+                                                                                                        kind: Var(
+                                                                                                            TVar {
+                                                                                                                id: 3,
+                                                                                                                constraint: None,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        mutable: false,
+                                                                                                        provenance: None,
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            ),
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                inferred_type: Some(
-                                                                    Type {
-                                                                        kind: Keyword(
-                                                                            Number,
+                                                                            },
                                                                         ),
-                                                                        mutable: false,
-                                                                        provenance: None,
+                                                                        inferred_type: Some(
+                                                                            Type {
+                                                                                kind: Keyword(
+                                                                                    Number,
+                                                                                ),
+                                                                                mutable: false,
+                                                                                provenance: None,
+                                                                            },
+                                                                        ),
                                                                     },
                                                                 ),
                                                             },
@@ -972,7 +1007,7 @@ Program {
                                     body: Block {
                                         span: 20..25,
                                         stmts: [
-                                            Expr {
+                                            Statement {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
@@ -984,23 +1019,23 @@ Program {
                                                     },
                                                 },
                                                 span: 20..25,
-                                                kind: BinaryExpr(
-                                                    BinaryExpr {
-                                                        op: Add,
-                                                        left: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 20,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 21,
-                                                                },
+                                                kind: ExprStmt(
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 20,
                                                             },
-                                                            span: 20..21,
-                                                            kind: Ident(
-                                                                Ident {
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
+                                                        },
+                                                        span: 20..25,
+                                                        kind: BinaryExpr(
+                                                            BinaryExpr {
+                                                                op: Add,
+                                                                left: Expr {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -1012,46 +1047,46 @@ Program {
                                                                         },
                                                                     },
                                                                     span: 20..21,
-                                                                    name: "a",
-                                                                },
-                                                            ),
-                                                            inferred_type: Some(
-                                                                Type {
-                                                                    kind: Keyword(
-                                                                        Number,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 20,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 21,
+                                                                                },
+                                                                            },
+                                                                            span: 20..21,
+                                                                            name: "a",
+                                                                        },
                                                                     ),
-                                                                    mutable: false,
-                                                                    provenance: Some(
-                                                                        Type(
-                                                                            Type {
-                                                                                kind: Var(
-                                                                                    TVar {
-                                                                                        id: 2,
-                                                                                        constraint: None,
+                                                                    inferred_type: Some(
+                                                                        Type {
+                                                                            kind: Keyword(
+                                                                                Number,
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: Some(
+                                                                                Type(
+                                                                                    Type {
+                                                                                        kind: Var(
+                                                                                            TVar {
+                                                                                                id: 2,
+                                                                                                constraint: None,
+                                                                                            },
+                                                                                        ),
+                                                                                        mutable: false,
+                                                                                        provenance: None,
                                                                                     },
                                                                                 ),
-                                                                                mutable: false,
-                                                                                provenance: None,
-                                                                            },
-                                                                        ),
+                                                                            ),
+                                                                        },
                                                                     ),
                                                                 },
-                                                            ),
-                                                        },
-                                                        right: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 24,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 25,
-                                                                },
-                                                            },
-                                                            span: 24..25,
-                                                            kind: Ident(
-                                                                Ident {
+                                                                right: Expr {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -1063,41 +1098,56 @@ Program {
                                                                         },
                                                                     },
                                                                     span: 24..25,
-                                                                    name: "b",
-                                                                },
-                                                            ),
-                                                            inferred_type: Some(
-                                                                Type {
-                                                                    kind: Keyword(
-                                                                        Number,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 24,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 25,
+                                                                                },
+                                                                            },
+                                                                            span: 24..25,
+                                                                            name: "b",
+                                                                        },
                                                                     ),
-                                                                    mutable: false,
-                                                                    provenance: Some(
-                                                                        Type(
-                                                                            Type {
-                                                                                kind: Var(
-                                                                                    TVar {
-                                                                                        id: 3,
-                                                                                        constraint: None,
+                                                                    inferred_type: Some(
+                                                                        Type {
+                                                                            kind: Keyword(
+                                                                                Number,
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: Some(
+                                                                                Type(
+                                                                                    Type {
+                                                                                        kind: Var(
+                                                                                            TVar {
+                                                                                                id: 3,
+                                                                                                constraint: None,
+                                                                                            },
+                                                                                        ),
+                                                                                        mutable: false,
+                                                                                        provenance: None,
                                                                                     },
                                                                                 ),
-                                                                                mutable: false,
-                                                                                provenance: None,
-                                                                            },
-                                                                        ),
+                                                                            ),
+                                                                        },
                                                                     ),
                                                                 },
-                                                            ),
-                                                        },
-                                                    },
-                                                ),
-                                                inferred_type: Some(
-                                                    Type {
-                                                        kind: Keyword(
-                                                            Number,
+                                                            },
                                                         ),
-                                                        mutable: false,
-                                                        provenance: None,
+                                                        inferred_type: Some(
+                                                            Type {
+                                                                kind: Keyword(
+                                                                    Number,
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: None,
+                                                            },
+                                                        ),
                                                     },
                                                 ),
                                             },

--- a/crates/escalier_infer/src/util.rs
+++ b/crates/escalier_infer/src/util.rs
@@ -77,6 +77,7 @@ pub fn close_over(s: &Subst, t: &Type, ctx: &Context) -> Type {
                 t.apply(&sub)
             }
             _ => {
+                eprintln!("t = {t}");
                 panic!("We shouldn't have any free type variables when closing over non-lambdas")
             }
         }

--- a/crates/escalier_lsp/src/semantic_tokens.rs
+++ b/crates/escalier_lsp/src/semantic_tokens.rs
@@ -105,7 +105,6 @@ impl SemanticTokenVisitor {
             ExprKind::Class(_) => None,
             ExprKind::Regex(_) => None, // TODO
             ExprKind::DoExpr(_) => None,
-            ExprKind::LetDecl(_) => None,
         };
 
         let Expr { loc, .. } = expr;

--- a/crates/escalier_parser/src/expr.rs
+++ b/crates/escalier_parser/src/expr.rs
@@ -25,7 +25,11 @@ pub fn parse_expression(node: &tree_sitter::Node, src: &str) -> Result<Expr, Par
                 "statement_block" => parse_block_statement(&body, src)?,
                 _ => Block {
                     span: body.byte_range(),
-                    stmts: vec![parse_expression(&body, src)?],
+                    stmts: vec![Statement {
+                        loc: SourceLocation::from(&body),
+                        span: body.byte_range(),
+                        kind: StmtKind::ExprStmt(parse_expression(&body, src)?),
+                    }],
                 },
             };
 
@@ -502,7 +506,11 @@ fn parse_if_expression(node: &tree_sitter::Node, src: &str) -> Result<Expr, Pars
                 match else_clause.kind() {
                     "if_expression" => Block {
                         span: else_clause.byte_range(),
-                        stmts: vec![parse_if_expression(&else_clause, src)?],
+                        stmts: vec![Statement {
+                            loc: SourceLocation::from(&else_clause),
+                            span: else_clause.byte_range(),
+                            kind: StmtKind::ExprStmt(parse_if_expression(&else_clause, src)?),
+                        }],
                     },
                     "statement_block" => parse_block_statement(&else_clause, src)?,
                     kind => panic!("Unexpected else_clause child kind: '{kind}'"),
@@ -536,7 +544,11 @@ fn parse_arm(node: &tree_sitter::Node, src: &str) -> Result<Arm, ParseError> {
         "statement_block" => parse_block_statement(&body, src)?,
         _ => Block {
             span: body.byte_range(),
-            stmts: vec![parse_expression(&body, src)?],
+            stmts: vec![Statement {
+                loc: SourceLocation::from(&body),
+                span: body.byte_range(),
+                kind: StmtKind::ExprStmt(parse_expression(&body, src)?),
+            }],
         },
     };
 

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-2.snap
@@ -70,7 +70,7 @@ Ok(
                                         body: Block {
                                             span: 22..34,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -82,43 +82,58 @@ Ok(
                                                         },
                                                     },
                                                     span: 24..32,
-                                                    kind: Await(
-                                                        Await {
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 30,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 32,
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 32,
+                                                                },
+                                                            },
+                                                            span: 24..32,
+                                                            kind: Await(
+                                                                Await {
+                                                                    expr: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 30,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 32,
+                                                                            },
+                                                                        },
+                                                                        span: 30..32,
+                                                                        kind: Lit(
+                                                                            Num(
+                                                                                Num {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 0,
+                                                                                            column: 30,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 0,
+                                                                                            column: 32,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 30..32,
+                                                                                    value: "10",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
                                                                 },
-                                                                span: 30..32,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 30,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 32,
-                                                                                },
-                                                                            },
-                                                                            span: 30..32,
-                                                                            value: "10",
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-3.snap
@@ -70,7 +70,7 @@ Ok(
                                         body: Block {
                                             span: 22..39,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -82,37 +82,37 @@ Ok(
                                                         },
                                                     },
                                                     span: 22..39,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Add,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 29,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
                                                                 },
-                                                                span: 22..29,
-                                                                kind: Await(
-                                                                    Await {
-                                                                        expr: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 28,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 29,
-                                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 39,
+                                                                },
+                                                            },
+                                                            span: 22..39,
+                                                            kind: BinaryExpr(
+                                                                BinaryExpr {
+                                                                    op: Add,
+                                                                    left: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 22,
                                                                             },
-                                                                            span: 28..29,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 29,
+                                                                            },
+                                                                        },
+                                                                        span: 22..29,
+                                                                        kind: Await(
+                                                                            Await {
+                                                                                expr: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -124,43 +124,43 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 28..29,
-                                                                                    name: "a",
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 32,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 39,
-                                                                    },
-                                                                },
-                                                                span: 32..39,
-                                                                kind: Await(
-                                                                    Await {
-                                                                        expr: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 38,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 39,
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 28,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 29,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 28..29,
+                                                                                            name: "a",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
                                                                             },
-                                                                            span: 38..39,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                        ),
+                                                                        inferred_type: None,
+                                                                    },
+                                                                    right: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 32,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 39,
+                                                                            },
+                                                                        },
+                                                                        span: 32..39,
+                                                                        kind: Await(
+                                                                            Await {
+                                                                                expr: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -172,18 +172,33 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 38..39,
-                                                                                    name: "b",
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 38,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 39,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 38..39,
+                                                                                            name: "b",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await-4.snap
@@ -70,7 +70,7 @@ Ok(
                                         body: Block {
                                             span: 22..33,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -82,36 +82,36 @@ Ok(
                                                         },
                                                     },
                                                     span: 22..33,
-                                                    kind: Await(
-                                                        Await {
-                                                            expr: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 28,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 33,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 22,
                                                                 },
-                                                                span: 28..33,
-                                                                kind: App(
-                                                                    App {
-                                                                        lam: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 28,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 31,
-                                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 33,
+                                                                },
+                                                            },
+                                                            span: 22..33,
+                                                            kind: Await(
+                                                                Await {
+                                                                    expr: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 28,
                                                                             },
-                                                                            span: 28..31,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 33,
+                                                                            },
+                                                                        },
+                                                                        span: 28..33,
+                                                                        kind: App(
+                                                                            App {
+                                                                                lam: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -123,20 +123,35 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 28..31,
-                                                                                    name: "bar",
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 28,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 31,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 28..31,
+                                                                                            name: "bar",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        args: [],
-                                                                        type_args: None,
+                                                                                args: [],
+                                                                                type_args: None,
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__async_await.snap
@@ -36,7 +36,7 @@ Ok(
                                 body: Block {
                                     span: 12..14,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -48,25 +48,40 @@ Ok(
                                                 },
                                             },
                                             span: 12..14,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 14,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
                                                         },
-                                                        span: 12..14,
-                                                        value: "10",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
                                                     },
-                                                ),
+                                                    span: 12..14,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                },
+                                                                span: 12..14,
+                                                                value: "10",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-2.snap
@@ -69,7 +69,7 @@ Ok(
                                         body: Block {
                                             span: 13..43,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -81,8 +81,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 14..24,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -115,43 +115,45 @@ Ok(
                                                                 inferred_type: None,
                                                             },
                                                             type_ann: None,
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 22..23,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 22,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 22..23,
-                                                                            value: "5",
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
                                                                         },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    kind: Lit(
+                                                                        Num(
+                                                                            Num {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 22,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 22..23,
+                                                                                value: "5",
+                                                                            },
+                                                                        ),
                                                                     ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -163,8 +165,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 25..36,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -197,43 +199,45 @@ Ok(
                                                                 inferred_type: None,
                                                             },
                                                             type_ann: None,
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 33,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 35,
-                                                                    },
-                                                                },
-                                                                span: 33..35,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 33,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 35,
-                                                                                },
-                                                                            },
-                                                                            span: 33..35,
-                                                                            value: "10",
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 33,
                                                                         },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 35,
+                                                                        },
+                                                                    },
+                                                                    span: 33..35,
+                                                                    kind: Lit(
+                                                                        Num(
+                                                                            Num {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 33,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 35,
+                                                                                    },
+                                                                                },
+                                                                                span: 33..35,
+                                                                                value: "10",
+                                                                            },
+                                                                        ),
                                                                     ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -245,23 +249,23 @@ Ok(
                                                         },
                                                     },
                                                     span: 37..42,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Add,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 37,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 38,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 37,
                                                                 },
-                                                                span: 37..38,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 42,
+                                                                },
+                                                            },
+                                                            span: 37..42,
+                                                            kind: BinaryExpr(
+                                                                BinaryExpr {
+                                                                    op: Add,
+                                                                    left: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -273,25 +277,25 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 37..38,
-                                                                        name: "x",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 37,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 38,
+                                                                                    },
+                                                                                },
+                                                                                span: 37..38,
+                                                                                name: "x",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 41,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 42,
-                                                                    },
-                                                                },
-                                                                span: 41..42,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                    right: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -303,14 +307,29 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 41..42,
-                                                                        name: "y",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 41,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 42,
+                                                                                    },
+                                                                                },
+                                                                                span: 41..42,
+                                                                                name: "y",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-3.snap
@@ -35,7 +35,7 @@ Ok(
                                 body: Block {
                                     span: 3..33,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -47,8 +47,8 @@ Ok(
                                                 },
                                             },
                                             span: 4..14,
-                                            kind: LetDecl(
-                                                LetDecl {
+                                            kind: VarDecl(
+                                                VarDecl {
                                                     pattern: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
@@ -81,43 +81,45 @@ Ok(
                                                         inferred_type: None,
                                                     },
                                                     type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
-                                                        },
-                                                        span: 12..13,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 12,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 13,
-                                                                        },
-                                                                    },
-                                                                    span: 12..13,
-                                                                    value: "5",
+                                                    init: Some(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 12,
                                                                 },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 13,
+                                                                },
+                                                            },
+                                                            span: 12..13,
+                                                            kind: Lit(
+                                                                Num(
+                                                                    Num {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 12,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 13,
+                                                                            },
+                                                                        },
+                                                                        span: 12..13,
+                                                                        value: "5",
+                                                                    },
+                                                                ),
                                                             ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                            inferred_type: None,
+                                                        },
+                                                    ),
+                                                    declare: false,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -129,8 +131,8 @@ Ok(
                                                 },
                                             },
                                             span: 15..26,
-                                            kind: LetDecl(
-                                                LetDecl {
+                                            kind: VarDecl(
+                                                VarDecl {
                                                     pattern: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
@@ -163,43 +165,45 @@ Ok(
                                                         inferred_type: None,
                                                     },
                                                     type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 25,
-                                                            },
-                                                        },
-                                                        span: 23..25,
-                                                        kind: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 23,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 25,
-                                                                        },
-                                                                    },
-                                                                    span: 23..25,
-                                                                    value: "10",
+                                                    init: Some(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 23,
                                                                 },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 23..25,
+                                                            kind: Lit(
+                                                                Num(
+                                                                    Num {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 23,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 25,
+                                                                            },
+                                                                        },
+                                                                        span: 23..25,
+                                                                        value: "10",
+                                                                    },
+                                                                ),
                                                             ),
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                            inferred_type: None,
+                                                        },
+                                                    ),
+                                                    declare: false,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -211,23 +215,23 @@ Ok(
                                                 },
                                             },
                                             span: 27..32,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 27,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 28,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 27,
                                                         },
-                                                        span: 27..28,
-                                                        kind: Ident(
-                                                            Ident {
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 32,
+                                                        },
+                                                    },
+                                                    span: 27..32,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -239,25 +243,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 27..28,
-                                                                name: "x",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 27,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 28,
+                                                                            },
+                                                                        },
+                                                                        span: 27..28,
+                                                                        name: "x",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 31,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 32,
-                                                            },
-                                                        },
-                                                        span: 31..32,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -269,14 +273,29 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 31..32,
-                                                                name: "y",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 31,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 32,
+                                                                            },
+                                                                        },
+                                                                        span: 31..32,
+                                                                        name: "y",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-4.snap
@@ -35,7 +35,7 @@ Ok(
                                 body: Block {
                                     span: 3..53,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -47,8 +47,8 @@ Ok(
                                                 },
                                             },
                                             span: 4..48,
-                                            kind: LetDecl(
-                                                LetDecl {
+                                            kind: VarDecl(
+                                                VarDecl {
                                                     pattern: Pattern {
                                                         loc: SourceLocation {
                                                             start: Position {
@@ -81,203 +81,206 @@ Ok(
                                                         inferred_type: None,
                                                     },
                                                     type_ann: None,
-                                                    init: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 14,
+                                                    init: Some(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 14,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 47,
+                                                                },
                                                             },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 47,
-                                                            },
-                                                        },
-                                                        span: 14..47,
-                                                        kind: DoExpr(
-                                                            DoExpr {
-                                                                body: Block {
-                                                                    span: 17..47,
-                                                                    stmts: [
-                                                                        Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 18,
+                                                            span: 14..47,
+                                                            kind: DoExpr(
+                                                                DoExpr {
+                                                                    body: Block {
+                                                                        span: 17..47,
+                                                                        stmts: [
+                                                                            Statement {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 18,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 28,
+                                                                                    },
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 28,
-                                                                                },
-                                                                            },
-                                                                            span: 18..28,
-                                                                            kind: LetDecl(
-                                                                                LetDecl {
-                                                                                    pattern: Pattern {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 22,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 23,
-                                                                                            },
-                                                                                        },
-                                                                                        span: 22..23,
-                                                                                        kind: Ident(
-                                                                                            BindingIdent {
-                                                                                                name: "x",
-                                                                                                mutable: false,
-                                                                                                span: 22..23,
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 22,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 23,
-                                                                                                    },
+                                                                                span: 18..28,
+                                                                                kind: VarDecl(
+                                                                                    VarDecl {
+                                                                                        pattern: Pattern {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 22,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 23,
                                                                                                 },
                                                                                             },
-                                                                                        ),
-                                                                                        inferred_type: None,
-                                                                                    },
-                                                                                    type_ann: None,
-                                                                                    init: Expr {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 26,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 27,
-                                                                                            },
-                                                                                        },
-                                                                                        span: 26..27,
-                                                                                        kind: Lit(
-                                                                                            Num(
-                                                                                                Num {
+                                                                                            span: 22..23,
+                                                                                            kind: Ident(
+                                                                                                BindingIdent {
+                                                                                                    name: "x",
+                                                                                                    mutable: false,
+                                                                                                    span: 22..23,
                                                                                                     loc: SourceLocation {
                                                                                                         start: Position {
                                                                                                             line: 0,
-                                                                                                            column: 26,
+                                                                                                            column: 22,
                                                                                                         },
                                                                                                         end: Position {
                                                                                                             line: 0,
-                                                                                                            column: 27,
+                                                                                                            column: 23,
                                                                                                         },
                                                                                                     },
-                                                                                                    span: 26..27,
-                                                                                                    value: "5",
                                                                                                 },
                                                                                             ),
-                                                                                        ),
-                                                                                        inferred_type: None,
-                                                                                    },
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 29,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 40,
-                                                                                },
-                                                                            },
-                                                                            span: 29..40,
-                                                                            kind: LetDecl(
-                                                                                LetDecl {
-                                                                                    pattern: Pattern {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 33,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 34,
-                                                                                            },
+                                                                                            inferred_type: None,
                                                                                         },
-                                                                                        span: 33..34,
-                                                                                        kind: Ident(
-                                                                                            BindingIdent {
-                                                                                                name: "y",
-                                                                                                mutable: false,
-                                                                                                span: 33..34,
+                                                                                        type_ann: None,
+                                                                                        init: Some(
+                                                                                            Expr {
                                                                                                 loc: SourceLocation {
                                                                                                     start: Position {
                                                                                                         line: 0,
-                                                                                                        column: 33,
+                                                                                                        column: 26,
                                                                                                     },
                                                                                                     end: Position {
                                                                                                         line: 0,
-                                                                                                        column: 34,
+                                                                                                        column: 27,
                                                                                                     },
                                                                                                 },
+                                                                                                span: 26..27,
+                                                                                                kind: Lit(
+                                                                                                    Num(
+                                                                                                        Num {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 26,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 27,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 26..27,
+                                                                                                            value: "5",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                                inferred_type: None,
                                                                                             },
                                                                                         ),
-                                                                                        inferred_type: None,
+                                                                                        declare: false,
                                                                                     },
-                                                                                    type_ann: None,
-                                                                                    init: Expr {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 37,
+                                                                                ),
+                                                                            },
+                                                                            Statement {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 29,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 40,
+                                                                                    },
+                                                                                },
+                                                                                span: 29..40,
+                                                                                kind: VarDecl(
+                                                                                    VarDecl {
+                                                                                        pattern: Pattern {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 33,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 34,
+                                                                                                },
                                                                                             },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 39,
-                                                                                            },
-                                                                                        },
-                                                                                        span: 37..39,
-                                                                                        kind: Lit(
-                                                                                            Num(
-                                                                                                Num {
+                                                                                            span: 33..34,
+                                                                                            kind: Ident(
+                                                                                                BindingIdent {
+                                                                                                    name: "y",
+                                                                                                    mutable: false,
+                                                                                                    span: 33..34,
                                                                                                     loc: SourceLocation {
                                                                                                         start: Position {
                                                                                                             line: 0,
-                                                                                                            column: 37,
+                                                                                                            column: 33,
                                                                                                         },
                                                                                                         end: Position {
                                                                                                             line: 0,
-                                                                                                            column: 39,
+                                                                                                            column: 34,
                                                                                                         },
                                                                                                     },
-                                                                                                    span: 37..39,
-                                                                                                    value: "10",
                                                                                                 },
                                                                                             ),
+                                                                                            inferred_type: None,
+                                                                                        },
+                                                                                        type_ann: None,
+                                                                                        init: Some(
+                                                                                            Expr {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 37,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 39,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 37..39,
+                                                                                                kind: Lit(
+                                                                                                    Num(
+                                                                                                        Num {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 37,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 39,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 37..39,
+                                                                                                            value: "10",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                                inferred_type: None,
+                                                                                            },
                                                                                         ),
-                                                                                        inferred_type: None,
+                                                                                        declare: false,
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                            Statement {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 41,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 46,
                                                                                     },
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 41,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 46,
-                                                                                },
-                                                                            },
-                                                                            span: 41..46,
-                                                                            kind: BinaryExpr(
-                                                                                BinaryExpr {
-                                                                                    op: Add,
-                                                                                    left: Expr {
+                                                                                span: 41..46,
+                                                                                kind: ExprStmt(
+                                                                                    Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 0,
@@ -285,73 +288,91 @@ Ok(
                                                                                             },
                                                                                             end: Position {
                                                                                                 line: 0,
-                                                                                                column: 42,
-                                                                                            },
-                                                                                        },
-                                                                                        span: 41..42,
-                                                                                        kind: Ident(
-                                                                                            Ident {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 41,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 42,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 41..42,
-                                                                                                name: "x",
-                                                                                            },
-                                                                                        ),
-                                                                                        inferred_type: None,
-                                                                                    },
-                                                                                    right: Expr {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 45,
-                                                                                            },
-                                                                                            end: Position {
-                                                                                                line: 0,
                                                                                                 column: 46,
                                                                                             },
                                                                                         },
-                                                                                        span: 45..46,
-                                                                                        kind: Ident(
-                                                                                            Ident {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 45,
+                                                                                        span: 41..46,
+                                                                                        kind: BinaryExpr(
+                                                                                            BinaryExpr {
+                                                                                                op: Add,
+                                                                                                left: Expr {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 41,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 42,
+                                                                                                        },
                                                                                                     },
-                                                                                                    end: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 46,
-                                                                                                    },
+                                                                                                    span: 41..42,
+                                                                                                    kind: Ident(
+                                                                                                        Ident {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 41,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 42,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 41..42,
+                                                                                                            name: "x",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    inferred_type: None,
                                                                                                 },
-                                                                                                span: 45..46,
-                                                                                                name: "y",
+                                                                                                right: Expr {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 45,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 46,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 45..46,
+                                                                                                    kind: Ident(
+                                                                                                        Ident {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 45,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 0,
+                                                                                                                    column: 46,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 45..46,
+                                                                                                            name: "y",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    inferred_type: None,
+                                                                                                },
                                                                                             },
                                                                                         ),
                                                                                         inferred_type: None,
                                                                                     },
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                    ],
+                                                                                ),
+                                                                            },
+                                                                        ],
+                                                                    },
                                                                 },
-                                                            },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
+                                                    ),
+                                                    declare: false,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -363,8 +384,8 @@ Ok(
                                                 },
                                             },
                                             span: 49..52,
-                                            kind: Ident(
-                                                Ident {
+                                            kind: ExprStmt(
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -376,10 +397,25 @@ Ok(
                                                         },
                                                     },
                                                     span: 49..52,
-                                                    name: "sum",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 49,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 52,
+                                                                },
+                                                            },
+                                                            span: 49..52,
+                                                            name: "sum",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-5.snap
@@ -69,7 +69,7 @@ Ok(
                                         body: Block {
                                             span: 13..43,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -81,8 +81,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 14..24,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -115,43 +115,45 @@ Ok(
                                                                 inferred_type: None,
                                                             },
                                                             type_ann: None,
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 22..23,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 22,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 22..23,
-                                                                            value: "5",
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
                                                                         },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    kind: Lit(
+                                                                        Num(
+                                                                            Num {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 22,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 22..23,
+                                                                                value: "5",
+                                                                            },
+                                                                        ),
                                                                     ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -159,40 +161,40 @@ Ok(
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 39,
+                                                            column: 40,
                                                         },
                                                     },
-                                                    span: 25..39,
-                                                    kind: App(
-                                                        App {
-                                                            lam: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 25,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 36,
-                                                                    },
+                                                    span: 25..40,
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 25,
                                                                 },
-                                                                span: 25..36,
-                                                                kind: Member(
-                                                                    Member {
-                                                                        obj: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 25,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 32,
-                                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 39,
+                                                                },
+                                                            },
+                                                            span: 25..39,
+                                                            kind: App(
+                                                                App {
+                                                                    lam: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 25,
                                                                             },
-                                                                            span: 25..32,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 36,
+                                                                            },
+                                                                        },
+                                                                        span: 25..36,
+                                                                        kind: Member(
+                                                                            Member {
+                                                                                obj: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -204,48 +206,48 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 25..32,
-                                                                                    name: "console",
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 25,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 32,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 25..32,
+                                                                                            name: "console",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        prop: Ident(
-                                                                            Ident {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 33,
+                                                                                prop: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 33,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 36,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 33..36,
+                                                                                        name: "log",
                                                                                     },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 36,
-                                                                                    },
-                                                                                },
-                                                                                span: 33..36,
-                                                                                name: "log",
+                                                                                ),
                                                                             },
                                                                         ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            args: [
-                                                                ExprOrSpread {
-                                                                    spread: None,
-                                                                    expr: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 37,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 38,
-                                                                            },
-                                                                        },
-                                                                        span: 37..38,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                    args: [
+                                                                        ExprOrSpread {
+                                                                            spread: None,
+                                                                            expr: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
@@ -257,19 +259,34 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 37..38,
-                                                                                name: "x",
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 37,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 38,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 37..38,
+                                                                                        name: "x",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
+                                                                        },
+                                                                    ],
+                                                                    type_args: None,
                                                                 },
-                                                            ],
-                                                            type_args: None,
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -281,8 +298,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 41..42,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -294,10 +311,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 41..42,
-                                                            name: "x",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 41,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 42,
+                                                                        },
+                                                                    },
+                                                                    span: 41..42,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks-6.snap
@@ -69,7 +69,7 @@ Ok(
                                         body: Block {
                                             span: 13..32,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -77,40 +77,40 @@ Ok(
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 28,
+                                                            column: 29,
                                                         },
                                                     },
-                                                    span: 14..28,
-                                                    kind: App(
-                                                        App {
-                                                            lam: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 14,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 25,
-                                                                    },
+                                                    span: 14..29,
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 14,
                                                                 },
-                                                                span: 14..25,
-                                                                kind: Member(
-                                                                    Member {
-                                                                        obj: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 14,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 21,
-                                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 28,
+                                                                },
+                                                            },
+                                                            span: 14..28,
+                                                            kind: App(
+                                                                App {
+                                                                    lam: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 14,
                                                                             },
-                                                                            span: 14..21,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 25,
+                                                                            },
+                                                                        },
+                                                                        span: 14..25,
+                                                                        kind: Member(
+                                                                            Member {
+                                                                                obj: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
@@ -122,48 +122,48 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 14..21,
-                                                                                    name: "console",
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 14,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 21,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 14..21,
+                                                                                            name: "console",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        prop: Ident(
-                                                                            Ident {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 22,
+                                                                                prop: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 22,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 25,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 22..25,
+                                                                                        name: "log",
                                                                                     },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 25,
-                                                                                    },
-                                                                                },
-                                                                                span: 22..25,
-                                                                                name: "log",
+                                                                                ),
                                                                             },
                                                                         ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            args: [
-                                                                ExprOrSpread {
-                                                                    spread: None,
-                                                                    expr: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 26,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 27,
-                                                                            },
-                                                                        },
-                                                                        span: 26..27,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                    args: [
+                                                                        ExprOrSpread {
+                                                                            spread: None,
+                                                                            expr: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
@@ -175,19 +175,34 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 26..27,
-                                                                                name: "x",
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 26,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 27,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 26..27,
+                                                                                        name: "x",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
+                                                                        },
+                                                                    ],
+                                                                    type_args: None,
                                                                 },
-                                                            ],
-                                                            type_args: None,
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -199,8 +214,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 30..31,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -212,10 +227,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 30..31,
-                                                            name: "x",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 30,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 31,
+                                                                        },
+                                                                    },
+                                                                    span: 30..31,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__blocks.snap
@@ -69,7 +69,7 @@ Ok(
                                         body: Block {
                                             span: 13..27,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -81,8 +81,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 14..24,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -115,43 +115,45 @@ Ok(
                                                                 inferred_type: None,
                                                             },
                                                             type_ann: None,
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 22..23,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 22,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 22..23,
-                                                                            value: "5",
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
                                                                         },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    kind: Lit(
+                                                                        Num(
+                                                                            Num {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 22,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 22..23,
+                                                                                value: "5",
+                                                                            },
+                                                                        ),
                                                                     ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -163,8 +165,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 25..26,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -176,10 +178,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 25..26,
-                                                            name: "x",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 26,
+                                                                        },
+                                                                    },
+                                                                    span: 25..26,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-11.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__classes-11.snap
@@ -126,7 +126,7 @@ Ok(
                                         body: Block {
                                             span: 54..97,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 3,
@@ -134,40 +134,40 @@ Ok(
                                                         },
                                                         end: Position {
                                                             line: 3,
-                                                            column: 26,
+                                                            column: 27,
                                                         },
                                                     },
-                                                    span: 72..82,
-                                                    kind: Assign(
-                                                        Assign {
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 3,
-                                                                        column: 16,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 22,
-                                                                    },
+                                                    span: 72..83,
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 3,
+                                                                    column: 16,
                                                                 },
-                                                                span: 72..78,
-                                                                kind: Member(
-                                                                    Member {
-                                                                        obj: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 3,
-                                                                                    column: 16,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 3,
-                                                                                    column: 20,
-                                                                                },
+                                                                end: Position {
+                                                                    line: 3,
+                                                                    column: 26,
+                                                                },
+                                                            },
+                                                            span: 72..82,
+                                                            kind: Assign(
+                                                                Assign {
+                                                                    left: Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 3,
+                                                                                column: 16,
                                                                             },
-                                                                            span: 72..76,
-                                                                            kind: Ident(
-                                                                                Ident {
+                                                                            end: Position {
+                                                                                line: 3,
+                                                                                column: 22,
+                                                                            },
+                                                                        },
+                                                                        span: 72..78,
+                                                                        kind: Member(
+                                                                            Member {
+                                                                                obj: Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 3,
@@ -179,45 +179,45 @@ Ok(
                                                                                         },
                                                                                     },
                                                                                     span: 72..76,
-                                                                                    name: "self",
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 3,
+                                                                                                    column: 16,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 3,
+                                                                                                    column: 20,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 72..76,
+                                                                                            name: "self",
+                                                                                        },
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
-                                                                            ),
-                                                                            inferred_type: None,
-                                                                        },
-                                                                        prop: Ident(
-                                                                            Ident {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 21,
+                                                                                prop: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 3,
+                                                                                                column: 21,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 3,
+                                                                                                column: 22,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 77..78,
+                                                                                        name: "x",
                                                                                     },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 22,
-                                                                                    },
-                                                                                },
-                                                                                span: 77..78,
-                                                                                name: "x",
+                                                                                ),
                                                                             },
                                                                         ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 3,
-                                                                        column: 25,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 3,
-                                                                        column: 26,
-                                                                    },
-                                                                },
-                                                                span: 81..82,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                    right: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 3,
@@ -229,15 +229,30 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 81..82,
-                                                                        name: "x",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 25,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                },
+                                                                                span: 81..82,
+                                                                                name: "x",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            op: Eq,
+                                                                    op: Eq,
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },
@@ -336,7 +351,7 @@ Ok(
                                             body: Block {
                                                 span: 123..166,
                                                 stmts: [
-                                                    Expr {
+                                                    Statement {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 6,
@@ -344,41 +359,41 @@ Ok(
                                                             },
                                                             end: Position {
                                                                 line: 6,
-                                                                column: 26,
+                                                                column: 27,
                                                             },
                                                         },
-                                                        span: 141..151,
-                                                        kind: BinaryExpr(
-                                                            BinaryExpr {
-                                                                op: Add,
-                                                                left: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 6,
-                                                                            column: 16,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 6,
-                                                                            column: 22,
-                                                                        },
+                                                        span: 141..152,
+                                                        kind: ExprStmt(
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 6,
+                                                                        column: 16,
                                                                     },
-                                                                    span: 141..147,
-                                                                    kind: Member(
-                                                                        Member {
-                                                                            obj: Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 6,
-                                                                                        column: 16,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 6,
-                                                                                        column: 20,
-                                                                                    },
+                                                                    end: Position {
+                                                                        line: 6,
+                                                                        column: 26,
+                                                                    },
+                                                                },
+                                                                span: 141..151,
+                                                                kind: BinaryExpr(
+                                                                    BinaryExpr {
+                                                                        op: Add,
+                                                                        left: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 6,
+                                                                                    column: 16,
                                                                                 },
-                                                                                span: 141..145,
-                                                                                kind: Ident(
-                                                                                    Ident {
+                                                                                end: Position {
+                                                                                    line: 6,
+                                                                                    column: 22,
+                                                                                },
+                                                                            },
+                                                                            span: 141..147,
+                                                                            kind: Member(
+                                                                                Member {
+                                                                                    obj: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 6,
@@ -390,45 +405,45 @@ Ok(
                                                                                             },
                                                                                         },
                                                                                         span: 141..145,
-                                                                                        name: "self",
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 6,
+                                                                                                        column: 16,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 6,
+                                                                                                        column: 20,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 141..145,
+                                                                                                name: "self",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            prop: Ident(
-                                                                                Ident {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 6,
-                                                                                            column: 21,
+                                                                                    prop: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 6,
+                                                                                                    column: 21,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 6,
+                                                                                                    column: 22,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 146..147,
+                                                                                            name: "x",
                                                                                         },
-                                                                                        end: Position {
-                                                                                            line: 6,
-                                                                                            column: 22,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 146..147,
-                                                                                    name: "x",
+                                                                                    ),
                                                                                 },
                                                                             ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                right: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 6,
-                                                                            column: 25,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 6,
-                                                                            column: 26,
-                                                                        },
-                                                                    },
-                                                                    span: 150..151,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                        right: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 6,
@@ -440,14 +455,29 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 150..151,
-                                                                            name: "y",
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 6,
+                                                                                            column: 25,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 6,
+                                                                                            column: 26,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 150..151,
+                                                                                    name: "y",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
                                                         ),
-                                                        inferred_type: None,
                                                     },
                                                 ],
                                             },
@@ -552,7 +582,7 @@ Ok(
                                             body: Block {
                                                 span: 196..239,
                                                 stmts: [
-                                                    Expr {
+                                                    Statement {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 9,
@@ -560,40 +590,40 @@ Ok(
                                                             },
                                                             end: Position {
                                                                 line: 9,
-                                                                column: 26,
+                                                                column: 27,
                                                             },
                                                         },
-                                                        span: 214..224,
-                                                        kind: Assign(
-                                                            Assign {
-                                                                left: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 9,
-                                                                            column: 16,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 9,
-                                                                            column: 22,
-                                                                        },
+                                                        span: 214..225,
+                                                        kind: ExprStmt(
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 9,
+                                                                        column: 16,
                                                                     },
-                                                                    span: 214..220,
-                                                                    kind: Member(
-                                                                        Member {
-                                                                            obj: Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 9,
-                                                                                        column: 16,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 9,
-                                                                                        column: 20,
-                                                                                    },
+                                                                    end: Position {
+                                                                        line: 9,
+                                                                        column: 26,
+                                                                    },
+                                                                },
+                                                                span: 214..224,
+                                                                kind: Assign(
+                                                                    Assign {
+                                                                        left: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 9,
+                                                                                    column: 16,
                                                                                 },
-                                                                                span: 214..218,
-                                                                                kind: Ident(
-                                                                                    Ident {
+                                                                                end: Position {
+                                                                                    line: 9,
+                                                                                    column: 22,
+                                                                                },
+                                                                            },
+                                                                            span: 214..220,
+                                                                            kind: Member(
+                                                                                Member {
+                                                                                    obj: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 9,
@@ -605,45 +635,45 @@ Ok(
                                                                                             },
                                                                                         },
                                                                                         span: 214..218,
-                                                                                        name: "self",
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 9,
+                                                                                                        column: 16,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 9,
+                                                                                                        column: 20,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 214..218,
+                                                                                                name: "self",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            prop: Ident(
-                                                                                Ident {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 9,
-                                                                                            column: 21,
+                                                                                    prop: Ident(
+                                                                                        Ident {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 9,
+                                                                                                    column: 21,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 9,
+                                                                                                    column: 22,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 219..220,
+                                                                                            name: "x",
                                                                                         },
-                                                                                        end: Position {
-                                                                                            line: 9,
-                                                                                            column: 22,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 219..220,
-                                                                                    name: "x",
+                                                                                    ),
                                                                                 },
                                                                             ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                right: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 9,
-                                                                            column: 25,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 9,
-                                                                            column: 26,
-                                                                        },
-                                                                    },
-                                                                    span: 223..224,
-                                                                    kind: Ident(
-                                                                        Ident {
+                                                                        right: Expr {
                                                                             loc: SourceLocation {
                                                                                 start: Position {
                                                                                     line: 9,
@@ -655,15 +685,30 @@ Ok(
                                                                                 },
                                                                             },
                                                                             span: 223..224,
-                                                                            name: "x",
+                                                                            kind: Ident(
+                                                                                Ident {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 9,
+                                                                                            column: 25,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 9,
+                                                                                            column: 26,
+                                                                                        },
+                                                                                    },
+                                                                                    span: 223..224,
+                                                                                    name: "x",
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
                                                                         },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                op: Eq,
+                                                                        op: Eq,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
                                                         ),
-                                                        inferred_type: None,
                                                     },
                                                 ],
                                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-2.snap
@@ -141,7 +141,7 @@ Ok(
                                         body: Block {
                                             span: 18..23,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -153,23 +153,23 @@ Ok(
                                                         },
                                                     },
                                                     span: 18..23,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Add,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 18,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 19,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 18,
                                                                 },
-                                                                span: 18..19,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 23,
+                                                                },
+                                                            },
+                                                            span: 18..23,
+                                                            kind: BinaryExpr(
+                                                                BinaryExpr {
+                                                                    op: Add,
+                                                                    left: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -181,25 +181,25 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 18..19,
-                                                                        name: "a",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 18,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 19,
+                                                                                    },
+                                                                                },
+                                                                                span: 18..19,
+                                                                                name: "a",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 22..23,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                    right: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -211,14 +211,29 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 22..23,
-                                                                        name: "b",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 22,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 22..23,
+                                                                                name: "b",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-3.snap
@@ -69,7 +69,7 @@ Ok(
                                         body: Block {
                                             span: 13..27,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -81,8 +81,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 14..24,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -115,43 +115,45 @@ Ok(
                                                                 inferred_type: None,
                                                             },
                                                             type_ann: None,
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 23,
-                                                                    },
-                                                                },
-                                                                span: 22..23,
-                                                                kind: Lit(
-                                                                    Num(
-                                                                        Num {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 22,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 22..23,
-                                                                            value: "5",
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
                                                                         },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    kind: Lit(
+                                                                        Num(
+                                                                            Num {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 22,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 23,
+                                                                                    },
+                                                                                },
+                                                                                span: 22..23,
+                                                                                value: "5",
+                                                                            },
+                                                                        ),
                                                                     ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -163,8 +165,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 25..26,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -176,10 +178,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 25..26,
-                                                            name: "x",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 26,
+                                                                        },
+                                                                    },
+                                                                    span: 25..26,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-4.snap
@@ -120,7 +120,7 @@ Ok(
                                                     body: Block {
                                                         span: 12..21,
                                                         stmts: [
-                                                            Expr {
+                                                            Statement {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -132,70 +132,100 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 12..21,
-                                                                kind: Lambda(
-                                                                    Lambda {
-                                                                        params: [],
-                                                                        body: Block {
-                                                                            span: 18..21,
-                                                                            stmts: [
-                                                                                Expr {
-                                                                                    loc: SourceLocation {
-                                                                                        start: Position {
-                                                                                            line: 0,
-                                                                                            column: 18,
-                                                                                        },
-                                                                                        end: Position {
-                                                                                            line: 0,
-                                                                                            column: 21,
-                                                                                        },
-                                                                                    },
-                                                                                    span: 18..21,
-                                                                                    kind: App(
-                                                                                        App {
-                                                                                            lam: Expr {
-                                                                                                loc: SourceLocation {
-                                                                                                    start: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 18,
-                                                                                                    },
-                                                                                                    end: Position {
-                                                                                                        line: 0,
-                                                                                                        column: 19,
-                                                                                                    },
-                                                                                                },
-                                                                                                span: 18..19,
-                                                                                                kind: Ident(
-                                                                                                    Ident {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 0,
-                                                                                                                column: 18,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 0,
-                                                                                                                column: 19,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 18..19,
-                                                                                                        name: "f",
-                                                                                                    },
-                                                                                                ),
-                                                                                                inferred_type: None,
-                                                                                            },
-                                                                                            args: [],
-                                                                                            type_args: None,
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                            ],
+                                                                kind: ExprStmt(
+                                                                    Expr {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 12,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 21,
+                                                                            },
                                                                         },
-                                                                        is_async: false,
-                                                                        return_type: None,
-                                                                        type_params: None,
+                                                                        span: 12..21,
+                                                                        kind: Lambda(
+                                                                            Lambda {
+                                                                                params: [],
+                                                                                body: Block {
+                                                                                    span: 18..21,
+                                                                                    stmts: [
+                                                                                        Statement {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 18,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 21,
+                                                                                                },
+                                                                                            },
+                                                                                            span: 18..21,
+                                                                                            kind: ExprStmt(
+                                                                                                Expr {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 18,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 21,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 18..21,
+                                                                                                    kind: App(
+                                                                                                        App {
+                                                                                                            lam: Expr {
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 0,
+                                                                                                                        column: 18,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 0,
+                                                                                                                        column: 19,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                span: 18..19,
+                                                                                                                kind: Ident(
+                                                                                                                    Ident {
+                                                                                                                        loc: SourceLocation {
+                                                                                                                            start: Position {
+                                                                                                                                line: 0,
+                                                                                                                                column: 18,
+                                                                                                                            },
+                                                                                                                            end: Position {
+                                                                                                                                line: 0,
+                                                                                                                                column: 19,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        span: 18..19,
+                                                                                                                        name: "f",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                inferred_type: None,
+                                                                                                            },
+                                                                                                            args: [],
+                                                                                                            type_args: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    inferred_type: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                    ],
+                                                                                },
+                                                                                is_async: false,
+                                                                                return_type: None,
+                                                                                type_params: None,
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
                                                                 ),
-                                                                inferred_type: None,
                                                             },
                                                         ],
                                                     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__declarations-6.snap
@@ -70,7 +70,7 @@ Ok(
                                         body: Block {
                                             span: 29..118,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -82,8 +82,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 47..84,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -136,43 +136,45 @@ Ok(
                                                                     inferred_type: None,
                                                                 },
                                                             ),
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 38,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 52,
-                                                                    },
-                                                                },
-                                                                span: 69..83,
-                                                                kind: Lit(
-                                                                    Str(
-                                                                        Str {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 2,
-                                                                                    column: 38,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 2,
-                                                                                    column: 52,
-                                                                                },
-                                                                            },
-                                                                            span: 69..83,
-                                                                            value: "hello, world",
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 38,
                                                                         },
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 52,
+                                                                        },
+                                                                    },
+                                                                    span: 69..83,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 38,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 52,
+                                                                                    },
+                                                                                },
+                                                                                span: 69..83,
+                                                                                value: "hello, world",
+                                                                            },
+                                                                        ),
                                                                     ),
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 3,
@@ -184,8 +186,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 101..104,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 3,
@@ -197,10 +199,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 101..104,
-                                                            name: "msg",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 16,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 19,
+                                                                        },
+                                                                    },
+                                                                    span: 101..104,
+                                                                    name: "msg",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-6.snap
@@ -168,7 +168,7 @@ Ok(
                                         body: Block {
                                             span: 22..23,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -180,8 +180,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 22..23,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -193,10 +193,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 22..23,
-                                                            name: "a",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    name: "a",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-7.snap
@@ -227,7 +227,7 @@ Ok(
                                         body: Block {
                                             span: 40..41,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -239,8 +239,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 40..41,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -252,10 +252,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 40..41,
-                                                            name: "a",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 40,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 41,
+                                                                        },
+                                                                    },
+                                                                    span: 40..41,
+                                                                    name: "a",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-8.snap
@@ -158,7 +158,7 @@ Ok(
                                         body: Block {
                                             span: 22..23,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -170,8 +170,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 22..23,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -183,10 +183,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 22..23,
-                                                            name: "b",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 22,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                    },
+                                                                    span: 22..23,
+                                                                    name: "b",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-9.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__destructuring-9.snap
@@ -253,7 +253,7 @@ Ok(
                                         body: Block {
                                             span: 46..47,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -265,8 +265,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 46..47,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -278,10 +278,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 46..47,
-                                                            name: "b",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 46,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 47,
+                                                                        },
+                                                                    },
+                                                                    span: 46..47,
+                                                                    name: "b",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_application-6.snap
@@ -106,7 +106,7 @@ Ok(
                                         body: Block {
                                             span: 24..48,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 1,
@@ -118,27 +118,24 @@ Ok(
                                                         },
                                                     },
                                                     span: 24..48,
-                                                    kind: Lambda(
-                                                        Lambda {
-                                                            params: [
-                                                                EFnParam {
-                                                                    pat: Pattern {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 24,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 25,
-                                                                            },
-                                                                        },
-                                                                        span: 25..26,
-                                                                        kind: Ident(
-                                                                            BindingIdent {
-                                                                                name: "g",
-                                                                                mutable: false,
-                                                                                span: 25..26,
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 1,
+                                                                    column: 23,
+                                                                },
+                                                                end: Position {
+                                                                    line: 1,
+                                                                    column: 47,
+                                                                },
+                                                            },
+                                                            span: 24..48,
+                                                            kind: Lambda(
+                                                                Lambda {
+                                                                    params: [
+                                                                        EFnParam {
+                                                                            pat: Pattern {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 1,
@@ -149,100 +146,114 @@ Ok(
                                                                                         column: 25,
                                                                                     },
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    type_ann: None,
-                                                                    optional: false,
-                                                                },
-                                                            ],
-                                                            body: Block {
-                                                                span: 31..48,
-                                                                stmts: [
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 30,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 47,
-                                                                            },
-                                                                        },
-                                                                        span: 31..48,
-                                                                        kind: Lambda(
-                                                                            Lambda {
-                                                                                params: [
-                                                                                    EFnParam {
-                                                                                        pat: Pattern {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 1,
-                                                                                                    column: 31,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 1,
-                                                                                                    column: 32,
-                                                                                                },
+                                                                                span: 25..26,
+                                                                                kind: Ident(
+                                                                                    BindingIdent {
+                                                                                        name: "g",
+                                                                                        mutable: false,
+                                                                                        span: 25..26,
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 1,
+                                                                                                column: 24,
                                                                                             },
-                                                                                            span: 32..33,
-                                                                                            kind: Ident(
-                                                                                                BindingIdent {
-                                                                                                    name: "x",
-                                                                                                    mutable: false,
-                                                                                                    span: 32..33,
-                                                                                                    loc: SourceLocation {
-                                                                                                        start: Position {
-                                                                                                            line: 1,
-                                                                                                            column: 31,
-                                                                                                        },
-                                                                                                        end: Position {
-                                                                                                            line: 1,
-                                                                                                            column: 32,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                            ),
-                                                                                            inferred_type: None,
+                                                                                            end: Position {
+                                                                                                line: 1,
+                                                                                                column: 25,
+                                                                                            },
                                                                                         },
-                                                                                        type_ann: None,
-                                                                                        optional: false,
                                                                                     },
-                                                                                ],
-                                                                                body: Block {
-                                                                                    span: 38..48,
-                                                                                    stmts: [
-                                                                                        Expr {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 1,
-                                                                                                    column: 37,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 1,
-                                                                                                    column: 47,
-                                                                                                },
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                            type_ann: None,
+                                                                            optional: false,
+                                                                        },
+                                                                    ],
+                                                                    body: Block {
+                                                                        span: 31..48,
+                                                                        stmts: [
+                                                                            Statement {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 30,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 47,
+                                                                                    },
+                                                                                },
+                                                                                span: 31..48,
+                                                                                kind: ExprStmt(
+                                                                                    Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 1,
+                                                                                                column: 30,
                                                                                             },
-                                                                                            span: 38..48,
-                                                                                            kind: App(
-                                                                                                App {
-                                                                                                    lam: Expr {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 37,
+                                                                                            end: Position {
+                                                                                                line: 1,
+                                                                                                column: 47,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 31..48,
+                                                                                        kind: Lambda(
+                                                                                            Lambda {
+                                                                                                params: [
+                                                                                                    EFnParam {
+                                                                                                        pat: Pattern {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 1,
+                                                                                                                    column: 31,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 1,
+                                                                                                                    column: 32,
+                                                                                                                },
                                                                                                             },
-                                                                                                            end: Position {
-                                                                                                                line: 1,
-                                                                                                                column: 41,
-                                                                                                            },
+                                                                                                            span: 32..33,
+                                                                                                            kind: Ident(
+                                                                                                                BindingIdent {
+                                                                                                                    name: "x",
+                                                                                                                    mutable: false,
+                                                                                                                    span: 32..33,
+                                                                                                                    loc: SourceLocation {
+                                                                                                                        start: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 31,
+                                                                                                                        },
+                                                                                                                        end: Position {
+                                                                                                                            line: 1,
+                                                                                                                            column: 32,
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            inferred_type: None,
                                                                                                         },
-                                                                                                        span: 38..42,
-                                                                                                        kind: App(
-                                                                                                            App {
-                                                                                                                lam: Expr {
+                                                                                                        type_ann: None,
+                                                                                                        optional: false,
+                                                                                                    },
+                                                                                                ],
+                                                                                                body: Block {
+                                                                                                    span: 38..48,
+                                                                                                    stmts: [
+                                                                                                        Statement {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 1,
+                                                                                                                    column: 37,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 1,
+                                                                                                                    column: 47,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 38..48,
+                                                                                                            kind: ExprStmt(
+                                                                                                                Expr {
                                                                                                                     loc: SourceLocation {
                                                                                                                         start: Position {
                                                                                                                             line: 1,
@@ -250,179 +261,213 @@ Ok(
                                                                                                                         },
                                                                                                                         end: Position {
                                                                                                                             line: 1,
-                                                                                                                            column: 38,
+                                                                                                                            column: 47,
                                                                                                                         },
                                                                                                                     },
-                                                                                                                    span: 38..39,
-                                                                                                                    kind: Ident(
-                                                                                                                        Ident {
-                                                                                                                            loc: SourceLocation {
-                                                                                                                                start: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 37,
+                                                                                                                    span: 38..48,
+                                                                                                                    kind: App(
+                                                                                                                        App {
+                                                                                                                            lam: Expr {
+                                                                                                                                loc: SourceLocation {
+                                                                                                                                    start: Position {
+                                                                                                                                        line: 1,
+                                                                                                                                        column: 37,
+                                                                                                                                    },
+                                                                                                                                    end: Position {
+                                                                                                                                        line: 1,
+                                                                                                                                        column: 41,
+                                                                                                                                    },
                                                                                                                                 },
-                                                                                                                                end: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 38,
-                                                                                                                                },
+                                                                                                                                span: 38..42,
+                                                                                                                                kind: App(
+                                                                                                                                    App {
+                                                                                                                                        lam: Expr {
+                                                                                                                                            loc: SourceLocation {
+                                                                                                                                                start: Position {
+                                                                                                                                                    line: 1,
+                                                                                                                                                    column: 37,
+                                                                                                                                                },
+                                                                                                                                                end: Position {
+                                                                                                                                                    line: 1,
+                                                                                                                                                    column: 38,
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            span: 38..39,
+                                                                                                                                            kind: Ident(
+                                                                                                                                                Ident {
+                                                                                                                                                    loc: SourceLocation {
+                                                                                                                                                        start: Position {
+                                                                                                                                                            line: 1,
+                                                                                                                                                            column: 37,
+                                                                                                                                                        },
+                                                                                                                                                        end: Position {
+                                                                                                                                                            line: 1,
+                                                                                                                                                            column: 38,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    span: 38..39,
+                                                                                                                                                    name: "f",
+                                                                                                                                                },
+                                                                                                                                            ),
+                                                                                                                                            inferred_type: None,
+                                                                                                                                        },
+                                                                                                                                        args: [
+                                                                                                                                            ExprOrSpread {
+                                                                                                                                                spread: None,
+                                                                                                                                                expr: Expr {
+                                                                                                                                                    loc: SourceLocation {
+                                                                                                                                                        start: Position {
+                                                                                                                                                            line: 1,
+                                                                                                                                                            column: 39,
+                                                                                                                                                        },
+                                                                                                                                                        end: Position {
+                                                                                                                                                            line: 1,
+                                                                                                                                                            column: 40,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    span: 40..41,
+                                                                                                                                                    kind: Ident(
+                                                                                                                                                        Ident {
+                                                                                                                                                            loc: SourceLocation {
+                                                                                                                                                                start: Position {
+                                                                                                                                                                    line: 1,
+                                                                                                                                                                    column: 39,
+                                                                                                                                                                },
+                                                                                                                                                                end: Position {
+                                                                                                                                                                    line: 1,
+                                                                                                                                                                    column: 40,
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            span: 40..41,
+                                                                                                                                                            name: "x",
+                                                                                                                                                        },
+                                                                                                                                                    ),
+                                                                                                                                                    inferred_type: None,
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        ],
+                                                                                                                                        type_args: None,
+                                                                                                                                    },
+                                                                                                                                ),
+                                                                                                                                inferred_type: None,
                                                                                                                             },
-                                                                                                                            span: 38..39,
-                                                                                                                            name: "f",
+                                                                                                                            args: [
+                                                                                                                                ExprOrSpread {
+                                                                                                                                    spread: None,
+                                                                                                                                    expr: Expr {
+                                                                                                                                        loc: SourceLocation {
+                                                                                                                                            start: Position {
+                                                                                                                                                line: 1,
+                                                                                                                                                column: 42,
+                                                                                                                                            },
+                                                                                                                                            end: Position {
+                                                                                                                                                line: 1,
+                                                                                                                                                column: 46,
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        span: 43..47,
+                                                                                                                                        kind: App(
+                                                                                                                                            App {
+                                                                                                                                                lam: Expr {
+                                                                                                                                                    loc: SourceLocation {
+                                                                                                                                                        start: Position {
+                                                                                                                                                            line: 1,
+                                                                                                                                                            column: 42,
+                                                                                                                                                        },
+                                                                                                                                                        end: Position {
+                                                                                                                                                            line: 1,
+                                                                                                                                                            column: 43,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    span: 43..44,
+                                                                                                                                                    kind: Ident(
+                                                                                                                                                        Ident {
+                                                                                                                                                            loc: SourceLocation {
+                                                                                                                                                                start: Position {
+                                                                                                                                                                    line: 1,
+                                                                                                                                                                    column: 42,
+                                                                                                                                                                },
+                                                                                                                                                                end: Position {
+                                                                                                                                                                    line: 1,
+                                                                                                                                                                    column: 43,
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            span: 43..44,
+                                                                                                                                                            name: "g",
+                                                                                                                                                        },
+                                                                                                                                                    ),
+                                                                                                                                                    inferred_type: None,
+                                                                                                                                                },
+                                                                                                                                                args: [
+                                                                                                                                                    ExprOrSpread {
+                                                                                                                                                        spread: None,
+                                                                                                                                                        expr: Expr {
+                                                                                                                                                            loc: SourceLocation {
+                                                                                                                                                                start: Position {
+                                                                                                                                                                    line: 1,
+                                                                                                                                                                    column: 44,
+                                                                                                                                                                },
+                                                                                                                                                                end: Position {
+                                                                                                                                                                    line: 1,
+                                                                                                                                                                    column: 45,
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            span: 45..46,
+                                                                                                                                                            kind: Ident(
+                                                                                                                                                                Ident {
+                                                                                                                                                                    loc: SourceLocation {
+                                                                                                                                                                        start: Position {
+                                                                                                                                                                            line: 1,
+                                                                                                                                                                            column: 44,
+                                                                                                                                                                        },
+                                                                                                                                                                        end: Position {
+                                                                                                                                                                            line: 1,
+                                                                                                                                                                            column: 45,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                    span: 45..46,
+                                                                                                                                                                    name: "x",
+                                                                                                                                                                },
+                                                                                                                                                            ),
+                                                                                                                                                            inferred_type: None,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                ],
+                                                                                                                                                type_args: None,
+                                                                                                                                            },
+                                                                                                                                        ),
+                                                                                                                                        inferred_type: None,
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            ],
+                                                                                                                            type_args: None,
                                                                                                                         },
                                                                                                                     ),
                                                                                                                     inferred_type: None,
                                                                                                                 },
-                                                                                                                args: [
-                                                                                                                    ExprOrSpread {
-                                                                                                                        spread: None,
-                                                                                                                        expr: Expr {
-                                                                                                                            loc: SourceLocation {
-                                                                                                                                start: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 39,
-                                                                                                                                },
-                                                                                                                                end: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 40,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            span: 40..41,
-                                                                                                                            kind: Ident(
-                                                                                                                                Ident {
-                                                                                                                                    loc: SourceLocation {
-                                                                                                                                        start: Position {
-                                                                                                                                            line: 1,
-                                                                                                                                            column: 39,
-                                                                                                                                        },
-                                                                                                                                        end: Position {
-                                                                                                                                            line: 1,
-                                                                                                                                            column: 40,
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    span: 40..41,
-                                                                                                                                    name: "x",
-                                                                                                                                },
-                                                                                                                            ),
-                                                                                                                            inferred_type: None,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                                type_args: None,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    args: [
-                                                                                                        ExprOrSpread {
-                                                                                                            spread: None,
-                                                                                                            expr: Expr {
-                                                                                                                loc: SourceLocation {
-                                                                                                                    start: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 42,
-                                                                                                                    },
-                                                                                                                    end: Position {
-                                                                                                                        line: 1,
-                                                                                                                        column: 46,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                span: 43..47,
-                                                                                                                kind: App(
-                                                                                                                    App {
-                                                                                                                        lam: Expr {
-                                                                                                                            loc: SourceLocation {
-                                                                                                                                start: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 42,
-                                                                                                                                },
-                                                                                                                                end: Position {
-                                                                                                                                    line: 1,
-                                                                                                                                    column: 43,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            span: 43..44,
-                                                                                                                            kind: Ident(
-                                                                                                                                Ident {
-                                                                                                                                    loc: SourceLocation {
-                                                                                                                                        start: Position {
-                                                                                                                                            line: 1,
-                                                                                                                                            column: 42,
-                                                                                                                                        },
-                                                                                                                                        end: Position {
-                                                                                                                                            line: 1,
-                                                                                                                                            column: 43,
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    span: 43..44,
-                                                                                                                                    name: "g",
-                                                                                                                                },
-                                                                                                                            ),
-                                                                                                                            inferred_type: None,
-                                                                                                                        },
-                                                                                                                        args: [
-                                                                                                                            ExprOrSpread {
-                                                                                                                                spread: None,
-                                                                                                                                expr: Expr {
-                                                                                                                                    loc: SourceLocation {
-                                                                                                                                        start: Position {
-                                                                                                                                            line: 1,
-                                                                                                                                            column: 44,
-                                                                                                                                        },
-                                                                                                                                        end: Position {
-                                                                                                                                            line: 1,
-                                                                                                                                            column: 45,
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    span: 45..46,
-                                                                                                                                    kind: Ident(
-                                                                                                                                        Ident {
-                                                                                                                                            loc: SourceLocation {
-                                                                                                                                                start: Position {
-                                                                                                                                                    line: 1,
-                                                                                                                                                    column: 44,
-                                                                                                                                                },
-                                                                                                                                                end: Position {
-                                                                                                                                                    line: 1,
-                                                                                                                                                    column: 45,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            span: 45..46,
-                                                                                                                                            name: "x",
-                                                                                                                                        },
-                                                                                                                                    ),
-                                                                                                                                    inferred_type: None,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        ],
-                                                                                                                        type_args: None,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                                inferred_type: None,
-                                                                                                            },
+                                                                                                            ),
                                                                                                         },
                                                                                                     ],
-                                                                                                    type_args: None,
                                                                                                 },
-                                                                                            ),
-                                                                                            inferred_type: None,
-                                                                                        },
-                                                                                    ],
-                                                                                },
-                                                                                is_async: false,
-                                                                                return_type: None,
-                                                                                type_params: None,
+                                                                                                is_async: false,
+                                                                                                return_type: None,
+                                                                                                type_params: None,
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                ),
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
+                                                                        ],
                                                                     },
-                                                                ],
-                                                            },
-                                                            is_async: false,
-                                                            return_type: None,
-                                                            type_params: None,
+                                                                    is_async: false,
+                                                                    return_type: None,
+                                                                    type_params: None,
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },
@@ -539,7 +584,7 @@ Ok(
                                         body: Block {
                                             span: 73..81,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -551,27 +596,24 @@ Ok(
                                                         },
                                                     },
                                                     span: 73..81,
-                                                    kind: Lambda(
-                                                        Lambda {
-                                                            params: [
-                                                                EFnParam {
-                                                                    pat: Pattern {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 2,
-                                                                                column: 24,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 2,
-                                                                                column: 25,
-                                                                            },
-                                                                        },
-                                                                        span: 74..75,
-                                                                        kind: Ident(
-                                                                            BindingIdent {
-                                                                                name: "y",
-                                                                                mutable: false,
-                                                                                span: 74..75,
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 23,
+                                                                },
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 31,
+                                                                },
+                                                            },
+                                                            span: 73..81,
+                                                            kind: Lambda(
+                                                                Lambda {
+                                                                    params: [
+                                                                        EFnParam {
+                                                                            pat: Pattern {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 2,
@@ -582,31 +624,34 @@ Ok(
                                                                                         column: 25,
                                                                                     },
                                                                                 },
+                                                                                span: 74..75,
+                                                                                kind: Ident(
+                                                                                    BindingIdent {
+                                                                                        name: "y",
+                                                                                        mutable: false,
+                                                                                        span: 74..75,
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 2,
+                                                                                                column: 24,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 2,
+                                                                                                column: 25,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                    type_ann: None,
-                                                                    optional: false,
-                                                                },
-                                                            ],
-                                                            body: Block {
-                                                                span: 80..81,
-                                                                stmts: [
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 2,
-                                                                                column: 30,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 2,
-                                                                                column: 31,
-                                                                            },
+                                                                            type_ann: None,
+                                                                            optional: false,
                                                                         },
+                                                                    ],
+                                                                    body: Block {
                                                                         span: 80..81,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                        stmts: [
+                                                                            Statement {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 2,
@@ -618,19 +663,49 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 80..81,
-                                                                                name: "x",
+                                                                                kind: ExprStmt(
+                                                                                    Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 2,
+                                                                                                column: 30,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 2,
+                                                                                                column: 31,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 80..81,
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 2,
+                                                                                                        column: 30,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 2,
+                                                                                                        column: 31,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 80..81,
+                                                                                                name: "x",
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                ),
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
+                                                                        ],
                                                                     },
-                                                                ],
-                                                            },
-                                                            is_async: false,
-                                                            return_type: None,
-                                                            type_params: None,
+                                                                    is_async: false,
+                                                                    return_type: None,
+                                                                    type_params: None,
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-2.snap
@@ -36,7 +36,7 @@ Ok(
                                 body: Block {
                                     span: 6..8,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -48,25 +48,40 @@ Ok(
                                                 },
                                             },
                                             span: 6..8,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 6,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 8,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 6,
                                                         },
-                                                        span: 6..8,
-                                                        value: "10",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 8,
+                                                        },
                                                     },
-                                                ),
+                                                    span: 6..8,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 6,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 8,
+                                                                    },
+                                                                },
+                                                                span: 6..8,
+                                                                value: "10",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-3.snap
@@ -72,7 +72,7 @@ Ok(
                                 body: Block {
                                     span: 7..14,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -84,25 +84,40 @@ Ok(
                                                 },
                                             },
                                             span: 7..14,
-                                            kind: Lit(
-                                                Str(
-                                                    Str {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 7,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 14,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 7,
                                                         },
-                                                        span: 7..14,
-                                                        value: "hello",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 14,
+                                                        },
                                                     },
-                                                ),
+                                                    span: 7..14,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 7,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                },
+                                                                span: 7..14,
+                                                                value: "hello",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-4.snap
@@ -125,7 +125,7 @@ Ok(
                                 body: Block {
                                     span: 13..17,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -137,25 +137,40 @@ Ok(
                                                 },
                                             },
                                             span: 13..17,
-                                            kind: Lit(
-                                                Bool(
-                                                    Bool {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 17,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 13,
                                                         },
-                                                        span: 13..17,
-                                                        value: true,
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
                                                     },
-                                                ),
+                                                    span: 13..17,
+                                                    kind: Lit(
+                                                        Bool(
+                                                            Bool {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 13,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 17,
+                                                                    },
+                                                                },
+                                                                span: 13..17,
+                                                                value: true,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-5.snap
@@ -124,7 +124,7 @@ Ok(
                                 body: Block {
                                     span: 12..17,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -136,23 +136,23 @@ Ok(
                                                 },
                                             },
                                             span: 12..17,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
                                                         },
-                                                        span: 12..13,
-                                                        kind: Ident(
-                                                            Ident {
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 17,
+                                                        },
+                                                    },
+                                                    span: 12..17,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -164,25 +164,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 12..13,
-                                                                name: "x",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 12,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 13,
+                                                                            },
+                                                                        },
+                                                                        span: 12..13,
+                                                                        name: "x",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 16,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 17,
-                                                            },
-                                                        },
-                                                        span: 16..17,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -194,14 +194,29 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 16..17,
-                                                                name: "y",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 16,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 17,
+                                                                            },
+                                                                        },
+                                                                        span: 16..17,
+                                                                        name: "y",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-6.snap
@@ -184,7 +184,7 @@ Ok(
                                 body: Block {
                                     span: 18..23,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -196,23 +196,23 @@ Ok(
                                                 },
                                             },
                                             span: 18..23,
-                                            kind: BinaryExpr(
-                                                BinaryExpr {
-                                                    op: Add,
-                                                    left: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 18,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 19,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 18,
                                                         },
-                                                        span: 18..19,
-                                                        kind: Ident(
-                                                            Ident {
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 23,
+                                                        },
+                                                    },
+                                                    span: 18..23,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -224,25 +224,25 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 18..19,
-                                                                name: "p",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 18,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 19,
+                                                                            },
+                                                                        },
+                                                                        span: 18..19,
+                                                                        name: "p",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
-                                                    right: Expr {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 23,
-                                                            },
-                                                        },
-                                                        span: 22..23,
-                                                        kind: Ident(
-                                                            Ident {
+                                                            right: Expr {
                                                                 loc: SourceLocation {
                                                                     start: Position {
                                                                         line: 0,
@@ -254,14 +254,29 @@ Ok(
                                                                     },
                                                                 },
                                                                 span: 22..23,
-                                                                name: "q",
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 22,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 23,
+                                                                            },
+                                                                        },
+                                                                        span: 22..23,
+                                                                        name: "q",
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
                                                             },
-                                                        ),
-                                                        inferred_type: None,
-                                                    },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition-7.snap
@@ -127,7 +127,7 @@ Ok(
                                 body: Block {
                                     span: 21..22,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -139,8 +139,8 @@ Ok(
                                                 },
                                             },
                                             span: 21..22,
-                                            kind: Ident(
-                                                Ident {
+                                            kind: ExprStmt(
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -152,10 +152,25 @@ Ok(
                                                         },
                                                     },
                                                     span: 21..22,
-                                                    name: "c",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                            },
+                                                            span: 21..22,
+                                                            name: "c",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__function_definition.snap
@@ -107,7 +107,7 @@ Ok(
                                 body: Block {
                                     span: 10..11,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -119,8 +119,8 @@ Ok(
                                                 },
                                             },
                                             span: 10..11,
-                                            kind: Ident(
-                                                Ident {
+                                            kind: ExprStmt(
+                                                Expr {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -132,10 +132,25 @@ Ok(
                                                         },
                                                     },
                                                     span: 10..11,
-                                                    name: "c",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 10,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 11,
+                                                                },
+                                                            },
+                                                            span: 10..11,
+                                                            name: "c",
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
                                                 },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else-2.snap
@@ -65,7 +65,7 @@ Ok(
                                 consequent: Block {
                                     span: 7..12,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -77,25 +77,40 @@ Ok(
                                                 },
                                             },
                                             span: 9..10,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 9,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 10,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 9,
                                                         },
-                                                        span: 9..10,
-                                                        value: "5",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 10,
+                                                        },
                                                     },
-                                                ),
+                                                    span: 9..10,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 9,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 10,
+                                                                    },
+                                                                },
+                                                                span: 9..10,
+                                                                value: "5",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },
@@ -103,7 +118,7 @@ Ok(
                                     Block {
                                         span: 18..43,
                                         stmts: [
-                                            Expr {
+                                            Statement {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
@@ -115,22 +130,22 @@ Ok(
                                                     },
                                                 },
                                                 span: 18..43,
-                                                kind: IfElse(
-                                                    IfElse {
-                                                        cond: Expr {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 22,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 23,
-                                                                },
+                                                kind: ExprStmt(
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 18,
                                                             },
-                                                            span: 22..23,
-                                                            kind: Ident(
-                                                                Ident {
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 43,
+                                                            },
+                                                        },
+                                                        span: 18..43,
+                                                        kind: IfElse(
+                                                            IfElse {
+                                                                cond: Expr {
                                                                     loc: SourceLocation {
                                                                         start: Position {
                                                                             line: 0,
@@ -142,90 +157,135 @@ Ok(
                                                                         },
                                                                     },
                                                                     span: 22..23,
-                                                                    name: "b",
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        consequent: Block {
-                                                            span: 25..31,
-                                                            stmts: [
-                                                                Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 27,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 29,
-                                                                        },
-                                                                    },
-                                                                    span: 27..29,
-                                                                    kind: Lit(
-                                                                        Num(
-                                                                            Num {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 0,
-                                                                                        column: 27,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 0,
-                                                                                        column: 29,
-                                                                                    },
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 22,
                                                                                 },
-                                                                                span: 27..29,
-                                                                                value: "10",
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 23,
+                                                                                },
                                                                             },
-                                                                        ),
+                                                                            span: 22..23,
+                                                                            name: "b",
+                                                                        },
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
-                                                            ],
-                                                        },
-                                                        alternate: Some(
-                                                            Block {
-                                                                span: 37..43,
-                                                                stmts: [
-                                                                    Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 39,
+                                                                consequent: Block {
+                                                                    span: 25..31,
+                                                                    stmts: [
+                                                                        Statement {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 27,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 29,
+                                                                                },
                                                                             },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 41,
-                                                                            },
-                                                                        },
-                                                                        span: 39..41,
-                                                                        kind: Lit(
-                                                                            Num(
-                                                                                Num {
+                                                                            span: 27..29,
+                                                                            kind: ExprStmt(
+                                                                                Expr {
                                                                                     loc: SourceLocation {
                                                                                         start: Position {
                                                                                             line: 0,
-                                                                                            column: 39,
+                                                                                            column: 27,
                                                                                         },
                                                                                         end: Position {
                                                                                             line: 0,
-                                                                                            column: 41,
+                                                                                            column: 29,
                                                                                         },
                                                                                     },
-                                                                                    span: 39..41,
-                                                                                    value: "20",
+                                                                                    span: 27..29,
+                                                                                    kind: Lit(
+                                                                                        Num(
+                                                                                            Num {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 27,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 29,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 27..29,
+                                                                                                value: "10",
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    inferred_type: None,
                                                                                 },
                                                                             ),
-                                                                        ),
-                                                                        inferred_type: None,
+                                                                        },
+                                                                    ],
+                                                                },
+                                                                alternate: Some(
+                                                                    Block {
+                                                                        span: 37..43,
+                                                                        stmts: [
+                                                                            Statement {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 39,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 41,
+                                                                                    },
+                                                                                },
+                                                                                span: 39..41,
+                                                                                kind: ExprStmt(
+                                                                                    Expr {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 39,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 41,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 39..41,
+                                                                                        kind: Lit(
+                                                                                            Num(
+                                                                                                Num {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 39,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 41,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 39..41,
+                                                                                                    value: "20",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ],
                                                                     },
-                                                                ],
+                                                                ),
                                                             },
                                                         ),
+                                                        inferred_type: None,
                                                     },
                                                 ),
-                                                inferred_type: None,
                                             },
                                         ],
                                     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_else.snap
@@ -67,7 +67,7 @@ Ok(
                                 consequent: Block {
                                     span: 10..15,
                                     stmts: [
-                                        Expr {
+                                        Statement {
                                             loc: SourceLocation {
                                                 start: Position {
                                                     line: 0,
@@ -79,25 +79,40 @@ Ok(
                                                 },
                                             },
                                             span: 12..13,
-                                            kind: Lit(
-                                                Num(
-                                                    Num {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 0,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 0,
-                                                                column: 13,
-                                                            },
+                                            kind: ExprStmt(
+                                                Expr {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 12,
                                                         },
-                                                        span: 12..13,
-                                                        value: "5",
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 13,
+                                                        },
                                                     },
-                                                ),
+                                                    span: 12..13,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 13,
+                                                                    },
+                                                                },
+                                                                span: 12..13,
+                                                                value: "5",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    inferred_type: None,
+                                                },
                                             ),
-                                            inferred_type: None,
                                         },
                                     ],
                                 },
@@ -105,7 +120,7 @@ Ok(
                                     Block {
                                         span: 21..27,
                                         stmts: [
-                                            Expr {
+                                            Statement {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 0,
@@ -117,25 +132,40 @@ Ok(
                                                     },
                                                 },
                                                 span: 23..25,
-                                                kind: Lit(
-                                                    Num(
-                                                        Num {
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 0,
-                                                                    column: 23,
-                                                                },
-                                                                end: Position {
-                                                                    line: 0,
-                                                                    column: 25,
-                                                                },
+                                                kind: ExprStmt(
+                                                    Expr {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 23,
                                                             },
-                                                            span: 23..25,
-                                                            value: "10",
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 25,
+                                                            },
                                                         },
-                                                    ),
+                                                        span: 23..25,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 23,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                    },
+                                                                    span: 23..25,
+                                                                    value: "10",
+                                                                },
+                                                            ),
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 ),
-                                                inferred_type: None,
                                             },
                                         ],
                                     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let-2.snap
@@ -215,7 +215,7 @@ Ok(
                                         consequent: Block {
                                             span: 55..95,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -227,25 +227,40 @@ Ok(
                                                         },
                                                     },
                                                     span: 73..81,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 16,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 24,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 16,
                                                                 },
-                                                                span: 73..81,
-                                                                value: "object",
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 24,
+                                                                },
                                                             },
-                                                        ),
+                                                            span: 73..81,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 16,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 24,
+                                                                            },
+                                                                        },
+                                                                        span: 73..81,
+                                                                        value: "object",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },
@@ -253,7 +268,7 @@ Ok(
                                             Block {
                                                 span: 101..225,
                                                 stmts: [
-                                                    Expr {
+                                                    Statement {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 3,
@@ -265,142 +280,139 @@ Ok(
                                                             },
                                                         },
                                                         span: 101..225,
-                                                        kind: IfElse(
-                                                            IfElse {
-                                                                cond: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 23,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 57,
-                                                                        },
+                                                        kind: ExprStmt(
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 19,
                                                                     },
-                                                                    span: 105..139,
-                                                                    kind: LetExpr(
-                                                                        LetExpr {
-                                                                            pat: Pattern {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 27,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 51,
-                                                                                    },
+                                                                    end: Position {
+                                                                        line: 7,
+                                                                        column: 13,
+                                                                    },
+                                                                },
+                                                                span: 101..225,
+                                                                kind: IfElse(
+                                                                    IfElse {
+                                                                        cond: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 3,
+                                                                                    column: 23,
                                                                                 },
-                                                                                span: 109..133,
-                                                                                kind: Array(
-                                                                                    ArrayPat {
-                                                                                        elems: [
-                                                                                            Some(
-                                                                                                ArrayPatElem {
-                                                                                                    pattern: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 28,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 38,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 110..120,
-                                                                                                        kind: Is(
-                                                                                                            IsPat {
-                                                                                                                ident: BindingIdent {
-                                                                                                                    name: "a",
-                                                                                                                    mutable: false,
-                                                                                                                    span: 110..111,
-                                                                                                                    loc: SourceLocation {
-                                                                                                                        start: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 28,
-                                                                                                                        },
-                                                                                                                        end: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 29,
-                                                                                                                        },
+                                                                                end: Position {
+                                                                                    line: 3,
+                                                                                    column: 57,
+                                                                                },
+                                                                            },
+                                                                            span: 105..139,
+                                                                            kind: LetExpr(
+                                                                                LetExpr {
+                                                                                    pat: Pattern {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 3,
+                                                                                                column: 27,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 3,
+                                                                                                column: 51,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 109..133,
+                                                                                        kind: Array(
+                                                                                            ArrayPat {
+                                                                                                elems: [
+                                                                                                    Some(
+                                                                                                        ArrayPatElem {
+                                                                                                            pattern: Pattern {
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 28,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 38,
                                                                                                                     },
                                                                                                                 },
-                                                                                                                is_id: Ident {
-                                                                                                                    loc: SourceLocation {
-                                                                                                                        start: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 33,
-                                                                                                                        },
-                                                                                                                        end: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 38,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    span: 115..120,
-                                                                                                                    name: "Array",
-                                                                                                                },
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    init: None,
-                                                                                                },
-                                                                                            ),
-                                                                                            Some(
-                                                                                                ArrayPatElem {
-                                                                                                    pattern: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 40,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 41,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 122..123,
-                                                                                                        kind: Wildcard,
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    init: None,
-                                                                                                },
-                                                                                            ),
-                                                                                            Some(
-                                                                                                ArrayPatElem {
-                                                                                                    pattern: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 43,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 50,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 125..132,
-                                                                                                        kind: Rest(
-                                                                                                            RestPat {
-                                                                                                                arg: Pattern {
-                                                                                                                    loc: SourceLocation {
-                                                                                                                        start: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 46,
-                                                                                                                        },
-                                                                                                                        end: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 50,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    span: 128..132,
-                                                                                                                    kind: Ident(
-                                                                                                                        BindingIdent {
-                                                                                                                            name: "rest",
+                                                                                                                span: 110..120,
+                                                                                                                kind: Is(
+                                                                                                                    IsPat {
+                                                                                                                        ident: BindingIdent {
+                                                                                                                            name: "a",
                                                                                                                             mutable: false,
-                                                                                                                            span: 128..132,
+                                                                                                                            span: 110..111,
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 28,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 29,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        is_id: Ident {
+                                                                                                                            loc: SourceLocation {
+                                                                                                                                start: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 33,
+                                                                                                                                },
+                                                                                                                                end: Position {
+                                                                                                                                    line: 3,
+                                                                                                                                    column: 38,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            span: 115..120,
+                                                                                                                            name: "Array",
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                inferred_type: None,
+                                                                                                            },
+                                                                                                            init: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    Some(
+                                                                                                        ArrayPatElem {
+                                                                                                            pattern: Pattern {
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 40,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 41,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                span: 122..123,
+                                                                                                                kind: Wildcard,
+                                                                                                                inferred_type: None,
+                                                                                                            },
+                                                                                                            init: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    Some(
+                                                                                                        ArrayPatElem {
+                                                                                                            pattern: Pattern {
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 43,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 50,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                span: 125..132,
+                                                                                                                kind: Rest(
+                                                                                                                    RestPat {
+                                                                                                                        arg: Pattern {
                                                                                                                             loc: SourceLocation {
                                                                                                                                 start: Position {
                                                                                                                                     line: 3,
@@ -411,37 +423,40 @@ Ok(
                                                                                                                                     column: 50,
                                                                                                                                 },
                                                                                                                             },
+                                                                                                                            span: 128..132,
+                                                                                                                            kind: Ident(
+                                                                                                                                BindingIdent {
+                                                                                                                                    name: "rest",
+                                                                                                                                    mutable: false,
+                                                                                                                                    span: 128..132,
+                                                                                                                                    loc: SourceLocation {
+                                                                                                                                        start: Position {
+                                                                                                                                            line: 3,
+                                                                                                                                            column: 46,
+                                                                                                                                        },
+                                                                                                                                        end: Position {
+                                                                                                                                            line: 3,
+                                                                                                                                            column: 50,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                            inferred_type: None,
                                                                                                                         },
-                                                                                                                    ),
-                                                                                                                    inferred_type: None,
-                                                                                                                },
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                inferred_type: None,
                                                                                                             },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    init: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ],
-                                                                                        optional: false,
+                                                                                                            init: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                                optional: false,
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            expr: Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 54,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 57,
-                                                                                    },
-                                                                                },
-                                                                                span: 136..139,
-                                                                                kind: Ident(
-                                                                                    Ident {
+                                                                                    expr: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 3,
@@ -453,94 +468,139 @@ Ok(
                                                                                             },
                                                                                         },
                                                                                         span: 136..139,
-                                                                                        name: "foo",
-                                                                                    },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                consequent: Block {
-                                                                    span: 141..180,
-                                                                    stmts: [
-                                                                        Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 4,
-                                                                                    column: 16,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 4,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 159..166,
-                                                                            kind: Lit(
-                                                                                Str(
-                                                                                    Str {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 4,
-                                                                                                column: 16,
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 54,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 57,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 136..139,
+                                                                                                name: "foo",
                                                                                             },
-                                                                                            end: Position {
-                                                                                                line: 4,
-                                                                                                column: 23,
-                                                                                            },
-                                                                                        },
-                                                                                        span: 159..166,
-                                                                                        value: "array",
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
+                                                                                },
                                                                             ),
                                                                             inferred_type: None,
                                                                         },
-                                                                    ],
-                                                                },
-                                                                alternate: Some(
-                                                                    Block {
-                                                                        span: 186..225,
-                                                                        stmts: [
-                                                                            Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 6,
-                                                                                        column: 16,
+                                                                        consequent: Block {
+                                                                            span: 141..180,
+                                                                            stmts: [
+                                                                                Statement {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 4,
+                                                                                            column: 16,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 4,
+                                                                                            column: 23,
+                                                                                        },
                                                                                     },
-                                                                                    end: Position {
-                                                                                        line: 6,
-                                                                                        column: 23,
-                                                                                    },
-                                                                                },
-                                                                                span: 204..211,
-                                                                                kind: Lit(
-                                                                                    Str(
-                                                                                        Str {
+                                                                                    span: 159..166,
+                                                                                    kind: ExprStmt(
+                                                                                        Expr {
                                                                                             loc: SourceLocation {
                                                                                                 start: Position {
-                                                                                                    line: 6,
+                                                                                                    line: 4,
                                                                                                     column: 16,
                                                                                                 },
                                                                                                 end: Position {
-                                                                                                    line: 6,
+                                                                                                    line: 4,
                                                                                                     column: 23,
                                                                                                 },
                                                                                             },
-                                                                                            span: 204..211,
-                                                                                            value: "other",
+                                                                                            span: 159..166,
+                                                                                            kind: Lit(
+                                                                                                Str(
+                                                                                                    Str {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 4,
+                                                                                                                column: 16,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 4,
+                                                                                                                column: 23,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 159..166,
+                                                                                                        value: "array",
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                            inferred_type: None,
                                                                                         },
                                                                                     ),
-                                                                                ),
-                                                                                inferred_type: None,
+                                                                                },
+                                                                            ],
+                                                                        },
+                                                                        alternate: Some(
+                                                                            Block {
+                                                                                span: 186..225,
+                                                                                stmts: [
+                                                                                    Statement {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 6,
+                                                                                                column: 16,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 6,
+                                                                                                column: 23,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 204..211,
+                                                                                        kind: ExprStmt(
+                                                                                            Expr {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 6,
+                                                                                                        column: 16,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 6,
+                                                                                                        column: 23,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 204..211,
+                                                                                                kind: Lit(
+                                                                                                    Str(
+                                                                                                        Str {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 6,
+                                                                                                                    column: 16,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 6,
+                                                                                                                    column: 23,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 204..211,
+                                                                                                            value: "other",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ],
                                                                             },
-                                                                        ],
+                                                                        ),
                                                                     },
                                                                 ),
+                                                                inferred_type: None,
                                                             },
                                                         ),
-                                                        inferred_type: None,
                                                     },
                                                 ],
                                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__if_let.snap
@@ -265,7 +265,7 @@ Ok(
                                         consequent: Block {
                                             span: 57..97,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -277,25 +277,40 @@ Ok(
                                                         },
                                                     },
                                                     span: 75..83,
-                                                    kind: Lit(
-                                                        Str(
-                                                            Str {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 16,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 24,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 16,
                                                                 },
-                                                                span: 75..83,
-                                                                value: "object",
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 24,
+                                                                },
                                                             },
-                                                        ),
+                                                            span: 75..83,
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 2,
+                                                                                column: 16,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 2,
+                                                                                column: 24,
+                                                                            },
+                                                                        },
+                                                                        span: 75..83,
+                                                                        value: "object",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            inferred_type: None,
+                                                        },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },
@@ -303,7 +318,7 @@ Ok(
                                             Block {
                                                 span: 103..218,
                                                 stmts: [
-                                                    Expr {
+                                                    Statement {
                                                         loc: SourceLocation {
                                                             start: Position {
                                                                 line: 3,
@@ -315,56 +330,53 @@ Ok(
                                                             },
                                                         },
                                                         span: 103..218,
-                                                        kind: IfElse(
-                                                            IfElse {
-                                                                cond: Expr {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 3,
-                                                                            column: 23,
-                                                                        },
-                                                                        end: Position {
-                                                                            line: 3,
-                                                                            column: 48,
-                                                                        },
+                                                        kind: ExprStmt(
+                                                            Expr {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 3,
+                                                                        column: 19,
                                                                     },
-                                                                    span: 107..132,
-                                                                    kind: LetExpr(
-                                                                        LetExpr {
-                                                                            pat: Pattern {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 27,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 42,
-                                                                                    },
+                                                                    end: Position {
+                                                                        line: 7,
+                                                                        column: 13,
+                                                                    },
+                                                                },
+                                                                span: 103..218,
+                                                                kind: IfElse(
+                                                                    IfElse {
+                                                                        cond: Expr {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 3,
+                                                                                    column: 23,
                                                                                 },
-                                                                                span: 111..126,
-                                                                                kind: Array(
-                                                                                    ArrayPat {
-                                                                                        elems: [
-                                                                                            Some(
-                                                                                                ArrayPatElem {
-                                                                                                    pattern: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 28,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 29,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 112..113,
-                                                                                                        kind: Ident(
-                                                                                                            BindingIdent {
-                                                                                                                name: "a",
-                                                                                                                mutable: false,
-                                                                                                                span: 112..113,
+                                                                                end: Position {
+                                                                                    line: 3,
+                                                                                    column: 48,
+                                                                                },
+                                                                            },
+                                                                            span: 107..132,
+                                                                            kind: LetExpr(
+                                                                                LetExpr {
+                                                                                    pat: Pattern {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 3,
+                                                                                                column: 27,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 3,
+                                                                                                column: 42,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 111..126,
+                                                                                        kind: Array(
+                                                                                            ArrayPat {
+                                                                                                elems: [
+                                                                                                    Some(
+                                                                                                        ArrayPatElem {
+                                                                                                            pattern: Pattern {
                                                                                                                 loc: SourceLocation {
                                                                                                                     start: Position {
                                                                                                                         line: 3,
@@ -375,66 +387,66 @@ Ok(
                                                                                                                         column: 29,
                                                                                                                     },
                                                                                                                 },
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    init: None,
-                                                                                                },
-                                                                                            ),
-                                                                                            Some(
-                                                                                                ArrayPatElem {
-                                                                                                    pattern: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 31,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 32,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 115..116,
-                                                                                                        kind: Wildcard,
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    init: None,
-                                                                                                },
-                                                                                            ),
-                                                                                            Some(
-                                                                                                ArrayPatElem {
-                                                                                                    pattern: Pattern {
-                                                                                                        loc: SourceLocation {
-                                                                                                            start: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 34,
-                                                                                                            },
-                                                                                                            end: Position {
-                                                                                                                line: 3,
-                                                                                                                column: 41,
-                                                                                                            },
-                                                                                                        },
-                                                                                                        span: 118..125,
-                                                                                                        kind: Rest(
-                                                                                                            RestPat {
-                                                                                                                arg: Pattern {
-                                                                                                                    loc: SourceLocation {
-                                                                                                                        start: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 37,
-                                                                                                                        },
-                                                                                                                        end: Position {
-                                                                                                                            line: 3,
-                                                                                                                            column: 41,
+                                                                                                                span: 112..113,
+                                                                                                                kind: Ident(
+                                                                                                                    BindingIdent {
+                                                                                                                        name: "a",
+                                                                                                                        mutable: false,
+                                                                                                                        span: 112..113,
+                                                                                                                        loc: SourceLocation {
+                                                                                                                            start: Position {
+                                                                                                                                line: 3,
+                                                                                                                                column: 28,
+                                                                                                                            },
+                                                                                                                            end: Position {
+                                                                                                                                line: 3,
+                                                                                                                                column: 29,
+                                                                                                                            },
                                                                                                                         },
                                                                                                                     },
-                                                                                                                    span: 121..125,
-                                                                                                                    kind: Ident(
-                                                                                                                        BindingIdent {
-                                                                                                                            name: "rest",
-                                                                                                                            mutable: false,
-                                                                                                                            span: 121..125,
+                                                                                                                ),
+                                                                                                                inferred_type: None,
+                                                                                                            },
+                                                                                                            init: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    Some(
+                                                                                                        ArrayPatElem {
+                                                                                                            pattern: Pattern {
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 31,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 32,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                span: 115..116,
+                                                                                                                kind: Wildcard,
+                                                                                                                inferred_type: None,
+                                                                                                            },
+                                                                                                            init: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    Some(
+                                                                                                        ArrayPatElem {
+                                                                                                            pattern: Pattern {
+                                                                                                                loc: SourceLocation {
+                                                                                                                    start: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 34,
+                                                                                                                    },
+                                                                                                                    end: Position {
+                                                                                                                        line: 3,
+                                                                                                                        column: 41,
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                span: 118..125,
+                                                                                                                kind: Rest(
+                                                                                                                    RestPat {
+                                                                                                                        arg: Pattern {
                                                                                                                             loc: SourceLocation {
                                                                                                                                 start: Position {
                                                                                                                                     line: 3,
@@ -445,37 +457,40 @@ Ok(
                                                                                                                                     column: 41,
                                                                                                                                 },
                                                                                                                             },
+                                                                                                                            span: 121..125,
+                                                                                                                            kind: Ident(
+                                                                                                                                BindingIdent {
+                                                                                                                                    name: "rest",
+                                                                                                                                    mutable: false,
+                                                                                                                                    span: 121..125,
+                                                                                                                                    loc: SourceLocation {
+                                                                                                                                        start: Position {
+                                                                                                                                            line: 3,
+                                                                                                                                            column: 37,
+                                                                                                                                        },
+                                                                                                                                        end: Position {
+                                                                                                                                            line: 3,
+                                                                                                                                            column: 41,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                            inferred_type: None,
                                                                                                                         },
-                                                                                                                    ),
-                                                                                                                    inferred_type: None,
-                                                                                                                },
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                inferred_type: None,
                                                                                                             },
-                                                                                                        ),
-                                                                                                        inferred_type: None,
-                                                                                                    },
-                                                                                                    init: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ],
-                                                                                        optional: false,
+                                                                                                            init: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                                optional: false,
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                            expr: Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 3,
-                                                                                        column: 45,
-                                                                                    },
-                                                                                    end: Position {
-                                                                                        line: 3,
-                                                                                        column: 48,
-                                                                                    },
-                                                                                },
-                                                                                span: 129..132,
-                                                                                kind: Ident(
-                                                                                    Ident {
+                                                                                    expr: Expr {
                                                                                         loc: SourceLocation {
                                                                                             start: Position {
                                                                                                 line: 3,
@@ -487,94 +502,139 @@ Ok(
                                                                                             },
                                                                                         },
                                                                                         span: 129..132,
-                                                                                        name: "foo",
-                                                                                    },
-                                                                                ),
-                                                                                inferred_type: None,
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                    inferred_type: None,
-                                                                },
-                                                                consequent: Block {
-                                                                    span: 134..173,
-                                                                    stmts: [
-                                                                        Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 4,
-                                                                                    column: 16,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 4,
-                                                                                    column: 23,
-                                                                                },
-                                                                            },
-                                                                            span: 152..159,
-                                                                            kind: Lit(
-                                                                                Str(
-                                                                                    Str {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 4,
-                                                                                                column: 16,
+                                                                                        kind: Ident(
+                                                                                            Ident {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 45,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 3,
+                                                                                                        column: 48,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 129..132,
+                                                                                                name: "foo",
                                                                                             },
-                                                                                            end: Position {
-                                                                                                line: 4,
-                                                                                                column: 23,
-                                                                                            },
-                                                                                        },
-                                                                                        span: 152..159,
-                                                                                        value: "array",
+                                                                                        ),
+                                                                                        inferred_type: None,
                                                                                     },
-                                                                                ),
+                                                                                },
                                                                             ),
                                                                             inferred_type: None,
                                                                         },
-                                                                    ],
-                                                                },
-                                                                alternate: Some(
-                                                                    Block {
-                                                                        span: 179..218,
-                                                                        stmts: [
-                                                                            Expr {
-                                                                                loc: SourceLocation {
-                                                                                    start: Position {
-                                                                                        line: 6,
-                                                                                        column: 16,
+                                                                        consequent: Block {
+                                                                            span: 134..173,
+                                                                            stmts: [
+                                                                                Statement {
+                                                                                    loc: SourceLocation {
+                                                                                        start: Position {
+                                                                                            line: 4,
+                                                                                            column: 16,
+                                                                                        },
+                                                                                        end: Position {
+                                                                                            line: 4,
+                                                                                            column: 23,
+                                                                                        },
                                                                                     },
-                                                                                    end: Position {
-                                                                                        line: 6,
-                                                                                        column: 23,
-                                                                                    },
-                                                                                },
-                                                                                span: 197..204,
-                                                                                kind: Lit(
-                                                                                    Str(
-                                                                                        Str {
+                                                                                    span: 152..159,
+                                                                                    kind: ExprStmt(
+                                                                                        Expr {
                                                                                             loc: SourceLocation {
                                                                                                 start: Position {
-                                                                                                    line: 6,
+                                                                                                    line: 4,
                                                                                                     column: 16,
                                                                                                 },
                                                                                                 end: Position {
-                                                                                                    line: 6,
+                                                                                                    line: 4,
                                                                                                     column: 23,
                                                                                                 },
                                                                                             },
-                                                                                            span: 197..204,
-                                                                                            value: "other",
+                                                                                            span: 152..159,
+                                                                                            kind: Lit(
+                                                                                                Str(
+                                                                                                    Str {
+                                                                                                        loc: SourceLocation {
+                                                                                                            start: Position {
+                                                                                                                line: 4,
+                                                                                                                column: 16,
+                                                                                                            },
+                                                                                                            end: Position {
+                                                                                                                line: 4,
+                                                                                                                column: 23,
+                                                                                                            },
+                                                                                                        },
+                                                                                                        span: 152..159,
+                                                                                                        value: "array",
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                            inferred_type: None,
                                                                                         },
                                                                                     ),
-                                                                                ),
-                                                                                inferred_type: None,
+                                                                                },
+                                                                            ],
+                                                                        },
+                                                                        alternate: Some(
+                                                                            Block {
+                                                                                span: 179..218,
+                                                                                stmts: [
+                                                                                    Statement {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 6,
+                                                                                                column: 16,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 6,
+                                                                                                column: 23,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 197..204,
+                                                                                        kind: ExprStmt(
+                                                                                            Expr {
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 6,
+                                                                                                        column: 16,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 6,
+                                                                                                        column: 23,
+                                                                                                    },
+                                                                                                },
+                                                                                                span: 197..204,
+                                                                                                kind: Lit(
+                                                                                                    Str(
+                                                                                                        Str {
+                                                                                                            loc: SourceLocation {
+                                                                                                                start: Position {
+                                                                                                                    line: 6,
+                                                                                                                    column: 16,
+                                                                                                                },
+                                                                                                                end: Position {
+                                                                                                                    line: 6,
+                                                                                                                    column: 23,
+                                                                                                                },
+                                                                                                            },
+                                                                                                            span: 197..204,
+                                                                                                            value: "other",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                                inferred_type: None,
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ],
                                                                             },
-                                                                        ],
+                                                                        ),
                                                                     },
                                                                 ),
+                                                                inferred_type: None,
                                                             },
                                                         ),
-                                                        inferred_type: None,
                                                     },
                                                 ],
                                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__it_works.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__it_works.snap
@@ -141,7 +141,7 @@ Ok(
                                         body: Block {
                                             span: 29..34,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 1,
@@ -153,23 +153,23 @@ Ok(
                                                         },
                                                     },
                                                     span: 29..34,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Add,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 28,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 29,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 1,
+                                                                    column: 28,
                                                                 },
-                                                                span: 29..30,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                end: Position {
+                                                                    line: 1,
+                                                                    column: 33,
+                                                                },
+                                                            },
+                                                            span: 29..34,
+                                                            kind: BinaryExpr(
+                                                                BinaryExpr {
+                                                                    op: Add,
+                                                                    left: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 1,
@@ -181,25 +181,25 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 29..30,
-                                                                        name: "a",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 28,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 29,
+                                                                                    },
+                                                                                },
+                                                                                span: 29..30,
+                                                                                name: "a",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 32,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 33,
-                                                                    },
-                                                                },
-                                                                span: 33..34,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                    right: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 1,
@@ -211,14 +211,29 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 33..34,
-                                                                        name: "b",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 1,
+                                                                                        column: 32,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 1,
+                                                                                        column: 33,
+                                                                                    },
+                                                                                },
+                                                                                span: 33..34,
+                                                                                name: "b",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },
@@ -370,7 +385,7 @@ Ok(
                                         body: Block {
                                             span: 64..69,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 2,
@@ -382,23 +397,23 @@ Ok(
                                                         },
                                                     },
                                                     span: 64..69,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Sub,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 28,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 29,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 2,
+                                                                    column: 28,
                                                                 },
-                                                                span: 64..65,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                end: Position {
+                                                                    line: 2,
+                                                                    column: 33,
+                                                                },
+                                                            },
+                                                            span: 64..69,
+                                                            kind: BinaryExpr(
+                                                                BinaryExpr {
+                                                                    op: Sub,
+                                                                    left: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 2,
@@ -410,25 +425,25 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 64..65,
-                                                                        name: "a",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 28,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 29,
+                                                                                    },
+                                                                                },
+                                                                                span: 64..65,
+                                                                                name: "a",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 2,
-                                                                        column: 32,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 2,
-                                                                        column: 33,
-                                                                    },
-                                                                },
-                                                                span: 68..69,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                    right: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 2,
@@ -440,14 +455,29 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 68..69,
-                                                                        name: "b",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 32,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 33,
+                                                                                    },
+                                                                                },
+                                                                                span: 68..69,
+                                                                                name: "b",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-2.snap
@@ -267,7 +267,7 @@ Ok(
                                                 body: Block {
                                                     span: 70..78,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 2,
@@ -279,25 +279,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 70..78,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 2,
-                                                                                column: 33,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 2,
-                                                                                column: 41,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 33,
                                                                         },
-                                                                        span: 70..78,
-                                                                        value: "object",
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 41,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 70..78,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 33,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 41,
+                                                                                    },
+                                                                                },
+                                                                                span: 70..78,
+                                                                                value: "object",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -333,7 +348,7 @@ Ok(
                                                 body: Block {
                                                     span: 101..114,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 3,
@@ -345,25 +360,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 101..114,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 34,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 21,
                                                                         },
-                                                                        span: 101..114,
-                                                                        value: "fallthrough",
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 34,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 101..114,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 34,
+                                                                                    },
+                                                                                },
+                                                                                span: 101..114,
+                                                                                value: "fallthrough",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-3.snap
@@ -160,7 +160,7 @@ Ok(
                                                 body: Block {
                                                     span: 68..76,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 2,
@@ -172,25 +172,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 68..76,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 2,
-                                                                                column: 31,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 2,
-                                                                                column: 39,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 31,
                                                                         },
-                                                                        span: 68..76,
-                                                                        value: "number",
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 39,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 68..76,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 31,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 39,
+                                                                                    },
+                                                                                },
+                                                                                span: 68..76,
+                                                                                value: "number",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -309,7 +324,7 @@ Ok(
                                                 body: Block {
                                                     span: 113..120,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 3,
@@ -321,25 +336,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 113..120,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 35,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 42,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 35,
                                                                         },
-                                                                        span: 113..120,
-                                                                        value: "Array",
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 42,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 113..120,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 35,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 42,
+                                                                                    },
+                                                                                },
+                                                                                span: 113..120,
+                                                                                value: "Array",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -375,7 +405,7 @@ Ok(
                                                 body: Block {
                                                     span: 143..156,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 4,
@@ -387,25 +417,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 143..156,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 4,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 4,
-                                                                                column: 34,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 4,
+                                                                            column: 21,
                                                                         },
-                                                                        span: 143..156,
-                                                                        value: "fallthrough",
+                                                                        end: Position {
+                                                                            line: 4,
+                                                                            column: 34,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 143..156,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 4,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 4,
+                                                                                        column: 34,
+                                                                                    },
+                                                                                },
+                                                                                span: 143..156,
+                                                                                value: "fallthrough",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching-4.snap
@@ -147,7 +147,7 @@ Ok(
                                                 body: Block {
                                                     span: 58..63,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 2,
@@ -159,25 +159,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 58..63,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 2,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 2,
-                                                                                column: 26,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 21,
                                                                         },
-                                                                        span: 58..63,
-                                                                        value: "one",
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 26,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 58..63,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                },
+                                                                                span: 58..63,
+                                                                                value: "one",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -232,7 +247,7 @@ Ok(
                                                 body: Block {
                                                     span: 86..91,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 3,
@@ -244,25 +259,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 86..91,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 26,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 21,
                                                                         },
-                                                                        span: 86..91,
-                                                                        value: "two",
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 26,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 86..91,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                },
+                                                                                span: 86..91,
+                                                                                value: "two",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -396,7 +426,7 @@ Ok(
                                                 body: Block {
                                                     span: 125..130,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 4,
@@ -408,25 +438,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 125..130,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 4,
-                                                                                column: 32,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 4,
-                                                                                column: 37,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 4,
+                                                                            column: 32,
                                                                         },
-                                                                        span: 125..130,
-                                                                        value: "few",
+                                                                        end: Position {
+                                                                            line: 4,
+                                                                            column: 37,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 125..130,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 4,
+                                                                                        column: 32,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 4,
+                                                                                        column: 37,
+                                                                                    },
+                                                                                },
+                                                                                span: 125..130,
+                                                                                value: "few",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -462,7 +507,7 @@ Ok(
                                                 body: Block {
                                                     span: 153..159,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 5,
@@ -474,25 +519,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 153..159,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 5,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 5,
-                                                                                column: 27,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 5,
+                                                                            column: 21,
                                                                         },
-                                                                        span: 153..159,
-                                                                        value: "many",
+                                                                        end: Position {
+                                                                            line: 5,
+                                                                            column: 27,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 153..159,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 5,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 5,
+                                                                                        column: 27,
+                                                                                    },
+                                                                                },
+                                                                                span: 153..159,
+                                                                                value: "many",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__pattern_matching.snap
@@ -325,7 +325,7 @@ Ok(
                                                 body: Block {
                                                     span: 81..89,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 2,
@@ -337,25 +337,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 81..89,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 2,
-                                                                                column: 44,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 2,
-                                                                                column: 52,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 2,
+                                                                            column: 44,
                                                                         },
-                                                                        span: 81..89,
-                                                                        value: "object",
+                                                                        end: Position {
+                                                                            line: 2,
+                                                                            column: 52,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 81..89,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 2,
+                                                                                        column: 44,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 2,
+                                                                                        column: 52,
+                                                                                    },
+                                                                                },
+                                                                                span: 81..89,
+                                                                                value: "object",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -507,7 +522,7 @@ Ok(
                                                 body: Block {
                                                     span: 126..133,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 3,
@@ -519,25 +534,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 126..133,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 3,
-                                                                                column: 35,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 3,
-                                                                                column: 42,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 3,
+                                                                            column: 35,
                                                                         },
-                                                                        span: 126..133,
-                                                                        value: "array",
+                                                                        end: Position {
+                                                                            line: 3,
+                                                                            column: 42,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 126..133,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 3,
+                                                                                        column: 35,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 3,
+                                                                                        column: 42,
+                                                                                    },
+                                                                                },
+                                                                                span: 126..133,
+                                                                                value: "array",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -592,7 +622,7 @@ Ok(
                                                 body: Block {
                                                     span: 163..171,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 4,
@@ -604,25 +634,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 163..171,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 4,
-                                                                                column: 28,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 4,
-                                                                                column: 36,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 4,
+                                                                            column: 28,
                                                                         },
-                                                                        span: 163..171,
-                                                                        value: "string",
+                                                                        end: Position {
+                                                                            line: 4,
+                                                                            column: 36,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 163..171,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 4,
+                                                                                        column: 28,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 4,
+                                                                                        column: 36,
+                                                                                    },
+                                                                                },
+                                                                                span: 163..171,
+                                                                                value: "string",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -677,7 +722,7 @@ Ok(
                                                 body: Block {
                                                     span: 197..203,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 5,
@@ -689,25 +734,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 197..203,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 5,
-                                                                                column: 24,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 5,
-                                                                                column: 30,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 5,
+                                                                            column: 24,
                                                                         },
-                                                                        span: 197..203,
-                                                                        value: "true",
+                                                                        end: Position {
+                                                                            line: 5,
+                                                                            column: 30,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 197..203,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 5,
+                                                                                        column: 24,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 5,
+                                                                                        column: 30,
+                                                                                    },
+                                                                                },
+                                                                                span: 197..203,
+                                                                                value: "true",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -762,7 +822,7 @@ Ok(
                                                 body: Block {
                                                     span: 230..237,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 6,
@@ -774,25 +834,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 230..237,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 6,
-                                                                                column: 25,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 6,
-                                                                                column: 32,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 6,
+                                                                            column: 25,
                                                                         },
-                                                                        span: 230..237,
-                                                                        value: "false",
+                                                                        end: Position {
+                                                                            line: 6,
+                                                                            column: 32,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 230..237,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 6,
+                                                                                        column: 25,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 6,
+                                                                                        column: 32,
+                                                                                    },
+                                                                                },
+                                                                                span: 230..237,
+                                                                                value: "false",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -844,7 +919,7 @@ Ok(
                                                 body: Block {
                                                     span: 260..270,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 7,
@@ -856,25 +931,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 260..270,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 7,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 7,
-                                                                                column: 31,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 7,
+                                                                            column: 21,
                                                                         },
-                                                                        span: 260..270,
-                                                                        value: "variable",
+                                                                        end: Position {
+                                                                            line: 7,
+                                                                            column: 31,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 260..270,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 7,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 7,
+                                                                                        column: 31,
+                                                                                    },
+                                                                                },
+                                                                                span: 260..270,
+                                                                                value: "variable",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },
@@ -910,7 +1000,7 @@ Ok(
                                                 body: Block {
                                                     span: 293..303,
                                                     stmts: [
-                                                        Expr {
+                                                        Statement {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 8,
@@ -922,25 +1012,40 @@ Ok(
                                                                 },
                                                             },
                                                             span: 293..303,
-                                                            kind: Lit(
-                                                                Str(
-                                                                    Str {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 8,
-                                                                                column: 21,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 8,
-                                                                                column: 31,
-                                                                            },
+                                                            kind: ExprStmt(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 8,
+                                                                            column: 21,
                                                                         },
-                                                                        span: 293..303,
-                                                                        value: "wildcard",
+                                                                        end: Position {
+                                                                            line: 8,
+                                                                            column: 31,
+                                                                        },
                                                                     },
-                                                                ),
+                                                                    span: 293..303,
+                                                                    kind: Lit(
+                                                                        Str(
+                                                                            Str {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 8,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 8,
+                                                                                        column: 31,
+                                                                                    },
+                                                                                },
+                                                                                span: 293..303,
+                                                                                value: "wildcard",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             ),
-                                                            inferred_type: None,
                                                         },
                                                     ],
                                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions-2.snap
@@ -70,7 +70,7 @@ Ok(
                                         body: Block {
                                             span: 16..45,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -82,8 +82,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 18..40,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -116,95 +116,97 @@ Ok(
                                                                 inferred_type: None,
                                                             },
                                                             type_ann: None,
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 26,
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 26,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 39,
+                                                                        },
                                                                     },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 39,
-                                                                    },
-                                                                },
-                                                                span: 26..39,
-                                                                kind: App(
-                                                                    App {
-                                                                        lam: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 26,
+                                                                    span: 26..39,
+                                                                    kind: App(
+                                                                        App {
+                                                                            lam: Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 37,
+                                                                                    },
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 37,
-                                                                                },
-                                                                            },
-                                                                            span: 26..37,
-                                                                            kind: Member(
-                                                                                Member {
-                                                                                    obj: Expr {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 26,
+                                                                                span: 26..37,
+                                                                                kind: Member(
+                                                                                    Member {
+                                                                                        obj: Expr {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 26,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 30,
+                                                                                                },
                                                                                             },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 30,
-                                                                                            },
+                                                                                            span: 26..30,
+                                                                                            kind: Ident(
+                                                                                                Ident {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 26,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 30,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 26..30,
+                                                                                                    name: "Math",
+                                                                                                },
+                                                                                            ),
+                                                                                            inferred_type: None,
                                                                                         },
-                                                                                        span: 26..30,
-                                                                                        kind: Ident(
+                                                                                        prop: Ident(
                                                                                             Ident {
                                                                                                 loc: SourceLocation {
                                                                                                     start: Position {
                                                                                                         line: 0,
-                                                                                                        column: 26,
+                                                                                                        column: 31,
                                                                                                     },
                                                                                                     end: Position {
                                                                                                         line: 0,
-                                                                                                        column: 30,
+                                                                                                        column: 37,
                                                                                                     },
                                                                                                 },
-                                                                                                span: 26..30,
-                                                                                                name: "Math",
+                                                                                                span: 31..37,
+                                                                                                name: "random",
                                                                                             },
                                                                                         ),
-                                                                                        inferred_type: None,
                                                                                     },
-                                                                                    prop: Ident(
-                                                                                        Ident {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 31,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 37,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 31..37,
-                                                                                            name: "random",
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                            args: [],
+                                                                            type_args: None,
                                                                         },
-                                                                        args: [],
-                                                                        type_args: None,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -212,12 +214,12 @@ Ok(
                                                         },
                                                         end: Position {
                                                             line: 0,
-                                                            column: 42,
+                                                            column: 43,
                                                         },
                                                     },
-                                                    span: 41..42,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    span: 41..43,
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -229,10 +231,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 41..42,
-                                                            name: "x",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 41,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 42,
+                                                                        },
+                                                                    },
+                                                                    span: 41..42,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__rust_style_functions.snap
@@ -70,7 +70,7 @@ Ok(
                                         body: Block {
                                             span: 16..44,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -82,8 +82,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 18..40,
-                                                    kind: LetDecl(
-                                                        LetDecl {
+                                                    kind: VarDecl(
+                                                        VarDecl {
                                                             pattern: Pattern {
                                                                 loc: SourceLocation {
                                                                     start: Position {
@@ -116,95 +116,97 @@ Ok(
                                                                 inferred_type: None,
                                                             },
                                                             type_ann: None,
-                                                            init: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 26,
+                                                            init: Some(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 26,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 39,
+                                                                        },
                                                                     },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 39,
-                                                                    },
-                                                                },
-                                                                span: 26..39,
-                                                                kind: App(
-                                                                    App {
-                                                                        lam: Expr {
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 0,
-                                                                                    column: 26,
+                                                                    span: 26..39,
+                                                                    kind: App(
+                                                                        App {
+                                                                            lam: Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 26,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 37,
+                                                                                    },
                                                                                 },
-                                                                                end: Position {
-                                                                                    line: 0,
-                                                                                    column: 37,
-                                                                                },
-                                                                            },
-                                                                            span: 26..37,
-                                                                            kind: Member(
-                                                                                Member {
-                                                                                    obj: Expr {
-                                                                                        loc: SourceLocation {
-                                                                                            start: Position {
-                                                                                                line: 0,
-                                                                                                column: 26,
+                                                                                span: 26..37,
+                                                                                kind: Member(
+                                                                                    Member {
+                                                                                        obj: Expr {
+                                                                                            loc: SourceLocation {
+                                                                                                start: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 26,
+                                                                                                },
+                                                                                                end: Position {
+                                                                                                    line: 0,
+                                                                                                    column: 30,
+                                                                                                },
                                                                                             },
-                                                                                            end: Position {
-                                                                                                line: 0,
-                                                                                                column: 30,
-                                                                                            },
+                                                                                            span: 26..30,
+                                                                                            kind: Ident(
+                                                                                                Ident {
+                                                                                                    loc: SourceLocation {
+                                                                                                        start: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 26,
+                                                                                                        },
+                                                                                                        end: Position {
+                                                                                                            line: 0,
+                                                                                                            column: 30,
+                                                                                                        },
+                                                                                                    },
+                                                                                                    span: 26..30,
+                                                                                                    name: "Math",
+                                                                                                },
+                                                                                            ),
+                                                                                            inferred_type: None,
                                                                                         },
-                                                                                        span: 26..30,
-                                                                                        kind: Ident(
+                                                                                        prop: Ident(
                                                                                             Ident {
                                                                                                 loc: SourceLocation {
                                                                                                     start: Position {
                                                                                                         line: 0,
-                                                                                                        column: 26,
+                                                                                                        column: 31,
                                                                                                     },
                                                                                                     end: Position {
                                                                                                         line: 0,
-                                                                                                        column: 30,
+                                                                                                        column: 37,
                                                                                                     },
                                                                                                 },
-                                                                                                span: 26..30,
-                                                                                                name: "Math",
+                                                                                                span: 31..37,
+                                                                                                name: "random",
                                                                                             },
                                                                                         ),
-                                                                                        inferred_type: None,
                                                                                     },
-                                                                                    prop: Ident(
-                                                                                        Ident {
-                                                                                            loc: SourceLocation {
-                                                                                                start: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 31,
-                                                                                                },
-                                                                                                end: Position {
-                                                                                                    line: 0,
-                                                                                                    column: 37,
-                                                                                                },
-                                                                                            },
-                                                                                            span: 31..37,
-                                                                                            name: "random",
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                            args: [],
+                                                                            type_args: None,
                                                                         },
-                                                                        args: [],
-                                                                        type_args: None,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                            ),
+                                                            declare: false,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -216,8 +218,8 @@ Ok(
                                                         },
                                                     },
                                                     span: 41..42,
-                                                    kind: Ident(
-                                                        Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
                                                             loc: SourceLocation {
                                                                 start: Position {
                                                                     line: 0,
@@ -229,10 +231,25 @@ Ok(
                                                                 },
                                                             },
                                                             span: 41..42,
-                                                            name: "x",
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 41,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 42,
+                                                                        },
+                                                                    },
+                                                                    span: 41..42,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__tuples-4.snap
@@ -70,7 +70,7 @@ Ok(
                                         body: Block {
                                             span: 16..22,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -82,25 +82,25 @@ Ok(
                                                         },
                                                     },
                                                     span: 16..22,
-                                                    kind: Tuple(
-                                                        Tuple {
-                                                            elems: [
-                                                                ExprOrSpread {
-                                                                    spread: None,
-                                                                    expr: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 17,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 18,
-                                                                            },
-                                                                        },
-                                                                        span: 17..18,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 16,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 22,
+                                                                },
+                                                            },
+                                                            span: 16..22,
+                                                            kind: Tuple(
+                                                                Tuple {
+                                                                    elems: [
+                                                                        ExprOrSpread {
+                                                                            spread: None,
+                                                                            expr: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
@@ -112,28 +112,28 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 17..18,
-                                                                                name: "a",
-                                                                            },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                },
-                                                                ExprOrSpread {
-                                                                    spread: None,
-                                                                    expr: Expr {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 0,
-                                                                                column: 20,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 0,
-                                                                                column: 21,
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 17,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 18,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 17..18,
+                                                                                        name: "a",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
                                                                         },
-                                                                        span: 20..21,
-                                                                        kind: Ident(
-                                                                            Ident {
+                                                                        ExprOrSpread {
+                                                                            spread: None,
+                                                                            expr: Expr {
                                                                                 loc: SourceLocation {
                                                                                     start: Position {
                                                                                         line: 0,
@@ -145,16 +145,31 @@ Ok(
                                                                                     },
                                                                                 },
                                                                                 span: 20..21,
-                                                                                name: "b",
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 20,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 21,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 20..21,
+                                                                                        name: "b",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
+                                                                        },
+                                                                    ],
                                                                 },
-                                                            ],
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__type_annotations-3.snap
@@ -181,7 +181,7 @@ Ok(
                                         body: Block {
                                             span: 44..49,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -193,23 +193,23 @@ Ok(
                                                         },
                                                     },
                                                     span: 44..49,
-                                                    kind: BinaryExpr(
-                                                        BinaryExpr {
-                                                            op: Add,
-                                                            left: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 44,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 45,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 44,
                                                                 },
-                                                                span: 44..45,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 49,
+                                                                },
+                                                            },
+                                                            span: 44..49,
+                                                            kind: BinaryExpr(
+                                                                BinaryExpr {
+                                                                    op: Add,
+                                                                    left: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -221,25 +221,25 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 44..45,
-                                                                        name: "a",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 44,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 45,
+                                                                                    },
+                                                                                },
+                                                                                span: 44..45,
+                                                                                name: "a",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            right: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 48,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 49,
-                                                                    },
-                                                                },
-                                                                span: 48..49,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                    right: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -251,14 +251,29 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 48..49,
-                                                                        name: "b",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 48,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 49,
+                                                                                    },
+                                                                                },
+                                                                                span: 48..49,
+                                                                                name: "b",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
+                                                                },
+                                                            ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__tests__types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__tests__types.snap
@@ -150,7 +150,7 @@ Ok(
                                         body: Block {
                                             span: 34..41,
                                             stmts: [
-                                                Expr {
+                                                Statement {
                                                     loc: SourceLocation {
                                                         start: Position {
                                                             line: 0,
@@ -162,22 +162,22 @@ Ok(
                                                         },
                                                     },
                                                     span: 34..41,
-                                                    kind: Member(
-                                                        Member {
-                                                            obj: Expr {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 0,
-                                                                        column: 34,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 0,
-                                                                        column: 37,
-                                                                    },
+                                                    kind: ExprStmt(
+                                                        Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 34,
                                                                 },
-                                                                span: 34..37,
-                                                                kind: Ident(
-                                                                    Ident {
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 41,
+                                                                },
+                                                            },
+                                                            span: 34..41,
+                                                            kind: Member(
+                                                                Member {
+                                                                    obj: Expr {
                                                                         loc: SourceLocation {
                                                                             start: Position {
                                                                                 line: 0,
@@ -189,30 +189,45 @@ Ok(
                                                                             },
                                                                         },
                                                                         span: 34..37,
-                                                                        name: "foo",
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 34,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 37,
+                                                                                    },
+                                                                                },
+                                                                                span: 34..37,
+                                                                                name: "foo",
+                                                                            },
+                                                                        ),
+                                                                        inferred_type: None,
                                                                     },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                            prop: Ident(
-                                                                Ident {
-                                                                    loc: SourceLocation {
-                                                                        start: Position {
-                                                                            line: 0,
-                                                                            column: 38,
+                                                                    prop: Ident(
+                                                                        Ident {
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 38,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 41,
+                                                                                },
+                                                                            },
+                                                                            span: 38..41,
+                                                                            name: "bar",
                                                                         },
-                                                                        end: Position {
-                                                                            line: 0,
-                                                                            column: 41,
-                                                                        },
-                                                                    },
-                                                                    span: 38..41,
-                                                                    name: "bar",
+                                                                    ),
                                                                 },
                                                             ),
+                                                            inferred_type: None,
                                                         },
                                                     ),
-                                                    inferred_type: None,
                                                 },
                                             ],
                                         },


### PR DESCRIPTION
This will allow us to support new statements like `for` loops in the future.