### PR TITLE
Replace Context's 'count' with Checker's 'next_id'

### DIFF
--- a/crates/escalier_ast/src/types/type.rs
+++ b/crates/escalier_ast/src/types/type.rs
@@ -50,7 +50,7 @@ pub struct TIndexAccess {
 #[derive(Clone, Debug, Drive, DriveMut, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TVar {
     #[drive(skip)]
-    pub id: i32, // This should never be mutated
+    pub id: u32, // This should never be mutated
     pub constraint: Option<Box<Type>>,
 }
 

--- a/crates/escalier_infer/src/checker.rs
+++ b/crates/escalier_infer/src/checker.rs
@@ -1,9 +1,11 @@
+use escalier_ast::types::{TVar, Type, TypeKind};
+
 use crate::context::Context;
 
-#[derive(Default)]
 pub struct Checker {
     pub current_scope: Context,
     parent_scopes: Vec<Context>,
+    next_id: u32,
 }
 
 impl From<Context> for Checker {
@@ -11,6 +13,17 @@ impl From<Context> for Checker {
         Checker {
             current_scope: ctx,
             parent_scopes: vec![],
+            next_id: 1,
+        }
+    }
+}
+
+impl Default for Checker {
+    fn default() -> Self {
+        Checker {
+            current_scope: Context::default(),
+            parent_scopes: vec![],
+            next_id: 1,
         }
     }
 }
@@ -42,8 +55,13 @@ impl Checker {
     }
 
     pub fn pop_scope(&mut self) {
-        let mut parent_scope = self.parent_scopes.pop().unwrap();
-        parent_scope.count = self.current_scope.count.clone();
+        let parent_scope = self.parent_scopes.pop().unwrap();
         self.current_scope = parent_scope;
+    }
+
+    pub fn fresh_var(&mut self, constraint: Option<Box<Type>>) -> Type {
+        let id = self.next_id;
+        self.next_id = id + 1;
+        Type::from(TypeKind::Var(TVar { id, constraint }))
     }
 }

