### PR TITLE
Replace Vec<usize> with generational_arena

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -163,7 +169,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -177,7 +183,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -187,7 +193,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -199,7 +205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
@@ -211,7 +217,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -221,7 +227,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -285,7 +291,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown",
  "lock_api",
  "once_cell",
@@ -429,6 +435,7 @@ dependencies = [
 name = "escalier_hm"
 version = "0.1.0"
 dependencies = [
+ "generational-arena",
  "im",
  "insta",
  "itertools",
@@ -526,6 +533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generational-arena"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,7 +557,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -761,7 +777,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -904,7 +920,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1193,7 +1209,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
@@ -1330,7 +1346,7 @@ dependencies = [
  "ahash",
  "ast_node",
  "better_scoped_tls",
- "cfg-if",
+ "cfg-if 1.0.0",
  "either",
  "from_variant",
  "new_debug_unreachable",
@@ -1632,7 +1648,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/escalier_hm/Cargo.toml
+++ b/crates/escalier_hm/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+generational-arena = "0.2.8"
 itertools = "0.10.5"
 im = "15.1.0"
 

--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -1,3 +1,4 @@
+use generational_arena::Arena;
 use im::hashmap::HashMap;
 use im::hashset::HashSet;
 
@@ -24,9 +25,9 @@ pub struct Context {
 /// Raises:
 ///     ParseError: Raised if name is an undefined symbol in the type
 ///         environment.
-pub fn get_type(a: &mut Vec<Type>, name: &str, ctx: &Context) -> Result<ArenaType, Errors> {
+pub fn get_type(arena: &mut Arena<Type>, name: &str, ctx: &Context) -> Result<ArenaType, Errors> {
     if let Some(value) = ctx.env.get(name) {
-        Ok(fresh(a, *value, ctx))
+        Ok(fresh(arena, *value, ctx))
     } else {
         Err(Errors::InferenceError(format!(
             "Undefined symbol {:?}",
@@ -43,12 +44,12 @@ pub fn get_type(a: &mut Vec<Type>, name: &str, ctx: &Context) -> Result<ArenaTyp
 /// Args:
 ///     t: A type to be copied.
 ///     non_generic: A set of non-generic TypeVariables
-pub fn fresh(a: &mut Vec<Type>, t: ArenaType, ctx: &Context) -> ArenaType {
+pub fn fresh(a: &mut Arena<Type>, t: ArenaType, ctx: &Context) -> ArenaType {
     // A mapping of TypeVariables to TypeVariables
     let mut mappings = HashMap::default();
 
     fn freshrec(
-        a: &mut Vec<Type>,
+        a: &mut Arena<Type>,
         tp: ArenaType,
         mappings: &mut HashMap<ArenaType, ArenaType>,
         ctx: &Context,
@@ -115,7 +116,7 @@ pub fn fresh(a: &mut Vec<Type>, t: ArenaType, ctx: &Context) -> ArenaType {
     }
 
     pub fn freshrec_many(
-        a: &mut Vec<Type>,
+        a: &mut Arena<Type>,
         types: &[ArenaType],
         mappings: &mut HashMap<ArenaType, ArenaType>,
         ctx: &Context,
@@ -143,6 +144,6 @@ pub fn fresh(a: &mut Vec<Type>, t: ArenaType, ctx: &Context) -> ArenaType {
 ///
 /// Returns:
 ///     True if v is a generic variable, otherwise False
-pub fn is_generic(a: &mut Vec<Type>, t: ArenaType, ctx: &Context) -> bool {
+pub fn is_generic(a: &mut Arena<Type>, t: ArenaType, ctx: &Context) -> bool {
     !occurs_in(a, t, &ctx.non_generic)
 }

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -1,4 +1,4 @@
-use generational_arena::Arena;
+use generational_arena::{Arena, Index};
 
 use crate::context::*;
 use crate::errors::*;
@@ -32,8 +32,8 @@ pub fn infer_expression<'a>(
     arena: &mut Arena<Type>,
     node: &'a mut Expression,
     ctx: &mut Context,
-) -> Result<ArenaType, Errors> {
-    let t: ArenaType = match &mut node.kind {
+) -> Result<Index, Errors> {
+    let t: Index = match &mut node.kind {
         ExprKind::Identifier(Identifier { name }) => get_type(arena, name, ctx)?,
         ExprKind::Literal(literal) => new_lit_type(arena, literal),
         ExprKind::Tuple(syntax::Tuple { elems }) => {
@@ -189,7 +189,7 @@ pub fn infer_statement<'a>(
     arena: &'a mut Arena<Type>,
     statement: &mut Statement,
     ctx: &mut Context,
-) -> Result<ArenaType, Errors> {
+) -> Result<Index, Errors> {
     let t = match &mut statement.kind {
         StmtKind::Declaration(Declaration { pattern, defn }) => {
             if let PatternKind::Ident(BindingIdent { name, mutable: _ }) = &pattern.kind {

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::infer::{infer_expression, infer_program};
 
 #[cfg(test)]
 mod tests {
-    use generational_arena::Arena;
+    use generational_arena::{Arena, Index};
 
     use crate::context::*;
     use crate::errors::*;
@@ -21,15 +21,15 @@ mod tests {
     use crate::syntax::{self, *};
     use crate::types::*;
 
-    pub fn new_num_lit_type(arena: &mut Arena<Type>, value: &str) -> ArenaType {
+    pub fn new_num_lit_type(arena: &mut Arena<Type>, value: &str) -> Index {
         new_lit_type(arena, &Literal::Number(value.to_string()))
     }
 
-    pub fn new_str_lit_type(arena: &mut Arena<Type>, value: &str) -> ArenaType {
+    pub fn new_str_lit_type(arena: &mut Arena<Type>, value: &str) -> Index {
         new_lit_type(arena, &Literal::String(value.to_string()))
     }
 
-    pub fn new_bool_lit_type(arena: &mut Arena<Type>, value: bool) -> ArenaType {
+    pub fn new_bool_lit_type(arena: &mut Arena<Type>, value: bool) -> Index {
         new_lit_type(arena, &Literal::Boolean(value))
     }
 

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -12,12 +12,26 @@ pub use crate::infer::{infer_expression, infer_program};
 
 #[cfg(test)]
 mod tests {
+    use generational_arena::Arena;
+
     use crate::context::*;
     use crate::errors::*;
     use crate::infer::*;
     use crate::literal::*;
     use crate::syntax::{self, *};
     use crate::types::*;
+
+    pub fn new_num_lit_type(arena: &mut Arena<Type>, value: &str) -> ArenaType {
+        new_lit_type(arena, &Literal::Number(value.to_string()))
+    }
+
+    pub fn new_str_lit_type(arena: &mut Arena<Type>, value: &str) -> ArenaType {
+        new_lit_type(arena, &Literal::String(value.to_string()))
+    }
+
+    pub fn new_bool_lit_type(arena: &mut Arena<Type>, value: bool) -> ArenaType {
+        new_lit_type(arena, &Literal::Boolean(value))
+    }
 
     pub fn new_lambda(params: &[&str], body: &Expression) -> Expression {
         let kind = ExprKind::Lambda(Lambda {
@@ -201,8 +215,8 @@ mod tests {
         }
     }
 
-    fn test_env() -> (Vec<Type>, Context) {
-        let mut a = vec![];
+    fn test_env() -> (Arena<Type>, Context) {
+        let mut a: Arena<Type> = Arena::new();
         let mut my_ctx = Context::default();
 
         let var1 = new_var_type(&mut a);

--- a/crates/escalier_hm/src/syntax.rs
+++ b/crates/escalier_hm/src/syntax.rs
@@ -1,7 +1,7 @@
+use generational_arena::Index;
 use std::fmt;
 
 use crate::literal::Literal;
-use crate::types::ArenaType;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BindingIdent {
@@ -99,7 +99,7 @@ pub struct Pattern {
     // pub loc: SourceLocation,
     // pub span: Span,
     pub kind: PatternKind,
-    pub inferred_type: Option<ArenaType>,
+    pub inferred_type: Option<Index>,
 }
 
 impl fmt::Display for Pattern {
@@ -233,7 +233,7 @@ pub enum ExprKind {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Expression {
     pub kind: ExprKind,
-    pub inferred_type: Option<ArenaType>,
+    pub inferred_type: Option<Index>,
 }
 
 impl fmt::Display for Expression {
@@ -326,7 +326,7 @@ pub enum StmtKind {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Statement {
     pub kind: StmtKind,
-    pub inferred_type: Option<ArenaType>,
+    pub inferred_type: Option<Index>,
 }
 
 impl fmt::Display for Statement {

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -1,7 +1,9 @@
 // Types and type constructors
+use generational_arena::{Arena, Index};
+
 use crate::literal::Literal;
 
-pub type ArenaType = usize;
+pub type ArenaType = Index;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Variable {
@@ -54,7 +56,7 @@ pub enum TypeKind {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Type {
-    pub id: ArenaType,
+    // pub id: ArenaType,
     pub kind: TypeKind,
 }
 
@@ -64,67 +66,6 @@ pub struct Type {
 /// only assigned lazily, when required.
 
 impl Type {
-    pub fn new_variable(idx: ArenaType) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Variable(Variable { instance: None }),
-        }
-    }
-
-    pub fn new_constructor(idx: ArenaType, name: &str, types: &[ArenaType]) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Constructor(Constructor {
-                name: name.to_string(),
-                types: types.to_vec(),
-            }),
-        }
-    }
-
-    pub fn new_literal(idx: ArenaType, lit: &Literal) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Literal(lit.clone()),
-        }
-    }
-
-    pub fn new_function(idx: ArenaType, param_types: &[ArenaType], ret_type: ArenaType) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Function(Function {
-                params: param_types.to_vec(),
-                ret: ret_type,
-            }),
-        }
-    }
-
-    pub fn new_union(idx: ArenaType, types: &[ArenaType]) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Union(Union {
-                types: types.to_vec(),
-            }),
-        }
-    }
-
-    pub fn new_tuple(idx: ArenaType, types: &[ArenaType]) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Tuple(Tuple {
-                types: types.to_vec(),
-            }),
-        }
-    }
-
-    pub fn new_object(idx: ArenaType, props: &[(String, ArenaType)]) -> Type {
-        Type {
-            id: idx,
-            kind: TypeKind::Object(Object {
-                props: props.to_vec(),
-            }),
-        }
-    }
-
     pub fn set_instance(&mut self, instance: ArenaType) {
         match &mut self.kind {
             TypeKind::Variable(Variable {
@@ -139,51 +80,54 @@ impl Type {
         }
     }
 
-    pub fn as_string(&self, a: &Vec<Type>) -> String {
+    pub fn as_string(&self, arena: &Arena<Type>) -> String {
         match &self.kind {
             TypeKind::Variable(Variable {
                 instance: Some(inst),
-            }) => a[*inst].as_string(a),
-            TypeKind::Variable(_) => format!("t{}", self.id),
+            }) => arena[*inst].as_string(arena),
+            TypeKind::Variable(_) => {
+                // TODO: figure out how to get the id of the type variable
+                "t?".to_string()
+            }
             TypeKind::Constructor(con) => match con.types.len() {
                 0 => con.name.clone(),
                 2 => {
-                    let l = a[con.types[0]].as_string(a);
-                    let r = a[con.types[1]].as_string(a);
+                    let l = arena[con.types[0]].as_string(arena);
+                    let r = arena[con.types[1]].as_string(arena);
                     format!("({} {} {})", l, con.name, r)
                 }
                 _ => {
                     let mut coll = vec![];
                     for v in &con.types {
-                        coll.push(a[*v].as_string(a));
+                        coll.push(arena[*v].as_string(arena));
                     }
                     format!("{} {}", con.name, coll.join(" "))
                 }
             },
             TypeKind::Literal(lit) => lit.to_string(),
             TypeKind::Tuple(tuple) => {
-                format!("[{}]", types_to_strings(a, &tuple.types).join(", "))
+                format!("[{}]", types_to_strings(arena, &tuple.types).join(", "))
             }
             TypeKind::Object(object) => {
                 let mut fields = vec![];
                 for (k, v) in &object.props {
-                    fields.push(format!("{}: {}", k, a[*v].as_string(a)));
+                    fields.push(format!("{}: {}", k, arena[*v].as_string(arena)));
                 }
                 format!("{{{}}}", fields.join(", "))
             }
             TypeKind::Function(func) => {
                 format!(
                     "({}) => {}",
-                    types_to_strings(a, &func.params).join(", "),
-                    a[func.ret].as_string(a),
+                    types_to_strings(arena, &func.params).join(", "),
+                    arena[func.ret].as_string(arena),
                 )
             }
-            TypeKind::Union(union) => types_to_strings(a, &union.types).join(" | "),
+            TypeKind::Union(union) => types_to_strings(arena, &union.types).join(" | "),
         }
     }
 }
 
-fn types_to_strings(a: &Vec<Type>, types: &[ArenaType]) -> Vec<String> {
+fn types_to_strings(a: &Arena<Type>, types: &[ArenaType]) -> Vec<String> {
     let mut strings = vec![];
     for v in types {
         strings.push(a[*v].as_string(a));
@@ -192,66 +136,60 @@ fn types_to_strings(a: &Vec<Type>, types: &[ArenaType]) -> Vec<String> {
 }
 
 /// A binary type constructor which builds function types
-pub fn new_func_type(a: &mut Vec<Type>, params: &[ArenaType], ret: ArenaType) -> ArenaType {
-    let t = Type::new_function(a.len(), params, ret);
-    a.push(t);
-    a.len() - 1
+pub fn new_func_type(arena: &mut Arena<Type>, params: &[ArenaType], ret: ArenaType) -> ArenaType {
+    arena.insert(Type {
+        kind: TypeKind::Function(Function {
+            params: params.to_vec(),
+            ret,
+        }),
+    })
 }
 
-pub fn new_union_type(a: &mut Vec<Type>, types: &[ArenaType]) -> ArenaType {
-    let t = Type::new_union(a.len(), types);
-    a.push(t);
-    a.len() - 1
+pub fn new_union_type(arena: &mut Arena<Type>, types: &[ArenaType]) -> ArenaType {
+    arena.insert(Type {
+        kind: TypeKind::Union(Union {
+            types: types.to_vec(),
+        }),
+    })
 }
 
-pub fn new_tuple_type(a: &mut Vec<Type>, types: &[ArenaType]) -> ArenaType {
-    let t = Type::new_tuple(a.len(), types);
-    a.push(t);
-    a.len() - 1
+pub fn new_tuple_type(arena: &mut Arena<Type>, types: &[ArenaType]) -> ArenaType {
+    arena.insert(Type {
+        kind: TypeKind::Tuple(Tuple {
+            types: types.to_vec(),
+        }),
+    })
 }
 
-pub fn new_object_type(a: &mut Vec<Type>, props: &[(String, ArenaType)]) -> ArenaType {
-    let t = Type::new_object(a.len(), props);
-    a.push(t);
-    a.len() - 1
+pub fn new_object_type(arena: &mut Arena<Type>, props: &[(String, ArenaType)]) -> ArenaType {
+    arena.insert(Type {
+        kind: TypeKind::Object(Object {
+            props: props.to_vec(),
+        }),
+    })
 }
 
 /// A binary type constructor which builds function types
-pub fn new_var_type(a: &mut Vec<Type>) -> ArenaType {
-    let t = Type::new_variable(a.len());
-    a.push(t);
-    a.len() - 1
+pub fn new_var_type(arena: &mut Arena<Type>) -> ArenaType {
+    arena.insert(Type {
+        kind: TypeKind::Variable(Variable { instance: None }),
+    })
 }
 
 /// A binary type constructor which builds function types
-pub fn new_constructor(a: &mut Vec<Type>, name: &str, types: &[ArenaType]) -> ArenaType {
-    let t = Type::new_constructor(a.len(), name, types);
-    a.push(t);
-    a.len() - 1
+pub fn new_constructor(arena: &mut Arena<Type>, name: &str, types: &[ArenaType]) -> ArenaType {
+    arena.insert(Type {
+        kind: TypeKind::Constructor(Constructor {
+            name: name.to_string(),
+            types: types.to_vec(),
+        }),
+    })
 }
 
-pub fn new_lit_type(a: &mut Vec<Type>, lit: &Literal) -> ArenaType {
-    let t = Type::new_literal(a.len(), lit);
-    a.push(t);
-    a.len() - 1
-}
-
-pub fn new_num_lit_type(a: &mut Vec<Type>, value: &str) -> ArenaType {
-    let t = Type::new_literal(a.len(), &Literal::Number(value.to_string()));
-    a.push(t);
-    a.len() - 1
-}
-
-pub fn new_str_lit_type(a: &mut Vec<Type>, value: &str) -> ArenaType {
-    let t = Type::new_literal(a.len(), &Literal::String(value.to_string()));
-    a.push(t);
-    a.len() - 1
-}
-
-pub fn new_bool_lit_type(a: &mut Vec<Type>, value: bool) -> ArenaType {
-    let t = Type::new_literal(a.len(), &Literal::Boolean(value));
-    a.push(t);
-    a.len() - 1
+pub fn new_lit_type(arena: &mut Arena<Type>, lit: &Literal) -> ArenaType {
+    arena.insert(Type {
+        kind: TypeKind::Literal(lit.clone()),
+    })
 }
 
 //impl fmt::Debug for Type {

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -7,6 +7,7 @@ pub type ArenaType = Index;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Variable {
+    pub id: usize,
     pub instance: Option<ArenaType>,
 }
 
@@ -84,10 +85,10 @@ impl Type {
         match &self.kind {
             TypeKind::Variable(Variable {
                 instance: Some(inst),
+                ..
             }) => arena[*inst].as_string(arena),
-            TypeKind::Variable(_) => {
-                // TODO: figure out how to get the id of the type variable
-                "t?".to_string()
+            TypeKind::Variable(Variable { id, .. }) => {
+                format!("t{id}")
             }
             TypeKind::Constructor(con) => match con.types.len() {
                 0 => con.name.clone(),
@@ -172,7 +173,10 @@ pub fn new_object_type(arena: &mut Arena<Type>, props: &[(String, ArenaType)]) -
 /// A binary type constructor which builds function types
 pub fn new_var_type(arena: &mut Arena<Type>) -> ArenaType {
     arena.insert(Type {
-        kind: TypeKind::Variable(Variable { instance: None }),
+        kind: TypeKind::Variable(Variable {
+            instance: None,
+            id: arena.len(),
+        }),
     })
 }
 

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -3,45 +3,43 @@ use generational_arena::{Arena, Index};
 
 use crate::literal::Literal;
 
-pub type ArenaType = Index;
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Variable {
     pub id: usize,
-    pub instance: Option<ArenaType>,
+    pub instance: Option<Index>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Constructor {
     pub name: String,
-    pub types: Vec<ArenaType>,
+    pub types: Vec<Index>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Function {
-    pub params: Vec<ArenaType>,
-    pub ret: ArenaType,
+    pub params: Vec<Index>,
+    pub ret: Index,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Call {
-    pub args: Vec<ArenaType>,
-    pub ret: ArenaType,
+    pub args: Vec<Index>,
+    pub ret: Index,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Union {
-    pub types: Vec<ArenaType>,
+    pub types: Vec<Index>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Tuple {
-    pub types: Vec<ArenaType>,
+    pub types: Vec<Index>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Object {
-    pub props: Vec<(String, ArenaType)>,
+    pub props: Vec<(String, Index)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -57,7 +55,7 @@ pub enum TypeKind {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Type {
-    // pub id: ArenaType,
+    // pub id: Index,
     pub kind: TypeKind,
 }
 
@@ -67,7 +65,7 @@ pub struct Type {
 /// only assigned lazily, when required.
 
 impl Type {
-    pub fn set_instance(&mut self, instance: ArenaType) {
+    pub fn set_instance(&mut self, instance: Index) {
         match &mut self.kind {
             TypeKind::Variable(Variable {
                 instance: ref mut inst,
@@ -128,7 +126,7 @@ impl Type {
     }
 }
 
-fn types_to_strings(a: &Arena<Type>, types: &[ArenaType]) -> Vec<String> {
+fn types_to_strings(a: &Arena<Type>, types: &[Index]) -> Vec<String> {
     let mut strings = vec![];
     for v in types {
         strings.push(a[*v].as_string(a));
@@ -137,7 +135,7 @@ fn types_to_strings(a: &Arena<Type>, types: &[ArenaType]) -> Vec<String> {
 }
 
 /// A binary type constructor which builds function types
-pub fn new_func_type(arena: &mut Arena<Type>, params: &[ArenaType], ret: ArenaType) -> ArenaType {
+pub fn new_func_type(arena: &mut Arena<Type>, params: &[Index], ret: Index) -> Index {
     arena.insert(Type {
         kind: TypeKind::Function(Function {
             params: params.to_vec(),
@@ -146,7 +144,7 @@ pub fn new_func_type(arena: &mut Arena<Type>, params: &[ArenaType], ret: ArenaTy
     })
 }
 
-pub fn new_union_type(arena: &mut Arena<Type>, types: &[ArenaType]) -> ArenaType {
+pub fn new_union_type(arena: &mut Arena<Type>, types: &[Index]) -> Index {
     arena.insert(Type {
         kind: TypeKind::Union(Union {
             types: types.to_vec(),
@@ -154,7 +152,7 @@ pub fn new_union_type(arena: &mut Arena<Type>, types: &[ArenaType]) -> ArenaType
     })
 }
 
-pub fn new_tuple_type(arena: &mut Arena<Type>, types: &[ArenaType]) -> ArenaType {
+pub fn new_tuple_type(arena: &mut Arena<Type>, types: &[Index]) -> Index {
     arena.insert(Type {
         kind: TypeKind::Tuple(Tuple {
             types: types.to_vec(),
@@ -162,7 +160,7 @@ pub fn new_tuple_type(arena: &mut Arena<Type>, types: &[ArenaType]) -> ArenaType
     })
 }
 
-pub fn new_object_type(arena: &mut Arena<Type>, props: &[(String, ArenaType)]) -> ArenaType {
+pub fn new_object_type(arena: &mut Arena<Type>, props: &[(String, Index)]) -> Index {
     arena.insert(Type {
         kind: TypeKind::Object(Object {
             props: props.to_vec(),
@@ -171,7 +169,7 @@ pub fn new_object_type(arena: &mut Arena<Type>, props: &[(String, ArenaType)]) -
 }
 
 /// A binary type constructor which builds function types
-pub fn new_var_type(arena: &mut Arena<Type>) -> ArenaType {
+pub fn new_var_type(arena: &mut Arena<Type>) -> Index {
     arena.insert(Type {
         kind: TypeKind::Variable(Variable {
             instance: None,
@@ -181,7 +179,7 @@ pub fn new_var_type(arena: &mut Arena<Type>) -> ArenaType {
 }
 
 /// A binary type constructor which builds function types
-pub fn new_constructor(arena: &mut Arena<Type>, name: &str, types: &[ArenaType]) -> ArenaType {
+pub fn new_constructor(arena: &mut Arena<Type>, name: &str, types: &[Index]) -> Index {
     arena.insert(Type {
         kind: TypeKind::Constructor(Constructor {
             name: name.to_string(),
@@ -190,7 +188,7 @@ pub fn new_constructor(arena: &mut Arena<Type>, name: &str, types: &[ArenaType])
     })
 }
 
-pub fn new_lit_type(arena: &mut Arena<Type>, lit: &Literal) -> ArenaType {
+pub fn new_lit_type(arena: &mut Arena<Type>, lit: &Literal) -> Index {
     arena.insert(Type {
         kind: TypeKind::Literal(lit.clone()),
     })

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -1,4 +1,4 @@
-use generational_arena::Arena;
+use generational_arena::{Arena, Index};
 use itertools::Itertools;
 
 use crate::errors::*;
@@ -19,7 +19,7 @@ use crate::util::*;
 ///
 /// Raises:
 ///     InferenceError: Raised if the types cannot be unified.
-pub fn unify(arena: &mut Arena<Type>, t1: ArenaType, t2: ArenaType) -> Result<(), Errors> {
+pub fn unify(arena: &mut Arena<Type>, t1: Index, t2: Index) -> Result<(), Errors> {
     let a = prune(arena, t1);
     let b = prune(arena, t2);
     // Why do we clone here?
@@ -133,9 +133,9 @@ pub fn unify(arena: &mut Arena<Type>, t1: ArenaType, t2: ArenaType) -> Result<()
 // This function unifies and infers the return type of a function call.
 pub fn unify_call(
     alloc: &mut Arena<Type>,
-    arg_types: &[ArenaType],
-    t2: ArenaType,
-) -> Result<ArenaType, Errors> {
+    arg_types: &[Index],
+    t2: Index,
+) -> Result<Index, Errors> {
     let ret_type = new_var_type(alloc);
     let call_type = new_func_type(alloc, arg_types, ret_type);
 
@@ -191,7 +191,7 @@ pub fn unify_call(
     Ok(ret_type)
 }
 
-fn bind(arena: &mut Arena<Type>, a: ArenaType, b: ArenaType) -> Result<(), Errors> {
+fn bind(arena: &mut Arena<Type>, a: Index, b: Index) -> Result<(), Errors> {
     if a != b {
         if occurs_in_type(arena, a, b) {
             // raise InferenceError("recursive unification")

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -1,3 +1,5 @@
+use generational_arena::Arena;
+
 use crate::types::*;
 
 /// Checks whether a type variable occurs in a type expression.
@@ -10,7 +12,7 @@ use crate::types::*;
 ///
 /// Returns:
 ///     True if v occurs in type2, otherwise False
-pub fn occurs_in_type(a: &mut Vec<Type>, v: ArenaType, type2: ArenaType) -> bool {
+pub fn occurs_in_type(a: &mut Arena<Type>, v: ArenaType, type2: ArenaType) -> bool {
     let pruned_type2 = prune(a, type2);
     if pruned_type2 == v {
         return true;
@@ -42,7 +44,7 @@ pub fn occurs_in_type(a: &mut Vec<Type>, v: ArenaType, type2: ArenaType) -> bool
 /// Returns:
 ///     True if t occurs in any of types, otherwise False
 ///
-pub fn occurs_in<'a, I>(a: &mut Vec<Type>, t: ArenaType, types: I) -> bool
+pub fn occurs_in<'a, I>(a: &mut Arena<Type>, t: ArenaType, types: I) -> bool
 where
     I: IntoIterator<Item = &'a ArenaType>,
 {
@@ -68,11 +70,12 @@ where
 ///
 /// Returns:
 ///     An uninstantiated TypeVariable or a TypeOperator
-pub fn prune(a: &mut Vec<Type>, t: ArenaType) -> ArenaType {
+pub fn prune(a: &mut Arena<Type>, t: ArenaType) -> ArenaType {
     let v2 = match a.get(t).unwrap().kind {
         // TODO: handle .unwrap() panicing
         TypeKind::Variable(Variable {
             instance: Some(value),
+            ..
         }) => value,
         _ => {
             return t;

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -1,4 +1,4 @@
-use generational_arena::Arena;
+use generational_arena::{Arena, Index};
 
 use crate::types::*;
 
@@ -12,7 +12,7 @@ use crate::types::*;
 ///
 /// Returns:
 ///     True if v occurs in type2, otherwise False
-pub fn occurs_in_type(a: &mut Arena<Type>, v: ArenaType, type2: ArenaType) -> bool {
+pub fn occurs_in_type(a: &mut Arena<Type>, v: Index, type2: Index) -> bool {
     let pruned_type2 = prune(a, type2);
     if pruned_type2 == v {
         return true;
@@ -44,9 +44,9 @@ pub fn occurs_in_type(a: &mut Arena<Type>, v: ArenaType, type2: ArenaType) -> bo
 /// Returns:
 ///     True if t occurs in any of types, otherwise False
 ///
-pub fn occurs_in<'a, I>(a: &mut Arena<Type>, t: ArenaType, types: I) -> bool
+pub fn occurs_in<'a, I>(a: &mut Arena<Type>, t: Index, types: I) -> bool
 where
-    I: IntoIterator<Item = &'a ArenaType>,
+    I: IntoIterator<Item = &'a Index>,
 {
     for t2 in types.into_iter() {
         if occurs_in_type(a, t, *t2) {
@@ -70,7 +70,7 @@ where
 ///
 /// Returns:
 ///     An uninstantiated TypeVariable or a TypeOperator
-pub fn prune(a: &mut Arena<Type>, t: ArenaType) -> ArenaType {
+pub fn prune(a: &mut Arena<Type>, t: Index) -> Index {
     let v2 = match a.get(t).unwrap().kind {
         // TODO: handle .unwrap() panicing
         TypeKind::Variable(Variable {


### PR DESCRIPTION
The generational arena is a better than `Vec<usize>` because it solves the ABA problem when updating a tree/graph.  See https://docs.rs/generational-arena/latest/generational_arena/index.html#what-why for details.