### PR TITLE
Improve logic operators in escalier_hm

### DIFF
--- a/crates/escalier_hm/src/ast/expr.rs
+++ b/crates/escalier_hm/src/ast/expr.rs
@@ -104,6 +104,8 @@ pub enum BinOp {
     GtEq,
     Lt,
     LtEq,
+    And,
+    Or,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -288,9 +288,10 @@ pub fn infer_expression<'a>(
                     boolean
                 }
                 BinOp::EqEq | BinOp::NotEq => {
-                    let var_t = new_var_type(arena, None);
-                    unify(arena, left_type, var_t)?;
-                    unify(arena, right_type, var_t)?;
+                    let var_a = new_var_type(arena, None);
+                    let var_b = new_var_type(arena, None);
+                    unify(arena, left_type, var_a)?;
+                    unify(arena, right_type, var_b)?;
                     boolean
                 }
             }

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -270,20 +270,29 @@ pub fn infer_expression<'a>(
             let boolean = new_constructor(arena, "boolean", &[]);
             let left_type = infer_expression(arena, left, ctx)?;
             let right_type = infer_expression(arena, right, ctx)?;
-            unify(arena, left_type, number)?;
-            unify(arena, right_type, number)?;
 
             match op {
-                BinOp::Add => number,
-                BinOp::Sub => number,
-                BinOp::Mul => number,
-                BinOp::Div => number,
-                BinOp::EqEq => boolean,
-                BinOp::NotEq => boolean,
-                BinOp::Gt => boolean,
-                BinOp::GtEq => boolean,
-                BinOp::Lt => boolean,
-                BinOp::LtEq => boolean,
+                BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div => {
+                    unify(arena, left_type, number)?;
+                    unify(arena, right_type, number)?;
+                    number
+                }
+                BinOp::Gt | BinOp::GtEq | BinOp::Lt | BinOp::LtEq => {
+                    unify(arena, left_type, number)?;
+                    unify(arena, right_type, number)?;
+                    boolean
+                }
+                BinOp::And | BinOp::Or => {
+                    unify(arena, left_type, boolean)?;
+                    unify(arena, right_type, boolean)?;
+                    boolean
+                }
+                BinOp::EqEq | BinOp::NotEq => {
+                    let var_t = new_var_type(arena, None);
+                    unify(arena, left_type, var_t)?;
+                    unify(arena, right_type, var_t)?;
+                    boolean
+                }
             }
         }
         ExprKind::UnaryExpr(UnaryExpr { op, arg }) => {

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -65,6 +65,48 @@ mod tests {
     /// from each.
 
     #[test]
+    fn test_complex_logic() -> Result<(), Errors> {
+        let (mut arena, mut my_ctx) = test_env();
+
+        let src = r#"
+        declare let a: number;
+        declare let b: number;
+        declare let c: number;
+        let result = a > b || b >= c || c != a && c != b;
+        "#;
+        let mut program = parse(src).unwrap();
+
+        infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+        let t = my_ctx.env.get("result").unwrap();
+        assert_eq!(arena[*t].as_string(&arena), r#"boolean"#);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_string_equality() -> Result<(), Errors> {
+        let (mut arena, mut my_ctx) = test_env();
+
+        let src = r#"
+        declare let a: string;
+        declare let b: string;
+        let eq = a == b;
+        let neq = a != b;
+        "#;
+        let mut program = parse(src).unwrap();
+
+        infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+        let t = my_ctx.env.get("eq").unwrap();
+        assert_eq!(arena[*t].as_string(&arena), r#"boolean"#);
+        let t = my_ctx.env.get("neq").unwrap();
+        assert_eq!(arena[*t].as_string(&arena), r#"boolean"#);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_factorial() -> Result<(), Errors> {
         let (mut arena, mut my_ctx) = test_env();
 

--- a/crates/escalier_hm/src/parser/expr.rs
+++ b/crates/escalier_hm/src/parser/expr.rs
@@ -72,8 +72,8 @@ pub fn parse_expression(node: &tree_sitter::Node, src: &str) -> Result<Expr, Par
             let right = Box::from(parse_expression(&right, src)?);
 
             let op = match operator.as_str() {
-                "&&" => todo!(),
-                "||" => todo!(),
+                "&&" => BinOp::And,
+                "||" => BinOp::Or,
                 // TODO: decide what to do with bitwise operators
                 ">>" => todo!(),
                 ">>>" => todo!(),


### PR DESCRIPTION
- `==` and `!=` can be used with any types now, but both operands must have the same type
- `&&` and `||` have been added, their operands must both be boolean values