### PR TITLE
Add TypeKind::Rest to escalier_hm

### DIFF
--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -91,6 +91,14 @@ pub fn fresh(arena: &mut Arena<Type>, t: Index, ctx: &Context) -> Index {
                     p
                 }
             }
+            TypeKind::Rest(rest) => {
+                let arg = freshrec(arena, rest.arg, mappings, ctx);
+                if arg != rest.arg {
+                    new_rest_type(arena, arg)
+                } else {
+                    p
+                }
+            }
             TypeKind::Function(func) => {
                 let params = freshrec_many(arena, &func.params, mappings, ctx);
                 let ret = freshrec(arena, func.ret, mappings, ctx);

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -639,6 +639,10 @@ pub fn generalize_func(arena: &'_ mut Arena<Type>, func: &Function) -> Index {
                     .collect();
                 new_object_type(arena, &fields)
             }
+            TypeKind::Rest(rest) => {
+                let arg = generalize_rec(arena, rest.arg, mappings);
+                new_rest_type(arena, arg)
+            }
             TypeKind::Function(func) => {
                 let params = generalize_rec_many(arena, &func.params, mappings);
                 let ret = generalize_rec(arena, func.ret, mappings);

--- a/crates/escalier_hm/src/infer_pattern.rs
+++ b/crates/escalier_hm/src/infer_pattern.rs
@@ -45,29 +45,7 @@ pub fn infer_pattern(
                 t
             }
             PatternKind::Rest(RestPat { arg }) => {
-                let arg_type = match &arg.kind {
-                    PatternKind::Ident(BindingIdent { name, mutable, .. }) => {
-                        let t = new_var_type(arena);
-                        if assump
-                            .insert(
-                                name.to_owned(),
-                                Binding {
-                                    mutable: *mutable,
-                                    // NOTE: We set the binding's type to Array<T>
-                                    // instead of T.
-                                    t: new_constructor(arena, "Array", &[t]),
-                                },
-                            )
-                            .is_some()
-                        {
-                            return Err(Errors::InferenceError(
-                                "Duplicate identifier in pattern".to_string(),
-                            ));
-                        }
-                        t
-                    }
-                    _ => infer_pattern_rec(arena, arg.as_mut(), assump, ctx)?,
-                };
+                let arg_type = infer_pattern_rec(arena, arg.as_mut(), assump, ctx)?;
                 new_rest_type(arena, arg_type)
             }
             PatternKind::Object(ObjectPat { props, .. }) => {

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -1482,23 +1482,28 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn test_tuple_destrcuturing_assignment_with_rest() -> Result<(), Errors> {
+    fn test_tuple_destructuring_assignment_with_rest() -> Result<(), Errors> {
         let (mut arena, mut my_ctx) = test_env();
 
         // TODO: handle destructuring of arrays with rest as well
         let src = r#"
         declare let tuple: [number, string, boolean];
-        let [a, ...rest] = tuple;
+        let [a, ...tuple_rest] = tuple;
+        // declare let array: Array<string>;
+        // let [b, ...array_rest] = array;
         "#;
         let mut program = parse(src).unwrap();
         infer_program(&mut arena, &mut program, &mut my_ctx)?;
 
         let t = my_ctx.env.get("a").unwrap();
         assert_eq!(arena[*t].as_string(&arena), r#"number"#);
-
-        let t = my_ctx.env.get("rest").unwrap();
+        let t = my_ctx.env.get("tuple_rest").unwrap();
         assert_eq!(arena[*t].as_string(&arena), r#"[string, boolean]"#);
+
+        // let t = my_ctx.env.get("b").unwrap();
+        // assert_eq!(arena[*t].as_string(&arena), r#"string | undefined"#);
+        // let t = my_ctx.env.get("array_rest").unwrap();
+        // assert_eq!(arena[*t].as_string(&arena), r#"Array<string>"#);
 
         Ok(())
     }

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -1500,10 +1500,25 @@ mod tests {
         let t = my_ctx.env.get("tuple_rest").unwrap();
         assert_eq!(arena[*t].as_string(&arena), r#"[string, boolean]"#);
 
-        // let t = my_ctx.env.get("b").unwrap();
-        // assert_eq!(arena[*t].as_string(&arena), r#"string | undefined"#);
-        // let t = my_ctx.env.get("array_rest").unwrap();
-        // assert_eq!(arena[*t].as_string(&arena), r#"Array<string>"#);
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_destructuring_assignment_with_rest() -> Result<(), Errors> {
+        let (mut arena, mut my_ctx) = test_env();
+
+        // TODO: handle destructuring of arrays with rest as well
+        let src = r#"
+        declare let array: Array<string>;
+        let [a, ...array_rest] = array;
+        "#;
+        let mut program = parse(src).unwrap();
+        infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+        let t = my_ctx.env.get("a").unwrap();
+        assert_eq!(arena[*t].as_string(&arena), r#"string | undefined"#);
+        let t = my_ctx.env.get("array_rest").unwrap();
+        assert_eq!(arena[*t].as_string(&arena), r#"Array<string>"#);
 
         Ok(())
     }

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -1485,12 +1485,9 @@ mod tests {
     fn test_tuple_destructuring_assignment_with_rest() -> Result<(), Errors> {
         let (mut arena, mut my_ctx) = test_env();
 
-        // TODO: handle destructuring of arrays with rest as well
         let src = r#"
         declare let tuple: [number, string, boolean];
         let [a, ...tuple_rest] = tuple;
-        // declare let array: Array<string>;
-        // let [b, ...array_rest] = array;
         "#;
         let mut program = parse(src).unwrap();
         infer_program(&mut arena, &mut program, &mut my_ctx)?;
@@ -1507,7 +1504,6 @@ mod tests {
     fn test_array_destructuring_assignment_with_rest() -> Result<(), Errors> {
         let (mut arena, mut my_ctx) = test_env();
 
-        // TODO: handle destructuring of arrays with rest as well
         let src = r#"
         declare let array: Array<string>;
         let [a, ...array_rest] = array;

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -293,7 +293,6 @@ pub fn new_rest_type(arena: &mut Arena<Type>, t: Index) -> Index {
     arena.insert(Type {
         kind: TypeKind::Rest(Rest { arg: t }),
     })
-    // new_constructor(arena, "Array", &[t])
 }
 
 pub fn new_lit_type(arena: &mut Arena<Type>, lit: &Lit) -> Index {

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -98,6 +98,13 @@ pub struct Object {
     pub props: Vec<TObjElem>,
 }
 
+// NOTE: this is only used for the rest element in array patterns since we
+// treat `{a, ...x}` as `{a} & x` where `x` is a type variable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Rest {
+    pub arg: Index,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeKind {
     Variable(Variable),
@@ -105,6 +112,7 @@ pub enum TypeKind {
     Literal(Lit),
     Function(Function),
     Object(Object),
+    Rest(Rest),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -193,6 +201,9 @@ impl Type {
                 }
                 format!("{{{}}}", fields.join(", "))
             }
+            TypeKind::Rest(rest) => {
+                format!("...{}", arena[rest.arg].as_string(arena))
+            }
             TypeKind::Function(func) => {
                 let type_params = match &func.type_params {
                     Some(type_params) if !type_params.is_empty() => {
@@ -279,7 +290,10 @@ pub fn new_constructor(arena: &mut Arena<Type>, name: &str, types: &[Index]) -> 
 }
 
 pub fn new_rest_type(arena: &mut Arena<Type>, t: Index) -> Index {
-    new_constructor(arena, "Array", &[t])
+    arena.insert(Type {
+        kind: TypeKind::Rest(Rest { arg: t }),
+    })
+    // new_constructor(arena, "Array", &[t])
 }
 
 pub fn new_lit_type(arena: &mut Arena<Type>, lit: &Lit) -> Index {

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -95,7 +95,6 @@ pub fn unify(arena: &mut Arena<Type>, t1: Index, t2: Index) -> Result<(), Errors
         (TypeKind::Constructor(array), TypeKind::Constructor(tuple))
             if array.name == "Array" && tuple.name == "@@tuple" =>
         {
-            // NOTE: everything in the tuple must be include | undefined
             let p = array.types[0];
             for q in &tuple.types {
                 let undefined = new_constructor(arena, "undefined", &[]);

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -26,6 +26,7 @@ pub fn occurs_in_type(a: &mut Arena<Type>, v: Index, type2: Index) -> bool {
             TObjElem::Index(index) => occurs_in_type(a, v, index.t),
             TObjElem::Prop(prop) => occurs_in_type(a, v, prop.t),
         }),
+        TypeKind::Rest(Rest { arg }) => occurs_in_type(a, v, arg),
         TypeKind::Function(Function {
             params,
             ret,


### PR DESCRIPTION
Having a separate type kind to model array/tuple rest makes unifying a bunch of different situations much easier.