### PR TITLE
Add current_scope/parent_scopes to Checker struct

### DIFF
--- a/crates/escalier_cli/tests/integration_test.rs
+++ b/crates/escalier_cli/tests/integration_test.rs
@@ -9,12 +9,11 @@ pub fn messages(report: &[TypeError]) -> Vec<String> {
 }
 
 fn infer(input: &str) -> String {
-    let mut ctx = escalier_infer::Context::default();
     let prog = parse(input).unwrap();
     let mut stmt = prog.body.get(0).unwrap().to_owned();
-    let mut checker = Checker {};
+    let mut checker = Checker::default();
     let result = match &stmt.kind {
-        StmtKind::ExprStmt(_) => checker.infer_stmt(&mut stmt, &mut ctx, true),
+        StmtKind::ExprStmt(_) => checker.infer_stmt(&mut stmt, true),
         _ => Err(vec![TypeError::Unspecified]),
     };
     match result {

--- a/crates/escalier_codegen/tests/codegen_test.rs
+++ b/crates/escalier_codegen/tests/codegen_test.rs
@@ -457,7 +457,7 @@ fn destructuring_function_object_params() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @r###"
@@ -480,7 +480,7 @@ fn destructuring_function_array_params() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const foo: ([a, b]: readonly [number, number]) => number;
@@ -499,7 +499,7 @@ fn function_with_rest_param() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const foo: (x: number, ...y: readonly number[]) => number;
@@ -518,7 +518,7 @@ fn function_with_optional_param() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const foo: (x: number, y?: number) => number;
@@ -537,7 +537,7 @@ fn function_with_optional_param_and_rest_param() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const foo: (x?: number, ...y: readonly number[]) => number | undefined;
@@ -556,7 +556,7 @@ fn generic_function() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const fst: <A>(a: A, b: A) => A;
@@ -575,7 +575,7 @@ fn constrained_generic_function() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const fst: <A extends number | string>(a: A, b: A) => A;
@@ -599,7 +599,7 @@ fn variable_declaration_with_destructuring() {
     // TODO: Support destructuring in top-level decls
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @r###"
@@ -698,7 +698,7 @@ fn mutable_array() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const arr: number[];
@@ -713,7 +713,7 @@ fn mutable_obj() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     // This should be:
@@ -739,7 +739,7 @@ fn mutable_indexer() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @r###"
@@ -809,7 +809,7 @@ fn for_of_loop() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @r###"export declare const sum: number;
@@ -841,7 +841,7 @@ fn for_loop_inside_fn() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const sum: (arr: readonly number[]) => number;
@@ -872,7 +872,7 @@ fn type_decl_inside_block() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const result: number;
@@ -903,7 +903,7 @@ fn type_decl_inside_block_with_escape() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     // TODO: How do we ensure that types defined within a block can't escape?
@@ -944,7 +944,7 @@ fn class_inside_function() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const foo: () => Point;
@@ -1005,7 +1005,7 @@ fn multiple_returns_stress_test() {
 
     let mut program = parse(src).unwrap();
     let mut ctx = Context::default();
-    infer_prog(&mut program, &mut ctx).unwrap();
+    let ctx = infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @"export declare const foo: (cond: boolean) => 10 | 5;

--- a/crates/escalier_infer/src/checker.rs
+++ b/crates/escalier_infer/src/checker.rs
@@ -1,1 +1,20 @@
-pub struct Checker {}
+use crate::context::Context;
+
+#[derive(Default)]
+pub struct Checker {
+    pub current_scope: Context,
+    pub parent_scopes: Vec<Context>,
+}
+
+impl Checker {
+    pub fn push_scope(&mut self) {
+        self.parent_scopes.push(self.current_scope.to_owned());
+        self.current_scope = self.current_scope.clone();
+    }
+
+    pub fn pop_scope(&mut self) {
+        let mut parent_scope = self.parent_scopes.pop().unwrap();
+        parent_scope.count = self.current_scope.count.clone();
+        self.current_scope = parent_scope;
+    }
+}

--- a/crates/escalier_infer/src/checker.rs
+++ b/crates/escalier_infer/src/checker.rs
@@ -3,13 +3,42 @@ use crate::context::Context;
 #[derive(Default)]
 pub struct Checker {
     pub current_scope: Context,
-    pub parent_scopes: Vec<Context>,
+    parent_scopes: Vec<Context>,
+}
+
+impl From<Context> for Checker {
+    fn from(ctx: Context) -> Self {
+        Checker {
+            current_scope: ctx,
+            parent_scopes: vec![],
+        }
+    }
+}
+
+pub enum ScopeKind {
+    Inherit,
+    Async,
+    Sync,
+}
+
+impl From<bool> for ScopeKind {
+    fn from(is_async: bool) -> Self {
+        match is_async {
+            true => ScopeKind::Async,
+            false => ScopeKind::Sync,
+        }
+    }
 }
 
 impl Checker {
-    pub fn push_scope(&mut self) {
+    pub fn push_scope(&mut self, scope_kind: ScopeKind) {
         self.parent_scopes.push(self.current_scope.to_owned());
         self.current_scope = self.current_scope.clone();
+        match scope_kind {
+            ScopeKind::Inherit => (),
+            ScopeKind::Async => self.current_scope.is_async = true,
+            ScopeKind::Sync => self.current_scope.is_async = false,
+        }
     }
 
     pub fn pop_scope(&mut self) {

--- a/crates/escalier_infer/src/context.rs
+++ b/crates/escalier_infer/src/context.rs
@@ -125,16 +125,16 @@ impl Context {
         Err(vec![TypeError::CantFindIdent(name.to_owned())])
     }
 
-    pub fn fresh_id(&self) -> i32 {
+    fn fresh_id(&self) -> i32 {
         let id = self.count.get() + 1;
         self.count.set(id);
         id
     }
 
-    pub fn fresh_var(&self) -> Type {
+    pub fn fresh_var(&self, constraint: Option<Box<Type>>) -> Type {
         Type::from(TypeKind::Var(TVar {
             id: self.fresh_id(),
-            constraint: None,
+            constraint,
         }))
     }
 }

--- a/crates/escalier_infer/src/infer_class.rs
+++ b/crates/escalier_infer/src/infer_class.rs
@@ -2,7 +2,7 @@ use escalier_ast::types::*;
 use escalier_ast::values::{class::*, Lambda, PatternKind};
 use im::hashmap::HashMap;
 
-use crate::context::{Binding, Context};
+use crate::context::Binding;
 use crate::scheme::Scheme;
 use crate::substitutable::{Subst, Substitutable};
 use crate::type_error::TypeError;
@@ -15,12 +15,8 @@ fn is_promise(t: &Type) -> bool {
 }
 
 impl Checker {
-    pub fn infer_class(
-        &mut self,
-        ctx: &mut Context,
-        class: &mut Class,
-    ) -> Result<(Subst, Type), Vec<TypeError>> {
-        let interface = self.infer_interface_from_class(ctx, class)?;
+    pub fn infer_class(&mut self, class: &mut Class) -> Result<(Subst, Type), Vec<TypeError>> {
+        let interface = self.infer_interface_from_class(class)?;
 
         let class_name = class.ident.name.to_owned();
 
@@ -30,8 +26,8 @@ impl Checker {
         for member in &mut class.body {
             match member {
                 ClassMember::Constructor(Constructor { params, body }) => {
-                    let mut new_ctx = ctx.clone();
-                    new_ctx.is_async = false; // Constructors cannot be async
+                    self.push_scope();
+                    self.current_scope.is_async = false; // Constructors cannot be async
 
                     // Constructors can't have type parameters.
                     let type_params_map = HashMap::default();
@@ -39,7 +35,7 @@ impl Checker {
                     let mut iter = params.iter_mut();
                     iter.next(); // skip `self`
                     let params: Result<Vec<(Subst, TFnParam)>, Vec<TypeError>> = iter
-                        .map(|e_param| self.infer_fn_param(e_param, &mut new_ctx, &type_params_map))
+                        .map(|e_param| self.infer_fn_param(e_param, &type_params_map))
                         .collect();
                     let (mut ss, t_params): (Vec<_>, Vec<_>) = params?.iter().cloned().unzip();
 
@@ -50,11 +46,12 @@ impl Checker {
                         mutable: false, // this should be false since we don't want to allow `self` to be re-assigned
                         t: interface_t,
                     };
-                    new_ctx.insert_binding("self".to_string(), binding);
-                    let (body_s, _body_t) = self.infer_block(body, &mut new_ctx)?;
+                    self.current_scope
+                        .insert_binding("self".to_string(), binding);
+                    let (body_s, _body_t) = self.infer_block(body)?;
                     ss.push(body_s);
 
-                    ctx.count = new_ctx.count;
+                    self.pop_scope();
 
                     let type_args = class.type_params.as_ref().map(|type_params| {
                         type_params
@@ -110,8 +107,8 @@ impl Checker {
                         type_params,
                     } = lambda;
 
-                    let mut new_ctx = ctx.clone();
-                    new_ctx.is_async = is_async.to_owned();
+                    self.push_scope();
+                    self.current_scope.is_async = is_async.to_owned();
 
                     // TODO: aggregate method type params with class type params
                     // This maps type params to type refs with the same name.
@@ -123,7 +120,8 @@ impl Checker {
                                     name: param.name.name.to_owned(),
                                     type_args: None,
                                 }));
-                                new_ctx.insert_type(param.name.name.clone(), t.clone());
+                                self.current_scope
+                                    .insert_type(param.name.name.clone(), t.clone());
                                 Ok((param.name.name.to_owned(), t))
                             })
                             .collect::<Result<HashMap<String, Type>, Vec<TypeError>>>()?,
@@ -148,7 +146,7 @@ impl Checker {
                                 return Err(vec![TypeError::MethodsMustHaveTypes]);
                             }
 
-                            self.infer_fn_param(e_param, &mut new_ctx, &type_params_map)
+                            self.infer_fn_param(e_param, &type_params_map)
                         })
                         .collect();
                     let (mut ss, t_params): (Vec<_>, Vec<_>) = params?.iter().cloned().unzip();
@@ -159,12 +157,13 @@ impl Checker {
                         mutable: false, // this should be false since we don't want to allow `self` to be re-assigned
                         t: interface_t,
                     };
-                    new_ctx.insert_binding("self".to_string(), binding);
+                    self.current_scope
+                        .insert_binding("self".to_string(), binding);
 
-                    let (body_s, mut body_t) = self.infer_block_or_expr(body, &mut new_ctx)?;
+                    let (body_s, mut body_t) = self.infer_block_or_expr(body)?;
                     ss.push(body_s);
 
-                    ctx.count = new_ctx.count;
+                    self.pop_scope();
 
                     if *is_async && !is_promise(&body_t) {
                         body_t = Type::from(TypeKind::Ref(TRef {
@@ -175,9 +174,9 @@ impl Checker {
 
                     if let Some(ret_type_ann) = return_type {
                         let (ret_s, ret_t) =
-                            self.infer_type_ann_with_params(ret_type_ann, ctx, &type_params_map)?;
+                            self.infer_type_ann_with_params(ret_type_ann, &type_params_map)?;
                         ss.push(ret_s);
-                        ss.push(self.unify(&body_t, &ret_t, ctx)?);
+                        ss.push(self.unify(&body_t, &ret_t)?);
                     } else if kind != &MethodKind::Setter {
                         return Err(vec![TypeError::MethodsMustHaveTypes]);
                     }
@@ -188,11 +187,8 @@ impl Checker {
                         MethodKind::Method => {
                             let ret_t = match &mut lambda.return_type {
                                 Some(type_ann) => {
-                                    let (s, t) = self.infer_type_ann_with_params(
-                                        type_ann,
-                                        ctx,
-                                        &type_params_map,
-                                    )?;
+                                    let (s, t) = self
+                                        .infer_type_ann_with_params(type_ann, &type_params_map)?;
                                     ss.push(s);
                                     t
                                 }
@@ -223,7 +219,7 @@ impl Checker {
                         MethodKind::Getter => {
                             let ret_t = match &mut lambda.return_type {
                                 Some(type_ann) => {
-                                    let (s, t) = self.infer_type_ann(type_ann, ctx, type_params)?;
+                                    let (s, t) = self.infer_type_ann(type_ann, type_params)?;
                                     ss.push(s);
                                     t
                                 }
@@ -271,12 +267,12 @@ impl Checker {
                     // as part of the class declaration b/c it doesn't make sense
                     // to assign them in the constructor.
                     let (_s, t) = if let Some(type_ann) = type_ann {
-                        self.infer_type_ann(type_ann, ctx, &mut None)?
+                        self.infer_type_ann(type_ann, &mut None)?
                     } else if let Some(value) = value {
-                        self.infer_expr(ctx, value, false)?
+                        self.infer_expr(value, false)?
                     } else {
                         return Err(vec![TypeError::PropertiesMustHaveTypes]);
-                        // (Subst::default(), ctx.fresh_var())
+                        // (Subst::default(), self.current_scope.fresh_var())
                     };
 
                     let elem = TObjElem::Prop(TProp {
@@ -322,7 +318,7 @@ impl Checker {
             type_params,
         };
         eprintln!("infer_class, scheme = {scheme}");
-        ctx.insert_scheme(class_name, scheme);
+        self.current_scope.insert_scheme(class_name, scheme);
 
         // TODO: capture all of the subsitutions and return them
         let s = Subst::default();
@@ -332,11 +328,7 @@ impl Checker {
         Ok((s, statics_t))
     }
 
-    fn infer_interface_from_class(
-        &mut self,
-        ctx: &mut Context,
-        class: &mut Class,
-    ) -> Result<Scheme, Vec<TypeError>> {
+    fn infer_interface_from_class(&mut self, class: &mut Class) -> Result<Scheme, Vec<TypeError>> {
         let mut instance_elems: Vec<TObjElem> = vec![];
 
         for member in &mut class.body {
@@ -370,7 +362,8 @@ impl Checker {
                                     name: param.name.name.to_owned(),
                                     type_args: None,
                                 }));
-                                ctx.insert_type(param.name.name.clone(), t.clone());
+                                self.current_scope
+                                    .insert_type(param.name.name.clone(), t.clone());
                                 Ok((param.name.name.to_owned(), t))
                             })
                             .collect::<Result<HashMap<String, Type>, Vec<TypeError>>>()?,
@@ -388,18 +381,19 @@ impl Checker {
                         }
                     }
 
-                    // We create a new Context here so that bindings inferred from
-                    // function params aren't added to the current context.
-                    let mut new_ctx = ctx.clone();
+                    // We create a new Scope here so that bindings inferred from
+                    // function params aren't added to the current scope.
+                    self.push_scope();
                     let params: Result<Vec<(Subst, TFnParam)>, Vec<TypeError>> = iter
                         .map(|e_param| {
                             if e_param.type_ann.is_none() {
                                 return Err(vec![TypeError::MethodsMustHaveTypes]);
                             }
 
-                            self.infer_fn_param(e_param, &mut new_ctx, &type_params_map)
+                            self.infer_fn_param(e_param, &type_params_map)
                         })
                         .collect();
+                    self.pop_scope();
                     let (mut ss, t_params): (Vec<_>, Vec<_>) = params?.iter().cloned().unzip();
 
                     let name = TPropKey::StringKey(key.name.to_owned());
@@ -408,11 +402,8 @@ impl Checker {
                         MethodKind::Method => {
                             let ret_t = match &mut lambda.return_type {
                                 Some(type_ann) => {
-                                    let (s, t) = self.infer_type_ann_with_params(
-                                        type_ann,
-                                        ctx,
-                                        &type_params_map,
-                                    )?;
+                                    let (s, t) = self
+                                        .infer_type_ann_with_params(type_ann, &type_params_map)?;
                                     ss.push(s);
                                     t
                                 }
@@ -443,7 +434,7 @@ impl Checker {
                         MethodKind::Getter => {
                             let ret_t = match &mut lambda.return_type {
                                 Some(type_ann) => {
-                                    let (s, t) = self.infer_type_ann(type_ann, ctx, type_params)?;
+                                    let (s, t) = self.infer_type_ann(type_ann, type_params)?;
                                     ss.push(s);
                                     t
                                 }
@@ -493,12 +484,12 @@ impl Checker {
                     // as part of the class declaration b/c it doesn't make sense
                     // to assign them in the constructor.
                     let (_s, t) = if let Some(type_ann) = type_ann {
-                        self.infer_type_ann(type_ann, ctx, &mut None)?
+                        self.infer_type_ann(type_ann, &mut None)?
                     } else if let Some(value) = value {
-                        self.infer_expr(ctx, value, false)?
+                        self.infer_expr(value, false)?
                     } else {
                         return Err(vec![TypeError::PropertiesMustHaveTypes]);
-                        // (Subst::default(), ctx.fresh_var())
+                        // (Subst::default(), self.current_scope.fresh_var())
                     };
 
                     let elem = TObjElem::Prop(TProp {

--- a/crates/escalier_infer/src/infer_expr.rs
+++ b/crates/escalier_infer/src/infer_expr.rs
@@ -7,7 +7,6 @@ use escalier_ast::types::{
 };
 use escalier_ast::values::*;
 
-use crate::context::Context;
 use crate::infer_pattern::PatternUsage;
 use crate::scheme::get_type_param_map;
 use crate::substitutable::{Subst, Substitutable};
@@ -19,7 +18,6 @@ use crate::checker::Checker;
 impl Checker {
     pub fn infer_expr(
         &mut self,
-        ctx: &mut Context,
         expr: &mut Expr,
         is_lvalue: bool,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
@@ -32,11 +30,11 @@ impl Checker {
                 let mut ss: Vec<Subst> = vec![];
                 let mut arg_types: Vec<Type> = vec![];
 
-                let (s1, lam_type) = self.infer_expr(ctx, lam, false)?;
+                let (s1, lam_type) = self.infer_expr(lam, false)?;
                 ss.push(s1);
 
                 for arg in args {
-                    let (arg_s, mut arg_t) = self.infer_expr(ctx, &mut arg.expr, false)?;
+                    let (arg_s, mut arg_t) = self.infer_expr(&mut arg.expr, false)?;
                     ss.push(arg_s);
                     if arg.spread.is_some() {
                         match &mut arg_t.kind {
@@ -48,12 +46,12 @@ impl Checker {
                     }
                 }
 
-                let ret_type = ctx.fresh_var();
+                let ret_type = self.current_scope.fresh_var();
                 let type_args = match type_args {
                     Some(type_args) => {
                         let tuples = type_args
                             .iter_mut()
-                            .map(|type_arg| self.infer_type_ann(type_arg, ctx, &mut None))
+                            .map(|type_arg| self.infer_type_ann(type_arg, &mut None))
                             .collect::<Result<Vec<_>, _>>()?;
                         let (mut subs, types): (Vec<_>, Vec<_>) = tuples.iter().cloned().unzip();
                         ss.append(&mut subs);
@@ -73,7 +71,7 @@ impl Checker {
                 call_type.provenance =
                     Some(Box::from(Provenance::Expr(Box::from(expr.to_owned()))));
 
-                let s3 = self.unify(&call_type, &lam_type, ctx)?;
+                let s3 = self.unify(&call_type, &lam_type)?;
 
                 ss.push(s3);
 
@@ -91,12 +89,12 @@ impl Checker {
                 let mut ss: Vec<Subst> = vec![];
                 let mut arg_types: Vec<Type> = vec![];
 
-                let (s1, t) = self.infer_expr(ctx, expr, false)?;
+                let (s1, t) = self.infer_expr(expr, false)?;
                 ss.push(s1);
-                let t = self.get_obj_type(&t, ctx)?;
+                let t = self.get_obj_type(&t)?;
 
                 for arg in args {
-                    let (arg_s, mut arg_t) = self.infer_expr(ctx, &mut arg.expr, false)?;
+                    let (arg_s, mut arg_t) = self.infer_expr(&mut arg.expr, false)?;
                     ss.push(arg_s);
                     if arg.spread.is_some() {
                         match &mut arg_t.kind {
@@ -133,13 +131,13 @@ impl Checker {
                                             type_params.iter().zip(type_args)
                                         {
                                             let (s, t) =
-                                                self.infer_type_ann(type_arg, ctx, &mut None)?;
+                                                self.infer_type_ann(type_arg, &mut None)?;
                                             ss.push(s);
                                             type_param_map.insert(type_param.name.to_string(), t);
                                         }
                                         type_param_map
                                     } else {
-                                        get_type_param_map(ctx, type_params)
+                                        get_type_param_map(&self.current_scope, type_params)
                                     }
                                 }
                                 None => HashMap::new(),
@@ -158,14 +156,14 @@ impl Checker {
                             lam_type.provenance =
                                 Some(Box::from(Provenance::TObjElem(Box::from(elem.to_owned()))));
 
-                            let ret_type = ctx.fresh_var();
+                            let ret_type = self.current_scope.fresh_var();
                             let call_type = Type::from(TypeKind::App(types::TApp {
                                 args: arg_types.clone(),
                                 ret: Box::from(ret_type.clone()),
                                 type_args: None,
                             }));
 
-                            if let Ok(s3) = self.unify(&call_type, &lam_type, ctx) {
+                            if let Ok(s3) = self.unify(&call_type, &lam_type) {
                                 ss.push(s3);
 
                                 let s = compose_many_subs(&ss.clone());
@@ -204,9 +202,9 @@ impl Checker {
                 }
             }
             ExprKind::Fix(Fix { expr, .. }) => {
-                let (s1, t) = self.infer_expr(ctx, expr, false)?;
+                let (s1, t) = self.infer_expr(expr, false)?;
                 eprintln!("t = {t}");
-                let tv = ctx.fresh_var();
+                let tv = self.current_scope.fresh_var();
                 let param = TFnParam {
                     pat: TPat::Ident(types::BindingIdent {
                         name: String::from("fix_param"),
@@ -222,7 +220,6 @@ impl Checker {
                         type_params: None,
                     })),
                     &t,
-                    ctx,
                 )?;
 
                 let s = compose_subs(&s2, &s1);
@@ -237,7 +234,7 @@ impl Checker {
             }
             ExprKind::Ident(Ident { name, .. }) => {
                 let s = Subst::default();
-                let t = ctx.lookup_value_and_instantiate(name)?;
+                let t = self.current_scope.lookup_value_and_instantiate(name)?;
 
                 Ok((s, t))
             }
@@ -251,24 +248,23 @@ impl Checker {
                     match &mut cond.kind {
                         ExprKind::LetExpr(LetExpr { pat, expr, .. }) => {
                             // TODO: warn if the pattern isn't refutable
-                            let mut new_ctx = ctx.clone();
-                            let init = self.infer_expr(ctx, expr, false)?;
+                            let init = self.infer_expr(expr, false)?;
+                            self.push_scope(); // TODO: move this before infer_expr?
                             let s1 = self.infer_pattern_and_init(
                                 pat,
                                 None,
                                 &init,
-                                &mut new_ctx,
                                 &PatternUsage::Match,
                                 false,
                             )?;
 
-                            let (s2, t2) = self.infer_block(consequent, &mut new_ctx)?;
+                            let (s2, t2) = self.infer_block(consequent)?;
 
-                            ctx.count = new_ctx.count;
+                            self.pop_scope();
 
                             let s = compose_subs(&s2, &s1);
 
-                            let (s3, t3) = self.infer_block(alternate, ctx)?;
+                            let (s3, t3) = self.infer_block(alternate)?;
 
                             let s = compose_subs(&s3, &s);
                             let t = union_types(&t2, &t3);
@@ -276,14 +272,11 @@ impl Checker {
                             Ok((s, t))
                         }
                         _ => {
-                            let (s1, t1) = self.infer_expr(ctx, cond, false)?;
-                            let (s2, t2) = self.infer_block(consequent, ctx)?;
-                            let (s3, t3) = self.infer_block(alternate, ctx)?;
-                            let s4 = self.unify(
-                                &t1,
-                                &Type::from(TypeKind::Keyword(TKeyword::Boolean)),
-                                ctx,
-                            )?;
+                            let (s1, t1) = self.infer_expr(cond, false)?;
+                            let (s2, t2) = self.infer_block(consequent)?;
+                            let (s3, t3) = self.infer_block(alternate)?;
+                            let s4 =
+                                self.unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Boolean)))?;
 
                             let s = compose_many_subs(&[s1, s2, s3, s4]);
                             let t = union_types(&t2, &t3);
@@ -294,20 +287,19 @@ impl Checker {
                 }
                 None => match &mut cond.kind {
                     ExprKind::LetExpr(LetExpr { pat, expr, .. }) => {
-                        let mut new_ctx = ctx.clone();
-                        let init = self.infer_expr(ctx, expr, false)?;
+                        let init = self.infer_expr(expr, false)?;
+                        self.push_scope(); // TODO: move this before infer_expr?
                         let s1 = self.infer_pattern_and_init(
                             pat,
                             None,
                             &init,
-                            &mut new_ctx,
                             &PatternUsage::Match,
                             false,
                         )?;
 
-                        let (s2, t2) = self.infer_block(consequent, &mut new_ctx)?;
+                        let (s2, t2) = self.infer_block(consequent)?;
 
-                        ctx.count = new_ctx.count;
+                        self.pop_scope();
 
                         let s = compose_subs(&s2, &s1);
 
@@ -317,13 +309,10 @@ impl Checker {
                         Ok((s, t))
                     }
                     _ => {
-                        let (s1, t1) = self.infer_expr(ctx, cond, false)?;
-                        let (s2, t2) = self.infer_block(consequent, ctx)?;
-                        let s3 = self.unify(
-                            &t1,
-                            &Type::from(TypeKind::Keyword(TKeyword::Boolean)),
-                            ctx,
-                        )?;
+                        let (s1, t1) = self.infer_expr(cond, false)?;
+                        let (s2, t2) = self.infer_block(consequent)?;
+                        let s3 =
+                            self.unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Boolean)))?;
 
                         let s = compose_many_subs(&[s1, s2, s3]);
 
@@ -343,7 +332,7 @@ impl Checker {
                 let first_char = name.chars().next().unwrap();
                 // JSXElement's starting with an uppercase char are user defined.
                 if first_char.is_uppercase() {
-                    let t = ctx.lookup_value_and_instantiate(name)?;
+                    let t = self.current_scope.lookup_value_and_instantiate(name)?;
                     match &t.kind {
                         TypeKind::Lam(_) => {
                             let mut ss: Vec<_> = vec![];
@@ -358,12 +347,12 @@ impl Checker {
                                             kind,
                                             inferred_type: None,
                                         };
-                                        self.infer_expr(ctx, &mut expr, false)?
+                                        self.infer_expr(&mut expr, false)?
                                     }
                                     JSXAttrValue::JSXExprContainer(JSXExprContainer {
                                         expr,
                                         ..
-                                    }) => self.infer_expr(ctx, expr, false)?,
+                                    }) => self.infer_expr(expr, false)?,
                                 };
                                 ss.push(s);
 
@@ -391,7 +380,7 @@ impl Checker {
                             }));
 
                             let s1 = compose_many_subs(&ss);
-                            let s2 = self.unify(&call_type, &t, ctx)?;
+                            let s2 = self.unify(&call_type, &t)?;
 
                             let s = compose_subs(&s2, &s1);
                             let t = ret_type;
@@ -419,8 +408,8 @@ impl Checker {
                 type_params,
                 ..
             }) => {
-                let mut new_ctx = ctx.clone();
-                new_ctx.is_async = is_async.to_owned();
+                self.push_scope();
+                self.current_scope.is_async = is_async.to_owned();
 
                 let type_params_map: HashMap<String, Type> = match type_params {
                     Some(type_params) => type_params
@@ -429,16 +418,16 @@ impl Checker {
                             let tv = match &mut type_param.constraint {
                                 Some(type_ann) => {
                                     // TODO: push `s` on to `ss`
-                                    let (_s, t) =
-                                        self.infer_type_ann(type_ann, &mut new_ctx, &mut None)?;
+                                    let (_s, t) = self.infer_type_ann(type_ann, &mut None)?;
                                     Type::from(TypeKind::Var(TVar {
-                                        id: new_ctx.fresh_id(),
+                                        id: self.current_scope.fresh_id(),
                                         constraint: Some(Box::from(t)),
                                     }))
                                 }
-                                None => new_ctx.fresh_var(),
+                                None => self.current_scope.fresh_var(),
                             };
-                            new_ctx.insert_type(type_param.name.name.clone(), tv.clone());
+                            self.current_scope
+                                .insert_type(type_param.name.name.clone(), tv.clone());
                             Ok((type_param.name.name.to_owned(), tv))
                         })
                         .collect::<Result<HashMap<String, Type>, Vec<TypeError>>>()?,
@@ -447,14 +436,14 @@ impl Checker {
 
                 let params: Result<Vec<(Subst, TFnParam)>, Vec<TypeError>> = params
                     .iter_mut()
-                    .map(|e_param| self.infer_fn_param(e_param, &mut new_ctx, &type_params_map))
+                    .map(|e_param| self.infer_fn_param(e_param, &type_params_map))
                     .collect();
                 let (mut ss, t_params): (Vec<_>, Vec<_>) = params?.iter().cloned().unzip();
 
-                let (body_s, mut body_t) = self.infer_block_or_expr(body, &mut new_ctx)?;
+                let (body_s, mut body_t) = self.infer_block_or_expr(body)?;
                 ss.push(body_s);
 
-                ctx.count = new_ctx.count;
+                self.pop_scope();
 
                 if *is_async && !is_promise(&body_t) {
                     body_t = Type::from(TypeKind::Ref(types::TRef {
@@ -465,9 +454,9 @@ impl Checker {
 
                 if let Some(rt_type_ann) = rt_type_ann {
                     let (ret_s, ret_t) =
-                        self.infer_type_ann_with_params(rt_type_ann, ctx, &type_params_map)?;
+                        self.infer_type_ann_with_params(rt_type_ann, &type_params_map)?;
                     ss.push(ret_s);
-                    ss.push(self.unify(&body_t, &ret_t, ctx)?);
+                    ss.push(self.unify(&body_t, &ret_t)?);
                 }
 
                 let t = Type::from(TypeKind::Lam(types::TLam {
@@ -490,7 +479,7 @@ impl Checker {
                 // - if it does, check if its mutable or not
                 if let ExprKind::Ident(id) = &assign.left.kind {
                     let name = &id.name;
-                    let binding = ctx.lookup_binding(name)?;
+                    let binding = self.current_scope.lookup_binding(name)?;
                     if !binding.mutable {
                         return Err(vec![TypeError::NonMutableBindingAssignment(Box::from(
                             assign.to_owned(),
@@ -500,15 +489,15 @@ impl Checker {
 
                 // This is similar to infer let, but without the type annotation and
                 // with pat being an expression instead of a pattern.
-                let (rs, rt) = self.infer_expr(ctx, &mut assign.right, false)?;
+                let (rs, rt) = self.infer_expr(&mut assign.right, false)?;
                 // TODO: figure out how to get the type of a setter
-                let (ls, lt) = self.infer_expr(ctx, &mut assign.left, true)?;
+                let (ls, lt) = self.infer_expr(&mut assign.left, true)?;
 
                 if assign.op != AssignOp::Eq {
                     todo!("handle update assignment operators");
                 }
 
-                let s = self.unify(&rt, &lt, ctx)?;
+                let s = self.unify(&rt, &lt)?;
 
                 let s = compose_many_subs(&[rs, ls, s]);
                 let t = rt; // This is JavaScript's behavior
@@ -537,10 +526,10 @@ impl Checker {
                 // differently from arithmetic operators
                 // TODO: if both are literals, compute the result at compile
                 // time and set the result to be appropriate number literal.
-                let (s1, t1) = self.infer_expr(ctx, left, false)?;
-                let (s2, t2) = self.infer_expr(ctx, right, false)?;
-                let s3 = self.unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Number)), ctx)?;
-                let s4 = self.unify(&t2, &Type::from(TypeKind::Keyword(TKeyword::Number)), ctx)?;
+                let (s1, t1) = self.infer_expr(left, false)?;
+                let (s2, t2) = self.infer_expr(right, false)?;
+                let s3 = self.unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Number)))?;
+                let s4 = self.unify(&t2, &Type::from(TypeKind::Keyword(TKeyword::Number)))?;
 
                 let s = compose_many_subs(&[s1, s2, s3, s4]);
 
@@ -592,8 +581,8 @@ impl Checker {
                 Ok((s, t))
             }
             ExprKind::UnaryExpr(UnaryExpr { op, arg, .. }) => {
-                let (s1, t1) = self.infer_expr(ctx, arg, false)?;
-                let s2 = self.unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Number)), ctx)?;
+                let (s1, t1) = self.infer_expr(arg, false)?;
+                let s2 = self.unify(&t1, &Type::from(TypeKind::Keyword(TKeyword::Number)))?;
 
                 let s = compose_many_subs(&[s1, s2]);
                 let t = match op {
@@ -611,7 +600,8 @@ impl Checker {
                         PropOrSpread::Prop(p) => {
                             match p.as_mut() {
                                 Prop::Shorthand(Ident { name, .. }) => {
-                                    let t = ctx.lookup_value_and_instantiate(name)?;
+                                    let t =
+                                        self.current_scope.lookup_value_and_instantiate(name)?;
                                     elems.push(types::TObjElem::Prop(types::TProp {
                                         name: TPropKey::StringKey(name.to_owned()),
                                         optional: false,
@@ -620,7 +610,7 @@ impl Checker {
                                     }));
                                 }
                                 Prop::KeyValue(KeyValueProp { key, value, .. }) => {
-                                    let (s, t) = self.infer_expr(ctx, value, false)?;
+                                    let (s, t) = self.infer_expr(value, false)?;
                                     ss.push(s);
                                     // TODO: check if the inferred type is T | undefined and use that
                                     // determine the value of optional
@@ -634,7 +624,7 @@ impl Checker {
                             }
                         }
                         PropOrSpread::Spread(SpreadElement { expr, .. }) => {
-                            let (s, t) = self.infer_expr(ctx, expr, false)?;
+                            let (s, t) = self.infer_expr(expr, false)?;
                             ss.push(s);
                             spread_types.push(t);
                         }
@@ -659,18 +649,18 @@ impl Checker {
                 Ok((s, t))
             }
             ExprKind::Await(Await { expr, .. }) => {
-                if !ctx.is_async() {
+                if !self.current_scope.is_async() {
                     return Err(vec![TypeError::AwaitOutsideOfAsync]);
                 }
 
-                let (s1, t1) = self.infer_expr(ctx, expr, false)?;
-                let inner_t = ctx.fresh_var();
+                let (s1, t1) = self.infer_expr(expr, false)?;
+                let inner_t = self.current_scope.fresh_var();
                 let promise_t = Type::from(TypeKind::Ref(types::TRef {
                     name: String::from("Promise"),
                     type_args: Some(vec![inner_t.clone()]),
                 }));
 
-                let s2 = self.unify(&t1, &promise_t, ctx)?;
+                let s2 = self.unify(&t1, &promise_t)?;
                 let s = compose_subs(&s2, &s1);
 
                 Ok((s, inner_t))
@@ -683,7 +673,7 @@ impl Checker {
                     let expr = elem.expr.as_mut();
                     match elem.spread {
                         Some(_) => {
-                            let (s, mut t) = self.infer_expr(ctx, expr, false)?;
+                            let (s, mut t) = self.infer_expr(expr, false)?;
                             ss.push(s);
                             match &mut t.kind {
                                 TypeKind::Tuple(types) => ts.append(types),
@@ -693,7 +683,7 @@ impl Checker {
                             }
                         }
                         None => {
-                            let (s, t) = self.infer_expr(ctx, expr, false)?;
+                            let (s, t) = self.infer_expr(expr, false)?;
                             ss.push(s);
                             ts.push(t);
                         }
@@ -706,9 +696,8 @@ impl Checker {
                 Ok((s, t))
             }
             ExprKind::Member(Member { obj, prop, .. }) => {
-                let (obj_s, mut obj_t) = self.infer_expr(ctx, obj, false)?;
-                let (prop_s, prop_t) =
-                    self.infer_property_type(&mut obj_t, prop, ctx, is_lvalue)?;
+                let (obj_s, mut obj_t) = self.infer_expr(obj, false)?;
+                let (prop_s, prop_t) = self.infer_property_type(&mut obj_t, prop, is_lvalue)?;
 
                 let s = compose_subs(&prop_s, &obj_s);
                 let t = prop_t;
@@ -727,7 +716,7 @@ impl Checker {
                 let t = Type::from(TypeKind::Keyword(TKeyword::String));
                 let result: Result<Vec<(Subst, Type)>, Vec<TypeError>> = exprs
                     .iter_mut()
-                    .map(|expr| self.infer_expr(ctx, expr, false))
+                    .map(|expr| self.infer_expr(expr, false))
                     .collect();
                 // We ignore the types of expressions if there are any because any expression
                 // in JavaScript has a string representation.
@@ -748,20 +737,19 @@ impl Checker {
                 let mut ss: Vec<Subst> = vec![];
                 let mut ts: Vec<Type> = vec![];
                 for arm in arms {
-                    let mut new_ctx = ctx.clone();
-                    let init = self.infer_expr(ctx, expr, false)?;
+                    let init = self.infer_expr(expr, false)?;
+                    self.push_scope(); // TODO: move this before infer_expr?
                     let s1 = self.infer_pattern_and_init(
                         &mut arm.pattern,
                         None,
                         &init,
-                        &mut new_ctx,
                         &PatternUsage::Match,
                         false,
                     )?;
 
-                    let (s2, t2) = self.infer_block(&mut arm.body, &mut new_ctx)?;
+                    let (s2, t2) = self.infer_block(&mut arm.body)?;
 
-                    ctx.count = new_ctx.count;
+                    self.pop_scope();
 
                     let s = compose_subs(&s2, &s1);
                     let t = t2;
@@ -798,13 +786,13 @@ impl Checker {
             // This is only need for classes that are expressions.  Allowing this
             // seems like a bad idea.
             ExprKind::Class(_) => todo!(),
-            ExprKind::DoExpr(DoExpr { body }) => self.infer_block(body, ctx),
+            ExprKind::DoExpr(DoExpr { body }) => self.infer_block(body),
         };
 
         let (s, mut t) = result?;
 
-        // QUESTION: Do we need to update ctx.types as well?
-        ctx.values = ctx.values.apply(&s);
+        // QUESTION: Do we need to update self.current_scope.types as well?
+        self.current_scope.values = self.current_scope.values.apply(&s);
 
         expr.inferred_type = Some(t.clone());
         t.provenance = Some(Box::from(Provenance::from(expr)));
@@ -816,39 +804,38 @@ impl Checker {
         &mut self,
         obj_t: &mut Type,
         prop: &mut MemberProp,
-        ctx: &mut Context,
         is_lvalue: bool,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
         // TODO: figure out when we have to copy .mutable from `obj_t` to the `t`
         // being returned.
         match &mut obj_t.kind {
             TypeKind::Var(TVar { constraint, .. }) => match constraint {
-                Some(constraint) => self.infer_property_type(constraint, prop, ctx, is_lvalue),
+                Some(constraint) => self.infer_property_type(constraint, prop, is_lvalue),
                 None => Err(vec![TypeError::PossiblyNotAnObject(Box::from(
                     obj_t.to_owned(),
                 ))]),
             },
-            TypeKind::Object(obj) => self.get_prop_value(obj, prop, ctx, is_lvalue, obj_t.mutable),
+            TypeKind::Object(obj) => self.get_prop_value(obj, prop, is_lvalue, obj_t.mutable),
             TypeKind::Ref(_) => {
-                let mut t = self.get_obj_type(obj_t, ctx)?;
+                let mut t = self.get_obj_type(obj_t)?;
                 t.mutable = obj_t.mutable;
-                self.infer_property_type(&mut t, prop, ctx, is_lvalue)
+                self.infer_property_type(&mut t, prop, is_lvalue)
             }
             TypeKind::Lit(_) => {
-                let mut t = self.get_obj_type(obj_t, ctx)?;
-                self.infer_property_type(&mut t, prop, ctx, is_lvalue)
+                let mut t = self.get_obj_type(obj_t)?;
+                self.infer_property_type(&mut t, prop, is_lvalue)
             }
             TypeKind::Keyword(_) => {
-                let mut t = self.get_obj_type(obj_t, ctx)?;
-                self.infer_property_type(&mut t, prop, ctx, is_lvalue)
+                let mut t = self.get_obj_type(obj_t)?;
+                self.infer_property_type(&mut t, prop, is_lvalue)
             }
             TypeKind::Array(type_param) => {
                 let type_param = type_param.clone();
 
-                let mut t = self.get_obj_type(obj_t, ctx)?;
+                let mut t = self.get_obj_type(obj_t)?;
                 t.mutable = obj_t.mutable;
 
-                let (s, mut t) = self.infer_property_type(&mut t, prop, ctx, is_lvalue)?;
+                let (s, mut t) = self.infer_property_type(&mut t, prop, is_lvalue)?;
 
                 // Replaces `this` with `mut <type_param>[]`
                 let rep_t = Type {
@@ -876,7 +863,7 @@ impl Checker {
                             return Ok((s, t));
                         }
 
-                        let scheme = ctx.lookup_scheme("Array")?;
+                        let scheme = self.current_scope.lookup_scheme("Array")?;
 
                         let mut type_param_map: HashMap<String, Type> = HashMap::new();
                         let type_param = Type::from(TypeKind::Union(elem_types.to_owned()));
@@ -887,10 +874,10 @@ impl Checker {
                         let mut t = replace_aliases_rec(&scheme.t, &type_param_map);
                         t.mutable = obj_t.mutable;
 
-                        self.infer_property_type(&mut t, prop, ctx, is_lvalue)
+                        self.infer_property_type(&mut t, prop, is_lvalue)
                     }
                     MemberProp::Computed(ComputedPropName { expr, .. }) => {
-                        let (prop_s, prop_t) = self.infer_expr(ctx, expr, false)?;
+                        let (prop_s, prop_t) = self.infer_expr(expr, false)?;
 
                         match &prop_t.kind {
                             TypeKind::Keyword(TKeyword::Number) => {
@@ -920,7 +907,7 @@ impl Checker {
             }
             TypeKind::Intersection(types) => {
                 for t in types {
-                    let result = self.infer_property_type(t, prop, ctx, is_lvalue);
+                    let result = self.infer_property_type(t, prop, is_lvalue);
                     if result.is_ok() {
                         return result;
                     }
@@ -937,7 +924,6 @@ impl Checker {
         &mut self,
         obj: &TObject,
         prop: &mut MemberProp,
-        ctx: &mut Context,
         is_lvalue: bool,
         obj_is_mutable: bool,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
@@ -992,7 +978,7 @@ impl Checker {
                 Err(vec![TypeError::MissingKey(name.to_owned())])
             }
             MemberProp::Computed(ComputedPropName { expr, .. }) => {
-                let (prop_s, prop_t) = self.infer_expr(ctx, expr, false)?;
+                let (prop_s, prop_t) = self.infer_expr(expr, false)?;
 
                 let prop_t_clone = prop_t.clone();
                 let prop_s_clone = prop_s.clone();
@@ -1066,7 +1052,7 @@ impl Checker {
                         } else {
                             for indexer in indexers {
                                 let key_clone = indexer.key.t.clone();
-                                let result = self.unify(&prop_t_clone, &key_clone, ctx);
+                                let result = self.unify(&prop_t_clone, &key_clone);
                                 if result.is_ok() {
                                     let key_s = result?;
                                     let s = compose_subs(&key_s, &prop_s_clone);

--- a/crates/escalier_infer/src/infer_fn_param.rs
+++ b/crates/escalier_infer/src/infer_fn_param.rs
@@ -3,7 +3,7 @@ use im::hashmap::HashMap;
 use escalier_ast::types::{self as types, TFnParam, TKeyword, TPat, Type, TypeKind};
 use escalier_ast::values::*;
 
-use crate::context::{Binding, Context};
+use crate::context::Binding;
 use crate::substitutable::Subst;
 use crate::type_error::TypeError;
 
@@ -15,11 +15,10 @@ impl Checker {
     pub fn infer_fn_param(
         &mut self,
         param: &mut EFnParam,
-        ctx: &mut Context,
         type_param_map: &HashMap<String, Type>,
     ) -> Result<(Subst, TFnParam), Vec<TypeError>> {
         let (ps, mut pa, pt) =
-            self.infer_pattern(&mut param.pat, param.type_ann.as_mut(), ctx, type_param_map)?;
+            self.infer_pattern(&mut param.pat, param.type_ann.as_mut(), type_param_map)?;
 
         // TypeScript annotates rest params using an array type so we do the
         // same thing by converting top-level rest types to array types.
@@ -52,7 +51,7 @@ impl Checker {
             optional: param.optional,
         };
 
-        ctx.insert_bindings(&pa);
+        self.current_scope.insert_bindings(&pa);
 
         Ok((ps, param))
     }

--- a/crates/escalier_infer/src/infer_pattern.rs
+++ b/crates/escalier_infer/src/infer_pattern.rs
@@ -19,13 +19,12 @@ impl Checker {
         &mut self,
         pat: &mut Pattern,
         type_ann: Option<&mut TypeAnn>,
-        ctx: &mut Context,
         type_param_map: &HashMap<String, Type>,
     ) -> Result<(Subst, Assump, Type), Vec<TypeError>> {
         // Keeps track of all of the variables the need to be introduced by this pattern.
         let mut new_vars: HashMap<String, Binding> = HashMap::new();
 
-        let pat_type = infer_pattern_rec(pat, ctx, &mut new_vars)?;
+        let pat_type = infer_pattern_rec(pat, &self.current_scope, &mut new_vars)?;
 
         // If the pattern had a type annotation associated with it, we infer type of the
         // type annotation and add a constraint between the types of the pattern and its
@@ -33,11 +32,11 @@ impl Checker {
         match type_ann {
             Some(type_ann) => {
                 let (type_ann_s, type_ann_t) =
-                    self.infer_type_ann_with_params(type_ann, ctx, type_param_map)?;
+                    self.infer_type_ann_with_params(type_ann, type_param_map)?;
 
                 // Allowing type_ann_ty to be a subtype of pat_type because
                 // only non-refutable patterns can have type annotations.
-                let s = self.unify(&type_ann_t, &pat_type, ctx)?;
+                let s = self.unify(&type_ann_t, &pat_type)?;
                 let s = compose_subs(&s, &type_ann_s);
 
                 // Substs are applied to any new variables introduced.  This handles
@@ -55,21 +54,20 @@ impl Checker {
         pattern: &mut Pattern,
         type_ann: Option<&mut TypeAnn>,
         init: &(Subst, Type),
-        ctx: &mut Context,
         pu: &PatternUsage,
         top_level: bool,
     ) -> Result<Subst, Vec<TypeError>> {
         let type_param_map = HashMap::new();
-        let (ps, pa, pt) = self.infer_pattern(pattern, type_ann, ctx, &type_param_map)?;
+        let (ps, pa, pt) = self.infer_pattern(pattern, type_ann, &type_param_map)?;
 
         // Unifies initializer and pattern.
         let s = match pu {
             // Assign: The inferred type of the init value must be a sub-type
             // of the pattern it's being assigned to.
-            PatternUsage::Assign => self.unify(&init.1, &pt, ctx)?,
+            PatternUsage::Assign => self.unify(&init.1, &pt)?,
             // Matching: The pattern must be a sub-type of the expression
             // it's being matched against
-            PatternUsage::Match => self.unify(&pt, &init.1, ctx)?,
+            PatternUsage::Match => self.unify(&pt, &init.1)?,
         };
 
         // infer_pattern can generate a non-empty Subst when the pattern includes
@@ -80,9 +78,9 @@ impl Checker {
 
         for (name, mut binding) in pa {
             if top_level {
-                binding.t = close_over(&s, &binding.t, ctx);
+                binding.t = close_over(&s, &binding.t, &self.current_scope);
             }
-            ctx.insert_binding(name, binding);
+            self.current_scope.insert_binding(name, binding);
         }
 
         update_pattern(pattern, &s);

--- a/crates/escalier_infer/src/infer_pattern.rs
+++ b/crates/escalier_infer/src/infer_pattern.rs
@@ -96,7 +96,7 @@ fn infer_pattern_rec(
 ) -> Result<Type, Vec<TypeError>> {
     let result: Result<Type, Vec<TypeError>> = match &mut pat.kind {
         PatternKind::Ident(values::BindingIdent { name, mutable, .. }) => {
-            let tv = ctx.fresh_var();
+            let tv = ctx.fresh_var(None);
             if assump
                 .insert(
                     name.to_owned(),
@@ -114,7 +114,7 @@ fn infer_pattern_rec(
         PatternKind::Wildcard => {
             // Same as Pattern::Ident but we don't insert an assumption since
             // we don't want to bind it to a variable.
-            let tv = ctx.fresh_var();
+            let tv = ctx.fresh_var(None);
             Ok(tv)
         }
         PatternKind::Lit(LitPat { lit, .. }) => Ok(Type::from(lit.to_owned())),
@@ -205,7 +205,7 @@ fn infer_pattern_rec(
                         // default values.
                         // TODO: handle default values
 
-                        let tv = ctx.fresh_var();
+                        let tv = ctx.fresh_var(None);
                         if assump
                             .insert(
                                 ident.name.to_owned(),

--- a/crates/escalier_infer/src/infer_prog.rs
+++ b/crates/escalier_infer/src/infer_prog.rs
@@ -37,10 +37,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
     ctx.insert_type(String::from("JSXElement"), jsx_element_type);
 
     let mut reports: Vec<TypeError> = vec![];
-    let mut checker = Checker {
-        current_scope: ctx.to_owned(),
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx.to_owned());
 
     // TODO: figure out how report multiple errors
     for stmt in &mut prog.body {

--- a/crates/escalier_infer/src/infer_prog.rs
+++ b/crates/escalier_infer/src/infer_prog.rs
@@ -37,18 +37,21 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
     ctx.insert_type(String::from("JSXElement"), jsx_element_type);
 
     let mut reports: Vec<TypeError> = vec![];
-    let mut checker = Checker {};
+    let mut checker = Checker {
+        current_scope: ctx.to_owned(),
+        parent_scopes: vec![],
+    };
 
     // TODO: figure out how report multiple errors
     for stmt in &mut prog.body {
-        match checker.infer_stmt(stmt, ctx, true) {
+        match checker.infer_stmt(stmt, true) {
             Ok(_) => (),
             Err(mut errors) => reports.append(&mut errors),
         }
     }
 
     if reports.is_empty() {
-        Ok(ctx.to_owned())
+        Ok(checker.current_scope)
     } else {
         Err(reports)
     }

--- a/crates/escalier_infer/src/infer_stmt.rs
+++ b/crates/escalier_infer/src/infer_stmt.rs
@@ -2,7 +2,7 @@ use derive_visitor::{DriveMut, VisitorMut};
 use escalier_ast::types::{TKeyword, TRef, Type, TypeKind};
 use escalier_ast::values::*;
 
-use crate::context::{Context, Env};
+use crate::context::Env;
 use crate::infer_pattern::*;
 use crate::scheme::generalize;
 use crate::substitutable::Subst;
@@ -17,7 +17,6 @@ impl Checker {
     pub fn infer_stmt(
         &mut self,
         stmt: &mut Statement,
-        ctx: &mut Context,
         top_level: bool,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
         match &mut stmt.kind {
@@ -33,13 +32,12 @@ impl Checker {
                         // An initial value should always be used when using a normal
                         // `let` statement
                         let init = init.as_mut().unwrap();
-                        let inferred_init = self.infer_expr(ctx, init, false)?;
+                        let inferred_init = self.infer_expr(init, false)?;
 
                         let s = self.infer_pattern_and_init(
                             pattern,
                             type_ann.as_mut(),
                             &inferred_init,
-                            ctx,
                             &PatternUsage::Assign,
                             top_level,
                         )?;
@@ -56,15 +54,15 @@ impl Checker {
                             PatternKind::Ident(BindingIdent { name, .. }) => {
                                 match type_ann {
                                     Some(type_ann) => {
-                                        let (s, t) =
-                                            self.infer_type_ann(type_ann, ctx, &mut None)?;
+                                        let (s, t) = self.infer_type_ann(type_ann, &mut None)?;
 
                                         let t = if top_level {
-                                            close_over(&s, &t, ctx)
+                                            close_over(&s, &t, &self.current_scope)
                                         } else {
                                             t
                                         };
-                                        ctx.insert_value(name.to_owned(), t.to_owned());
+                                        self.current_scope
+                                            .insert_value(name.to_owned(), t.to_owned());
 
                                         update_type_ann(type_ann, &s);
                                         update_pattern(pattern, &s);
@@ -90,29 +88,30 @@ impl Checker {
                 type_params,
                 ..
             }) => {
-                let (s, t) = self.infer_type_ann(type_ann, ctx, type_params)?;
+                let (s, t) = self.infer_type_ann(type_ann, type_params)?;
 
                 let t = t.apply(&s);
 
                 let empty_env = Env::default();
                 let scheme = generalize(&empty_env, &t);
 
-                ctx.insert_scheme(name.to_owned(), scheme);
+                self.current_scope.insert_scheme(name.to_owned(), scheme);
 
                 update_type_ann(type_ann, &s);
 
                 Ok((s, t))
             }
             StmtKind::ClassDecl(ClassDecl { ident, class }) => {
-                let (s, t) = self.infer_class(ctx, class)?;
+                let (s, t) = self.infer_class(class)?;
 
                 let t = t.apply(&s);
 
                 // This follows the same pattern found in lib.es5.d.ts.
                 let name = ident.name.to_owned();
                 eprintln!("inserting {name}Constructor = {t}");
-                ctx.insert_type(format!("{name}Constructor"), t.to_owned());
-                ctx.insert_value(
+                self.current_scope
+                    .insert_type(format!("{name}Constructor"), t.to_owned());
+                self.current_scope.insert_value(
                     name.to_owned(),
                     Type::from(TypeKind::Ref(TRef {
                         name: format!("{name}Constructor"),
@@ -124,14 +123,14 @@ impl Checker {
             }
 
             StmtKind::ExprStmt(expr) => {
-                let (s, t) = self.infer_expr(ctx, expr, false)?;
+                let (s, t) = self.infer_expr(expr, false)?;
 
                 // We ignore the type that was inferred, we only care that
                 // it succeeds since we aren't assigning it to variable.
                 update_expr(expr, &s);
 
                 let t = if top_level {
-                    close_over(&s, &t, ctx)
+                    close_over(&s, &t, &self.current_scope)
                 } else {
                     t
                 };
@@ -143,27 +142,26 @@ impl Checker {
                 expr,
                 body,
             }) => {
-                let elem_t = ctx.fresh_var();
+                let elem_t = self.current_scope.fresh_var();
                 let array_t = Type::from(TypeKind::Array(Box::from(elem_t.clone())));
 
-                let (_expr_s, expr_t) = self.infer_expr(ctx, expr, false)?;
+                let (_expr_s, expr_t) = self.infer_expr(expr, false)?;
 
-                let s1 = self.unify(&expr_t, &array_t, ctx)?;
+                let s1 = self.unify(&expr_t, &array_t)?;
                 let elem_t = elem_t.apply(&s1);
 
-                let mut new_ctx = ctx.clone();
+                self.push_scope();
                 let s2 = self.infer_pattern_and_init(
                     pattern,
                     None,
                     &(Subst::new(), elem_t),
-                    &mut new_ctx,
                     &PatternUsage::Assign,
                     top_level,
                 )?;
 
-                let (s3, _) = self.infer_block(body, &mut new_ctx)?;
+                let (s3, _) = self.infer_block(body)?;
 
-                ctx.count = new_ctx.count;
+                self.pop_scope();
 
                 let s = compose_many_subs(&[s3, s2, s1]);
                 let t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
@@ -171,7 +169,7 @@ impl Checker {
                 Ok((s, t))
             }
             StmtKind::ReturnStmt(ReturnStmt { arg }) => match arg {
-                Some(arg) => self.infer_expr(ctx, arg.as_mut(), false),
+                Some(arg) => self.infer_expr(arg.as_mut(), false),
                 None => {
                     let s = Subst::default();
                     let t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
@@ -182,24 +180,21 @@ impl Checker {
         }
     }
 
-    pub fn infer_block(
-        &mut self,
-        body: &mut Block,
-        ctx: &mut Context,
-    ) -> Result<(Subst, Type), Vec<TypeError>> {
-        let mut new_ctx = ctx.clone();
+    pub fn infer_block(&mut self, body: &mut Block) -> Result<(Subst, Type), Vec<TypeError>> {
+        self.push_scope();
+
         let mut t = Type::from(TypeKind::Keyword(TKeyword::Undefined));
         let mut s = Subst::new();
 
         for stmt in &mut body.stmts {
-            new_ctx = new_ctx.clone();
-            let (new_s, new_t) = self.infer_stmt(stmt, &mut new_ctx, false)?;
+            self.current_scope = self.current_scope.clone();
+            let (new_s, new_t) = self.infer_stmt(stmt, false)?;
 
             t = new_t.apply(&s);
             s = compose_subs(&new_s, &s);
         }
 
-        ctx.count = new_ctx.count;
+        self.pop_scope();
 
         Ok((s, t))
     }
@@ -207,11 +202,10 @@ impl Checker {
     pub fn infer_block_or_expr(
         &mut self,
         body: &mut BlockOrExpr,
-        ctx: &mut Context,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
         match body {
             BlockOrExpr::Block(block) => {
-                let (s, _) = self.infer_block(block, ctx)?;
+                let (s, _) = self.infer_block(block)?;
 
                 let mut visitor = FindReturnsVisitor::default();
                 block.drive_mut(&mut visitor);
@@ -236,7 +230,7 @@ impl Checker {
 
                 Ok((s, t))
             }
-            BlockOrExpr::Expr(expr) => self.infer_expr(ctx, expr, false),
+            BlockOrExpr::Expr(expr) => self.infer_expr(expr, false),
         }
     }
 }

--- a/crates/escalier_infer/src/infer_type_ann.rs
+++ b/crates/escalier_infer/src/infer_type_ann.rs
@@ -3,7 +3,7 @@ use std::iter::Iterator;
 
 use escalier_ast::types::{
     self as types, Provenance, TConditionalType, TFnParam, TIndex, TIndexAccess, TIndexKey,
-    TInferType, TMappedType, TObjElem, TObject, TProp, TPropKey, TVar, Type, TypeKind,
+    TInferType, TMappedType, TObjElem, TObject, TProp, TPropKey, Type, TypeKind,
 };
 use escalier_ast::values::*;
 
@@ -40,12 +40,9 @@ impl Checker {
                         Some(type_ann) => {
                             // TODO: push `s` on to `ss`
                             let (_s, t) = self.infer_type_ann(type_ann, &mut None)?;
-                            Type::from(TypeKind::Var(TVar {
-                                id: self.current_scope.fresh_id(),
-                                constraint: Some(Box::from(t)),
-                            }))
+                            self.current_scope.fresh_var(Some(Box::from(t)))
                         }
-                        None => self.current_scope.fresh_var(),
+                        None => self.current_scope.fresh_var(None),
                     };
 
                     Ok((param.name.name.to_owned(), tv))

--- a/crates/escalier_infer/src/infer_type_ann.rs
+++ b/crates/escalier_infer/src/infer_type_ann.rs
@@ -7,7 +7,6 @@ use escalier_ast::types::{
 };
 use escalier_ast::values::*;
 
-use crate::context::Context;
 use crate::infer_fn_param::pattern_to_tpat;
 use crate::substitutable::{Subst, Substitutable};
 use crate::type_error::TypeError;
@@ -19,7 +18,6 @@ impl Checker {
     pub fn infer_type_ann(
         &mut self,
         type_ann: &mut TypeAnn,
-        ctx: &mut Context,
         type_params: &mut Option<Vec<TypeParam>>,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
         let mut type_params = if type_params.is_none() {
@@ -41,13 +39,13 @@ impl Checker {
                     let tv = match &mut param.constraint {
                         Some(type_ann) => {
                             // TODO: push `s` on to `ss`
-                            let (_s, t) = self.infer_type_ann(type_ann, ctx, &mut None)?;
+                            let (_s, t) = self.infer_type_ann(type_ann, &mut None)?;
                             Type::from(TypeKind::Var(TVar {
-                                id: ctx.fresh_id(),
+                                id: self.current_scope.fresh_id(),
                                 constraint: Some(Box::from(t)),
                             }))
                         }
-                        None => ctx.fresh_var(),
+                        None => self.current_scope.fresh_var(),
                     };
 
                     Ok((param.name.name.to_owned(), tv))
@@ -56,22 +54,20 @@ impl Checker {
             None => HashMap::default(),
         };
 
-        self.infer_type_ann_with_params(type_ann, ctx, &type_param_map)
+        self.infer_type_ann_with_params(type_ann, &type_param_map)
     }
 
     pub fn infer_type_ann_with_params(
         &mut self,
         type_ann: &mut TypeAnn,
-        ctx: &mut Context,
         type_param_map: &HashMap<String, Type>,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
-        self.infer_type_ann_rec(type_ann, ctx, type_param_map)
+        self.infer_type_ann_rec(type_ann, type_param_map)
     }
 
     fn infer_type_ann_rec(
         &mut self,
         type_ann: &mut TypeAnn,
-        ctx: &mut Context,
         type_param_map: &HashMap<String, Type>,
     ) -> Result<(Subst, Type), Vec<TypeError>> {
         let (s, mut t) = match &mut type_ann.kind {
@@ -81,7 +77,7 @@ impl Checker {
 
                 for param in &mut lam.params {
                     let (param_s, param_t) =
-                        self.infer_type_ann_rec(&mut param.type_ann, ctx, type_param_map)?;
+                        self.infer_type_ann_rec(&mut param.type_ann, type_param_map)?;
                     ss.push(param_s);
                     params.push(TFnParam {
                         pat: pattern_to_tpat(&param.pat),
@@ -90,7 +86,7 @@ impl Checker {
                     });
                 }
 
-                let (ret_s, ret_t) = self.infer_type_ann_rec(&mut lam.ret, ctx, type_param_map)?;
+                let (ret_s, ret_t) = self.infer_type_ann_rec(&mut lam.ret, type_param_map)?;
                 let ret = Box::from(ret_t);
                 ss.push(ret_s);
 
@@ -123,13 +119,10 @@ impl Checker {
                     match elem {
                         escalier_ast::values::TObjElem::Index(index) => {
                             let (index_s, index_t) =
-                                self.infer_type_ann_rec(&mut index.type_ann, ctx, type_param_map)?;
+                                self.infer_type_ann_rec(&mut index.type_ann, type_param_map)?;
 
-                            let (key_s, key_t) = self.infer_type_ann_rec(
-                                &mut index.key.type_ann,
-                                ctx,
-                                type_param_map,
-                            )?;
+                            let (key_s, key_t) =
+                                self.infer_type_ann_rec(&mut index.key.type_ann, type_param_map)?;
 
                             ss.push(index_s);
                             ss.push(key_s);
@@ -151,7 +144,7 @@ impl Checker {
                         }
                         escalier_ast::values::TObjElem::Prop(prop) => {
                             let (prop_s, prop_t) =
-                                self.infer_type_ann_rec(&mut prop.type_ann, ctx, type_param_map)?;
+                                self.infer_type_ann_rec(&mut prop.type_ann, type_param_map)?;
 
                             ss.push(prop_s);
                             elems.push(TObjElem::Prop(TProp {
@@ -190,7 +183,7 @@ impl Checker {
                     if let Some(type_params) = type_params {
                         for param in type_params {
                             let (type_arg_s, type_arg_t) =
-                                self.infer_type_ann_rec(param, ctx, type_param_map)?;
+                                self.infer_type_ann_rec(param, type_param_map)?;
                             ss.push(type_arg_s);
                             type_args.push(type_arg_t);
                         }
@@ -214,7 +207,7 @@ impl Checker {
                 let mut ss: Vec<Subst> = vec![];
 
                 for t in &mut union.types {
-                    let (s, t) = self.infer_type_ann_rec(t, ctx, type_param_map)?;
+                    let (s, t) = self.infer_type_ann_rec(t, type_param_map)?;
 
                     ss.push(s);
                     ts.push(t);
@@ -230,7 +223,7 @@ impl Checker {
                 let mut ss: Vec<Subst> = vec![];
 
                 for t in &mut intersection.types {
-                    let (s, t) = self.infer_type_ann_rec(t, ctx, type_param_map)?;
+                    let (s, t) = self.infer_type_ann_rec(t, type_param_map)?;
 
                     ss.push(s);
                     ts.push(t);
@@ -246,7 +239,7 @@ impl Checker {
                 let mut ss: Vec<Subst> = vec![];
 
                 for t in &mut tuple.types {
-                    let (s, t) = self.infer_type_ann_rec(t, ctx, type_param_map)?;
+                    let (s, t) = self.infer_type_ann_rec(t, type_param_map)?;
 
                     ss.push(s);
                     ts.push(t);
@@ -258,22 +251,22 @@ impl Checker {
                 Ok((s, t))
             }
             TypeAnnKind::Array(ArrayType { elem_type, .. }) => {
-                let (elem_s, elem_t) = self.infer_type_ann_rec(elem_type, ctx, type_param_map)?;
+                let (elem_s, elem_t) = self.infer_type_ann_rec(elem_type, type_param_map)?;
                 let s = elem_s;
                 let t = Type::from(TypeKind::Array(Box::from(elem_t)));
                 type_ann.inferred_type = Some(t.clone());
                 Ok((s, t))
             }
             TypeAnnKind::KeyOf(KeyOfType { type_ann, .. }) => {
-                let (arg_s, arg_t) = self.infer_type_ann_rec(type_ann, ctx, type_param_map)?;
+                let (arg_s, arg_t) = self.infer_type_ann_rec(type_ann, type_param_map)?;
                 let s = arg_s;
                 let t = Type::from(TypeKind::KeyOf(Box::from(arg_t)));
                 type_ann.inferred_type = Some(t.clone());
                 Ok((s, t))
             }
-            TypeAnnKind::Query(QueryType { expr, .. }) => self.infer_expr(ctx, expr, false),
+            TypeAnnKind::Query(QueryType { expr, .. }) => self.infer_expr(expr, false),
             TypeAnnKind::Mutable(MutableType { type_ann, .. }) => {
-                let (s, mut t) = self.infer_type_ann_rec(type_ann, ctx, type_param_map)?;
+                let (s, mut t) = self.infer_type_ann_rec(type_ann, type_param_map)?;
 
                 match &t.kind {
                     TypeKind::Keyword(_) => {
@@ -306,9 +299,8 @@ impl Checker {
                 index_type,
                 ..
             }) => {
-                let (obj_s, obj_t) = self.infer_type_ann_rec(obj_type, ctx, type_param_map)?;
-                let (index_s, index_t) =
-                    self.infer_type_ann_rec(index_type, ctx, type_param_map)?;
+                let (obj_s, obj_t) = self.infer_type_ann_rec(obj_type, type_param_map)?;
+                let (index_s, index_t) = self.infer_type_ann_rec(index_type, type_param_map)?;
 
                 let s = compose_many_subs(&[obj_s, index_s]);
                 let t = Type::from(TypeKind::IndexAccess(TIndexAccess {
@@ -328,12 +320,12 @@ impl Checker {
             }) => {
                 if let Some(constraint) = &mut type_param.constraint {
                     let (constraint_s, constraint_t) =
-                        self.infer_type_ann_rec(constraint.as_mut(), ctx, type_param_map)?;
+                        self.infer_type_ann_rec(constraint.as_mut(), type_param_map)?;
 
                     constraint.inferred_type = Some(constraint_t.clone());
 
                     let (type_ann_s, type_ann_t) =
-                        self.infer_type_ann_rec(type_ann, ctx, type_param_map)?;
+                        self.infer_type_ann_rec(type_ann, type_param_map)?;
 
                     // QUESTION: Do we need to apply `constraint_s` to `type_ann_t`?
                     type_ann.inferred_type = Some(type_ann_t.clone());
@@ -372,10 +364,10 @@ impl Checker {
                 false_type: alternate,
                 ..
             }) => {
-                let (check_s, check_t) = self.infer_type_ann_rec(left, ctx, type_param_map)?;
-                let (extends_s, extends_t) = self.infer_type_ann_rec(right, ctx, type_param_map)?;
-                let (true_s, true_t) = self.infer_type_ann_rec(consequent, ctx, type_param_map)?;
-                let (false_s, false_t) = self.infer_type_ann_rec(alternate, ctx, type_param_map)?;
+                let (check_s, check_t) = self.infer_type_ann_rec(left, type_param_map)?;
+                let (extends_s, extends_t) = self.infer_type_ann_rec(right, type_param_map)?;
+                let (true_s, true_t) = self.infer_type_ann_rec(consequent, type_param_map)?;
+                let (false_s, false_t) = self.infer_type_ann_rec(alternate, type_param_map)?;
 
                 let t = Type::from(TypeKind::ConditionalType(TConditionalType {
                     check_type: Box::from(check_t),

--- a/crates/escalier_infer/src/scheme.rs
+++ b/crates/escalier_infer/src/scheme.rs
@@ -81,12 +81,7 @@ pub fn get_type_param_map(ctx: &Context, type_params: &[TypeParam]) -> HashMap<S
             default: _, // TODO: figure out what to do for defaults
         } = type_param;
 
-        // TODO: make a helper for this
-        let t = Type::from(TypeKind::Var(TVar {
-            id: ctx.fresh_id(),
-            constraint: constraint.to_owned(),
-        }));
-
+        let t = ctx.fresh_var(constraint.to_owned());
         type_param_map.insert(name.to_owned(), t);
     }
 
@@ -168,13 +163,13 @@ mod tests {
                     name: TPropKey::StringKey(String::from("a")),
                     optional: false,
                     mutable: false,
-                    t: ctx.fresh_var(),
+                    t: ctx.fresh_var(None),
                 }),
                 TObjElem::Prop(TProp {
                     name: TPropKey::StringKey(String::from("b")),
                     optional: false,
                     mutable: false,
-                    t: ctx.fresh_var(),
+                    t: ctx.fresh_var(None),
                 }),
             ],
             is_interface: false,
@@ -190,7 +185,7 @@ mod tests {
     fn test_generalize_with_reused_type_vars() {
         let ctx = Context::default();
 
-        let tv = ctx.fresh_var();
+        let tv = ctx.fresh_var(None);
         let t = Type::from(TypeKind::Object(TObject {
             elems: vec![
                 TObjElem::Prop(TProp {
@@ -245,7 +240,7 @@ mod tests {
     fn test_generalize_lam_to_scheme() {
         let ctx = Context::default();
 
-        let tv = ctx.fresh_var();
+        let tv = ctx.fresh_var(None);
 
         let lam = TLam {
             type_params: None,
@@ -263,7 +258,7 @@ mod tests {
                         name: "b".to_string(),
                         mutable: false,
                     }),
-                    t: ctx.fresh_var(),
+                    t: ctx.fresh_var(None),
                     optional: false,
                 },
             ],

--- a/crates/escalier_infer/src/util.rs
+++ b/crates/escalier_infer/src/util.rs
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn test_close_over() {
         let ctx = Context::default();
-        let tv = ctx.fresh_var();
+        let tv = ctx.fresh_var(None);
         let lam = TLam {
             type_params: None,
             params: vec![
@@ -515,7 +515,7 @@ mod tests {
                         name: "b".to_string(),
                         mutable: false,
                     }),
-                    t: ctx.fresh_var(),
+                    t: ctx.fresh_var(None),
                     optional: false,
                 },
             ],

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -28,8 +28,8 @@ pub struct InterfaceCollector {
 pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, String> {
     match type_ann {
         TsType::TsKeywordType(keyword) => match &keyword.kind {
-            TsKeywordTypeKind::TsAnyKeyword => Ok(ctx.fresh_var()),
-            TsKeywordTypeKind::TsUnknownKeyword => Ok(ctx.fresh_var()),
+            TsKeywordTypeKind::TsAnyKeyword => Ok(ctx.fresh_var(None)),
+            TsKeywordTypeKind::TsUnknownKeyword => Ok(ctx.fresh_var(None)),
             TsKeywordTypeKind::TsNumberKeyword => {
                 Ok(Type::from(TypeKind::Keyword(TKeyword::Number)))
             }

--- a/crates/escalier_interop/tests/integration_test.rs
+++ b/crates/escalier_interop/tests/integration_test.rs
@@ -384,10 +384,7 @@ fn infer_partial() {
     "#;
     let (_, ctx) = infer_prog(src);
     let t = ctx.lookup_type("PartialObj", false).unwrap();
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -405,10 +402,7 @@ fn infer_required() {
     "#;
     let (_, ctx) = infer_prog(src);
     let t = ctx.lookup_type("RequiredObj", false).unwrap();
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -426,10 +420,7 @@ fn infer_readonly() {
     "#;
     let (_, ctx) = infer_prog(src);
     let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -444,10 +435,7 @@ fn infer_readonly_with_indexer_only() {
     "#;
     let (_, ctx) = infer_prog(src);
     let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -462,10 +450,7 @@ fn infer_readonly_with_indexer_and_other_properties() {
     "#;
     let (_, ctx) = infer_prog(src);
     let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -483,10 +468,7 @@ fn infer_pick() {
     "#;
     let (_, ctx) = infer_prog(src);
     let t = ctx.lookup_type("PickObj", false).unwrap();
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -521,10 +503,7 @@ fn infer_partial_with_getters_and_setters_on_class_instance() {
     "#;
 
     let (_, ctx) = infer_prog(src);
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
 
     let t = checker.current_scope.lookup_type("T1", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
@@ -572,10 +551,7 @@ fn infer_exclude() {
     let result = format!("{}", t);
     assert_eq!(result, "Exclude<\"a\" | \"b\" | \"c\", \"a\" | \"b\">");
 
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -603,10 +579,7 @@ fn infer_out_of_order_exclude() {
     let ctx = escalier_infer::infer_prog(&mut prog, &mut ctx).unwrap();
 
     let t = ctx.lookup_type("T1", false).unwrap();
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "\"c\"");
@@ -624,10 +597,7 @@ fn infer_omit() {
     let result = format!("{}", t);
     assert_eq!(result, "Omit<Obj, \"b\" | \"c\">");
 
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -645,10 +615,7 @@ fn infer_omit_string() {
     let result = format!("{}", t);
     assert_eq!(result, "Omit<String, \"length\">");
 
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -663,10 +630,7 @@ fn infer_method_type_with_indexed_access() {
     let (_, ctx) = infer_prog(src);
     let t = ctx.lookup_type("T1", false).unwrap();
 
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -686,10 +650,7 @@ fn infer_getter_setter_types_with_indexed_access() {
     type T3 = Foo["qux"];
     "#;
     let (_, ctx) = infer_prog(src);
-    let mut checker = Checker {
-        current_scope: ctx,
-        parent_scopes: vec![],
-    };
+    let mut checker = Checker::from(ctx);
 
     let t = checker.current_scope.lookup_type("T1", false).unwrap();
     let t = checker.expand_type(&t).unwrap();


### PR DESCRIPTION
This allows our type inference code to be simplified greatly since `current_scope` can be accessed via `self` instead of having to pass `ctx` as a param to every function that needed it.  Many functions didn't need it, but we were passing it anyways because something else that we called needed it downstream.