### PR TITLE
Parse JSX within expressions

### DIFF
--- a/crates/escalier_parser/src/expr.rs
+++ b/crates/escalier_parser/src/expr.rs
@@ -1,5 +1,5 @@
 use crate::func_param::FuncParam;
-use crate::jsx::JSXElement;
+use crate::jsx::{JSXElement, JSXFragment};
 use crate::literal::Literal;
 use crate::pattern::Pattern;
 use crate::source_location::SourceLocation;
@@ -104,9 +104,8 @@ pub enum ExprKind {
     Do {
         body: Block,
     },
-    JSXElement {
-        element: JSXElement,
-    },
+    JSXElement(JSXElement),
+    JSXFragment(JSXFragment),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/escalier_parser/src/expr.rs
+++ b/crates/escalier_parser/src/expr.rs
@@ -1,4 +1,5 @@
 use crate::func_param::FuncParam;
+use crate::jsx::JSXElement;
 use crate::literal::Literal;
 use crate::pattern::Pattern;
 use crate::source_location::SourceLocation;
@@ -102,6 +103,9 @@ pub enum ExprKind {
     },
     Do {
         body: Block,
+    },
+    JSXElement {
+        element: JSXElement,
     },
 }
 

--- a/crates/escalier_parser/src/jsx_parser.rs
+++ b/crates/escalier_parser/src/jsx_parser.rs
@@ -83,12 +83,20 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_jsx_fragment(&mut self) -> JSXFragment {
-        assert_eq!(self.scanner.pop(), Some('<'));
-        assert_eq!(self.scanner.pop(), Some('>'));
+        assert_eq!(self.next().unwrap_or(EOF.clone()).kind, TokenKind::LessThan);
+        assert_eq!(
+            self.next().unwrap_or(EOF.clone()).kind,
+            TokenKind::GreaterThan
+        );
+
         let children = self.parse_jsx_children();
-        assert_eq!(self.scanner.pop(), Some('<'));
-        assert_eq!(self.scanner.pop(), Some('/'));
-        assert_eq!(self.scanner.pop(), Some('>'));
+
+        assert_eq!(self.next().unwrap_or(EOF.clone()).kind, TokenKind::LessThan);
+        assert_eq!(self.next().unwrap_or(EOF.clone()).kind, TokenKind::Divide);
+        assert_eq!(
+            self.next().unwrap_or(EOF.clone()).kind,
+            TokenKind::GreaterThan
+        );
 
         JSXFragment {
             opening: JSXOpeningFragment {},

--- a/crates/escalier_parser/src/parser.rs
+++ b/crates/escalier_parser/src/parser.rs
@@ -137,9 +137,9 @@ impl<'a> Parser<'a> {
                     // We've matched already matched all of the braces but have
                     // encountered an extra closing brace.  We could be in a
                     // template string or a JSX expression so we return and let
-                    // the caller handle it.
+                    // the caller handle it.  The caller is responsible for
+                    // consuming this token.
                     if brace_count == &0 {
-                        self.scanner.pop();
                         return None;
                     }
                     *brace_count -= 1;
@@ -406,11 +406,13 @@ impl<'a> Parser<'a> {
                                 end: string_end,
                             },
                         });
-                        self.scanner.pop();
+                        self.scanner.pop(); // consumes '{'
 
                         self.brace_counts.push(0);
                         exprs.push(self.parse_expr());
                         self.brace_counts.pop();
+
+                        self.scanner.pop(); // consumes '}'
 
                         string = String::new();
                         string_start = self.scanner.position();

--- a/crates/escalier_parser/src/scanner.rs
+++ b/crates/escalier_parser/src/scanner.rs
@@ -66,4 +66,6 @@ impl<'a> Scanner<'a> {
             None => None,
         }
     }
