### PR TITLE
Update test_env() to only reuse types when necessary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,10 +428,6 @@ dependencies = [
 [[package]]
 name = "escalier_hm"
 version = "0.1.0"
-dependencies = [
- "lazy_static",
- "maplit",
-]
 
 [[package]]
 name = "escalier_infer"
@@ -787,12 +783,6 @@ dependencies = [
  "serde_repr",
  "url",
 ]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"

--- a/crates/escalier_hm/Cargo.toml
+++ b/crates/escalier_hm/Cargo.toml
@@ -6,5 +6,3 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4.0"
-maplit = "1.0.2"

--- a/crates/escalier_hm/src/syntax.rs
+++ b/crates/escalier_hm/src/syntax.rs
@@ -12,6 +12,11 @@ pub struct Identifier {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Number {
+    pub value: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Apply {
     pub func: Box<Syntax>,
     pub args: Vec<Syntax>,
@@ -35,6 +40,7 @@ pub struct Letrec {
 pub enum Syntax {
     Lambda(Lambda),
     Identifier(Identifier),
+    Number(Number),
     Apply(Apply),
     Let(Let),
     Letrec(Letrec),
@@ -52,6 +58,9 @@ impl fmt::Display for Syntax {
             }
             Syntax::Identifier(Identifier { name }) => {
                 write!(f, "{}", name)
+            }
+            Syntax::Number(Number { value }) => {
+                write!(f, "{}", value)
             }
             Syntax::Apply(Apply { func, args }) => {
                 let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -46,7 +46,7 @@ impl Type {
         }
     }
 
-    pub fn new_operator(idx: ArenaType, name: &str, types: &[ArenaType]) -> Type {
+    pub fn new_constructor(idx: ArenaType, name: &str, types: &[ArenaType]) -> Type {
         Type {
             id: idx,
             kind: TypeKind::Constructor(Constructor {


### PR DESCRIPTION
This PR also:
- renames a few more `operator`s to `constructor`s
- gets rid of static definitions of `INTEGER` and `BOOLEAN`
- removes unnecessary dependencies