### PR TITLE
Update escalier_hm to use derive_visitor crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
 name = "escalier_hm"
 version = "0.1.0"
 dependencies = [
+ "derive-visitor",
  "im",
  "itertools",
 ]

--- a/crates/escalier_hm/Cargo.toml
+++ b/crates/escalier_hm/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+derive-visitor = "0.3.0"
 itertools = "0.10.5"
 im = "15.1.0"

--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -78,7 +78,10 @@ pub fn fresh(a: &mut Vec<Type>, t: &ArenaType, ctx: &Context) -> ArenaType {
                 let fields: Vec<_> = object
                     .props
                     .iter()
-                    .map(|(name, tp)| (name.clone(), freshrec(a, tp, mappings, ctx)))
+                    .map(|prop| ObjProp {
+                        name: prop.name.clone(),
+                        t: freshrec(a, &prop.t, mappings, ctx),
+                    })
                     .collect();
                 new_object_type(a, &fields)
             }

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -49,8 +49,10 @@ pub fn infer_expression(
         Expression::Object(syntax::Object { props }) => {
             let mut prop_types = vec![];
             for (name, value) in props {
-                let t = infer_expression(a, value, ctx)?;
-                prop_types.push((name.to_owned(), t));
+                prop_types.push(ObjProp {
+                    name: name.to_owned(),
+                    t: infer_expression(a, value, ctx)?,
+                });
             }
             let t = new_object_type(a, &prop_types);
             Ok(t)
@@ -139,9 +141,9 @@ pub fn infer_expression(
 
             match (&obj_type.kind, &prop_type.kind) {
                 (TypeKind::Object(object), TypeKind::Literal(Literal::String(name))) => {
-                    for (key, t) in &object.props {
-                        if key == name {
-                            return Ok(*t);
+                    for prop in &object.props {
+                        if &prop.name == name {
+                            return Ok(prop.t);
                         }
                     }
                     Err(Errors::InferenceError(format!(

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
         );
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"(number) => number"#);
+        assert_eq!(a[t.value].as_string(&a), r#"(number) => number"#);
         Ok(())
     }
 
@@ -234,7 +234,7 @@ mod tests {
         );
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"(number) => number"#);
+        assert_eq!(a[t.value].as_string(&a), r#"(number) => number"#);
 
         Ok(())
     }
@@ -306,7 +306,7 @@ mod tests {
         infer_program(&mut a, &program, &mut my_ctx)?;
 
         let t = my_ctx.env.get("result").unwrap();
-        assert_eq!(a[*t].as_string(&a), r#"(4 * true)"#);
+        assert_eq!(a[t.value].as_string(&a), r#"(4 * true)"#);
         Ok(())
     }
 
@@ -349,7 +349,7 @@ mod tests {
         infer_program(&mut a, &program, &mut my_ctx)?;
 
         let t = my_ctx.env.get("result").unwrap();
-        assert_eq!(a[*t].as_string(&a), r#"5"#);
+        assert_eq!(a[t.value].as_string(&a), r#"5"#);
         Ok(())
     }
 
@@ -379,7 +379,7 @@ mod tests {
         );
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"(t21) => (t21 * t21)"#);
+        assert_eq!(a[t.value].as_string(&a), r#"(t21) => (t21 * t21)"#);
         Ok(())
     }
 
@@ -392,8 +392,8 @@ mod tests {
         let syntax = new_lambda(&["x"], &[new_expr_stmt(new_identifier("x"))]);
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"(t17) => t17"#);
-        let t = &a[t];
+        assert_eq!(a[t.value].as_string(&a), r#"(t17) => t17"#);
+        let t = &a[t.value];
         eprintln!("t = {t:#?}");
         Ok(())
     }
@@ -420,7 +420,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
         assert_eq!(
-            a[t].as_string(&a),
+            a[t.value].as_string(&a),
             r#"((t19) => t20) => ((t20) => t51) => (t19) => t51"#
         );
         Ok(())
@@ -442,7 +442,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
         assert_eq!(
-            a[t].as_string(&a),
+            a[t.value].as_string(&a),
             r#"((t19) => t20, (t20) => t22, t19) => t22"#
         );
         Ok(())
@@ -458,7 +458,7 @@ mod tests {
         );
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"number"#);
+        assert_eq!(a[t.value].as_string(&a), r#"number"#);
         Ok(())
     }
 
@@ -493,7 +493,7 @@ mod tests {
         let syntax = new_apply(new_identifier("foo"), &[new_identifier("bar")]);
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"boolean"#);
+        assert_eq!(a[t.value].as_string(&a), r#"boolean"#);
         Ok(())
     }
 
@@ -522,7 +522,7 @@ mod tests {
         let result = infer_expression(&mut a, &syntax, &mut my_ctx);
         assert_eq!(
             result,
-            Err(Errors::InferenceError("Type { id: 31, kind: Function(Function { params: [28, 29], ret: 30 }) } is not a subtype of Type { id: 25, kind: Function(Function { params: [23], ret: 24 }) } since it requires more params".to_string())),
+            Err(Errors::InferenceError("(number, string) => boolean is not a subtype of (number) => boolean since it requires more params".to_string())),
         );
         Ok(())
     }
@@ -543,7 +543,7 @@ mod tests {
         );
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"number"#);
+        assert_eq!(a[t.value].as_string(&a), r#"number"#);
         Ok(())
     }
 
@@ -562,7 +562,7 @@ mod tests {
         let syntax = new_apply(new_identifier("foo"), &[]);
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
-        assert_eq!(a[t].as_string(&a), r#"boolean | string"#);
+        assert_eq!(a[t.value].as_string(&a), r#"boolean | string"#);
         Ok(())
     }
 
@@ -613,7 +613,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
 
-        assert_eq!(a[t].as_string(&a), "[5, \"hello\"]".to_string(),);
+        assert_eq!(a[t.value].as_string(&a), "[5, \"hello\"]".to_string(),);
 
         Ok(())
     }
@@ -627,7 +627,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
 
-        assert_eq!(a[t].as_string(&a), "\"hello\"".to_string(),);
+        assert_eq!(a[t.value].as_string(&a), "\"hello\"".to_string(),);
 
         Ok(())
     }
@@ -675,7 +675,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
 
-        assert_eq!(a[t].as_string(&a), "boolean".to_string(),);
+        assert_eq!(a[t.value].as_string(&a), "boolean".to_string(),);
 
         Ok(())
     }
@@ -716,7 +716,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
 
-        assert_eq!(a[t].as_string(&a), "{a: 5, b: \"hello\"}".to_string(),);
+        assert_eq!(a[t.value].as_string(&a), "{a: 5, b: \"hello\"}".to_string(),);
 
         Ok(())
     }
@@ -733,7 +733,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
 
-        assert_eq!(a[t].as_string(&a), "5".to_string(),);
+        assert_eq!(a[t.value].as_string(&a), "5".to_string(),);
 
         Ok(())
     }
@@ -784,7 +784,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &syntax, &mut my_ctx)?;
 
-        assert_eq!(a[t].as_string(&a), "boolean".to_string(),);
+        assert_eq!(a[t.value].as_string(&a), "boolean".to_string(),);
 
         Ok(())
     }
@@ -810,8 +810,7 @@ mod tests {
         assert_eq!(
             result,
             Err(Errors::InferenceError(
-                "'a' is missing in Type { id: 28, kind: Object(Object { props: [(\"b\", 27)] }) }"
-                    .to_string()
+                "'a' is missing in {b: \"hello\"}".to_string()
             ))
         );
 
@@ -819,8 +818,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "called `Result::unwrap()` on an `Err` value: InferenceError(\"type mismatch: unify(Type { id: 22, kind: Literal(String(\\\"hello\\\")) }, Type { id: 18, kind: Constructor(Constructor { name: \\\"number\\\", types: [] }) }) failed\")"]
-    fn test_subtype_error() {
+    fn test_subtype_error() -> Result<(), Errors> {
         let (mut a, mut my_ctx) = test_env();
 
         let syntax = new_apply(
@@ -828,12 +826,20 @@ mod tests {
             &[new_number("5"), new_string("hello")],
         );
 
-        infer_expression(&mut a, &syntax, &mut my_ctx).unwrap();
+        let result = infer_expression(&mut a, &syntax, &mut my_ctx);
+
+        assert_eq!(
+            result,
+            Err(Errors::InferenceError(
+                "type mismatch: unify(\"hello\", number) failed".to_string()
+            ))
+        );
+
+        Ok(())
     }
 
     #[test]
-    #[should_panic = "called `Result::unwrap()` on an `Err` value: InferenceError(\"type mismatch: unify(Type { id: 25, kind: Literal(String(\\\"hello\\\")) }, Type { id: 20, kind: Constructor(Constructor { name: \\\"number\\\", types: [] }) }) failed\")"]
-    fn test_union_subtype_error() {
+    fn test_union_subtype_error() -> Result<(), Errors> {
         let (mut a, mut my_ctx) = test_env();
 
         let lit1 = new_lit_type(&mut a, &Literal::Number("5".to_string()));
@@ -847,7 +853,16 @@ mod tests {
             &[new_identifier("foo"), new_number("2")],
         );
 
-        infer_expression(&mut a, &syntax, &mut my_ctx).unwrap();
+        let result = infer_expression(&mut a, &syntax, &mut my_ctx);
+
+        assert_eq!(
+            result,
+            Err(Errors::InferenceError(
+                "type mismatch: unify(\"hello\", number) failed".to_string()
+            ))
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -874,10 +889,10 @@ mod tests {
         infer_program(&mut a, &program, &mut my_ctx)?;
 
         let t = my_ctx.env.get("num").unwrap();
-        assert_eq!(a[*t].as_string(&a), r#"5"#);
+        assert_eq!(a[t.value].as_string(&a), r#"5"#);
 
         let t = my_ctx.env.get("str").unwrap();
-        assert_eq!(a[*t].as_string(&a), r#""hello""#);
+        assert_eq!(a[t.value].as_string(&a), r#""hello""#);
 
         Ok(())
     }
@@ -906,10 +921,10 @@ mod tests {
         infer_program(&mut a, &program, &mut my_ctx)?;
 
         let t = my_ctx.env.get("a").unwrap();
-        assert_eq!(a[*t].as_string(&a), r#"5"#);
+        assert_eq!(a[t.value].as_string(&a), r#"5"#);
 
         let t = my_ctx.env.get("b").unwrap();
-        assert_eq!(a[*t].as_string(&a), r#""hello""#);
+        assert_eq!(a[t.value].as_string(&a), r#""hello""#);
 
         Ok(())
     }
@@ -940,7 +955,7 @@ mod tests {
 
         let t = infer_expression(&mut a, &lambda, &mut my_ctx)?;
 
-        assert_eq!(a[t].as_string(&a), r#"() => number"#);
+        assert_eq!(a[t.value].as_string(&a), r#"() => number"#);
 
         Ok(())
     }

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -766,7 +766,19 @@ mod tests {
 
         let num = new_constructor(&mut a, "number", &[]);
         let str = new_constructor(&mut a, "string", &[]);
-        let param_type = new_object_type(&mut a, &[("a".to_string(), num), ("b".to_string(), str)]);
+        let param_type = new_object_type(
+            &mut a,
+            &[
+                ObjProp {
+                    name: "a".to_string(),
+                    t: num,
+                },
+                ObjProp {
+                    name: "b".to_string(),
+                    t: str,
+                },
+            ],
+        );
         let bool = new_constructor(&mut a, "boolean", &[]);
         let func = new_func_type(&mut a, &[param_type], bool);
         my_ctx.env.insert("foo".to_string(), func);
@@ -795,7 +807,19 @@ mod tests {
 
         let num = new_constructor(&mut a, "number", &[]);
         let str = new_constructor(&mut a, "string", &[]);
-        let param_type = new_object_type(&mut a, &[("a".to_string(), num), ("b".to_string(), str)]);
+        let param_type = new_object_type(
+            &mut a,
+            &[
+                ObjProp {
+                    name: "a".to_string(),
+                    t: num,
+                },
+                ObjProp {
+                    name: "b".to_string(),
+                    t: str,
+                },
+            ],
+        );
         let bool = new_constructor(&mut a, "boolean", &[]);
         let func = new_func_type(&mut a, &[param_type], bool);
         my_ctx.env.insert("foo".to_string(), func);

--- a/crates/escalier_hm/src/literal.rs
+++ b/crates/escalier_hm/src/literal.rs
@@ -1,9 +1,13 @@
+use derive_visitor::{Drive, DriveMut};
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Drive, DriveMut, PartialEq, Eq, Hash)]
 pub enum Literal {
+    #[drive(skip)]
     Number(String),
+    #[drive(skip)]
     String(String),
+    #[drive(skip)]
     Boolean(bool),
 }
 

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -18,29 +18,35 @@ use crate::util::*;
 ///
 /// Raises:
 ///     InferenceError: Raised if the types cannot be unified.
-pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), Errors> {
+pub fn unify(alloc: &mut Vec<Type>, t1: &ArenaType, t2: &ArenaType) -> Result<(), Errors> {
     let a = prune(alloc, t1);
     let b = prune(alloc, t2);
     // Why do we clone here?
-    let a_t = alloc.get(a).unwrap().clone();
-    let b_t = alloc.get(b).unwrap().clone();
+    let a_t = alloc.get(a.value).unwrap().clone();
+    let b_t = alloc.get(b.value).unwrap().clone();
     match (&a_t.kind, &b_t.kind) {
-        (TypeKind::Variable(_), _) => bind(alloc, a, b),
-        (_, TypeKind::Variable(_)) => bind(alloc, b, a),
+        (TypeKind::Variable(_), _) => bind(alloc, &a, &b),
+        (_, TypeKind::Variable(_)) => bind(alloc, &b, &a),
         (TypeKind::Constructor(con_a), TypeKind::Constructor(con_b)) => {
             // TODO: support type constructors with optional and default type params
             if con_a.name != con_b.name || con_a.types.len() != con_b.types.len() {
-                return Err(Errors::InferenceError(format!("type mismatch: {a} != {b}")));
+                return Err(Errors::InferenceError(format!(
+                    "type mismatch: {} != {}",
+                    a_t.as_string(alloc),
+                    b_t.as_string(alloc)
+                )));
             }
             for (p, q) in con_a.types.iter().zip(con_b.types.iter()) {
-                unify(alloc, *p, *q)?;
+                unify(alloc, p, q)?;
             }
             Ok(())
         }
         (TypeKind::Function(func_a), TypeKind::Function(func_b)) => {
             if func_a.params.len() > func_b.params.len() {
                 return Err(Errors::InferenceError(format!(
-                    "{a_t:?} is not a subtype of {b_t:?} since it requires more params",
+                    "{} is not a subtype of {} since it requires more params",
+                    a_t.as_string(alloc),
+                    b_t.as_string(alloc)
                 )));
             }
 
@@ -48,9 +54,9 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
                 // NOTE: We reverse the order of the params here because func_a
                 // should be able to accept any params that func_b can accept,
                 // its params may be more lenient.  Thus q is a subtype of p.
-                unify(alloc, *q, *p)?;
+                unify(alloc, q, p)?;
             }
-            unify(alloc, func_a.ret, func_b.ret)?;
+            unify(alloc, &func_a.ret, &func_b.ret)?;
             Ok(())
         }
         (
@@ -68,7 +74,7 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
         (TypeKind::Union(Union { types }), _) => {
             // All types in the union must be subtypes of t2
             for t in types.iter() {
-                unify(alloc, *t, b)?;
+                unify(alloc, t, &b)?;
             }
             Ok(())
         }
@@ -76,7 +82,7 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
             // If t1 is a subtype of any of the types in the union, then it is a
             // subtype of the union.
             for t2 in types.iter() {
-                if unify(alloc, a, *t2).is_ok() {
+                if unify(alloc, &a, t2).is_ok() {
                     return Ok(());
                 }
             }
@@ -95,7 +101,7 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
             }
 
             for (p, q) in tuple1.types.iter().zip(tuple2.types.iter()) {
-                unify(alloc, *p, *q)?;
+                unify(alloc, p, q)?;
             }
             Ok(())
         }
@@ -103,17 +109,20 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
             // object1 must have atleast as the same properties as object2
             for (name, t) in &object2.props {
                 if let Some(prop) = object1.props.iter().find(|props| &props.0 == name) {
-                    unify(alloc, prop.1, *t)?;
+                    unify(alloc, &prop.1, t)?;
                 } else {
                     return Err(Errors::InferenceError(format!(
-                        "'{name}' is missing in {a_t:?}"
+                        "'{name}' is missing in {}",
+                        a_t.as_string(alloc),
                     )));
                 }
             }
             Ok(())
         }
         _ => Err(Errors::InferenceError(format!(
-            "type mismatch: unify({a_t:?}, {b_t:?}) failed"
+            "type mismatch: unify({}, {}) failed",
+            a_t.as_string(alloc),
+            b_t.as_string(alloc)
         ))),
     }
 }
@@ -122,16 +131,16 @@ pub fn unify(alloc: &mut Vec<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), 
 pub fn unify_call(
     alloc: &mut Vec<Type>,
     arg_types: &[ArenaType],
-    t2: ArenaType,
+    t2: &ArenaType,
 ) -> Result<ArenaType, Errors> {
     let ret_type = new_var_type(alloc);
     let call_type = new_func_type(alloc, arg_types, ret_type);
 
     let b = prune(alloc, t2);
-    let b_t = alloc.get(b).unwrap().clone();
+    let b_t = alloc.get(b.value).unwrap().clone();
 
     match b_t.kind {
-        TypeKind::Variable(_) => bind(alloc, b, call_type)?,
+        TypeKind::Variable(_) => bind(alloc, &b, &call_type)?,
         TypeKind::Constructor(_) => {
             // lookup definition of type constructor, and see if its instances
             // have any callable signatures
@@ -158,14 +167,14 @@ pub fn unify_call(
             }
 
             for (p, q) in arg_types.iter().zip(func.params.iter()) {
-                unify(alloc, *p, *q)?;
+                unify(alloc, p, q)?;
             }
-            unify(alloc, ret_type, func.ret)?;
+            unify(alloc, &ret_type, &func.ret)?;
         }
         TypeKind::Union(union) => {
             let mut ret_types = vec![];
             for t in union.types.iter() {
-                let ret_type = unify_call(alloc, arg_types, *t)?;
+                let ret_type = unify_call(alloc, arg_types, t)?;
                 ret_types.push(ret_type);
             }
 
@@ -179,13 +188,13 @@ pub fn unify_call(
     Ok(ret_type)
 }
 
-fn bind(alloc: &mut Vec<Type>, a: usize, b: usize) -> Result<(), Errors> {
+fn bind(alloc: &mut Vec<Type>, a: &ArenaType, b: &ArenaType) -> Result<(), Errors> {
     if a != b {
         if occurs_in_type(alloc, a, b) {
             // raise InferenceError("recursive unification")
             return Err(Errors::InferenceError("recursive unification".to_string()));
         }
-        alloc.get_mut(a).unwrap().set_instance(b);
+        alloc.get_mut(a.value).unwrap().set_instance(b);
     }
     Ok(())
 }

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -107,9 +107,9 @@ pub fn unify(alloc: &mut Vec<Type>, t1: &ArenaType, t2: &ArenaType) -> Result<()
         }
         (TypeKind::Object(object1), TypeKind::Object(object2)) => {
             // object1 must have atleast as the same properties as object2
-            for (name, t) in &object2.props {
-                if let Some(prop) = object1.props.iter().find(|props| &props.0 == name) {
-                    unify(alloc, &prop.1, t)?;
+            for ObjProp { name, t } in &object2.props {
+                if let Some(prop) = object1.props.iter().find(|prop| &prop.name == name) {
+                    unify(alloc, &prop.t, t)?;
                 } else {
                     return Err(Errors::InferenceError(format!(
                         "'{name}' is missing in {}",

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -22,7 +22,7 @@ pub fn occurs_in_type(a: &mut Vec<Type>, v: &ArenaType, type2: &ArenaType) -> bo
         TypeKind::Literal(_) => false,  // leaf node
         TypeKind::Tuple(Tuple { types }) => occurs_in(a, v, &types),
         TypeKind::Object(Object { props }) => {
-            let types = props.iter().map(|(_, v)| *v).collect::<Vec<_>>();
+            let types = props.iter().map(|prop| prop.t).collect::<Vec<_>>();
             occurs_in(a, v, &types)
         }
         TypeKind::Constructor(Constructor { types, .. }) => occurs_in(a, v, &types),


### PR DESCRIPTION
This will make it easier to maintain functions that need to visit all of the nodes in a type or syntax tree.