+
+    // pub fn backup(&mut self) ->
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component.snap
@@ -1,0 +1,159 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(\"fn (props) => <div>{props.children}</div>\")"
+---
+Expr {
+    kind: Function {
+        params: [
+            FuncParam {
+                pattern: Pattern {
+                    loc: SourceLocation {
+                        start: Position {
+                            line: 1,
+                            column: 5,
+                        },
+                        end: Position {
+                            line: 1,
+                            column: 10,
+                        },
+                    },
+                    kind: Ident(
+                        BindingIdent {
+                            name: "props",
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 1,
+                                    column: 5,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    column: 10,
+                                },
+                            },
+                            mutable: false,
+                        },
+                    ),
+                },
+                type_ann: None,
+                optional: false,
+            },
+        ],
+        body: Expr(
+            Expr {
+                kind: JSXElement {
+                    element: JSXElement {
+                        opening: JSXOpeningElement {
+                            name: Ident(
+                                Ident {
+                                    name: "div",
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 1,
+                                            column: 16,
+                                        },
+                                        end: Position {
+                                            line: 1,
+                                            column: 19,
+                                        },
+                                    },
+                                },
+                            ),
+                            attrs: [],
+                            self_closing: false,
+                        },
+                        children: [
+                            ExprContainer(
+                                JSXExprContainer {
+                                    expr: Expr {
+                                        kind: Member {
+                                            object: Expr {
+                                                kind: Identifier(
+                                                    "props",
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 1,
+                                                        column: 21,
+                                                    },
+                                                    end: Position {
+                                                        line: 1,
+                                                        column: 26,
+                                                    },
+                                                },
+                                            },
+                                            property: Expr {
+                                                kind: Identifier(
+                                                    "children",
+                                                ),
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 1,
+                                                        column: 27,
+                                                    },
+                                                    end: Position {
+                                                        line: 1,
+                                                        column: 35,
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 1,
+                                                column: 21,
+                                            },
+                                            end: Position {
+                                                line: 1,
+                                                column: 35,
+                                            },
+                                        },
+                                    },
+                                },
+                            ),
+                        ],
+                        closing: Some(
+                            JSXClosingElement {
+                                name: Ident(
+                                    Ident {
+                                        name: "div",
+                                        loc: SourceLocation {
+                                            start: Position {
+                                                line: 1,
+                                                column: 38,
+                                            },
+                                            end: Position {
+                                                line: 1,
+                                                column: 41,
+                                            },
+                                        },
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                },
+                loc: SourceLocation {
+                    start: Position {
+                        line: 1,
+                        column: 14,
+                    },
+                    end: Position {
+                        line: 1,
+                        column: 16,
+                    },
+                },
+            },
+        ),
+        type_ann: None,
+    },
+    loc: SourceLocation {
+        start: Position {
+            line: 1,
+            column: 1,
+        },
+        end: Position {
+            line: 1,
+            column: 16,
+        },
+    },
+}

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component_with_fragment.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component_with_fragment.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"fn (props) => <div>{props.children}</div>\")"
+expression: "parse(\"fn (props) => <>{props.children}</>\")"
 ---
 Expr {
     kind: Function {
@@ -40,27 +40,9 @@ Expr {
         ],
         body: Expr(
             Expr {
-                kind: JSXElement(
-                    JSXElement {
-                        opening: JSXOpeningElement {
-                            name: Ident(
-                                Ident {
-                                    name: "div",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 16,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 19,
-                                        },
-                                    },
-                                },
-                            ),
-                            attrs: [],
-                            self_closing: false,
-                        },
+                kind: JSXFragment(
+                    JSXFragment {
+                        opening: JSXOpeningFragment,
                         children: [
                             ExprContainer(
                                 JSXExprContainer {
@@ -73,11 +55,11 @@ Expr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 1,
-                                                        column: 21,
+                                                        column: 18,
                                                     },
                                                     end: Position {
                                                         line: 1,
-                                                        column: 26,
+                                                        column: 23,
                                                     },
                                                 },
                                             },
@@ -88,11 +70,11 @@ Expr {
                                                 loc: SourceLocation {
                                                     start: Position {
                                                         line: 1,
-                                                        column: 27,
+                                                        column: 24,
                                                     },
                                                     end: Position {
                                                         line: 1,
-                                                        column: 35,
+                                                        column: 32,
                                                     },
                                                 },
                                             },
@@ -100,36 +82,18 @@ Expr {
                                         loc: SourceLocation {
                                             start: Position {
                                                 line: 1,
-                                                column: 21,
+                                                column: 18,
                                             },
                                             end: Position {
                                                 line: 1,
-                                                column: 35,
+                                                column: 32,
                                             },
                                         },
                                     },
                                 },
                             ),
                         ],
-                        closing: Some(
-                            JSXClosingElement {
-                                name: Ident(
-                                    Ident {
-                                        name: "div",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 38,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 41,
-                                            },
-                                        },
-                                    },
-                                ),
-                            },
-                        ),
+                        closing: JSXClosingFragment,
                     },
                 ),
                 loc: SourceLocation {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-5.snap
@@ -4,7 +4,7 @@ expression: "parse(\"undefined\")"
 ---
 Expr {
     kind: Literal(
-        Null,
+        Undefined,
     ),
     loc: SourceLocation {
         start: Position {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_props_dot_children.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_props_dot_children.snap
@@ -1,0 +1,95 @@
+---
+source: crates/escalier_parser/src/jsx_parser.rs
+expression: jsx_elem
+---
+JSXElement {
+    opening: JSXOpeningElement {
+        name: Ident(
+            Ident {
+                name: "div",
+                loc: SourceLocation {
+                    start: Position {
+                        line: 1,
+                        column: 2,
+                    },
+                    end: Position {
+                        line: 1,
+                        column: 5,
+                    },
+                },
+            },
+        ),
+        attrs: [],
+        self_closing: false,
+    },
+    children: [
+        ExprContainer(
+            JSXExprContainer {
+                expr: Expr {
+                    kind: Binary {
+                        left: Expr {
+                            kind: Identifier(
+                                "a",
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 1,
+                                    column: 7,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    column: 8,
+                                },
+                            },
+                        },
+                        op: Plus,
+                        right: Expr {
+                            kind: Identifier(
+                                "b",
+                            ),
+                            loc: SourceLocation {
+                                start: Position {
+                                    line: 1,
+                                    column: 9,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    column: 10,
+                                },
+                            },
+                        },
+                    },
+                    loc: SourceLocation {
+                        start: Position {
+                            line: 1,
+                            column: 7,
+                        },
+                        end: Position {
+                            line: 1,
+                            column: 10,
+                        },
+                    },
+                },
+            },
+        ),
+    ],
+    closing: Some(
+        JSXClosingElement {
+            name: Ident(
+                Ident {
+                    name: "div",
+                    loc: SourceLocation {
+                        start: Position {
+                            line: 1,
+                            column: 13,
+                        },
+                        end: Position {
+                            line: 1,
+                            column: 16,
+                        },
+                    },
+                },
+            ),
+        },
+    ),
+}


### PR DESCRIPTION
Up til now we've only be able to parse JSX in isolation.  This PR will make it possible to parse JSX within larger expressions and statements.

TODO:
- [x] update `parse_atom()` use `peek()` instead of `next()`
- [x] handle JSX fragments as well