### PR TITLE
Fix #503

### DIFF
--- a/crates/escalier/tests/fixture_tests.rs
+++ b/crates/escalier/tests/fixture_tests.rs
@@ -32,12 +32,10 @@ fn pass(in_path: PathBuf) {
     let input = fs::read_to_string(in_path).unwrap();
     let lib = fs::read_to_string(LIB_ES5_D_TS).unwrap();
 
-    let (js_output, srcmap_output, d_ts_output, _errors) = compile(&input, &lib);
-    // TODO: Renable once #503 is fixed
-    // if !errors.is_empty() {
-    //     println!("{errors:#?}");
-    //     panic!("Unexpected error");
-    // }
+    let (js_output, srcmap_output, d_ts_output, errors) = compile(&input, &lib);
+    if !errors.is_empty() {
+        panic!("Unexpected error(s): {errors:#?}");
+    }
 
     match mode {
         Mode::Check => {

--- a/crates/escalier_infer/src/expand_type.rs
+++ b/crates/escalier_infer/src/expand_type.rs
@@ -78,7 +78,7 @@ impl Checker {
 
         // Replaces qualifiers in the type with the corresponding type params
         // from the alias type.
-        let result = match (&alias.type_args, &scheme.type_params) {
+        match (&alias.type_args, &scheme.type_params) {
             (None, None) => self.expand_type(&scheme.t),
             (None, Some(_)) => Err(vec![TypeError::TypeInstantiationFailure]),
             (Some(_), None) => Err(vec![TypeError::TypeInstantiationFailure]),
@@ -147,11 +147,7 @@ impl Checker {
                 let t = replace_aliases_rec(&scheme.t, &type_param_map);
                 self.expand_type(&t)
             }
-        };
-        if let Ok(t) = &result {
-            eprintln!("expanded type = {:}", t);
-        };
-        result
+        }
     }
 
     fn expand_conditional_type(&mut self, cond: &TConditionalType) -> Result<Type, Vec<TypeError>> {

--- a/crates/escalier_interop/tests/integration_test.rs
+++ b/crates/escalier_interop/tests/integration_test.rs
@@ -689,14 +689,11 @@ fn new_expressions() {
     assert_eq!(result, "1 | 2 | 3[]");
 }
 
-// TODO(#503): Fix this test case.  It fails becaues it can't unify
-// app and lam: ("a", "b", "c") => t205 and (...items: mut t204[]) => mut t204[]
 #[test]
-#[ignore]
 fn new_expressions_instantiation_check() {
     let src = r#"
     let numbers = new Array(1, 2, 3);
-    let letters = new Array<string>("a", "b", "c");
+    let letters = new Array("a", "b", "c");
     "#;
 
     let (_, ctx) = infer_prog(src);


### PR DESCRIPTION
I forgot that we handle overloads of `new` inside `infer_expr()` instead of `unify()` like with other overloads.  This PR updates `infer_expr()` to handle recoverable errors in `new` calls in a similar way to what we do in `unify()` for regular function calls.