### PR TITLE
Dedupe code in js codegen and other misc cleanup

### DIFF
--- a/crates/escalier_codegen/src/js.rs
+++ b/crates/escalier_codegen/src/js.rs
@@ -723,9 +723,13 @@ fn build_expr(expr: &values::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> 
     }
 }
 
+// NOTE: If an identifier has been specified in `assign_id` the last statement
+// in the block will assign the final expression to that identifier.  If it's
+// `None`, the last statement will be an actual return statement returning the
+// final expression.
 fn build_body_block_stmt(
     body: &values::Block,
-    ret_id: Option<&Ident>,
+    assign_id: Option<&Ident>,
     ctx: &mut Context,
 ) -> BlockStmt {
     let mut new_stmts: Vec<Stmt> = vec![];
@@ -751,7 +755,7 @@ fn build_body_block_stmt(
                 let expr = build_expr(expr, &mut new_stmts, ctx);
 
                 if i == len - 1 {
-                    let stmt = match ret_id {
+                    let stmt = match assign_id {
                         Some(ret_id) => {
                             let expr = Box::from(Expr::Assign(AssignExpr {
                                 span: DUMMY_SP,
@@ -790,7 +794,7 @@ fn build_body_block_stmt(
             sym: swc_atoms::JsWord::from(String::from("undefined")),
             optional: false,
         });
-        let stmt = match ret_id {
+        let stmt = match assign_id {
             Some(ret_id) => {
                 let expr = Box::from(Expr::Assign(AssignExpr {
                     span: DUMMY_SP,

--- a/crates/escalier_infer/src/scheme.rs
+++ b/crates/escalier_infer/src/scheme.rs
@@ -104,7 +104,7 @@ pub fn instantiate(ctx: &Context, sc: &Scheme) -> Type {
     replace_aliases_rec(&sc.t, &type_param_map)
 }
 
-pub fn instantiate_gen_lam(ctx: &Context, lam: &TLam, type_args: &Option<Vec<Type>>) -> TLam {
+pub fn instantiate_gen_lam(ctx: &Context, lam: &TLam, type_args: Option<&Vec<Type>>) -> TLam {
     if lam.type_params.is_none() {
         return lam.to_owned();
     }
@@ -492,7 +492,7 @@ mod tests {
             }))),
         };
 
-        let lam = instantiate_gen_lam(&ctx, &gen_lam, &None);
+        let lam = instantiate_gen_lam(&ctx, &gen_lam, None);
 
         assert_eq!(lam.to_string(), "(a: t1, b: t2) => t1");
     }

--- a/crates/escalier_infer/src/unify.rs
+++ b/crates/escalier_infer/src/unify.rs
@@ -161,7 +161,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &mut Context) -> Result<Subst, Vec<TypeE
         // NOTE: this arm is only hit by the `infer_skk` test case
         (TypeKind::Lam(_), TypeKind::App(_)) => unify(t2, t1, ctx),
         (TypeKind::App(app), TypeKind::Lam(lam)) => {
-            let lam = instantiate_gen_lam(ctx, lam, &app.type_args);
+            let lam = instantiate_gen_lam(ctx, lam, app.type_args.as_ref());
             let mut s = Subst::new();
 
             let maybe_rest_param = if let Some(param) = lam.params.last() {


### PR DESCRIPTION
I also changed some `&Option<T>`s to `Option<&T>`s.