### PR TITLE
Get rid of TypeKind::Call and add support for objects and tuples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,9 @@ dependencies = [
 [[package]]
 name = "escalier_hm"
 version = "0.1.0"
+dependencies = [
+ "itertools",
+]
 
 [[package]]
 name = "escalier_infer"

--- a/crates/escalier_hm/Cargo.toml
+++ b/crates/escalier_hm/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools = "0.10.5"

--- a/crates/escalier_hm/src/env.rs
+++ b/crates/escalier_hm/src/env.rs
@@ -84,15 +84,6 @@ pub fn fresh(a: &mut Vec<Type>, t: ArenaType, non_generic: &[ArenaType]) -> Aren
                 let ret = freshrec(a, func.ret, mappings, non_generic);
                 new_func_type(a, &params, ret)
             }
-            TypeKind::Call(call) => {
-                let args = call
-                    .args
-                    .iter()
-                    .map(|x| freshrec(a, *x, mappings, non_generic))
-                    .collect::<Vec<_>>();
-                let ret = freshrec(a, call.ret, mappings, non_generic);
-                new_call_type(a, &args, ret)
-            }
             TypeKind::Union(union) => {
                 let args = union
                     .types

--- a/crates/escalier_hm/src/errors.rs
+++ b/crates/escalier_hm/src/errors.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Errors {
     InferenceError(String),
     ParseError(String),

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -155,7 +155,7 @@ pub fn infer_expression(
                         }
                     }
                     Err(Errors::InferenceError(format!(
-                        "Couldn't find property {name} on object",
+                        "Couldn't find property '{name}' on object",
                     )))
                 }
                 (TypeKind::Tuple(tuple), TypeKind::Literal(Literal::Number(value))) => {
@@ -164,7 +164,8 @@ pub fn infer_expression(
                         return Ok(tuple.types[index]);
                     }
                     Err(Errors::InferenceError(format!(
-                        "Couldn't find index {index} on tuple",
+                        "{index} was outside the bounds 0..{} of the tuple",
+                        tuple.types.len()
                     )))
                 }
                 _ => Err(Errors::InferenceError(

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -75,7 +75,6 @@ pub fn infer_expression(
             // TODO: create a new type for undefined and use that as the return type
             let ret_t = infer_statement(a, &body[0], &mut new_env, &new_non_generic)?;
             let t = new_func_type(a, &param_types, ret_t);
-            eprintln!("t = {:#?}", a[t]);
             Ok(t)
         }
         Expression::Let(Let { defn, var, body }) => {

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::env::*;
 use crate::errors::*;
@@ -46,12 +46,8 @@ pub fn infer_expression(
                 .iter()
                 .map(|arg| infer_expression(a, arg, env, non_generic))
                 .collect::<Result<Vec<_>, _>>()?;
-            let ret_type = new_var_type(a);
 
-            let call_type = Type::new_function(a.len(), &arg_types, ret_type);
-            a.push(call_type.clone());
-
-            unify_call(a, call_type, func_type)?;
+            let ret_type = unify_call(a, &arg_types, func_type)?;
             Ok(ret_type)
         }
         Expression::Lambda(Lambda { params, body }) => {

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -48,7 +48,7 @@ pub fn infer_expression(
                 .collect::<Result<Vec<_>, _>>()?;
             let ret_type = new_var_type(a);
 
-            let call_type = Type::new_call(a.len(), &arg_types, ret_type);
+            let call_type = Type::new_function(a.len(), &arg_types, ret_type);
             a.push(call_type.clone());
 
             unify_call(a, call_type, func_type)?;

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -739,6 +739,25 @@ mod tests {
     }
 
     #[test]
+    fn tuple_member_error_out_of_bounds() -> Result<(), Errors> {
+        let (mut a, mut my_env) = test_env();
+
+        let tuple = new_tuple(&[new_number("5"), new_string("hello")]);
+        let syntax = new_member(&tuple, &new_number("2"));
+
+        let result = infer_expression(&mut a, &syntax, &mut my_env, &HashSet::default());
+
+        assert_eq!(
+            result,
+            Err(Errors::InferenceError(
+                "2 was outside the bounds 0..2 of the tuple".to_string()
+            ))
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn tuple_subtyping() -> Result<(), Errors> {
         let (mut a, mut my_env) = test_env();
 
@@ -847,6 +866,28 @@ mod tests {
                 }
             ),
             "5".to_string(),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn object_member_missing_prop() -> Result<(), Errors> {
+        let (mut a, mut my_env) = test_env();
+
+        let object = new_object(&[
+            ("a".to_string(), new_number("5")),
+            ("b".to_string(), new_string("hello")),
+        ]);
+        let syntax = new_member(&object, &new_string("c"));
+
+        let result = infer_expression(&mut a, &syntax, &mut my_env, &HashSet::default());
+
+        assert_eq!(
+            result,
+            Err(Errors::InferenceError(
+                "Couldn't find property 'c' on object".to_string()
+            ))
         );
 
         Ok(())

--- a/crates/escalier_hm/src/syntax.rs
+++ b/crates/escalier_hm/src/syntax.rs
@@ -14,13 +14,13 @@ pub struct Identifier {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Number {
-    pub value: String,
+pub struct Tuple {
+    pub elems: Vec<Expression>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Str {
-    pub value: String,
+pub struct Object {
+    pub props: Vec<(String, Expression)>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -50,14 +50,23 @@ pub struct IfElse {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Member {
+    pub obj: Box<Expression>,
+    pub prop: Box<Expression>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Expression {
     Lambda(Lambda),
     Identifier(Identifier),
     Literal(Literal),
+    Tuple(Tuple),
+    Object(Object),
     Apply(Apply),
     Let(Let),
     Letrec(Letrec),
     IfElse(IfElse),
+    Member(Member),
 }
 
 impl fmt::Display for Expression {
@@ -99,6 +108,23 @@ impl fmt::Display for Expression {
                 alternate,
             }) => {
                 write!(f, "(if {cond} then {consequent} else {alternate})",)
+            }
+            Expression::Member(Member { obj, prop }) => {
+                write!(f, "{obj}.{prop}")
+            }
+            Expression::Tuple(Tuple { elems }) => {
+                let elems = elems
+                    .iter()
+                    .map(|elem| elem.to_string())
+                    .collect::<Vec<_>>();
+                write!(f, "[{}]", elems.join(", "))
+            }
+            Expression::Object(Object { props }) => {
+                let props = props
+                    .iter()
+                    .map(|(key, value)| format!("{}: {}", key, value))
+                    .collect::<Vec<_>>();
+                write!(f, "{{{}}}", props.join(", "))
             }
         }
     }

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -39,7 +39,6 @@ pub enum TypeKind {
     Constructor(Constructor),
     Literal(Literal),
     Function(Function),
-    Call(Call),
     Union(Union),
 }
 
@@ -84,16 +83,6 @@ impl Type {
             id: idx,
             kind: TypeKind::Function(Function {
                 params: param_types.to_vec(),
-                ret: ret_type,
-            }),
-        }
-    }
-
-    pub fn new_call(idx: ArenaType, arg_types: &[ArenaType], ret_type: ArenaType) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Call(Call {
-                args: arg_types.to_vec(),
                 ret: ret_type,
             }),
         }
@@ -155,19 +144,6 @@ impl Type {
 
                 format!("({}) => {ret}", params.join(", "))
             }
-            TypeKind::Call(call) => {
-                eprintln!("call: {:?}", call);
-                let args = call
-                    .args
-                    .iter()
-                    .map(|arg| a[*arg].as_string(a, namer))
-                    .collect::<Vec<_>>();
-
-                let ret = a[call.ret].as_string(a, namer);
-
-                // Should this be formatted more like a function call
-                format!("({}) => {ret}", args.join(", "))
-            }
             TypeKind::Union(union) => {
                 let types = union
                     .types
@@ -184,12 +160,6 @@ impl Type {
 /// A binary type constructor which builds function types
 pub fn new_func_type(a: &mut Vec<Type>, params: &[ArenaType], ret: ArenaType) -> ArenaType {
     let t = Type::new_function(a.len(), params, ret);
-    a.push(t);
-    a.len() - 1
-}
-
-pub fn new_call_type(a: &mut Vec<Type>, args: &[ArenaType], ret: ArenaType) -> ArenaType {
-    let t = Type::new_call(a.len(), args, ret);
     a.push(t);
     a.len() - 1
 }

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -10,8 +10,8 @@ use crate::util::*;
 /// Makes the types t1 and t2 the same.
 ///
 /// Args:
-///     t1: The first type to be made equivalent
-///     t2: The second type to be be equivalent
+///     t1: The first type to be made equivalent (subtype)
+///     t2: The second type to be be equivalent (supertype)
 ///
 /// Returns:
 ///     None
@@ -73,6 +73,8 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
             Ok(())
         }
         (_, TypeKind::Union(Union { types })) => {
+            // If t1 is a subtype of any of the types in the union, then it is a
+            // subtype of the union.
             for t2 in types.iter() {
                 if unify(alloc, a, *t2).is_ok() {
                     return Ok(());
@@ -112,6 +114,12 @@ pub fn unify_call(
             return Err(Errors::InferenceError(format!(
                 "literal {lit} is not callable"
             )));
+        }
+        TypeKind::Tuple(_) => {
+            return Err(Errors::InferenceError("tuple is not callable".to_string()));
+        }
+        TypeKind::Object(_) => {
+            return Err(Errors::InferenceError("object is not callable".to_string()));
         }
         TypeKind::Function(func) => {
             if arg_types.len() < func.params.len() {

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -42,20 +42,6 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
             unify(alloc, func_a.ret, func_b.ret)?;
             Ok(())
         }
-        (TypeKind::Call(call), TypeKind::Function(func)) => {
-            for (p, q) in call.args.iter().zip(func.params.iter()) {
-                unify(alloc, *p, *q)?;
-            }
-            unify(alloc, call.ret, func.ret)?;
-            Ok(())
-        }
-        (TypeKind::Call(call_a), TypeKind::Call(call_b)) => {
-            for (p, q) in call_a.args.iter().zip(call_b.args.iter()) {
-                unify(alloc, *p, *q)?;
-            }
-            unify(alloc, call_a.ret, call_b.ret)?;
-            Ok(())
-        }
         (
             TypeKind::Literal(Literal::Number(_)),
             TypeKind::Constructor(Constructor { name, .. }),
@@ -93,7 +79,7 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
 }
 
 pub fn unify_call(alloc: &mut Vec<Type>, t1: Type, t2: ArenaType) -> Result<(), Errors> {
-    if let TypeKind::Call(call) = t1.kind {
+    if let TypeKind::Function(call) = t1.kind {
         let b = prune(alloc, t2);
         // Why do we clone here?
         let b_t = alloc.get(b).unwrap().clone();
@@ -109,16 +95,7 @@ pub fn unify_call(alloc: &mut Vec<Type>, t1: Type, t2: ArenaType) -> Result<(), 
                 todo!("literal")
             }
             TypeKind::Function(func) => {
-                for (p, q) in call.args.iter().zip(func.params.iter()) {
-                    unify(alloc, *p, *q)?;
-                }
-                unify(alloc, call.ret, func.ret)?;
-                Ok(())
-            }
-            TypeKind::Call(func) => {
-                // drop the call type since it's redundant now that we have
-                // unify_call
-                for (p, q) in call.args.iter().zip(func.args.iter()) {
+                for (p, q) in call.params.iter().zip(func.params.iter()) {
                     unify(alloc, *p, *q)?;
                 }
                 unify(alloc, call.ret, func.ret)?;

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -20,6 +20,11 @@ pub fn occurs_in_type(a: &mut Vec<Type>, v: ArenaType, type2: ArenaType) -> bool
     match a.get(pruned_type2).unwrap().clone().kind {
         TypeKind::Variable(_) => false, // leaf node
         TypeKind::Literal(_) => false,  // leaf node
+        TypeKind::Tuple(Tuple { types }) => occurs_in(a, v, &types),
+        TypeKind::Object(Object { props }) => {
+            let types = props.iter().map(|(_, v)| *v).collect::<Vec<_>>();
+            occurs_in(a, v, &types)
+        }
         TypeKind::Constructor(Constructor { types, .. }) => occurs_in(a, v, &types),
         TypeKind::Function(Function { params, ret }) => {
             occurs_in(a, v, &params) || occurs_in_type(a, v, ret)

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -24,7 +24,6 @@ pub fn occurs_in_type(a: &mut Vec<Type>, v: ArenaType, type2: ArenaType) -> bool
         TypeKind::Function(Function { params, ret }) => {
             occurs_in(a, v, &params) || occurs_in_type(a, v, ret)
         }
-        TypeKind::Call(Call { args, ret }) => occurs_in(a, v, &args) || occurs_in_type(a, v, ret),
         TypeKind::Union(Union { types }) => occurs_in(a, v, &types),
     }
 }


### PR DESCRIPTION
This type kind didn't make much sense.  Instead, having a separate `unify_call()` function to handle unifying calls with different things such as objects with callables or type constructors that might be callable makes more sense.