### PR TITLE
Fix I = S(K)(K) identity in escalier_hm

### DIFF
--- a/crates/escalier_cli/tests/integration_test.rs
+++ b/crates/escalier_cli/tests/integration_test.rs
@@ -192,6 +192,10 @@ fn infer_skk() {
     let I = S(K)(K);
     "#;
     let (_, checker) = infer_prog(src);
+    let result = format!("{}", checker.lookup_value("S").unwrap());
+    insta::assert_snapshot!(result, @"<A, B, C>(f: (A) => (B) => C) => (g: (A) => B) => (x: A) => C");
+    let result = format!("{}", checker.lookup_value("K").unwrap());
+    insta::assert_snapshot!(result, @"<A, B>(x: A) => (y: B) => A");
     let result = format!("{}", checker.lookup_value("I").unwrap());
     insta::assert_snapshot!(result, @"<A>(x: A) => A");
 }

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -260,6 +260,32 @@ mod tests {
     }
 
     #[test]
+    fn test_skk() -> Result<(), Errors> {
+        let (mut arena, mut my_ctx) = test_env();
+
+        let src = r#"
+        let S = (f) => (g) => (x) => f(x)(g(x));
+        let K = (x) => (y) => x;
+        let I = S(K)(K);
+        "#;
+        let mut program = parse(src).unwrap();
+
+        infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+        let t = my_ctx.env.get("S").unwrap();
+        assert_eq!(
+            arena[*t].as_string(&arena),
+            r#"<A, B, C>((A) => (B) => C) => ((A) => B) => (A) => C"#
+        );
+        let t = my_ctx.env.get("K").unwrap();
+        assert_eq!(arena[*t].as_string(&arena), r#"<A, B>(A) => (B) => A"#);
+        let t = my_ctx.env.get("I").unwrap();
+        assert_eq!(arena[*t].as_string(&arena), r#"<A>(A) => A"#);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_composition_with_statements() -> Result<(), Errors> {
         let (mut arena, mut my_ctx) = test_env();
 

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -99,6 +99,9 @@ pub fn unify(arena: &mut Arena<Type>, t1: Index, t2: Index) -> Result<(), Errors
             Ok(())
         }
         (TypeKind::Function(func_a), TypeKind::Function(func_b)) => {
+            // Is this the right place to instantiate the function types?
+            let func_a = instantiate_func(arena, func_a);
+            let func_b = instantiate_func(arena, func_b);
             if func_a.params.len() > func_b.params.len() {
                 return Err(Errors::InferenceError(format!(
                     "{} is not a subtype of {} since it requires more params",


### PR DESCRIPTION
We weren't instantiating the function types which meant that the type params weren't being converted to the appropriate type variables in the function definition.