--- a/crates/escalier_infer/src/infer_stmt.rs
+++ b/crates/escalier_infer/src/infer_stmt.rs
@@ -142,7 +142,7 @@ impl Checker {
                 expr,
                 body,
             }) => {
-                let elem_t = self.current_scope.fresh_var(None);
+                let elem_t = self.fresh_var(None);
                 let array_t = Type::from(TypeKind::Array(Box::from(elem_t.clone())));
 
                 let (_expr_s, expr_t) = self.infer_expr(expr, false)?;

--- a/crates/escalier_infer/src/infer_type_ann.rs
+++ b/crates/escalier_infer/src/infer_type_ann.rs
@@ -40,9 +40,9 @@ impl Checker {
                         Some(type_ann) => {
                             // TODO: push `s` on to `ss`
                             let (_s, t) = self.infer_type_ann(type_ann, &mut None)?;
-                            self.current_scope.fresh_var(Some(Box::from(t)))
+                            self.fresh_var(Some(Box::from(t)))
                         }
-                        None => self.current_scope.fresh_var(None),
+                        None => self.fresh_var(None),
                     };
 
                     Ok((param.name.name.to_owned(), tv))

--- a/crates/escalier_infer/src/substitutable.rs
+++ b/crates/escalier_infer/src/substitutable.rs
@@ -9,7 +9,7 @@ use crate::context::Binding;
 use crate::infer_regex::parse_regex;
 use crate::scheme::Scheme;
 
-pub type Subst = HashMap<i32, Type>;
+pub type Subst = HashMap<u32, Type>;
 
 pub trait Substitutable {
     fn apply(&self, subs: &Subst) -> Self;

--- a/crates/escalier_infer/src/unify.rs
+++ b/crates/escalier_infer/src/unify.rs
@@ -7,7 +7,6 @@ use escalier_ast::types::{
 use escalier_ast::values::{ExprKind, TypeAnn, TypeAnnKind};
 use types::TKeyword;
 
-use crate::scheme::{instantiate_callable, instantiate_gen_lam};
 use crate::substitutable::{Subst, Substitutable};
 use crate::type_error::TypeError;
 use crate::util::*;
@@ -161,7 +160,7 @@ impl Checker {
             // NOTE: this arm is only hit by the `infer_skk` test case
             (TypeKind::Lam(_), TypeKind::App(_)) => self.unify(t2, t1),
             (TypeKind::App(app), TypeKind::Lam(lam)) => {
-                let lam = instantiate_gen_lam(&self.current_scope, lam, app.type_args.as_ref());
+                let lam = self.instantiate_gen_lam(lam, app.type_args.as_ref());
                 let mut s = Subst::new();
 
                 let maybe_rest_param = if let Some(param) = lam.params.last() {
@@ -331,7 +330,7 @@ impl Checker {
                             let t = if call.type_params.is_some() {
                                 lam
                             } else {
-                                instantiate_callable(&self.current_scope, call)
+                                self.instantiate_callable(call)
                             };
                             eprintln!("callable instantiated as {t}");
                             Some(t)

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -9,7 +9,7 @@ use swc_ecma_visit::*;
 use escalier_ast::types::{
     self as types, RestPat, TCallable, TConditionalType, TFnParam, TIndex, TIndexAccess, TIndexKey,
     TKeyword, TLam, TMappedType, TMappedTypeChangeProp, TObjElem, TObject, TPat, TProp, TPropKey,
-    TRef, Type, TypeKind, TypeParam,
+    TRef, TVar, Type, TypeKind, TypeParam,
 };
 use escalier_ast::values::{Lit, DUMMY_LOC};
 use escalier_infer::{get_sub_and_type_params, Context, Scheme, Subst, Substitutable};
@@ -28,8 +28,22 @@ pub struct InterfaceCollector {
 pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, String> {
     match type_ann {
         TsType::TsKeywordType(keyword) => match &keyword.kind {
-            TsKeywordTypeKind::TsAnyKeyword => Ok(ctx.fresh_var(None)),
-            TsKeywordTypeKind::TsUnknownKeyword => Ok(ctx.fresh_var(None)),
+            TsKeywordTypeKind::TsAnyKeyword => {
+                // TODO: update to use Checker
+                // Ok(ctx.fresh_var(None))
+                Ok(Type::from(TypeKind::Var(TVar {
+                    id: 0,
+                    constraint: None,
+                })))
+            }
+            TsKeywordTypeKind::TsUnknownKeyword => {
+                // TODO: update to use Checker
+                // Ok(ctx.fresh_var(None))
+                Ok(Type::from(TypeKind::Var(TVar {
+                    id: 0,
+                    constraint: None,
+                })))
+            }
             TsKeywordTypeKind::TsNumberKeyword => {
                 Ok(Type::from(TypeKind::Keyword(TKeyword::Number)))
             }

--- a/crates/escalier_interop/tests/integration_test.rs
+++ b/crates/escalier_interop/tests/integration_test.rs
@@ -383,8 +383,8 @@ fn infer_partial() {
     type PartialObj = Partial<Obj>;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("PartialObj", false).unwrap();
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("PartialObj", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -401,8 +401,8 @@ fn infer_required() {
     type RequiredObj = Required<Obj>;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("RequiredObj", false).unwrap();
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("RequiredObj", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -419,8 +419,8 @@ fn infer_readonly() {
     type ReadonlyObj = Readonly<Obj>;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("ReadonlyObj", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -434,8 +434,8 @@ fn infer_readonly_with_indexer_only() {
     type ReadonlyObj = Readonly<Obj>;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("ReadonlyObj", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -449,8 +449,8 @@ fn infer_readonly_with_indexer_and_other_properties() {
     type ReadonlyObj = Readonly<Obj>;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("ReadonlyObj", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -467,8 +467,8 @@ fn infer_pick() {
     type PickObj = Pick<Obj, "a" | "b">;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("PickObj", false).unwrap();
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("PickObj", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
 
     let result = format!("{}", t);
@@ -505,17 +505,17 @@ fn infer_partial_with_getters_and_setters_on_class_instance() {
     let (_, ctx) = infer_prog(src);
     let mut checker = Checker::from(ctx);
 
-    let t = checker.current_scope.lookup_type("T1", false).unwrap();
+    let t = checker.lookup_type("T1", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "number | undefined");
 
-    let t = checker.current_scope.lookup_type("T2", false).unwrap();
+    let t = checker.lookup_type("T2", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "string | undefined");
 
-    let t = checker.current_scope.lookup_type("T3", false).unwrap();
+    let t = checker.lookup_type("T3", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "() => boolean | undefined"); // should be (() => boolean) | undefined
@@ -546,12 +546,12 @@ fn infer_exclude() {
     type T1 = Exclude<"a" | "b" | "c", "a" | "b">;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("T1", false).unwrap();
+    let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("T1", false).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "Exclude<\"a\" | \"b\" | \"c\", \"a\" | \"b\">");
 
-    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -578,8 +578,8 @@ fn infer_out_of_order_exclude() {
     };
     let ctx = escalier_infer::infer_prog(&mut prog, &mut ctx).unwrap();
 
-    let t = ctx.lookup_type("T1", false).unwrap();
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("T1", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "\"c\"");
@@ -592,12 +592,12 @@ fn infer_omit() {
     type T1 = Omit<Obj, "b" | "c">;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("T1", false).unwrap();
+    let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("T1", false).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "Omit<Obj, \"b\" | \"c\">");
 
-    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -610,12 +610,12 @@ fn infer_omit_string() {
     type T1 = Omit<String, "length">;
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("T1", false).unwrap();
+    let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("T1", false).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "Omit<String, \"length\">");
 
-    let mut checker = Checker::from(ctx);
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -628,9 +628,9 @@ fn infer_method_type_with_indexed_access() {
     type T1 = String["charAt"];
     "#;
     let (_, ctx) = infer_prog(src);
-    let t = ctx.lookup_type("T1", false).unwrap();
-
     let mut checker = Checker::from(ctx);
+    let t = checker.lookup_type("T1", false).unwrap();
+
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
 
@@ -652,17 +652,17 @@ fn infer_getter_setter_types_with_indexed_access() {
     let (_, ctx) = infer_prog(src);
     let mut checker = Checker::from(ctx);
 
-    let t = checker.current_scope.lookup_type("T1", false).unwrap();
+    let t = checker.lookup_type("T1", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "number");
 
-    let t = checker.current_scope.lookup_type("T2", false).unwrap();
+    let t = checker.lookup_type("T2", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "string");
 
-    let t = checker.current_scope.lookup_type("T3", false).unwrap();
+    let t = checker.lookup_type("T3", false).unwrap();
     let t = checker.expand_type(&t).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "() => boolean");


### PR DESCRIPTION
This means that we don't have to synchronize `count` when popping scopes any more.