### PR TITLE
Add recoverable diagnostic for assigning the wrong type to a variable decl with a type annotation

### DIFF
--- a/crates/escalier/src/compile_error.rs
+++ b/crates/escalier/src/compile_error.rs
@@ -1,11 +1,12 @@
 use std::fmt;
 
-use escalier_infer::TypeError;
+use escalier_infer::{Diagnostic, TypeError};
 use escalier_parser::ParseError;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum CompileError {
     TypeError(Vec<TypeError>),
+    Diagnostic(Vec<Diagnostic>),
     ParseError(ParseError),
 }
 

--- a/crates/escalier/src/diagnostics.rs
+++ b/crates/escalier/src/diagnostics.rs
@@ -41,80 +41,94 @@ fn get_diagnostic_string(
     None
 }
 
-pub fn get_diagnostics(report: CompileError, src: &str) -> Vec<String> {
-    let diagnostics = match report {
-        CompileError::TypeError(errors) => {
-            errors
-                .iter()
-                .filter_map(|error| {
-                    match error {
-                        TypeError::UnificationError(t1, t2) => get_diagnostic_string(
-                            t1,
-                            t2,
-                            src,
-                            "Incompatible types",
-                            &format!("{t1}"),
-                            &format!("{t2}"),
-                        ),
-                        TypeError::TooFewArguments(app_t, lam_t) => {
-                            let provided = if let TypeKind::App(app) = &app_t.kind {
-                                app.args.len()
-                            } else {
-                                0
-                            };
-                            let expected = if let TypeKind::Lam(lam) = &lam_t.kind {
-                                lam.params.len()
-                            } else {
-                                0
-                            };
-                            let expr = if let Some(prov) = &lam_t.provenance {
-                                prov.get_expr()
-                            } else {
-                                None
-                            };
-                            if let Some(expr) = expr {
-                                if let ExprKind::Lambda(lam) = &expr.kind {
-                                    // TODO: Add a span to lam.params so that we don't
-                                    // have to compute it here.
-                                    eprintln!("params = {:#?}", lam.params)
-                                }
-                            }
-                            // TODO: figure out how to get a span for just the function
-                            // signature or just the param list.
-                            get_diagnostic_string(
-                                app_t,
-                                lam_t,
-                                src,
-                                "Not enough args provided",
-                                &format!("was passed {provided} args"),
-                                &format!("expected {expected} args"),
-                            )
-                        }
-                        TypeError::IndexOutOfBounds(obj_t, prop_t) => get_diagnostic_string(
-                            obj_t,
-                            prop_t,
-                            src,
-                            "Index out of bounds",
-                            "for this tuple",
-                            &format!("{prop_t} is out of bounds"),
-                        ),
-                        TypeError::InvalidIndex(obj_t, prop_t) => get_diagnostic_string(
-                            obj_t,
-                            prop_t,
-                            src,
-                            "Invalid Index",
-                            "for tuples",
-                            &format!("{prop_t} is not a valid index"),
-                        ),
-                        error => {
-                            eprintln!("TODO: handle {error}");
-                            None
+fn type_errors_to_string(errors: &[TypeError], src: &str) -> String {
+    errors
+        .iter()
+        .filter_map(|error| {
+            match error {
+                TypeError::UnificationError(t1, t2) => get_diagnostic_string(
+                    t1,
+                    t2,
+                    src,
+                    "Incompatible types",
+                    &format!("{t1}"),
+                    &format!("{t2}"),
+                ),
+                TypeError::TooFewArguments(app_t, lam_t) => {
+                    let provided = if let TypeKind::App(app) = &app_t.kind {
+                        app.args.len()
+                    } else {
+                        0
+                    };
+                    let expected = if let TypeKind::Lam(lam) = &lam_t.kind {
+                        lam.params.len()
+                    } else {
+                        0
+                    };
+                    let expr = if let Some(prov) = &lam_t.provenance {
+                        prov.get_expr()
+                    } else {
+                        None
+                    };
+                    if let Some(expr) = expr {
+                        if let ExprKind::Lambda(lam) = &expr.kind {
+                            // TODO: Add a span to lam.params so that we don't
+                            // have to compute it here.
+                            eprintln!("params = {:#?}", lam.params)
                         }
                     }
-                })
-                .collect::<Vec<String>>()
-        }
-        CompileError::ParseError(error) => vec![error.to_string()],
+                    // TODO: figure out how to get a span for just the function
+                    // signature or just the param list.
+                    get_diagnostic_string(
+                        app_t,
+                        lam_t,
+                        src,
+                        "Not enough args provided",
+                        &format!("was passed {provided} args"),
+                        &format!("expected {expected} args"),
+                    )
+                }
+                TypeError::IndexOutOfBounds(obj_t, prop_t) => get_diagnostic_string(
+                    obj_t,
+                    prop_t,
+                    src,
+                    "Index out of bounds",
+                    "for this tuple",
+                    &format!("{prop_t} is out of bounds"),
+                ),
+                TypeError::InvalidIndex(obj_t, prop_t) => get_diagnostic_string(
+                    obj_t,
+                    prop_t,
+                    src,
+                    "Invalid Index",
+                    "for tuples",
+                    &format!("{prop_t} is not a valid index"),
+                ),
+                error => {
+                    eprintln!("TODO: handle {error}");
+                    None
+                }
+            }
+        })
+        .collect::<Vec<String>>()
+        .join("\n")
+}
+
+pub fn get_diagnostics_from_compile_error(report: CompileError, src: &str) -> String {
+    let diagnostics = match report {
+        CompileError::TypeError(errors) => type_errors_to_string(&errors, src),
+        CompileError::Diagnostic(diagnostics) => diagnostics
+            .iter()
+            .map(|diagnostic| {
+                format!(
+                    "{}: {}",
+                    diagnostic.message,
+                    type_errors_to_string(&diagnostic.reasons, src)
+                )
+            })
+            .collect::<Vec<String>>()
+            .join("\n"),
+        CompileError::ParseError(error) => error.to_string(),
     };
 
     diagnostics

--- a/crates/escalier/src/lib.rs
+++ b/crates/escalier/src/lib.rs
@@ -9,7 +9,7 @@ pub mod compile_error;
 pub mod diagnostics;
 
 use crate::compile_error::CompileError;
-use crate::diagnostics::get_diagnostics;
+use crate::diagnostics::get_diagnostics_from_compile_error;
 
 #[repr(C)]
 pub struct WasmString {
@@ -87,15 +87,15 @@ pub unsafe extern "C" fn compile(input: *const c_char, lib: *const c_char) -> *c
             };
             Box::into_raw(Box::new(result))
         }
-        Err(report) => {
-            let diagnostics = get_diagnostics(report, input);
+        Err(e) => {
+            let diagnostics = get_diagnostics_from_compile_error(e, input);
             let result = CompileResult {
                 js: string_to_wasm_string(""),
                 srcmap: string_to_wasm_string(""),
                 dts: string_to_wasm_string(""),
                 ast: string_to_wasm_string(""),
                 // TODO: update report to exclude Escalier source code locations
-                error: string_to_wasm_string(&diagnostics.join("\n")),
+                error: string_to_wasm_string(&diagnostics),
             };
             Box::into_raw(Box::new(result))
         }

--- a/crates/escalier/tests/errors/incompatible_types.error
+++ b/crates/escalier/tests/errors/incompatible_types.error
@@ -41,13 +41,3 @@ Error: Incompatible types
    ·              ───┬───  
    ·                 ╰───── "world"
 ───╯
-
-Error: Incompatible types
-   ╭─[<unknown>:8:17]
-   │
- 8 │ let b: number = "5";
-   ·        ───┬──   ─┬─  
-   ·           ╰────────── number
-   ·                  │   
-   ·                  ╰─── "5"
-───╯

--- a/crates/escalier/tests/fixture_tests.rs
+++ b/crates/escalier/tests/fixture_tests.rs
@@ -9,7 +9,7 @@ use escalier_infer::*;
 use escalier_interop::parse::parse_dts;
 
 use escalier::compile_error::CompileError;
-use escalier::diagnostics::get_diagnostics;
+use escalier::diagnostics::get_diagnostics_from_compile_error;
 
 enum Mode {
     Check,
@@ -78,11 +78,8 @@ fn fail(in_path: PathBuf) {
 
     match compile(&input, &lib) {
         Ok(_) => panic!("Expected an error"),
-        Err(report) => {
-            // let buf = strip_ansi_escapes::strip(format!("{report:#?}")).unwrap();
-            // let error_output = str::from_utf8(&buf).unwrap();
-            let diagnostics = get_diagnostics(report, &input);
-            let error_output = diagnostics.join("\n");
+        Err(e) => {
+            let error_output = get_diagnostics_from_compile_error(e, &input);
             match mode {
                 Mode::Check => {
                     let error_fixture = fs::read_to_string(error_output_path).unwrap();

--- a/crates/escalier_infer/src/checker.rs
+++ b/crates/escalier_infer/src/checker.rs
@@ -2,23 +2,26 @@ use escalier_ast::types::{TVar, Type, TypeKind};
 
 use crate::binding::Binding;
 use crate::context::Context;
+use crate::diagnostic::Diagnostic;
 use crate::scheme::Scheme;
 use crate::scope::Scope;
 use crate::substitutable::Subst;
 use crate::type_error::TypeError;
 
 pub struct Checker {
-    pub current_scope: Scope,
     pub next_id: u32,
+    pub current_scope: Scope,
     pub parent_scopes: Vec<Scope>,
+    pub diagnostics: Vec<Diagnostic>,
 }
 
 impl From<Scope> for Checker {
-    fn from(ctx: Scope) -> Self {
+    fn from(scope: Scope) -> Self {
         Checker {
-            current_scope: ctx,
-            parent_scopes: vec![],
             next_id: 1,
+            current_scope: scope,
+            parent_scopes: vec![],
+            diagnostics: vec![],
         }
     }
 }
@@ -26,9 +29,10 @@ impl From<Scope> for Checker {
 impl Default for Checker {
     fn default() -> Self {
         Checker {
+            next_id: 1,
             current_scope: Scope::default(),
             parent_scopes: vec![],
-            next_id: 1,
+            diagnostics: vec![],
         }
     }
 }

--- a/crates/escalier_infer/src/diagnostic.rs
+++ b/crates/escalier_infer/src/diagnostic.rs
@@ -1,0 +1,30 @@
+// Roadmap:
+// - start with type errors
+// - once the parser has been rewritten add parse errors as well
+
+use std::fmt;
+
+use crate::type_error::TypeError;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub code: u32,
+    pub message: String,
+    pub reasons: Vec<TypeError>,
+}
+
+impl fmt::Display for Diagnostic {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(fmt, "ESC_{} - {}:", self.code, self.message)?;
+        let len = self.reasons.len();
+        for (i, reason) in self.reasons.iter().enumerate() {
+            if i < len - 1 {
+                write!(fmt, "\u{251C}")?
+            } else {
+                write!(fmt, "\u{2514}")?
+            };
+            writeln!(fmt, " {reason}")?;
+        }
+        Ok(())
+    }
+}

--- a/crates/escalier_infer/src/infer_expr.rs
+++ b/crates/escalier_infer/src/infer_expr.rs
@@ -252,7 +252,7 @@ impl Checker {
                             self.push_scope(ScopeKind::Inherit);
                             let s1 = self.infer_pattern_and_init(
                                 pat,
-                                None,
+                                &mut None,
                                 &init,
                                 &PatternUsage::Match,
                                 false,
@@ -291,7 +291,7 @@ impl Checker {
                         self.push_scope(ScopeKind::Inherit);
                         let s1 = self.infer_pattern_and_init(
                             pat,
-                            None,
+                            &mut None,
                             &init,
                             &PatternUsage::Match,
                             false,
@@ -736,7 +736,7 @@ impl Checker {
                     self.push_scope(ScopeKind::Inherit);
                     let s1 = self.infer_pattern_and_init(
                         &mut arm.pattern,
-                        None,
+                        &mut None,
                         &init,
                         &PatternUsage::Match,
                         false,

--- a/crates/escalier_infer/src/infer_fn_param.rs
+++ b/crates/escalier_infer/src/infer_fn_param.rs
@@ -19,7 +19,7 @@ impl Checker {
         type_param_map: &HashMap<String, Type>,
     ) -> Result<(Subst, TFnParam), Vec<TypeError>> {
         let (ps, mut pa, pt) =
-            self.infer_pattern(&mut param.pat, param.type_ann.as_mut(), type_param_map)?;
+            self.infer_pattern(&mut param.pat, &mut param.type_ann, type_param_map)?;
 
         // TypeScript annotates rest params using an array type so we do the
         // same thing by converting top-level rest types to array types.

--- a/crates/escalier_infer/src/infer_stmt.rs
+++ b/crates/escalier_infer/src/infer_stmt.rs
@@ -37,7 +37,7 @@ impl Checker {
 
                         let s = self.infer_pattern_and_init(
                             pattern,
-                            type_ann.as_mut(),
+                            type_ann,
                             &inferred_init,
                             &PatternUsage::Assign,
                             top_level,
@@ -144,7 +144,7 @@ impl Checker {
                 self.push_scope(ScopeKind::Inherit);
                 let s2 = self.infer_pattern_and_init(
                     pattern,
-                    None,
+                    &mut None,
                     &(Subst::new(), elem_t),
                     &PatternUsage::Assign,
                     top_level,

--- a/crates/escalier_infer/src/unify.rs
+++ b/crates/escalier_infer/src/unify.rs
@@ -299,6 +299,7 @@ impl Checker {
                 let mut reports: Vec<TypeError> = vec![];
                 for (p1, p2) in args.iter_mut().zip(params.iter_mut()) {
                     // Each argument must be a subtype of the corresponding param.
+                    // TODO: collect unification errors as diagnostics
                     match self.unify(&p1.apply(&s), &p2.apply(&s)) {
                         Ok(s1) => s = compose_subs(&s, &s1),
                         Err(mut report) => reports.append(&mut report),

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -882,9 +882,10 @@ pub fn parse_dts(d_ts_source: &str) -> Result<escalier_infer::Checker, Error> {
     }
 
     let checker = escalier_infer::Checker {
-        current_scope: collector.checker.current_scope,
         next_id: collector.checker.next_id,
+        current_scope: collector.checker.current_scope,
         parent_scopes: vec![],
+        diagnostics: vec![], // TODO: report issues when parsing .d.ts files
     };
     Ok(checker)
 }


### PR DESCRIPTION
This is the first recoverable diagnostic.  I'll add more in future PRs.