### PR TITLE
Use type param constraints when inserting params into sig_ctx

### DIFF
--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -931,9 +931,14 @@ fn infer_type_params(
                 Some(constraint) => Some(infer_type_ann(arena, constraint.as_mut(), sig_ctx)?),
                 None => None,
             };
-            let t = new_var_type(arena, constraint);
+
+            // Adds the param to the context and set its type to the constraint
+            // or `unknown` if there is no constraint.
             let scheme = Scheme {
-                t,
+                t: match constraint {
+                    Some(constraint) => constraint,
+                    None => new_constructor(arena, "unknown", &[]),
+                },
                 type_params: None,
             };
             sig_ctx.schemes.insert(tp.name.name.to_owned(), scheme);

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -2312,10 +2312,8 @@ fn test_unknown_assignment_error() -> Result<(), Errors> {
     Ok(())
 }
 
-// TODO: this test should pass, but it doesn't
 #[test]
-#[ignore]
-fn test_unknown_with_generics() -> Result<(), Errors> {
+fn test_type_param_explicit_unknown_constraint() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 
     let src = r#"
@@ -2325,7 +2323,37 @@ fn test_unknown_with_generics() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+
+    assert_eq!(
+        result,
+        Err(Errors::InferenceError(
+            "type mismatch: unknown != number".to_string()
+        ))
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_type_param_implicit_unknown_constraint() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    let add = <T>(a: T, b: T): T => {
+        return a + b;
+    };
+    "#;
+    let mut program = parse(src).unwrap();
+
+    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+
+    assert_eq!(
+        result,
+        Err(Errors::InferenceError(
+            "type mismatch: unknown != number".to_string()
+        ))
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This fixes a long-standing problem where the following code wouldn't error:
```
let add = <T>(a: T, b: T) => {
   return a + b;
};
```
This issue still exists in `escalier_infer`, but it's fixed now in `escalier_hm` which is what we'll eventually be moving to.