### PR TITLE
Remove lookahead option from lexer.peek()

### DIFF
--- a/crates/escalier_parser/src/func_param.rs
+++ b/crates/escalier_parser/src/func_param.rs
@@ -16,17 +16,17 @@ pub fn parse_params(parser: &mut Parser) -> Vec<FuncParam> {
     assert_eq!(parser.next().kind, TokenKind::LeftParen);
 
     let mut params: Vec<FuncParam> = Vec::new();
-    while parser.peek(0).kind != TokenKind::RightParen {
+    while parser.peek().kind != TokenKind::RightParen {
         let pattern = parse_pattern(parser);
 
-        let optional = if let TokenKind::Question = parser.peek(0).kind {
+        let optional = if let TokenKind::Question = parser.peek().kind {
             parser.next();
             true
         } else {
             false
         };
 
-        if let TokenKind::Colon = parser.peek(0).kind {
+        if let TokenKind::Colon = parser.peek().kind {
             parser.next();
             params.push(FuncParam {
                 pattern,
@@ -43,12 +43,12 @@ pub fn parse_params(parser: &mut Parser) -> Vec<FuncParam> {
 
         // TODO: param defaults
 
-        match parser.peek(0).kind {
+        match parser.peek().kind {
             TokenKind::RightParen => break,
             TokenKind::Comma => {
                 parser.next();
             }
-            _ => panic!("Expected comma or right paren, got {:?}", parser.peek(0)),
+            _ => panic!("Expected comma or right paren, got {:?}", parser.peek()),
         }
     }
 

--- a/crates/escalier_parser/src/parser.rs
+++ b/crates/escalier_parser/src/parser.rs
@@ -13,25 +13,18 @@ impl Parser {
     }
 
     pub fn next(&mut self) -> Token {
-        let result = self.peek(0);
+        let result = self.peek();
         self.cursor += 1;
         result
     }
 
-    pub fn peek(&mut self, offset: usize) -> Token {
-        self.tokens
-            .get(self.cursor + offset)
-            .cloned()
-            .unwrap_or(Token {
-                kind: TokenKind::Eof,
-                loc: SourceLocation {
-                    start: Position { line: 0, column: 0 },
-                    end: Position { line: 0, column: 0 },
-                },
-            })
-    }
-
-    pub fn replace(&mut self, offset: usize, token: Token) {
-        self.tokens[self.cursor + offset] = token;
+    pub fn peek(&mut self) -> Token {
+        self.tokens.get(self.cursor).cloned().unwrap_or(Token {
+            kind: TokenKind::Eof,
+            loc: SourceLocation {
+                start: Position { line: 0, column: 0 },
+                end: Position { line: 0, column: 0 },
+            },
+        })
     }
 }

--- a/crates/escalier_parser/src/pattern_parser.rs
+++ b/crates/escalier_parser/src/pattern_parser.rs
@@ -6,7 +6,7 @@ use crate::source_location::merge_locations;
 use crate::token::TokenKind;
 
 pub fn parse_pattern(parser: &mut Parser) -> Pattern {
-    let mut loc = parser.peek(0).loc;
+    let mut loc = parser.peek().loc;
     let kind = match parser.next().kind {
         TokenKind::Identifier(name) => PatternKind::Ident(BindingIdent {
             name,
@@ -29,8 +29,8 @@ pub fn parse_pattern(parser: &mut Parser) -> Pattern {
         TokenKind::LeftBracket => {
             let mut elems: Vec<Option<TuplePatElem>> = vec![];
             let mut has_rest = false;
-            while parser.peek(0).kind != TokenKind::RightBracket {
-                match &parser.peek(0).kind {
+            while parser.peek().kind != TokenKind::RightBracket {
+                match &parser.peek().kind {
                     TokenKind::DotDotDot => {
                         if has_rest {
                             panic!("only one rest pattern is allowed per object pattern");
@@ -50,14 +50,14 @@ pub fn parse_pattern(parser: &mut Parser) -> Pattern {
                 }
 
                 // TODO: don't allow commas after rest pattern
-                if parser.peek(0).kind == TokenKind::Comma {
+                if parser.peek().kind == TokenKind::Comma {
                     parser.next();
                 } else {
                     break;
                 }
             }
 
-            loc = merge_locations(&loc, &parser.peek(0).loc);
+            loc = merge_locations(&loc, &parser.peek().loc);
             assert_eq!(parser.next().kind, TokenKind::RightBracket);
 
             PatternKind::Tuple(TuplePat {
@@ -69,11 +69,11 @@ pub fn parse_pattern(parser: &mut Parser) -> Pattern {
             let mut props: Vec<ObjectPatProp> = vec![];
             let mut has_rest = false;
 
-            while parser.peek(0).kind != TokenKind::RightBrace {
-                let first = parser.peek(0);
+            while parser.peek().kind != TokenKind::RightBrace {
+                let first = parser.peek();
                 match &parser.next().kind {
                     TokenKind::Identifier(name) => {
-                        if parser.peek(0).kind == TokenKind::Colon {
+                        if parser.peek().kind == TokenKind::Colon {
                             parser.next();
 
                             let pattern = parse_pattern(parser);
@@ -101,7 +101,7 @@ pub fn parse_pattern(parser: &mut Parser) -> Pattern {
                             }))
                         }
 
-                        if parser.peek(0).kind == TokenKind::Comma {
+                        if parser.peek().kind == TokenKind::Comma {
                             parser.next();
                         }
                     }
@@ -118,7 +118,7 @@ pub fn parse_pattern(parser: &mut Parser) -> Pattern {
                 }
             }
 
-            loc = merge_locations(&loc, &parser.peek(0).loc);
+            loc = merge_locations(&loc, &parser.peek().loc);
             assert_eq!(parser.next().kind, TokenKind::RightBrace);
 
             PatternKind::Object(ObjectPat {

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -8,15 +8,14 @@ use crate::token::TokenKind;
 use crate::type_ann_parser::parse_type_ann;
 
 pub fn parse_stmt(parser: &mut Parser) -> Stmt {
-    let token = parser.peek(0);
-    // let next = parser.peek(1);
+    let token = parser.peek();
 
     match &token.kind {
         TokenKind::Let => {
             parser.next();
             let pattern = parse_pattern(parser);
 
-            let type_ann = match parser.peek(0).kind {
+            let type_ann = match parser.peek().kind {
                 TokenKind::Colon => {
                     parser.next();
                     Some(parse_type_ann(parser))
@@ -40,7 +39,7 @@ pub fn parse_stmt(parser: &mut Parser) -> Stmt {
         }
         TokenKind::Return => {
             parser.next();
-            let next = parser.peek(0);
+            let next = parser.peek();
             match next.kind {
                 TokenKind::Semicolon => {
                     parser.next();
@@ -76,7 +75,7 @@ pub fn parse_stmt(parser: &mut Parser) -> Stmt {
 
 pub fn parse_program(parser: &mut Parser) -> Vec<Stmt> {
     let mut stmts = Vec::new();
-    while parser.peek(0).kind != TokenKind::Eof {
+    while parser.peek().kind != TokenKind::Eof {
         stmts.push(parse_stmt(parser));
     }
     stmts

--- a/crates/escalier_parser/src/type_ann_parser.rs
+++ b/crates/escalier_parser/src/type_ann_parser.rs
@@ -5,7 +5,7 @@ use crate::token::TokenKind;
 use crate::type_ann::{ObjectProp, TypeAnn, TypeAnnKind};
 
 pub fn parse_type_ann(parser: &mut Parser) -> TypeAnn {
-    let mut loc = parser.peek(0).loc;
+    let mut loc = parser.peek().loc;
     let mut kind = match parser.next().kind {
         TokenKind::BoolLit(value) => TypeAnnKind::BoolLit(value),
         TokenKind::Boolean => TypeAnnKind::Boolean,
@@ -19,9 +19,9 @@ pub fn parse_type_ann(parser: &mut Parser) -> TypeAnn {
         TokenKind::LeftBrace => {
             let mut props: Vec<ObjectProp> = vec![];
 
-            while parser.peek(0).kind != TokenKind::RightBrace {
+            while parser.peek().kind != TokenKind::RightBrace {
                 if let TokenKind::Identifier(name) = parser.next().kind {
-                    let optional = if parser.peek(0).kind == TokenKind::Question {
+                    let optional = if parser.peek().kind == TokenKind::Question {
                         parser.next();
                         true
                     } else {
@@ -37,7 +37,7 @@ pub fn parse_type_ann(parser: &mut Parser) -> TypeAnn {
                         type_ann,
                     });
 
-                    if parser.peek(0).kind == TokenKind::Comma {
+                    if parser.peek().kind == TokenKind::Comma {
                         parser.next();
                     } else {
                         break;
@@ -47,7 +47,7 @@ pub fn parse_type_ann(parser: &mut Parser) -> TypeAnn {
                 }
             }
 
-            loc = merge_locations(&loc, &parser.peek(0).loc);
+            loc = merge_locations(&loc, &parser.peek().loc);
             assert_eq!(parser.next().kind, TokenKind::RightBrace);
 
             TypeAnnKind::Object(props)
@@ -55,37 +55,37 @@ pub fn parse_type_ann(parser: &mut Parser) -> TypeAnn {
         TokenKind::LeftBracket => {
             let mut elems: Vec<TypeAnn> = vec![];
 
-            while parser.peek(0).kind != TokenKind::RightBracket {
+            while parser.peek().kind != TokenKind::RightBracket {
                 elems.push(parse_type_ann(parser));
 
-                if parser.peek(0).kind == TokenKind::Comma {
+                if parser.peek().kind == TokenKind::Comma {
                     parser.next();
                 } else {
                     break;
                 }
             }
 
-            loc = merge_locations(&loc, &parser.peek(0).loc);
+            loc = merge_locations(&loc, &parser.peek().loc);
             assert_eq!(parser.next().kind, TokenKind::RightBracket);
 
             TypeAnnKind::Tuple(elems)
         }
         TokenKind::Identifier(ident) => {
-            if parser.peek(0).kind == TokenKind::LessThan {
+            if parser.peek().kind == TokenKind::LessThan {
                 parser.next();
                 let mut params: Vec<TypeAnn> = vec![];
 
-                while parser.peek(0).kind != TokenKind::GreaterThan {
+                while parser.peek().kind != TokenKind::GreaterThan {
                     params.push(parse_type_ann(parser));
 
-                    if parser.peek(0).kind == TokenKind::Comma {
+                    if parser.peek().kind == TokenKind::Comma {
                         parser.next();
                     } else {
                         break;
                     }
                 }
 
-                loc = merge_locations(&loc, &parser.peek(0).loc);
+                loc = merge_locations(&loc, &parser.peek().loc);
                 assert_eq!(parser.next().kind, TokenKind::GreaterThan);
 
                 TypeAnnKind::TypeRef(ident, Some(params))
@@ -105,9 +105,9 @@ pub fn parse_type_ann(parser: &mut Parser) -> TypeAnn {
         }
     };
 
-    while parser.peek(0).kind == TokenKind::LeftBracket {
+    while parser.peek().kind == TokenKind::LeftBracket {
         parser.next();
-        let right = parser.peek(0).loc;
+        let right = parser.peek().loc;
         let merged_loc = merge_locations(&loc, &right);
         assert_eq!(parser.next().kind, TokenKind::RightBracket);
         kind = TypeAnnKind::Array(Box::new(TypeAnn { kind, loc }));


### PR DESCRIPTION
This is necessary before we attempt to make the lever return an iterator.