### PR TITLE
Improve literal types

### DIFF
--- a/crates/escalier_hm/src/literal.rs
+++ b/crates/escalier_hm/src/literal.rs
@@ -1,0 +1,18 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Literal {
+    Number(String),
+    String(String),
+    Boolean(bool),
+}
+
+impl fmt::Display for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            Literal::Number(value) => write!(f, "{}", value),
+            Literal::String(value) => write!(f, "\"{}\"", value),
+            Literal::Boolean(value) => write!(f, "{}", value),
+        }
+    }
+}

--- a/crates/escalier_hm/src/syntax.rs
+++ b/crates/escalier_hm/src/syntax.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::literal::Literal;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Lambda {
     pub params: Vec<String>,
@@ -52,8 +54,7 @@ pub struct IfElse {
 pub enum Syntax {
     Lambda(Lambda),
     Identifier(Identifier),
-    Number(Number),
-    String(Str),
+    Literal(Literal),
     Apply(Apply),
     Let(Let),
     Letrec(Letrec),
@@ -73,11 +74,8 @@ impl fmt::Display for Syntax {
             Syntax::Identifier(Identifier { name }) => {
                 write!(f, "{}", name)
             }
-            Syntax::Number(Number { value }) => {
-                write!(f, "{}", value)
-            }
-            Syntax::String(Str { value }) => {
-                write!(f, "{}", value)
+            Syntax::Literal(literal) => {
+                write!(f, "{literal}")
             }
             Syntax::Apply(Apply { func, args }) => {
                 let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -1,6 +1,8 @@
 // Types and type constructors
 use std::collections::HashMap;
 
+use crate::literal::Literal;
+
 pub type ArenaType = usize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12,18 +14,6 @@ pub struct Variable {
 pub struct Constructor {
     pub name: String,
     pub types: Vec<ArenaType>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum LiteralKind {
-    Number(String),
-    String(String),
-    Boolean(bool),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Literal {
-    pub kind: LiteralKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -153,11 +143,7 @@ impl Type {
                     format!("{} {}", con.name, coll.join(" "))
                 }
             },
-            TypeKind::Literal(lit) => match &lit.kind {
-                LiteralKind::Number(n) => n.clone(),
-                LiteralKind::String(s) => s.clone(),
-                LiteralKind::Boolean(b) => b.to_string(),
-            },
+            TypeKind::Literal(lit) => lit.to_string(),
             TypeKind::Function(func) => {
                 let params = func
                     .params
@@ -192,6 +178,63 @@ impl Type {
             }
         }
     }
+}
+
+/// A binary type constructor which builds function types
+pub fn new_func_type(a: &mut Vec<Type>, params: &[ArenaType], ret: ArenaType) -> ArenaType {
+    let t = Type::new_function(a.len(), params, ret);
+    a.push(t);
+    a.len() - 1
+}
+
+pub fn new_call_type(a: &mut Vec<Type>, args: &[ArenaType], ret: ArenaType) -> ArenaType {
+    let t = Type::new_call(a.len(), args, ret);
+    a.push(t);
+    a.len() - 1
+}
+
+pub fn new_union_type(a: &mut Vec<Type>, types: &[ArenaType]) -> ArenaType {
+    let t = Type::new_union(a.len(), types);
+    a.push(t);
+    a.len() - 1
+}
+
+/// A binary type constructor which builds function types
+pub fn new_var_type(a: &mut Vec<Type>) -> ArenaType {
+    let t = Type::new_variable(a.len());
+    a.push(t);
+    a.len() - 1
+}
+
+/// A binary type constructor which builds function types
+pub fn new_constructor(a: &mut Vec<Type>, name: &str, types: &[ArenaType]) -> ArenaType {
+    let t = Type::new_constructor(a.len(), name, types);
+    a.push(t);
+    a.len() - 1
+}
+
+pub fn new_lit_type(a: &mut Vec<Type>, lit: &Literal) -> ArenaType {
+    let t = Type::new_literal(a.len(), lit);
+    a.push(t);
+    a.len() - 1
+}
+
+pub fn new_num_lit_type(a: &mut Vec<Type>, value: &str) -> ArenaType {
+    let t = Type::new_literal(a.len(), &Literal::Number(value.to_string()));
+    a.push(t);
+    a.len() - 1
+}
+
+pub fn new_str_lit_type(a: &mut Vec<Type>, value: &str) -> ArenaType {
+    let t = Type::new_literal(a.len(), &Literal::String(value.to_string()));
+    a.push(t);
+    a.len() - 1
+}
+
+pub fn new_bool_lit_type(a: &mut Vec<Type>, value: bool) -> ArenaType {
+    let t = Type::new_literal(a.len(), &Literal::Boolean(value));
+    a.push(t);
+    a.len() - 1
 }
 
 //impl fmt::Debug for Type {


### PR DESCRIPTION
This PR simplifies the data structure used for literals and adds support for using `true` and `false` literals as subtypes of `boolean`.  We could try defining `boolean` as `true | false`.  This would remove at least one special case in `unify()`, but we need type aliases for that.  I'll add those in a future PR.