### PR TITLE
Continue working on using ids for all types

### DIFF
--- a/crates/escalier_ast/src/types/type.rs
+++ b/crates/escalier_ast/src/types/type.rs
@@ -51,6 +51,8 @@ pub struct TIndexAccess {
 pub struct TVar {
     #[drive(skip)]
     pub id: u32, // This should never be mutated
+    #[drive(skip)]
+    pub solution: Option<u32>,
     pub constraint: Option<Box<Type>>,
 }
 

--- a/crates/escalier_cli/tests/integration_test.rs
+++ b/crates/escalier_cli/tests/integration_test.rs
@@ -1021,12 +1021,12 @@ fn infer_with_constrained_polymorphism_failiure() {
 
     insta::assert_snapshot!(current_report_message(&checker), @r###"
     ESC_1 - args don't match expected params:
-    └ TypeError::UnificationError: {bar: "hello"}, {bar: t21}
+    └ TypeError::UnificationError: {bar: "hello"}, {bar: t18}
     "###);
 
     let result = format!("{}", checker.lookup_value("bar").unwrap());
     // TODO: this should be "number"
-    assert_eq!(result, "t21");
+    assert_eq!(result, "t18");
 }
 
 #[test]

--- a/crates/escalier_codegen/src/d_ts.rs
+++ b/crates/escalier_codegen/src/d_ts.rs
@@ -335,7 +335,11 @@ pub fn build_ts_fn_type_with_args(
 pub fn build_type(t: &Type, type_params: Option<&TsTypeParamDecl>, scope: &Scope) -> TsType {
     let mutable = t.mutable;
     match &t.kind {
-        TypeKind::Var(TVar { id, constraint: _ }) => {
+        TypeKind::Var(TVar {
+            id,
+            constraint: _,
+            solution: _,
+        }) => {
             // TODO: handle constraints on type variables
             // This will likely be easier if we stop using type variables for
             // type parameters.

--- a/crates/escalier_infer/src/checker.rs
+++ b/crates/escalier_infer/src/checker.rs
@@ -133,7 +133,11 @@ impl Checker {
         // self.from_type_kind(TypeKind::Var(TVar { id, constraint }))
         let t = Type {
             id,
-            kind: TypeKind::Var(TVar { id, constraint }),
+            kind: TypeKind::Var(TVar {
+                id,
+                constraint,
+                solution: None,
+            }),
             provenance: None,
             mutable: false,
         };

--- a/crates/escalier_infer/src/checker.rs
+++ b/crates/escalier_infer/src/checker.rs
@@ -130,7 +130,15 @@ impl Checker {
 
     pub fn fresh_var(&mut self, constraint: Option<Box<Type>>) -> Type {
         let id = self.fresh_id();
-        self.from_type_kind(TypeKind::Var(TVar { id, constraint }))
+        // self.from_type_kind(TypeKind::Var(TVar { id, constraint }))
+        let t = Type {
+            id,
+            kind: TypeKind::Var(TVar { id, constraint }),
+            provenance: None,
+            mutable: false,
+        };
+        self.types.insert(id, t.to_owned());
+        t
     }
 
     pub fn fresh_id(&mut self) -> u32 {

--- a/crates/escalier_infer/src/lib.rs
+++ b/crates/escalier_infer/src/lib.rs
@@ -1346,7 +1346,7 @@ mod tests {
 
         insta::assert_snapshot!(current_report_message(&checker), @r###"
         ESC_1 - args don't match expected params:
-        └ TypeError::UnificationError: (x: t12, y: t14, z: t16) => true, (a: number, b: number) => boolean
+        └ TypeError::UnificationError: (x: t12, y: t13, z: t14) => true, (a: number, b: number) => boolean
         "###);
     }
 

--- a/crates/escalier_infer/src/lib.rs
+++ b/crates/escalier_infer/src/lib.rs
@@ -29,7 +29,9 @@ pub use scheme::{get_sub_and_type_params, Scheme};
 pub use scope::*;
 pub use substitutable::{Subst, Substitutable};
 pub use type_error::TypeError;
-pub use util::{close_over, immutable_obj_type, normalize, replace_aliases_rec};
+pub use util::{
+    close_over, get_tvar_constraint, immutable_obj_type, normalize, replace_aliases_rec,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/escalier_infer/src/lib.rs
+++ b/crates/escalier_infer/src/lib.rs
@@ -29,9 +29,7 @@ pub use scheme::{get_sub_and_type_params, Scheme};
 pub use scope::*;
 pub use substitutable::{Subst, Substitutable};
 pub use type_error::TypeError;
-pub use util::{
-    close_over, get_tvar_constraint, immutable_obj_type, normalize, replace_aliases_rec,
-};
+pub use util::{close_over, get_tvar_constraint, immutable_obj_type, replace_aliases_rec};
 
 #[cfg(test)]
 mod tests {

--- a/crates/escalier_infer/src/scheme.rs
+++ b/crates/escalier_infer/src/scheme.rs
@@ -364,7 +364,7 @@ mod tests {
 
         let t = checker.instantiate(&sc);
 
-        assert_eq!(t.to_string(), "{a: t4, b: t6}");
+        assert_eq!(t.to_string(), "{a: t4, b: t5}");
     }
 
     #[test]
@@ -517,6 +517,6 @@ mod tests {
 
         let lam = checker.instantiate_gen_lam(&gen_lam, None);
 
-        assert_eq!(lam.to_string(), "(a: t5, b: t7) => t5");
+        assert_eq!(lam.to_string(), "(a: t5, b: t6) => t5");
     }
 }

--- a/crates/escalier_infer/src/snapshots/escalier_infer__scheme__tests__instantiate_scheme_with_constrained_type_param.snap
+++ b/crates/escalier_infer/src/snapshots/escalier_infer__scheme__tests__instantiate_scheme_with_constrained_type_param.snap
@@ -36,7 +36,7 @@ Type {
                         t: Type {
                             kind: Var(
                                 TVar {
-                                    id: 7,
+                                    id: 6,
                                     constraint: Some(
                                         Type {
                                             kind: Keyword(

--- a/crates/escalier_infer/src/snapshots/escalier_infer__scheme__tests__instantiate_scheme_with_constrained_type_param.snap
+++ b/crates/escalier_infer/src/snapshots/escalier_infer__scheme__tests__instantiate_scheme_with_constrained_type_param.snap
@@ -17,6 +17,7 @@ Type {
                             kind: Var(
                                 TVar {
                                     id: 5,
+                                    solution: None,
                                     constraint: None,
                                 },
                             ),
@@ -37,6 +38,7 @@ Type {
                             kind: Var(
                                 TVar {
                                     id: 6,
+                                    solution: None,
                                     constraint: Some(
                                         Type {
                                             kind: Keyword(

--- a/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
@@ -63,7 +63,7 @@ Program {
                                                     kind: Keyword(
                                                         Number,
                                                     ),
-                                                    id: 6,
+                                                    id: 5,
                                                     mutable: false,
                                                     provenance: Some(
                                                         Type(
@@ -74,7 +74,7 @@ Program {
                                                                         constraint: None,
                                                                     },
                                                                 ),
-                                                                id: 6,
+                                                                id: 5,
                                                                 mutable: false,
                                                                 provenance: Some(
                                                                     Pattern(
@@ -115,7 +115,7 @@ Program {
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
-                                                                                    id: 6,
+                                                                                    id: 5,
                                                                                     mutable: false,
                                                                                     provenance: None,
                                                                                 },
@@ -140,18 +140,18 @@ Program {
                                                     kind: Keyword(
                                                         Number,
                                                     ),
-                                                    id: 8,
+                                                    id: 6,
                                                     mutable: false,
                                                     provenance: Some(
                                                         Type(
                                                             Type {
                                                                 kind: Var(
                                                                     TVar {
-                                                                        id: 7,
+                                                                        id: 6,
                                                                         constraint: None,
                                                                     },
                                                                 ),
-                                                                id: 8,
+                                                                id: 6,
                                                                 mutable: false,
                                                                 provenance: Some(
                                                                     Pattern(
@@ -188,11 +188,11 @@ Program {
                                                                                 Type {
                                                                                     kind: Var(
                                                                                         TVar {
-                                                                                            id: 7,
+                                                                                            id: 6,
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
-                                                                                    id: 8,
+                                                                                    id: 6,
                                                                                     mutable: false,
                                                                                     provenance: None,
                                                                                 },
@@ -211,7 +211,7 @@ Program {
                                             kind: Keyword(
                                                 Number,
                                             ),
-                                            id: 11,
+                                            id: 9,
                                             mutable: false,
                                             provenance: Some(
                                                 Expr(
@@ -266,7 +266,7 @@ Program {
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
-                                                                            id: 6,
+                                                                            id: 5,
                                                                             mutable: false,
                                                                             provenance: None,
                                                                         },
@@ -304,11 +304,11 @@ Program {
                                                                         Type {
                                                                             kind: Var(
                                                                                 TVar {
-                                                                                    id: 7,
+                                                                                    id: 6,
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
-                                                                            id: 8,
+                                                                            id: 6,
                                                                             mutable: false,
                                                                             provenance: None,
                                                                         },
@@ -321,7 +321,7 @@ Program {
                                                                 kind: Keyword(
                                                                     Number,
                                                                 ),
-                                                                id: 11,
+                                                                id: 9,
                                                                 mutable: false,
                                                                 provenance: None,
                                                             },
@@ -333,7 +333,7 @@ Program {
                                         type_params: None,
                                     },
                                 ),
-                                id: 14,
+                                id: 11,
                                 mutable: false,
                                 provenance: Some(
                                     Expr(
@@ -390,7 +390,7 @@ Program {
                                                                                 constraint: None,
                                                                             },
                                                                         ),
-                                                                        id: 6,
+                                                                        id: 5,
                                                                         mutable: false,
                                                                         provenance: None,
                                                                     },
@@ -433,11 +433,11 @@ Program {
                                                                     Type {
                                                                         kind: Var(
                                                                             TVar {
-                                                                                id: 7,
+                                                                                id: 6,
                                                                                 constraint: None,
                                                                             },
                                                                         ),
-                                                                        id: 8,
+                                                                        id: 6,
                                                                         mutable: false,
                                                                         provenance: None,
                                                                     },
@@ -499,7 +499,7 @@ Program {
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),
-                                                                                id: 6,
+                                                                                id: 5,
                                                                                 mutable: false,
                                                                                 provenance: None,
                                                                             },
@@ -537,11 +537,11 @@ Program {
                                                                             Type {
                                                                                 kind: Var(
                                                                                     TVar {
-                                                                                        id: 7,
+                                                                                        id: 6,
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),
-                                                                                id: 8,
+                                                                                id: 6,
                                                                                 mutable: false,
                                                                                 provenance: None,
                                                                             },
@@ -554,7 +554,7 @@ Program {
                                                                     kind: Keyword(
                                                                         Number,
                                                                     ),
-                                                                    id: 11,
+                                                                    id: 9,
                                                                     mutable: false,
                                                                     provenance: None,
                                                                 },
@@ -582,7 +582,7 @@ Program {
                                                                         kind: Keyword(
                                                                             Number,
                                                                         ),
-                                                                        id: 6,
+                                                                        id: 5,
                                                                         mutable: false,
                                                                         provenance: Some(
                                                                             Type(
@@ -593,7 +593,7 @@ Program {
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
-                                                                                    id: 6,
+                                                                                    id: 5,
                                                                                     mutable: false,
                                                                                     provenance: Some(
                                                                                         Pattern(
@@ -634,7 +634,7 @@ Program {
                                                                                                                 constraint: None,
                                                                                                             },
                                                                                                         ),
-                                                                                                        id: 6,
+                                                                                                        id: 5,
                                                                                                         mutable: false,
                                                                                                         provenance: None,
                                                                                                     },
@@ -659,18 +659,18 @@ Program {
                                                                         kind: Keyword(
                                                                             Number,
                                                                         ),
-                                                                        id: 8,
+                                                                        id: 6,
                                                                         mutable: false,
                                                                         provenance: Some(
                                                                             Type(
                                                                                 Type {
                                                                                     kind: Var(
                                                                                         TVar {
-                                                                                            id: 7,
+                                                                                            id: 6,
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
-                                                                                    id: 8,
+                                                                                    id: 6,
                                                                                     mutable: false,
                                                                                     provenance: Some(
                                                                                         Pattern(
@@ -707,11 +707,11 @@ Program {
                                                                                                     Type {
                                                                                                         kind: Var(
                                                                                                             TVar {
-                                                                                                                id: 7,
+                                                                                                                id: 6,
                                                                                                                 constraint: None,
                                                                                                             },
                                                                                                         ),
-                                                                                                        id: 8,
+                                                                                                        id: 6,
                                                                                                         mutable: false,
                                                                                                         provenance: None,
                                                                                                     },
@@ -730,7 +730,7 @@ Program {
                                                                 kind: Keyword(
                                                                     Number,
                                                                 ),
-                                                                id: 11,
+                                                                id: 9,
                                                                 mutable: false,
                                                                 provenance: Some(
                                                                     Expr(
@@ -785,7 +785,7 @@ Program {
                                                                                                         constraint: None,
                                                                                                     },
                                                                                                 ),
-                                                                                                id: 6,
+                                                                                                id: 5,
                                                                                                 mutable: false,
                                                                                                 provenance: None,
                                                                                             },
@@ -823,11 +823,11 @@ Program {
                                                                                             Type {
                                                                                                 kind: Var(
                                                                                                     TVar {
-                                                                                                        id: 7,
+                                                                                                        id: 6,
                                                                                                         constraint: None,
                                                                                                     },
                                                                                                 ),
-                                                                                                id: 8,
+                                                                                                id: 6,
                                                                                                 mutable: false,
                                                                                                 provenance: None,
                                                                                             },
@@ -840,7 +840,7 @@ Program {
                                                                                     kind: Keyword(
                                                                                         Number,
                                                                                     ),
-                                                                                    id: 11,
+                                                                                    id: 9,
                                                                                     mutable: false,
                                                                                     provenance: None,
                                                                                 },
@@ -852,7 +852,7 @@ Program {
                                                             type_params: None,
                                                         },
                                                     ),
-                                                    id: 12,
+                                                    id: 10,
                                                     mutable: false,
                                                     provenance: None,
                                                 },
@@ -915,7 +915,7 @@ Program {
                                                         kind: Keyword(
                                                             Number,
                                                         ),
-                                                        id: 6,
+                                                        id: 5,
                                                         mutable: false,
                                                         provenance: Some(
                                                             Type(
@@ -926,7 +926,7 @@ Program {
                                                                             constraint: None,
                                                                         },
                                                                     ),
-                                                                    id: 6,
+                                                                    id: 5,
                                                                     mutable: false,
                                                                     provenance: None,
                                                                 },
@@ -973,18 +973,18 @@ Program {
                                                         kind: Keyword(
                                                             Number,
                                                         ),
-                                                        id: 8,
+                                                        id: 6,
                                                         mutable: false,
                                                         provenance: Some(
                                                             Type(
                                                                 Type {
                                                                     kind: Var(
                                                                         TVar {
-                                                                            id: 7,
+                                                                            id: 6,
                                                                             constraint: None,
                                                                         },
                                                                     ),
-                                                                    id: 8,
+                                                                    id: 6,
                                                                     mutable: false,
                                                                     provenance: None,
                                                                 },
@@ -1046,7 +1046,7 @@ Program {
                                                                 kind: Keyword(
                                                                     Number,
                                                                 ),
-                                                                id: 6,
+                                                                id: 5,
                                                                 mutable: false,
                                                                 provenance: Some(
                                                                     Type(
@@ -1057,7 +1057,7 @@ Program {
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
-                                                                            id: 6,
+                                                                            id: 5,
                                                                             mutable: false,
                                                                             provenance: None,
                                                                         },
@@ -1099,18 +1099,18 @@ Program {
                                                                 kind: Keyword(
                                                                     Number,
                                                                 ),
-                                                                id: 8,
+                                                                id: 6,
                                                                 mutable: false,
                                                                 provenance: Some(
                                                                     Type(
                                                                         Type {
                                                                             kind: Var(
                                                                                 TVar {
-                                                                                    id: 7,
+                                                                                    id: 6,
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
-                                                                            id: 8,
+                                                                            id: 6,
                                                                             mutable: false,
                                                                             provenance: None,
                                                                         },
@@ -1126,7 +1126,7 @@ Program {
                                                     kind: Keyword(
                                                         Number,
                                                     ),
-                                                    id: 11,
+                                                    id: 9,
                                                     mutable: false,
                                                     provenance: None,
                                                 },
@@ -1154,7 +1154,7 @@ Program {
                                                         kind: Keyword(
                                                             Number,
                                                         ),
-                                                        id: 6,
+                                                        id: 5,
                                                         mutable: false,
                                                         provenance: Some(
                                                             Type(
@@ -1165,7 +1165,7 @@ Program {
                                                                             constraint: None,
                                                                         },
                                                                     ),
-                                                                    id: 6,
+                                                                    id: 5,
                                                                     mutable: false,
                                                                     provenance: Some(
                                                                         Pattern(
@@ -1206,7 +1206,7 @@ Program {
                                                                                                 constraint: None,
                                                                                             },
                                                                                         ),
-                                                                                        id: 6,
+                                                                                        id: 5,
                                                                                         mutable: false,
                                                                                         provenance: None,
                                                                                     },
@@ -1231,18 +1231,18 @@ Program {
                                                         kind: Keyword(
                                                             Number,
                                                         ),
-                                                        id: 8,
+                                                        id: 6,
                                                         mutable: false,
                                                         provenance: Some(
                                                             Type(
                                                                 Type {
                                                                     kind: Var(
                                                                         TVar {
-                                                                            id: 7,
+                                                                            id: 6,
                                                                             constraint: None,
                                                                         },
                                                                     ),
-                                                                    id: 8,
+                                                                    id: 6,
                                                                     mutable: false,
                                                                     provenance: Some(
                                                                         Pattern(
@@ -1279,11 +1279,11 @@ Program {
                                                                                     Type {
                                                                                         kind: Var(
                                                                                             TVar {
-                                                                                                id: 7,
+                                                                                                id: 6,
                                                                                                 constraint: None,
                                                                                             },
                                                                                         ),
-                                                                                        id: 8,
+                                                                                        id: 6,
                                                                                         mutable: false,
                                                                                         provenance: None,
                                                                                     },
@@ -1302,7 +1302,7 @@ Program {
                                                 kind: Keyword(
                                                     Number,
                                                 ),
-                                                id: 11,
+                                                id: 9,
                                                 mutable: false,
                                                 provenance: Some(
                                                     Expr(
@@ -1357,7 +1357,7 @@ Program {
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),
-                                                                                id: 6,
+                                                                                id: 5,
                                                                                 mutable: false,
                                                                                 provenance: None,
                                                                             },
@@ -1395,11 +1395,11 @@ Program {
                                                                             Type {
                                                                                 kind: Var(
                                                                                     TVar {
-                                                                                        id: 7,
+                                                                                        id: 6,
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),
-                                                                                id: 8,
+                                                                                id: 6,
                                                                                 mutable: false,
                                                                                 provenance: None,
                                                                             },
@@ -1412,7 +1412,7 @@ Program {
                                                                     kind: Keyword(
                                                                         Number,
                                                                     ),
-                                                                    id: 11,
+                                                                    id: 9,
                                                                     mutable: false,
                                                                     provenance: None,
                                                                 },
@@ -1424,7 +1424,7 @@ Program {
                                             type_params: None,
                                         },
                                     ),
-                                    id: 12,
+                                    id: 10,
                                     mutable: false,
                                     provenance: None,
                                 },

--- a/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/escalier_infer/src/snapshots/escalier_infer__tests__infer_ident_inside_lam.snap
@@ -71,6 +71,7 @@ Program {
                                                                 kind: Var(
                                                                     TVar {
                                                                         id: 5,
+                                                                        solution: None,
                                                                         constraint: None,
                                                                     },
                                                                 ),
@@ -112,6 +113,7 @@ Program {
                                                                                     kind: Var(
                                                                                         TVar {
                                                                                             id: 5,
+                                                                                            solution: None,
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
@@ -148,6 +150,7 @@ Program {
                                                                 kind: Var(
                                                                     TVar {
                                                                         id: 6,
+                                                                        solution: None,
                                                                         constraint: None,
                                                                     },
                                                                 ),
@@ -189,6 +192,7 @@ Program {
                                                                                     kind: Var(
                                                                                         TVar {
                                                                                             id: 6,
+                                                                                            solution: None,
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
@@ -263,6 +267,7 @@ Program {
                                                                             kind: Var(
                                                                                 TVar {
                                                                                     id: 5,
+                                                                                    solution: None,
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
@@ -305,6 +310,7 @@ Program {
                                                                             kind: Var(
                                                                                 TVar {
                                                                                     id: 6,
+                                                                                    solution: None,
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
@@ -387,6 +393,7 @@ Program {
                                                                         kind: Var(
                                                                             TVar {
                                                                                 id: 5,
+                                                                                solution: None,
                                                                                 constraint: None,
                                                                             },
                                                                         ),
@@ -434,6 +441,7 @@ Program {
                                                                         kind: Var(
                                                                             TVar {
                                                                                 id: 6,
+                                                                                solution: None,
                                                                                 constraint: None,
                                                                             },
                                                                         ),
@@ -496,6 +504,7 @@ Program {
                                                                                 kind: Var(
                                                                                     TVar {
                                                                                         id: 5,
+                                                                                        solution: None,
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),
@@ -538,6 +547,7 @@ Program {
                                                                                 kind: Var(
                                                                                     TVar {
                                                                                         id: 6,
+                                                                                        solution: None,
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),
@@ -590,6 +600,7 @@ Program {
                                                                                     kind: Var(
                                                                                         TVar {
                                                                                             id: 5,
+                                                                                            solution: None,
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
@@ -631,6 +642,7 @@ Program {
                                                                                                         kind: Var(
                                                                                                             TVar {
                                                                                                                 id: 5,
+                                                                                                                solution: None,
                                                                                                                 constraint: None,
                                                                                                             },
                                                                                                         ),
@@ -667,6 +679,7 @@ Program {
                                                                                     kind: Var(
                                                                                         TVar {
                                                                                             id: 6,
+                                                                                            solution: None,
                                                                                             constraint: None,
                                                                                         },
                                                                                     ),
@@ -708,6 +721,7 @@ Program {
                                                                                                         kind: Var(
                                                                                                             TVar {
                                                                                                                 id: 6,
+                                                                                                                solution: None,
                                                                                                                 constraint: None,
                                                                                                             },
                                                                                                         ),
@@ -782,6 +796,7 @@ Program {
                                                                                                 kind: Var(
                                                                                                     TVar {
                                                                                                         id: 5,
+                                                                                                        solution: None,
                                                                                                         constraint: None,
                                                                                                     },
                                                                                                 ),
@@ -824,6 +839,7 @@ Program {
                                                                                                 kind: Var(
                                                                                                     TVar {
                                                                                                         id: 6,
+                                                                                                        solution: None,
                                                                                                         constraint: None,
                                                                                                     },
                                                                                                 ),
@@ -923,6 +939,7 @@ Program {
                                                                     kind: Var(
                                                                         TVar {
                                                                             id: 5,
+                                                                            solution: None,
                                                                             constraint: None,
                                                                         },
                                                                     ),
@@ -981,6 +998,7 @@ Program {
                                                                     kind: Var(
                                                                         TVar {
                                                                             id: 6,
+                                                                            solution: None,
                                                                             constraint: None,
                                                                         },
                                                                     ),
@@ -1054,6 +1072,7 @@ Program {
                                                                             kind: Var(
                                                                                 TVar {
                                                                                     id: 5,
+                                                                                    solution: None,
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
@@ -1107,6 +1126,7 @@ Program {
                                                                             kind: Var(
                                                                                 TVar {
                                                                                     id: 6,
+                                                                                    solution: None,
                                                                                     constraint: None,
                                                                                 },
                                                                             ),
@@ -1162,6 +1182,7 @@ Program {
                                                                     kind: Var(
                                                                         TVar {
                                                                             id: 5,
+                                                                            solution: None,
                                                                             constraint: None,
                                                                         },
                                                                     ),
@@ -1203,6 +1224,7 @@ Program {
                                                                                         kind: Var(
                                                                                             TVar {
                                                                                                 id: 5,
+                                                                                                solution: None,
                                                                                                 constraint: None,
                                                                                             },
                                                                                         ),
@@ -1239,6 +1261,7 @@ Program {
                                                                     kind: Var(
                                                                         TVar {
                                                                             id: 6,
+                                                                            solution: None,
                                                                             constraint: None,
                                                                         },
                                                                     ),
@@ -1280,6 +1303,7 @@ Program {
                                                                                         kind: Var(
                                                                                             TVar {
                                                                                                 id: 6,
+                                                                                                solution: None,
                                                                                                 constraint: None,
                                                                                             },
                                                                                         ),
@@ -1354,6 +1378,7 @@ Program {
                                                                                 kind: Var(
                                                                                     TVar {
                                                                                         id: 5,
+                                                                                        solution: None,
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),
@@ -1396,6 +1421,7 @@ Program {
                                                                                 kind: Var(
                                                                                     TVar {
                                                                                         id: 6,
+                                                                                        solution: None,
                                                                                         constraint: None,
                                                                                     },
                                                                                 ),

--- a/crates/escalier_infer/src/substitutable.rs
+++ b/crates/escalier_infer/src/substitutable.rs
@@ -32,12 +32,14 @@ impl Substitutable for Type {
 
                         // TODO: apply the constraint and then check if the replacement
                         // is a subtype of it.
-                        return Type {
+                        let t = Type {
                             id: self.id,
                             kind: replacement.kind.to_owned(),
                             mutable: replacement.mutable,
                             provenance,
                         };
+                        checker.types.insert(self.id, t.clone());
+                        return t;
                     }
                     None => {
                         if let Some(constraint) = &tv.constraint {
@@ -88,7 +90,9 @@ impl Substitutable for Type {
                                     checker.from_type_kind(TypeKind::Keyword(TKeyword::String));
                                 return checker.from_type_kind(TypeKind::Array(Box::from(string)));
                             } else {
-                                return parse_regex(pattern, checker);
+                                let t = parse_regex(pattern, checker);
+                                checker.types.insert(self.id, t.clone());
+                                return t;
                             }
                         }
                     }
@@ -132,6 +136,8 @@ impl Substitutable for Type {
         };
 
         norm_type(&mut t);
+
+        checker.types.insert(self.id, t.clone());
 
         t
     }

--- a/crates/escalier_infer/src/unify.rs
+++ b/crates/escalier_infer/src/unify.rs
@@ -31,6 +31,17 @@ fn get_param_types(params: &[TFnParam], checker: &'_ mut Checker) -> Vec<Type> {
 impl Checker {
     // Returns Ok(substitions) if t2 admits all values from t1 and an Err() otherwise.
     pub fn unify(&mut self, t1: &Type, t2: &Type) -> Result<Subst, Vec<TypeError>> {
+        // Verify that both t1 and t2 are always in self.types and they the types
+        // passed to unify() match what's in self.types.
+        match self.types.get(&t1.id) {
+            Some(_cached_t1) => (),
+            None => panic!("Couldn't find {t1} in self.types, t1.id = {}", t1.id),
+        }
+        match self.types.get(&t2.id) {
+            Some(_cached_t2) => (),
+            None => panic!("Couldn't find {t2} in self.types, t2.id = {}", t2.id),
+        }
+
         // All binding must be done first
         match (&t1.kind, &t2.kind) {
             // If both are type variables...

--- a/crates/escalier_infer/src/util.rs
+++ b/crates/escalier_infer/src/util.rs
@@ -400,6 +400,8 @@ pub fn replace_aliases_rec(t: &Type, type_param_map: &HashMap<String, Type>) -> 
         shadowed_type_param_names: vec![],
     };
     t.drive_mut(&mut visitor);
+    // TODO: give this a new id and insert it into checker.types.
+    eprintln!("replace_aliases_rec: t = {t}");
     t
 }
 

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -895,10 +895,5 @@ pub fn parse_dts(d_ts_source: &str) -> Result<escalier_infer::Checker, Error> {
         }
     }
 
-    let checker = escalier_infer::Checker {
-        next_id: collector.checker.next_id,
-        current_scope: collector.checker.current_scope,
-        ..escalier_infer::Checker::default()
-    };
-    Ok(checker)
+    Ok(collector.checker.clone())
 }


### PR DESCRIPTION
This moves us towards using ids for all types in the checker and replacing substation sets, see #507 for details.