### PR TITLE
Replace SourceLocation with Span

### DIFF
--- a/crates/escalier_parser/src/expr.rs
+++ b/crates/escalier_parser/src/expr.rs
@@ -2,7 +2,7 @@ use crate::func_param::FuncParam;
 use crate::jsx::{JSXElement, JSXFragment};
 use crate::literal::Literal;
 use crate::pattern::Pattern;
-use crate::source_location::SourceLocation;
+use crate::source_location::*;
 use crate::stmt::Stmt;
 use crate::type_ann::TypeAnn;
 
@@ -116,8 +116,8 @@ pub struct CatchClause {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MatchArm {
-    pub loc: SourceLocation,
-    // pub span: Span,
+    // pub loc: SourceLocation,
+    pub span: Span,
     pub pattern: Pattern,
     pub guard: Option<Box<Expr>>,
     pub body: BlockOrExpr,
@@ -131,7 +131,7 @@ pub enum BlockOrExpr {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Block {
-    pub loc: SourceLocation,
+    pub span: Span,
     pub stmts: Vec<Stmt>,
 }
 
@@ -171,5 +171,5 @@ pub enum UnaryOp {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Expr {
     pub kind: ExprKind,
-    pub loc: SourceLocation,
+    pub span: Span,
 }

--- a/crates/escalier_parser/src/identifier.rs
+++ b/crates/escalier_parser/src/identifier.rs
@@ -1,14 +1,14 @@
-use crate::source_location::SourceLocation;
+use crate::source_location::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Ident {
     pub name: String,
-    pub loc: SourceLocation,
+    pub span: Span,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BindingIdent {
     pub name: String,
-    pub loc: SourceLocation,
+    pub span: Span,
     pub mutable: bool,
 }

--- a/crates/escalier_parser/src/jsx.rs
+++ b/crates/escalier_parser/src/jsx.rs
@@ -1,5 +1,6 @@
 use crate::expr::Expr;
 use crate::identifier::Ident;
+use crate::source_location::Span;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum JSXElementName {
@@ -96,7 +97,7 @@ pub struct JSXSpreadChild {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct JSXText {
-    // pub span: Span,
+    pub span: Span,
     pub value: String,
     // pub raw: String,
 }

--- a/crates/escalier_parser/src/pattern.rs
+++ b/crates/escalier_parser/src/pattern.rs
@@ -1,7 +1,7 @@
 use crate::expr::Expr;
 use crate::identifier::{BindingIdent, Ident};
 use crate::literal::Literal;
-use crate::source_location::SourceLocation;
+use crate::source_location::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PatternKind {
@@ -18,8 +18,8 @@ pub enum PatternKind {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Pattern {
-    pub loc: SourceLocation,
-    // pub span: Span,
+    // pub loc: SourceLocation,
+    pub span: Span,
     pub kind: PatternKind,
     // pub inferred_type: Option<Index>,
 }
@@ -69,8 +69,8 @@ pub enum ObjectPatProp {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyValuePatProp {
-    pub loc: SourceLocation,
-    // pub span: Span,
+    // pub loc: SourceLocation,
+    pub span: Span,
     pub key: Ident,
     pub value: Box<Pattern>,
     pub init: Option<Box<Expr>>,
@@ -78,8 +78,8 @@ pub struct KeyValuePatProp {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShorthandPatProp {
-    pub loc: SourceLocation,
-    // pub span: Span,
+    // pub loc: SourceLocation,
+    pub span: Span,
     pub ident: BindingIdent,
     pub init: Option<Box<Expr>>,
 }

--- a/crates/escalier_parser/src/scanner.rs
+++ b/crates/escalier_parser/src/scanner.rs
@@ -1,12 +1,9 @@
-use crate::source_location::Position;
-
 #[derive(Clone)]
 pub struct Scanner<'a> {
     cursor: usize,
     column: usize,
     line: usize,
     input: &'a str,
-    // characters: Vec<char>,
 }
 
 impl<'a> Scanner<'a> {
@@ -16,20 +13,12 @@ impl<'a> Scanner<'a> {
             column: 1,
             line: 1,
             input,
-            // characters: string.chars().collect(),
         }
     }
 
     /// Returns the current cursor. Useful for reporting errors.
     pub fn cursor(&self) -> usize {
         self.cursor
-    }
-
-    pub fn position(&self) -> Position {
-        Position {
-            line: self.line,
-            column: self.column,
-        }
     }
 
     /// Returns the next character without advancing the cursor.
@@ -66,6 +55,4 @@ impl<'a> Scanner<'a> {
             None => None,
         }
     }
-
-    // pub fn backup(&mut self) ->
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_addition_and_subtraction.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_addition_and_subtraction.snap
@@ -14,16 +14,7 @@ Expr {
                                     "1",
                                 ),
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                            },
+                            span: 0..1,
                         },
                         op: Plus,
                         right: Expr {
@@ -32,28 +23,10 @@ Expr {
                                     "2",
                                 ),
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 0..5,
                 },
                 op: Minus,
                 right: Expr {
@@ -62,28 +35,10 @@ Expr {
                             "3",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 8..9,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 0..9,
         },
         op: Plus,
         right: Expr {
@@ -92,26 +47,8 @@ Expr {
                     "4",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 13,
-                },
-                end: Position {
-                    line: 1,
-                    column: 14,
-                },
-            },
+            span: 12..13,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 14,
-        },
-    },
+    span: 0..13,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_additive_and_multiplicative.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_additive_and_multiplicative.snap
@@ -12,16 +12,7 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 op: Times,
                 right: Expr {
@@ -30,28 +21,10 @@ Expr {
                             "2",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 6,
-                },
-            },
+            span: 0..5,
         },
         op: Plus,
         right: Expr {
@@ -60,26 +33,8 @@ Expr {
                     "3",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 9,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 8..9,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-2.snap
@@ -8,16 +8,7 @@ Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: Assign,
         right: Expr {
@@ -26,54 +17,18 @@ Expr {
                     kind: Identifier(
                         "y",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
                 op: Assign,
                 right: Expr {
                     kind: Identifier(
                         "z",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 8..9,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 5,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 4..9,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-3.snap
@@ -10,43 +10,16 @@ Expr {
                     kind: Identifier(
                         "x",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 property: Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 2..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
         op: Assign,
         right: Expr {
@@ -55,53 +28,17 @@ Expr {
                     kind: Identifier(
                         "y",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                    },
+                    span: 6..7,
                 },
                 property: Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 8..9,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 7,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 6..9,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-4.snap
@@ -8,16 +8,7 @@ Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: AddAssign,
         right: Expr {
@@ -26,26 +17,8 @@ Expr {
                     "1",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 5..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-5.snap
@@ -8,16 +8,7 @@ Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: SubAssign,
         right: Expr {
@@ -26,26 +17,8 @@ Expr {
                     "1",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 5..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-6.snap
@@ -8,16 +8,7 @@ Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: MulAssign,
         right: Expr {
@@ -26,26 +17,8 @@ Expr {
                     "2",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 5..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-7.snap
@@ -8,16 +8,7 @@ Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: DivAssign,
         right: Expr {
@@ -26,26 +17,8 @@ Expr {
                     "2",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 5..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-8.snap
@@ -8,16 +8,7 @@ Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: ModAssign,
         right: Expr {
@@ -26,26 +17,8 @@ Expr {
                     "2",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 5..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment.snap
@@ -8,42 +8,15 @@ Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: Assign,
         right: Expr {
             kind: Identifier(
                 "y",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 5,
-                },
-                end: Position {
-                    line: 1,
-                    column: 6,
-                },
-            },
+            span: 4..5,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 6,
-        },
-    },
+    span: 0..5,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_call_expr.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_call_expr.snap
@@ -11,16 +11,7 @@ Expr {
                         "5",
                     ),
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 10,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                },
+                span: 9..10,
             },
             Expr {
                 kind: Literal(
@@ -28,16 +19,7 @@ Expr {
                         "10",
                     ),
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 13,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 15,
-                    },
-                },
+                span: 12..14,
             },
         ],
         callee: Expr {
@@ -46,53 +28,17 @@ Expr {
                     kind: Identifier(
                         "foo",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 0..3,
                 },
                 right: Expr {
                     kind: Identifier(
                         "bar",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                    },
+                    span: 4..7,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 8,
-                },
-            },
+            span: 0..7,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 16,
-        },
-    },
+    span: 0..15,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_callback.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_callback.snap
@@ -11,16 +11,7 @@ Expr {
                         ", ",
                     ),
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 29,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 33,
-                    },
-                },
+                span: 28..32,
             },
         ],
         callee: Expr {
@@ -33,29 +24,11 @@ Expr {
                                     params: [
                                         FuncParam {
                                             pattern: Pattern {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 13,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 15,
-                                                    },
-                                                },
+                                                span: 12..14,
                                                 kind: Ident(
                                                     BindingIdent {
                                                         name: "id",
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 13,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 15,
-                                                            },
-                                                        },
+                                                        span: 12..14,
                                                         mutable: false,
                                                     },
                                                 ),
@@ -69,30 +42,12 @@ Expr {
                                             kind: Identifier(
                                                 "id",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 20,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 22,
-                                                },
-                                            },
+                                            span: 19..21,
                                         },
                                     ),
                                     type_ann: None,
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 22,
-                                    },
-                                },
+                                span: 8..21,
                             },
                         ],
                         callee: Expr {
@@ -101,92 +56,29 @@ Expr {
                                     kind: Identifier(
                                         "ids",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 1,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                    },
+                                    span: 0..3,
                                 },
                                 property: Expr {
                                     kind: Identifier(
                                         "map",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 5,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 8,
-                                        },
-                                    },
+                                    span: 4..7,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                            },
+                            span: 0..7,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 23,
-                        },
-                    },
+                    span: 0..22,
                 },
                 property: Expr {
                     kind: Identifier(
                         "join",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 24,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 28,
-                        },
-                    },
+                    span: 23..27,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 28,
-                },
-            },
+            span: 0..27,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 34,
-        },
-    },
+    span: 0..33,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_comparisons_and_logic-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_comparisons_and_logic-2.snap
@@ -10,44 +10,17 @@ Expr {
                     kind: Identifier(
                         "x",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 op: NotEquals,
                 right: Expr {
                     kind: Identifier(
                         "y",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                    },
+                    span: 5..6,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 0..6,
         },
         op: And,
         right: Expr {
@@ -56,54 +29,18 @@ Expr {
                     kind: Identifier(
                         "z",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 12,
-                        },
-                    },
+                    span: 10..11,
                 },
                 op: Equals,
                 right: Expr {
                     kind: Identifier(
                         "w",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                    },
+                    span: 15..16,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 11,
-                },
-                end: Position {
-                    line: 1,
-                    column: 17,
-                },
-            },
+            span: 10..16,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 17,
-        },
-    },
+    span: 0..16,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_comparisons_and_logic.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_comparisons_and_logic.snap
@@ -12,44 +12,17 @@ Expr {
                             kind: Identifier(
                                 "a",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                            },
+                            span: 0..1,
                         },
                         op: GreaterThan,
                         right: Expr {
                             kind: Identifier(
                                 "b",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 0..5,
                 },
                 op: And,
                 right: Expr {
@@ -58,56 +31,20 @@ Expr {
                             kind: Identifier(
                                 "c",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 10,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 11,
-                                },
-                            },
+                            span: 9..10,
                         },
                         op: GreaterThanOrEqual,
                         right: Expr {
                             kind: Identifier(
                                 "d",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 15,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 16,
-                                },
-                            },
+                            span: 14..15,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                    },
+                    span: 9..15,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 16,
-                },
-            },
+            span: 0..15,
         },
         op: Or,
         right: Expr {
@@ -118,44 +55,17 @@ Expr {
                             kind: Identifier(
                                 "e",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 20,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 21,
-                                },
-                            },
+                            span: 19..20,
                         },
                         op: LessThan,
                         right: Expr {
                             kind: Identifier(
                                 "f",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 24,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 25,
-                                },
-                            },
+                            span: 23..24,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 20,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 25,
-                        },
-                    },
+                    span: 19..24,
                 },
                 op: And,
                 right: Expr {
@@ -164,66 +74,21 @@ Expr {
                             kind: Identifier(
                                 "g",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 29,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 30,
-                                },
-                            },
+                            span: 28..29,
                         },
                         op: LessThanOrEqual,
                         right: Expr {
                             kind: Identifier(
                                 "h",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 34,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 35,
-                                },
-                            },
+                            span: 33..34,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 29,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 35,
-                        },
-                    },
+                    span: 28..34,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 20,
-                },
-                end: Position {
-                    line: 1,
-                    column: 35,
-                },
-            },
+            span: 19..34,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 35,
-        },
-    },
+    span: 0..34,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-2.snap
@@ -8,28 +8,10 @@ Expr {
             kind: Identifier(
                 "cond",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 5,
-                },
-                end: Position {
-                    line: 1,
-                    column: 9,
-                },
-            },
+            span: 4..8,
         },
         consequent: Block {
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 10,
-                },
-                end: Position {
-                    line: 1,
-                    column: 17,
-                },
-            },
+            span: 9..16,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -37,43 +19,16 @@ Expr {
                             kind: Identifier(
                                 "x",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 13,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 14,
-                                },
-                            },
+                            span: 12..13,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 14,
-                        },
-                    },
+                    span: 12..13,
                 },
             ],
         },
         alternate: Some(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 22,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 29,
-                    },
-                },
+                span: 21..28,
                 stmts: [
                     Stmt {
                         kind: Expr {
@@ -81,41 +36,14 @@ Expr {
                                 kind: Identifier(
                                     "y",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 25,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 26,
-                                    },
-                                },
+                                span: 24..25,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 25,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 26,
-                            },
-                        },
+                        span: 24..25,
                     },
                 ],
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 29,
-        },
-    },
+    span: 0..28,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-3.snap
@@ -8,28 +8,10 @@ Expr {
             kind: Identifier(
                 "cond",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 2,
-                    column: 17,
-                },
-                end: Position {
-                    line: 2,
-                    column: 21,
-                },
-            },
+            span: 17..21,
         },
         consequent: Block {
-            loc: SourceLocation {
-                start: Position {
-                    line: 2,
-                    column: 22,
-                },
-                end: Position {
-                    line: 4,
-                    column: 14,
-                },
-            },
+            span: 22..69,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -47,16 +29,7 @@ Expr {
                                                         "5",
                                                     ),
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 22,
-                                                    },
-                                                },
+                                                span: 45..46,
                                             },
                                         },
                                     ),
@@ -71,58 +44,22 @@ Expr {
                                                         "10",
                                                     ),
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 3,
-                                                        column: 27,
-                                                    },
-                                                    end: Position {
-                                                        line: 3,
-                                                        column: 29,
-                                                    },
-                                                },
+                                                span: 51..53,
                                             },
                                         },
                                     ),
                                 ],
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 2,
-                                    column: 24,
-                                },
-                                end: Position {
-                                    line: 3,
-                                    column: 30,
-                                },
-                            },
+                            span: 24..54,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 2,
-                            column: 24,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 30,
-                        },
-                    },
+                    span: 24..54,
                 },
             ],
         },
         alternate: Some(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 4,
-                        column: 19,
-                    },
-                    end: Position {
-                        line: 6,
-                        column: 14,
-                    },
-                },
+                span: 74..120,
                 stmts: [
                     Stmt {
                         kind: Expr {
@@ -140,16 +77,7 @@ Expr {
                                                             "1",
                                                         ),
                                                     ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
-                                                            column: 21,
-                                                        },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 22,
-                                                        },
-                                                    },
+                                                    span: 97..98,
                                                 },
                                             },
                                         ),
@@ -164,56 +92,20 @@ Expr {
                                                             "2",
                                                         ),
                                                     ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
-                                                            column: 27,
-                                                        },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 28,
-                                                        },
-                                                    },
+                                                    span: 103..104,
                                                 },
                                             },
                                         ),
                                     ],
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 4,
-                                        column: 21,
-                                    },
-                                    end: Position {
-                                        line: 5,
-                                        column: 29,
-                                    },
-                                },
+                                span: 76..105,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 4,
-                                column: 21,
-                            },
-                            end: Position {
-                                line: 5,
-                                column: 29,
-                            },
-                        },
+                        span: 76..105,
                     },
                 ],
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 2,
-            column: 13,
-        },
-        end: Position {
-            line: 6,
-            column: 14,
-        },
-    },
+    span: 13..120,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals.snap
@@ -8,28 +8,10 @@ Expr {
             kind: Identifier(
                 "cond",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 5,
-                },
-                end: Position {
-                    line: 1,
-                    column: 9,
-                },
-            },
+            span: 4..8,
         },
         consequent: Block {
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 10,
-                },
-                end: Position {
-                    line: 1,
-                    column: 17,
-                },
-            },
+            span: 9..16,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -37,41 +19,14 @@ Expr {
                             kind: Identifier(
                                 "x",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 13,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 14,
-                                },
-                            },
+                            span: 12..13,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 14,
-                        },
-                    },
+                    span: 12..13,
                 },
             ],
         },
         alternate: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 17,
-        },
-    },
+    span: 0..16,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_do_expr.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_do_expr.snap
@@ -5,43 +5,16 @@ expression: "parse(r#\"\n            do {\n                let x = 5;\n         
 Expr {
     kind: Do {
         body: Block {
-            loc: SourceLocation {
-                start: Position {
-                    line: 2,
-                    column: 15,
-                },
-                end: Position {
-                    line: 6,
-                    column: 14,
-                },
-            },
+            span: 15..109,
             stmts: [
                 Stmt {
                     kind: Let {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 3,
-                                    column: 21,
-                                },
-                                end: Position {
-                                    line: 3,
-                                    column: 22,
-                                },
-                            },
+                            span: 38..39,
                             kind: Ident(
                                 BindingIdent {
                                     name: "x",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 3,
-                                            column: 21,
-                                        },
-                                        end: Position {
-                                            line: 3,
-                                            column: 22,
-                                        },
-                                    },
+                                    span: 38..39,
                                     mutable: false,
                                 },
                             ),
@@ -52,56 +25,20 @@ Expr {
                                     "5",
                                 ),
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 3,
-                                    column: 25,
-                                },
-                                end: Position {
-                                    line: 3,
-                                    column: 26,
-                                },
-                            },
+                            span: 42..43,
                         },
                         type_ann: None,
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 26,
-                        },
-                    },
+                    span: 34..43,
                 },
                 Stmt {
                     kind: Let {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 4,
-                                    column: 21,
-                                },
-                                end: Position {
-                                    line: 4,
-                                    column: 22,
-                                },
-                            },
+                            span: 65..66,
                             kind: Ident(
                                 BindingIdent {
                                     name: "y",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 4,
-                                            column: 21,
-                                        },
-                                        end: Position {
-                                            line: 4,
-                                            column: 22,
-                                        },
-                                    },
+                                    span: 65..66,
                                     mutable: false,
                                 },
                             ),
@@ -112,29 +49,11 @@ Expr {
                                     "10",
                                 ),
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 4,
-                                    column: 25,
-                                },
-                                end: Position {
-                                    line: 4,
-                                    column: 27,
-                                },
-                            },
+                            span: 69..71,
                         },
                         type_ann: None,
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 4,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 4,
-                            column: 27,
-                        },
-                    },
+                    span: 61..71,
                 },
                 Stmt {
                     kind: Expr {
@@ -144,68 +63,23 @@ Expr {
                                     kind: Identifier(
                                         "x",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 5,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 5,
-                                            column: 18,
-                                        },
-                                    },
+                                    span: 89..90,
                                 },
                                 op: Plus,
                                 right: Expr {
                                     kind: Identifier(
                                         "y",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 5,
-                                            column: 21,
-                                        },
-                                        end: Position {
-                                            line: 5,
-                                            column: 22,
-                                        },
-                                    },
+                                    span: 93..94,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 5,
-                                    column: 17,
-                                },
-                                end: Position {
-                                    line: 5,
-                                    column: 22,
-                                },
-                            },
+                            span: 89..94,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 5,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 5,
-                            column: 22,
-                        },
-                    },
+                    span: 89..94,
                 },
             ],
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 2,
-            column: 13,
-        },
-        end: Position {
-            line: 6,
-            column: 14,
-        },
-    },
+    span: 13..109,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_exprs_with_template_strings.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_exprs_with_template_strings.snap
@@ -8,16 +8,7 @@ Expr {
             kind: Identifier(
                 "a",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: Plus,
         right: Expr {
@@ -35,39 +26,12 @@ Expr {
                         kind: Identifier(
                             "c",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 11,
-                            },
-                        },
+                        span: 9..10,
                     },
                 ],
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 4,
-                },
-                end: Position {
-                    line: 1,
-                    column: 15,
-                },
-            },
+            span: 3..14,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 15,
-        },
-    },
+    span: 0..14,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function.snap
@@ -7,43 +7,16 @@ Expr {
         params: [],
         body: Block(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 9,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 50,
-                    },
-                },
+                span: 8..49,
                 stmts: [
                     Stmt {
                         kind: Let {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 16,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 17,
-                                    },
-                                },
+                                span: 15..16,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "x",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 17,
-                                            },
-                                        },
+                                        span: 15..16,
                                         mutable: false,
                                     },
                                 ),
@@ -54,56 +27,20 @@ Expr {
                                         "5",
                                     ),
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 20,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 21,
-                                    },
-                                },
+                                span: 19..20,
                             },
                             type_ann: None,
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 21,
-                            },
-                        },
+                        span: 11..20,
                     },
                     Stmt {
                         kind: Let {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 27,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 28,
-                                    },
-                                },
+                                span: 26..27,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "y",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 27,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 28,
-                                            },
-                                        },
+                                        span: 26..27,
                                         mutable: false,
                                     },
                                 ),
@@ -114,29 +51,11 @@ Expr {
                                         "10",
                                     ),
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 31,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 33,
-                                    },
-                                },
+                                span: 30..32,
                             },
                             type_ann: None,
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 23,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 33,
-                            },
-                        },
+                        span: 22..32,
                     },
                     Stmt {
                         kind: Return {
@@ -147,71 +66,26 @@ Expr {
                                             kind: Identifier(
                                                 "x",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 42,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 43,
-                                                },
-                                            },
+                                            span: 41..42,
                                         },
                                         op: Plus,
                                         right: Expr {
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 46,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 47,
-                                                },
-                                            },
+                                            span: 45..46,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 42,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 47,
-                                        },
-                                    },
+                                    span: 41..46,
                                 },
                             ),
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 42,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 47,
-                            },
-                        },
+                        span: 41..46,
                     },
                 ],
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 50,
-        },
-    },
+    span: 0..49,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-2.snap
@@ -11,16 +11,7 @@ Expr {
                         "10",
                     ),
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 10,
-                    },
-                },
+                span: 7..9,
             },
         ],
         callee: Expr {
@@ -32,54 +23,18 @@ Expr {
                                 "5",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                        },
+                        span: 4..5,
                     },
                 ],
                 callee: Expr {
                     kind: Identifier(
                         "add",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 0..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 0..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 11,
-        },
-    },
+    span: 0..10,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-3.snap
@@ -11,43 +11,16 @@ Expr {
                         kind: Identifier(
                             "obj",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 4..7,
                     },
                     property: Expr {
                         kind: Identifier(
                             "x",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 9,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 10,
-                            },
-                        },
+                        span: 8..9,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 10,
-                    },
-                },
+                span: 4..9,
             },
             Expr {
                 kind: Member {
@@ -55,69 +28,24 @@ Expr {
                         kind: Identifier(
                             "obj",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 15,
-                            },
-                        },
+                        span: 11..14,
                     },
                     property: Expr {
                         kind: Identifier(
                             "y",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 16,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 17,
-                            },
-                        },
+                        span: 15..16,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 12,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 17,
-                    },
-                },
+                span: 11..16,
             },
         ],
         callee: Expr {
             kind: Identifier(
                 "add",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 18,
-        },
-    },
+    span: 0..17,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call.snap
@@ -11,16 +11,7 @@ Expr {
                         "5",
                     ),
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 6,
-                    },
-                },
+                span: 4..5,
             },
             Expr {
                 kind: Literal(
@@ -28,42 +19,15 @@ Expr {
                         "10",
                     ),
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 10,
-                    },
-                },
+                span: 7..9,
             },
         ],
         callee: Expr {
             kind: Identifier(
                 "add",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 11,
-        },
-    },
+    span: 0..10,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring.snap
@@ -7,43 +7,16 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                    },
+                    span: 4..10,
                     kind: Object(
                         ObjectPat {
                             props: [
                                 Shorthand(
                                     ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                        },
+                                        span: 5..6,
                                         ident: BindingIdent {
                                             name: "x",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 6,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 7,
-                                                },
-                                            },
+                                            span: 5..6,
                                             mutable: false,
                                         },
                                         init: None,
@@ -51,28 +24,10 @@ Expr {
                                 ),
                                 Shorthand(
                                     ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                        },
+                                        span: 8..9,
                                         ident: BindingIdent {
                                             name: "y",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 10,
-                                                },
-                                            },
+                                            span: 8..9,
                                             mutable: false,
                                         },
                                         init: None,
@@ -89,16 +44,7 @@ Expr {
         ],
         body: Block(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 15,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 33,
-                    },
-                },
+                span: 14..32,
                 stmts: [
                     Stmt {
                         kind: Return {
@@ -109,71 +55,26 @@ Expr {
                                             kind: Identifier(
                                                 "x",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 26,
-                                                },
-                                            },
+                                            span: 24..25,
                                         },
                                         op: Plus,
                                         right: Expr {
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 29,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 30,
-                                                },
-                                            },
+                                            span: 28..29,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 25,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 30,
-                                        },
-                                    },
+                                    span: 24..29,
                                 },
                             ),
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 25,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 30,
-                            },
-                        },
+                        span: 24..29,
                     },
                 ],
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 33,
-        },
-    },
+    span: 0..32,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring_and_type_annotation.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring_and_type_annotation.snap
@@ -7,43 +7,16 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                    },
+                    span: 4..10,
                     kind: Object(
                         ObjectPat {
                             props: [
                                 Shorthand(
                                     ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                        },
+                                        span: 5..6,
                                         ident: BindingIdent {
                                             name: "x",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 6,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 7,
-                                                },
-                                            },
+                                            span: 5..6,
                                             mutable: false,
                                         },
                                         init: None,
@@ -51,28 +24,10 @@ Expr {
                                 ),
                                 Shorthand(
                                     ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                        },
+                                        span: 8..9,
                                         ident: BindingIdent {
                                             name: "y",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 10,
-                                                },
-                                            },
+                                            span: 8..9,
                                             mutable: false,
                                         },
                                         init: None,
@@ -89,16 +44,7 @@ Expr {
                             "Point",
                             None,
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 13,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 18,
-                            },
-                        },
+                        span: 12..17,
                     },
                 ),
                 optional: false,
@@ -106,16 +52,7 @@ Expr {
         ],
         body: Block(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 30,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 48,
-                    },
-                },
+                span: 29..47,
                 stmts: [
                     Stmt {
                         kind: Return {
@@ -126,57 +63,21 @@ Expr {
                                             kind: Identifier(
                                                 "x",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 40,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 41,
-                                                },
-                                            },
+                                            span: 39..40,
                                         },
                                         op: Plus,
                                         right: Expr {
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 44,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 45,
-                                                },
-                                            },
+                                            span: 43..44,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 40,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 45,
-                                        },
-                                    },
+                                    span: 39..44,
                                 },
                             ),
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 40,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 45,
-                            },
-                        },
+                        span: 39..44,
                     },
                 ],
             },
@@ -184,27 +85,9 @@ Expr {
         type_ann: Some(
             TypeAnn {
                 kind: Number,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 21,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 27,
-                    },
-                },
+                span: 20..26,
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 48,
-        },
-    },
+    span: 0..47,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_optional_params.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_optional_params.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                     kind: Ident(
                         BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                     ),
@@ -37,45 +19,18 @@ Expr {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 14,
-                            },
-                        },
+                        span: 7..13,
                     },
                 ),
                 optional: false,
             },
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                    },
+                    span: 15..16,
                     kind: Ident(
                         BindingIdent {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 16,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 17,
-                                },
-                            },
+                            span: 15..16,
                             mutable: false,
                         },
                     ),
@@ -83,45 +38,18 @@ Expr {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 19,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 25,
-                            },
-                        },
+                        span: 18..24,
                     },
                 ),
                 optional: false,
             },
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 27,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 28,
-                        },
-                    },
+                    span: 26..27,
                     kind: Ident(
                         BindingIdent {
                             name: "z",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 27,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 28,
-                                },
-                            },
+                            span: 26..27,
                             mutable: false,
                         },
                     ),
@@ -129,16 +57,7 @@ Expr {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 31,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 37,
-                            },
-                        },
+                        span: 30..36,
                     },
                 ),
                 optional: true,
@@ -146,16 +65,7 @@ Expr {
         ],
         body: Block(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 49,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 67,
-                    },
-                },
+                span: 48..66,
                 stmts: [
                     Stmt {
                         kind: Return {
@@ -166,57 +76,21 @@ Expr {
                                             kind: Identifier(
                                                 "x",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 59,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 60,
-                                                },
-                                            },
+                                            span: 58..59,
                                         },
                                         op: Plus,
                                         right: Expr {
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 63,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 64,
-                                                },
-                                            },
+                                            span: 62..63,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 59,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 64,
-                                        },
-                                    },
+                                    span: 58..63,
                                 },
                             ),
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 59,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 64,
-                            },
-                        },
+                        span: 58..63,
                     },
                 ],
             },
@@ -224,27 +98,9 @@ Expr {
         type_ann: Some(
             TypeAnn {
                 kind: Number,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 40,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 46,
-                    },
-                },
+                span: 39..45,
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 67,
-        },
-    },
+    span: 0..66,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_params.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_params.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                     kind: Ident(
                         BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                     ),
@@ -39,29 +21,11 @@ Expr {
             },
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                    },
+                    span: 7..8,
                     kind: Ident(
                         BindingIdent {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 9,
-                                },
-                            },
+                            span: 7..8,
                             mutable: false,
                         },
                     ),
@@ -72,16 +36,7 @@ Expr {
         ],
         body: Block(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 13,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 31,
-                    },
-                },
+                span: 12..30,
                 stmts: [
                     Stmt {
                         kind: Return {
@@ -92,71 +47,26 @@ Expr {
                                             kind: Identifier(
                                                 "x",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 23,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 24,
-                                                },
-                                            },
+                                            span: 22..23,
                                         },
                                         op: Plus,
                                         right: Expr {
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 27,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 28,
-                                                },
-                                            },
+                                            span: 26..27,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 23,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 28,
-                                        },
-                                    },
+                                    span: 22..27,
                                 },
                             ),
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 23,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 28,
-                            },
-                        },
+                        span: 22..27,
                     },
                 ],
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 31,
-        },
-    },
+    span: 0..30,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_type_annotations.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_type_annotations.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                     kind: Ident(
                         BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                     ),
@@ -37,45 +19,18 @@ Expr {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 14,
-                            },
-                        },
+                        span: 7..13,
                     },
                 ),
                 optional: false,
             },
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                    },
+                    span: 15..16,
                     kind: Ident(
                         BindingIdent {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 16,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 17,
-                                },
-                            },
+                            span: 15..16,
                             mutable: false,
                         },
                     ),
@@ -83,16 +38,7 @@ Expr {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 19,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 25,
-                            },
-                        },
+                        span: 18..24,
                     },
                 ),
                 optional: false,
@@ -100,16 +46,7 @@ Expr {
         ],
         body: Block(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 37,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 55,
-                    },
-                },
+                span: 36..54,
                 stmts: [
                     Stmt {
                         kind: Return {
@@ -120,57 +57,21 @@ Expr {
                                             kind: Identifier(
                                                 "x",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 47,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 48,
-                                                },
-                                            },
+                                            span: 46..47,
                                         },
                                         op: Plus,
                                         right: Expr {
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 51,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 52,
-                                                },
-                                            },
+                                            span: 50..51,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 47,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 52,
-                                        },
-                                    },
+                                    span: 46..51,
                                 },
                             ),
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 47,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 52,
-                            },
-                        },
+                        span: 46..51,
                     },
                 ],
             },
@@ -178,27 +79,9 @@ Expr {
         type_ann: Some(
             TypeAnn {
                 kind: Number,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 28,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 34,
-                    },
-                },
+                span: 27..33,
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 55,
-        },
-    },
+    span: 0..54,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 4..9,
                     kind: Ident(
                         BindingIdent {
                             name: "props",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 10,
-                                },
-                            },
+                            span: 4..9,
                             mutable: false,
                         },
                     ),
@@ -46,16 +28,7 @@ Expr {
                             name: Ident(
                                 Ident {
                                     name: "div",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 16,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 19,
-                                        },
-                                    },
+                                    span: 15..18,
                                 },
                             ),
                             attrs: [],
@@ -70,43 +43,16 @@ Expr {
                                                 kind: Identifier(
                                                     "props",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 26,
-                                                    },
-                                                },
+                                                span: 20..25,
                                             },
                                             property: Expr {
                                                 kind: Identifier(
                                                     "children",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 27,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 35,
-                                                    },
-                                                },
+                                                span: 26..34,
                                             },
                                         },
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 21,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 35,
-                                            },
-                                        },
+                                        span: 20..34,
                                     },
                                 },
                             ),
@@ -116,44 +62,17 @@ Expr {
                                 name: Ident(
                                     Ident {
                                         name: "div",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 38,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 41,
-                                            },
-                                        },
+                                        span: 35..41,
                                     },
                                 ),
                             },
                         ),
                     },
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 14,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 16,
-                    },
-                },
+                span: 13..15,
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 16,
-        },
-    },
+    span: 0..15,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component_with_fragment.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component_with_fragment.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 4..9,
                     kind: Ident(
                         BindingIdent {
                             name: "props",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 10,
-                                },
-                            },
+                            span: 4..9,
                             mutable: false,
                         },
                     ),
@@ -52,43 +34,16 @@ Expr {
                                                 kind: Identifier(
                                                     "props",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 18,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 23,
-                                                    },
-                                                },
+                                                span: 17..22,
                                             },
                                             property: Expr {
                                                 kind: Identifier(
                                                     "children",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 24,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 32,
-                                                    },
-                                                },
+                                                span: 23..31,
                                             },
                                         },
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 18,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 32,
-                                            },
-                                        },
+                                        span: 17..31,
                                     },
                                 },
                             ),
@@ -96,28 +51,10 @@ Expr {
                         closing: JSXClosingFragment,
                     },
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 14,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 16,
-                    },
-                },
+                span: 13..15,
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 16,
-        },
-    },
+    span: 0..15,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_indexing.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_indexing.snap
@@ -10,16 +10,7 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 right: Expr {
                     kind: Literal(
@@ -27,53 +18,17 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 2..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
         right: Expr {
             kind: Identifier(
                 "c",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 5..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-2.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                     kind: Ident(
                         BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                     ),
@@ -44,29 +26,11 @@ Expr {
                     params: [
                         FuncParam {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 15,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 16,
-                                    },
-                                },
+                                span: 14..15,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "y",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 15,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 16,
-                                            },
-                                        },
+                                        span: 14..15,
                                         mutable: false,
                                     },
                                 ),
@@ -82,70 +46,25 @@ Expr {
                                     kind: Identifier(
                                         "x",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 21,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 22,
-                                        },
-                                    },
+                                    span: 20..21,
                                 },
                                 op: Plus,
                                 right: Expr {
                                     kind: Identifier(
                                         "y",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 25,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 26,
-                                        },
-                                    },
+                                    span: 24..25,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 21,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 26,
-                                },
-                            },
+                            span: 20..25,
                         },
                     ),
                     type_ann: None,
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 26,
-                    },
-                },
+                span: 10..25,
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 26,
-        },
-    },
+    span: 0..25,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-3.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                     kind: Ident(
                         BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                     ),
@@ -37,45 +19,18 @@ Expr {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 14,
-                            },
-                        },
+                        span: 7..13,
                     },
                 ),
                 optional: false,
             },
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                    },
+                    span: 15..16,
                     kind: Ident(
                         BindingIdent {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 16,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 17,
-                                },
-                            },
+                            span: 15..16,
                             mutable: false,
                         },
                     ),
@@ -83,16 +38,7 @@ Expr {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 19,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 25,
-                            },
-                        },
+                        span: 18..24,
                     },
                 ),
                 optional: false,
@@ -105,70 +51,25 @@ Expr {
                         kind: Identifier(
                             "x",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 38,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 39,
-                            },
-                        },
+                        span: 37..38,
                     },
                     op: Plus,
                     right: Expr {
                         kind: Identifier(
                             "y",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 42,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 43,
-                            },
-                        },
+                        span: 41..42,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 38,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 43,
-                    },
-                },
+                span: 37..42,
             },
         ),
         type_ann: Some(
             TypeAnn {
                 kind: Number,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 28,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 34,
-                    },
-                },
+                span: 27..33,
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 43,
-        },
-    },
+    span: 0..42,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas.snap
@@ -7,29 +7,11 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                     kind: Ident(
                         BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                     ),
@@ -39,29 +21,11 @@ Expr {
             },
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                    },
+                    span: 7..8,
                     kind: Ident(
                         BindingIdent {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 9,
-                                },
-                            },
+                            span: 7..8,
                             mutable: false,
                         },
                     ),
@@ -77,56 +41,20 @@ Expr {
                         kind: Identifier(
                             "x",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 14,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 15,
-                            },
-                        },
+                        span: 13..14,
                     },
                     op: Plus,
                     right: Expr {
                         kind: Identifier(
                             "y",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 18,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 19,
-                            },
-                        },
+                        span: 17..18,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 14,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 19,
-                    },
-                },
+                span: 13..18,
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 19,
-        },
-    },
+    span: 0..18,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-2.snap
@@ -8,14 +8,5 @@ Expr {
             true,
         ),
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 5,
-        },
-    },
+    span: 0..4,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-3.snap
@@ -8,14 +8,5 @@ Expr {
             false,
         ),
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 6,
-        },
-    },
+    span: 0..5,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-4.snap
@@ -6,14 +6,5 @@ Expr {
     kind: Literal(
         Null,
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 5,
-        },
-    },
+    span: 0..4,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-5.snap
@@ -6,14 +6,5 @@ Expr {
     kind: Literal(
         Undefined,
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals-6.snap
@@ -8,14 +8,5 @@ Expr {
             "hello",
         ),
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_literals.snap
@@ -8,14 +8,5 @@ Expr {
             "123",
         ),
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 4,
-        },
-    },
+    span: 0..3,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_member_access-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_member_access-2.snap
@@ -10,43 +10,16 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 property: Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 2..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
         op: Plus,
         right: Expr {
@@ -55,53 +28,17 @@ Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
                 property: Expr {
                     kind: Identifier(
                         "d",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                    },
+                    span: 6..7,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 5,
-                },
-                end: Position {
-                    line: 1,
-                    column: 8,
-                },
-            },
+            span: 4..7,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_member_access-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_member_access-3.snap
@@ -10,68 +10,23 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 right: Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 2..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
         right: Expr {
             kind: Identifier(
                 "c",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 5..6,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_member_access.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_member_access.snap
@@ -10,68 +10,23 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 property: Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 2..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
         property: Expr {
             kind: Identifier(
                 "c",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 5,
-                },
-                end: Position {
-                    line: 1,
-                    column: 6,
-                },
-            },
+            span: 4..5,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 6,
-        },
-    },
+    span: 0..5,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_multiplicative_operators.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_multiplicative_operators.snap
@@ -12,98 +12,35 @@ Expr {
                             kind: Identifier(
                                 "a",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                            },
+                            span: 0..1,
                         },
                         op: Times,
                         right: Expr {
                             kind: Identifier(
                                 "b",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 0..5,
                 },
                 op: Divide,
                 right: Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 8..9,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 0..9,
         },
         op: Modulo,
         right: Expr {
             kind: Identifier(
                 "d",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 13,
-                },
-                end: Position {
-                    line: 1,
-                    column: 14,
-                },
-            },
+            span: 12..13,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 14,
-        },
-    },
+    span: 0..13,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-2.snap
@@ -16,29 +16,11 @@ Expr {
                                 "1",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 7,
-                            },
-                        },
+                        span: 5..6,
                     },
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 9,
-        },
-    },
+    span: 0..8,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-3.snap
@@ -16,16 +16,7 @@ Expr {
                                 "1",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 7,
-                            },
-                        },
+                        span: 5..6,
                     },
                 },
             ),
@@ -40,29 +31,11 @@ Expr {
                                 "2",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 13,
-                            },
-                        },
+                        span: 11..12,
                     },
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 15,
-        },
-    },
+    span: 0..14,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-4.snap
@@ -16,16 +16,7 @@ Expr {
                                 "1",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 7,
-                            },
-                        },
+                        span: 5..6,
                     },
                 },
             ),
@@ -40,29 +31,11 @@ Expr {
                                 "2",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 13,
-                            },
-                        },
+                        span: 11..12,
                     },
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 16,
-        },
-    },
+    span: 0..15,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-5.snap
@@ -16,16 +16,7 @@ Expr {
                                 "1",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 9,
-                            },
-                        },
+                        span: 7..8,
                     },
                 },
             ),
@@ -36,16 +27,7 @@ Expr {
                             kind: Identifier(
                                 "b",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 12,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 13,
-                                },
-                            },
+                            span: 11..12,
                         },
                     ),
                     value: Expr {
@@ -54,16 +36,7 @@ Expr {
                                 "2",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 16,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 17,
-                            },
-                        },
+                        span: 15..16,
                     },
                 },
             ),
@@ -78,29 +51,11 @@ Expr {
                                 "zero",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 28,
-                            },
-                        },
+                        span: 21..27,
                     },
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 30,
-        },
-    },
+    span: 0..29,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-6.snap
@@ -16,16 +16,7 @@ Expr {
                                 "1",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 7,
-                            },
-                        },
+                        span: 5..6,
                     },
                 },
             ),
@@ -40,16 +31,7 @@ Expr {
                                 "2",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 13,
-                            },
-                        },
+                        span: 11..12,
                     },
                 },
             ),
@@ -58,28 +40,10 @@ Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 18,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
+                    span: 17..18,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 21,
-        },
-    },
+    span: 0..20,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-7.snap
@@ -10,16 +10,7 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                    },
+                    span: 5..6,
                 },
             ),
             Spread(
@@ -27,16 +18,7 @@ Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 12,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                    },
+                    span: 11..12,
                 },
             ),
             Spread(
@@ -44,28 +26,10 @@ Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 18,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 19,
-                        },
-                    },
+                    span: 17..18,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 21,
-        },
-    },
+    span: 0..20,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-8.snap
@@ -17,14 +17,5 @@ Expr {
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 9,
-        },
-    },
+    span: 0..8,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals.snap
@@ -6,14 +6,5 @@ Expr {
     kind: Object {
         properties: [],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 3,
-        },
-    },
+    span: 0..2,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining-2.snap
@@ -10,53 +10,17 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 right: Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 6,
-                },
-            },
+            span: 0..5,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 6,
-        },
-    },
+    span: 0..5,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining-3.snap
@@ -11,38 +11,11 @@ Expr {
                     kind: Identifier(
                         "foo",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 0..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 8,
-                },
-            },
+            span: 0..7,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining.snap
@@ -14,92 +14,29 @@ Expr {
                                     kind: Identifier(
                                         "a",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 1,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 2,
-                                        },
-                                    },
+                                    span: 0..1,
                                 },
                                 property: Expr {
                                     kind: Identifier(
                                         "b",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 5,
-                                        },
-                                    },
+                                    span: 3..4,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                            },
+                            span: 0..4,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                    },
+                    span: 0..4,
                 },
                 property: Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                    },
+                    span: 6..7,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 8,
-                },
-            },
+            span: 0..7,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring-2.snap
@@ -7,45 +7,18 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 20,
-                        },
-                    },
+                    span: 4..19,
                     kind: Tuple(
                         TuplePat {
                             elems: [
                                 Some(
                                     TuplePatElem {
                                         pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 6,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 10,
-                                                },
-                                            },
+                                            span: 5..9,
                                             kind: Ident(
                                                 BindingIdent {
                                                     name: "head",
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 6,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 10,
-                                                        },
-                                                    },
+                                                    span: 5..9,
                                                     mutable: false,
                                                 },
                                             ),
@@ -56,42 +29,15 @@ Expr {
                                 Some(
                                     TuplePatElem {
                                         pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 11,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 15,
-                                                },
-                                            },
+                                            span: 10..14,
                                             kind: Rest(
                                                 RestPat {
                                                     arg: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 15,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 19,
-                                                            },
-                                                        },
+                                                        span: 14..18,
                                                         kind: Ident(
                                                             BindingIdent {
                                                                 name: "tail",
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 15,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 19,
-                                                                    },
-                                                                },
+                                                                span: 14..18,
                                                                 mutable: false,
                                                             },
                                                         ),
@@ -116,28 +62,10 @@ Expr {
                 kind: Identifier(
                     "head",
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 25,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 29,
-                    },
-                },
+                span: 24..28,
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 29,
-        },
-    },
+    span: 0..28,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring.snap
@@ -7,43 +7,16 @@ Expr {
         params: [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                    },
+                    span: 4..10,
                     kind: Object(
                         ObjectPat {
                             props: [
                                 Shorthand(
                                     ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                        },
+                                        span: 5..6,
                                         ident: BindingIdent {
                                             name: "x",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 6,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 7,
-                                                },
-                                            },
+                                            span: 5..6,
                                             mutable: false,
                                         },
                                         init: None,
@@ -51,28 +24,10 @@ Expr {
                                 ),
                                 Shorthand(
                                     ShorthandPatProp {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                        },
+                                        span: 8..9,
                                         ident: BindingIdent {
                                             name: "y",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 9,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 10,
-                                                },
-                                            },
+                                            span: 8..9,
                                             mutable: false,
                                         },
                                         init: None,
@@ -89,16 +44,7 @@ Expr {
         ],
         body: Block(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 15,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 33,
-                    },
-                },
+                span: 14..32,
                 stmts: [
                     Stmt {
                         kind: Return {
@@ -109,71 +55,26 @@ Expr {
                                             kind: Identifier(
                                                 "x",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 26,
-                                                },
-                                            },
+                                            span: 24..25,
                                         },
                                         op: Plus,
                                         right: Expr {
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 29,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 30,
-                                                },
-                                            },
+                                            span: 28..29,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 25,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 30,
-                                        },
-                                    },
+                                    span: 24..29,
                                 },
                             ),
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 25,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 30,
-                            },
-                        },
+                        span: 24..29,
                     },
                 ],
             },
         ),
         type_ann: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 33,
-        },
-    },
+    span: 0..32,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_parens.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_parens.snap
@@ -10,16 +10,7 @@ Expr {
                     "5",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 2,
-                },
-            },
+            span: 0..1,
         },
         op: Times,
         right: Expr {
@@ -28,16 +19,7 @@ Expr {
                     kind: Identifier(
                         "x",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                    },
+                    span: 5..6,
                 },
                 op: Plus,
                 right: Expr {
@@ -46,38 +28,11 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                    },
+                    span: 9..10,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 11,
-                },
-            },
+            span: 5..10,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 11,
-        },
-    },
+    span: 0..10,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_pattern_matching.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_pattern_matching.snap
@@ -10,67 +10,22 @@ Expr {
                     kind: Identifier(
                         "obj",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 2,
-                            column: 20,
-                        },
-                        end: Position {
-                            line: 2,
-                            column: 23,
-                        },
-                    },
+                    span: 20..23,
                 },
                 property: Expr {
                     kind: Identifier(
                         "type",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 2,
-                            column: 24,
-                        },
-                        end: Position {
-                            line: 2,
-                            column: 28,
-                        },
-                    },
+                    span: 24..28,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 2,
-                    column: 20,
-                },
-                end: Position {
-                    line: 2,
-                    column: 28,
-                },
-            },
+            span: 20..28,
         },
         arms: [
             MatchArm {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 3,
-                        column: 17,
-                    },
-                    end: Position {
-                        line: 3,
-                        column: 33,
-                    },
-                },
+                span: 48..64,
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 22,
-                        },
-                    },
+                    span: 48..53,
                     kind: Lit(
                         LitPat {
                             lit: String(
@@ -87,68 +42,23 @@ Expr {
                                 kind: Identifier(
                                     "obj",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 3,
-                                        column: 26,
-                                    },
-                                    end: Position {
-                                        line: 3,
-                                        column: 29,
-                                    },
-                                },
+                                span: 57..60,
                             },
                             property: Expr {
                                 kind: Identifier(
                                     "foo",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 3,
-                                        column: 30,
-                                    },
-                                    end: Position {
-                                        line: 3,
-                                        column: 33,
-                                    },
-                                },
+                                span: 61..64,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 3,
-                                column: 26,
-                            },
-                            end: Position {
-                                line: 3,
-                                column: 33,
-                            },
-                        },
+                        span: 57..64,
                     },
                 ),
             },
             MatchArm {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 4,
-                        column: 17,
-                    },
-                    end: Position {
-                        line: 6,
-                        column: 18,
-                    },
-                },
+                span: 82..139,
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 4,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 4,
-                            column: 22,
-                        },
-                    },
+                    span: 82..87,
                     kind: Lit(
                         LitPat {
                             lit: String(
@@ -160,16 +70,7 @@ Expr {
                 guard: None,
                 body: Block(
                     Block {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 4,
-                                column: 25,
-                            },
-                            end: Position {
-                                line: 6,
-                                column: 18,
-                            },
-                        },
+                        span: 90..139,
                         stmts: [
                             Stmt {
                                 kind: Expr {
@@ -179,82 +80,28 @@ Expr {
                                                 kind: Identifier(
                                                     "obj",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 21,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 24,
-                                                    },
-                                                },
+                                                span: 113..116,
                                             },
                                             property: Expr {
                                                 kind: Identifier(
                                                     "bar",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 25,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 28,
-                                                    },
-                                                },
+                                                span: 117..120,
                                             },
                                         },
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 5,
-                                                column: 21,
-                                            },
-                                            end: Position {
-                                                line: 5,
-                                                column: 28,
-                                            },
-                                        },
+                                        span: 113..120,
                                     },
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 5,
-                                        column: 21,
-                                    },
-                                    end: Position {
-                                        line: 5,
-                                        column: 28,
-                                    },
-                                },
+                                span: 113..120,
                             },
                         ],
                     },
                 ),
             },
             MatchArm {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 7,
-                        column: 17,
-                    },
-                    end: Position {
-                        line: 7,
-                        column: 31,
-                    },
-                },
+                span: 157..171,
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 7,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 7,
-                            column: 18,
-                        },
-                    },
+                    span: 157..158,
                     kind: Wildcard,
                 },
                 guard: None,
@@ -265,29 +112,11 @@ Expr {
                                 "default",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 7,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 7,
-                                column: 31,
-                            },
-                        },
+                        span: 162..171,
                     },
                 ),
             },
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 2,
-            column: 20,
-        },
-        end: Position {
-            line: 7,
-            column: 31,
-        },
-    },
+    span: 20..171,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_simple_addition.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_simple_addition.snap
@@ -12,16 +12,7 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
                 op: Plus,
                 right: Expr {
@@ -30,28 +21,10 @@ Expr {
                             "2",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 6,
-                },
-            },
+            span: 0..5,
         },
         op: Plus,
         right: Expr {
@@ -60,26 +33,8 @@ Expr {
                     "3",
                 ),
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 9,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 8..9,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch.snap
@@ -5,16 +5,7 @@ expression: "parse(r#\"\n            try {\n                canThrow();\n       
 Expr {
     kind: Try {
         body: Block {
-            loc: SourceLocation {
-                start: Position {
-                    line: 2,
-                    column: 16,
-                },
-                end: Position {
-                    line: 4,
-                    column: 14,
-                },
-            },
+            span: 16..60,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -25,40 +16,13 @@ Expr {
                                     kind: Identifier(
                                         "canThrow",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 3,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 3,
-                                            column: 25,
-                                        },
-                                    },
+                                    span: 35..43,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 3,
-                                    column: 17,
-                                },
-                                end: Position {
-                                    line: 3,
-                                    column: 27,
-                                },
-                            },
+                            span: 35..45,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 27,
-                        },
-                    },
+                    span: 35..45,
                 },
             ],
         },
@@ -66,45 +30,18 @@ Expr {
             CatchClause {
                 param: Some(
                     Pattern {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 4,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 4,
-                                column: 23,
-                            },
-                        },
+                        span: 68..69,
                         kind: Ident(
                             BindingIdent {
                                 name: "e",
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 4,
-                                        column: 22,
-                                    },
-                                    end: Position {
-                                        line: 4,
-                                        column: 23,
-                                    },
-                                },
+                                span: 68..69,
                                 mutable: false,
                             },
                         ),
                     },
                 ),
                 body: Block {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 4,
-                            column: 24,
-                        },
-                        end: Position {
-                            line: 6,
-                            column: 14,
-                        },
-                    },
+                    span: 70..130,
                     stmts: [
                         Stmt {
                             kind: Expr {
@@ -119,44 +56,17 @@ Expr {
                                                                 "Error: ",
                                                             ),
                                                         ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 5,
-                                                                column: 29,
-                                                            },
-                                                            end: Position {
-                                                                line: 5,
-                                                                column: 38,
-                                                            },
-                                                        },
+                                                        span: 101..110,
                                                     },
                                                     op: Plus,
                                                     right: Expr {
                                                         kind: Identifier(
                                                             "e",
                                                         ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 5,
-                                                                column: 41,
-                                                            },
-                                                            end: Position {
-                                                                line: 5,
-                                                                column: 42,
-                                                            },
-                                                        },
+                                                        span: 113..114,
                                                     },
                                                 },
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 29,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 42,
-                                                    },
-                                                },
+                                                span: 101..114,
                                             },
                                         ],
                                         callee: Expr {
@@ -165,67 +75,22 @@ Expr {
                                                     kind: Identifier(
                                                         "console",
                                                     ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
-                                                            column: 17,
-                                                        },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 24,
-                                                        },
-                                                    },
+                                                    span: 89..96,
                                                 },
                                                 property: Expr {
                                                     kind: Identifier(
                                                         "log",
                                                     ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
-                                                            column: 25,
-                                                        },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 28,
-                                                        },
-                                                    },
+                                                    span: 97..100,
                                                 },
                                             },
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 5,
-                                                    column: 17,
-                                                },
-                                                end: Position {
-                                                    line: 5,
-                                                    column: 28,
-                                                },
-                                            },
+                                            span: 89..100,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 5,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 5,
-                                            column: 43,
-                                        },
-                                    },
+                                    span: 89..115,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 5,
-                                    column: 17,
-                                },
-                                end: Position {
-                                    line: 5,
-                                    column: 43,
-                                },
-                            },
+                            span: 89..115,
                         },
                     ],
                 },
@@ -233,14 +98,5 @@ Expr {
         ),
         finally: None,
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 2,
-            column: 13,
-        },
-        end: Position {
-            line: 6,
-            column: 14,
-        },
-    },
+    span: 13..130,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
@@ -5,16 +5,7 @@ expression: "parse(r#\"\n            try {\n                canThrow();\n       
 Expr {
     kind: Try {
         body: Block {
-            loc: SourceLocation {
-                start: Position {
-                    line: 2,
-                    column: 16,
-                },
-                end: Position {
-                    line: 4,
-                    column: 14,
-                },
-            },
+            span: 16..60,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -25,40 +16,13 @@ Expr {
                                     kind: Identifier(
                                         "canThrow",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 3,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 3,
-                                            column: 25,
-                                        },
-                                    },
+                                    span: 35..43,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 3,
-                                    column: 17,
-                                },
-                                end: Position {
-                                    line: 3,
-                                    column: 27,
-                                },
-                            },
+                            span: 35..45,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 27,
-                        },
-                    },
+                    span: 35..45,
                 },
             ],
         },
@@ -66,45 +30,18 @@ Expr {
             CatchClause {
                 param: Some(
                     Pattern {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 4,
-                                column: 22,
-                            },
-                            end: Position {
-                                line: 4,
-                                column: 23,
-                            },
-                        },
+                        span: 68..69,
                         kind: Ident(
                             BindingIdent {
                                 name: "e",
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 4,
-                                        column: 22,
-                                    },
-                                    end: Position {
-                                        line: 4,
-                                        column: 23,
-                                    },
-                                },
+                                span: 68..69,
                                 mutable: false,
                             },
                         ),
                     },
                 ),
                 body: Block {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 4,
-                            column: 24,
-                        },
-                        end: Position {
-                            line: 6,
-                            column: 14,
-                        },
-                    },
+                    span: 70..130,
                     stmts: [
                         Stmt {
                             kind: Expr {
@@ -119,44 +56,17 @@ Expr {
                                                                 "Error: ",
                                                             ),
                                                         ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 5,
-                                                                column: 29,
-                                                            },
-                                                            end: Position {
-                                                                line: 5,
-                                                                column: 38,
-                                                            },
-                                                        },
+                                                        span: 101..110,
                                                     },
                                                     op: Plus,
                                                     right: Expr {
                                                         kind: Identifier(
                                                             "e",
                                                         ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 5,
-                                                                column: 41,
-                                                            },
-                                                            end: Position {
-                                                                line: 5,
-                                                                column: 42,
-                                                            },
-                                                        },
+                                                        span: 113..114,
                                                     },
                                                 },
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 5,
-                                                        column: 29,
-                                                    },
-                                                    end: Position {
-                                                        line: 5,
-                                                        column: 42,
-                                                    },
-                                                },
+                                                span: 101..114,
                                             },
                                         ],
                                         callee: Expr {
@@ -165,67 +75,22 @@ Expr {
                                                     kind: Identifier(
                                                         "console",
                                                     ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
-                                                            column: 17,
-                                                        },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 24,
-                                                        },
-                                                    },
+                                                    span: 89..96,
                                                 },
                                                 property: Expr {
                                                     kind: Identifier(
                                                         "log",
                                                     ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 5,
-                                                            column: 25,
-                                                        },
-                                                        end: Position {
-                                                            line: 5,
-                                                            column: 28,
-                                                        },
-                                                    },
+                                                    span: 97..100,
                                                 },
                                             },
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 5,
-                                                    column: 17,
-                                                },
-                                                end: Position {
-                                                    line: 5,
-                                                    column: 28,
-                                                },
-                                            },
+                                            span: 89..100,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 5,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 5,
-                                            column: 43,
-                                        },
-                                    },
+                                    span: 89..115,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 5,
-                                    column: 17,
-                                },
-                                end: Position {
-                                    line: 5,
-                                    column: 43,
-                                },
-                            },
+                            span: 89..115,
                         },
                     ],
                 },
@@ -233,16 +98,7 @@ Expr {
         ),
         finally: Some(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 6,
-                        column: 22,
-                    },
-                    end: Position {
-                        line: 8,
-                        column: 14,
-                    },
-                },
+                span: 138..181,
                 stmts: [
                     Stmt {
                         kind: Expr {
@@ -253,53 +109,17 @@ Expr {
                                         kind: Identifier(
                                             "cleanup",
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 7,
-                                                column: 17,
-                                            },
-                                            end: Position {
-                                                line: 7,
-                                                column: 24,
-                                            },
-                                        },
+                                        span: 157..164,
                                     },
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 7,
-                                        column: 17,
-                                    },
-                                    end: Position {
-                                        line: 7,
-                                        column: 26,
-                                    },
-                                },
+                                span: 157..166,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 7,
-                                column: 17,
-                            },
-                            end: Position {
-                                line: 7,
-                                column: 26,
-                            },
-                        },
+                        span: 157..166,
                     },
                 ],
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 2,
-            column: 13,
-        },
-        end: Position {
-            line: 8,
-            column: 14,
-        },
-    },
+    span: 13..181,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_finally.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_finally.snap
@@ -5,16 +5,7 @@ expression: "parse(r#\"\n            try {\n                canThrow();\n       
 Expr {
     kind: Try {
         body: Block {
-            loc: SourceLocation {
-                start: Position {
-                    line: 2,
-                    column: 16,
-                },
-                end: Position {
-                    line: 4,
-                    column: 14,
-                },
-            },
+            span: 16..60,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -25,56 +16,20 @@ Expr {
                                     kind: Identifier(
                                         "canThrow",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 3,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 3,
-                                            column: 25,
-                                        },
-                                    },
+                                    span: 35..43,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 3,
-                                    column: 17,
-                                },
-                                end: Position {
-                                    line: 3,
-                                    column: 27,
-                                },
-                            },
+                            span: 35..45,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 27,
-                        },
-                    },
+                    span: 35..45,
                 },
             ],
         },
         catch: None,
         finally: Some(
             Block {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 4,
-                        column: 22,
-                    },
-                    end: Position {
-                        line: 6,
-                        column: 14,
-                    },
-                },
+                span: 68..111,
                 stmts: [
                     Stmt {
                         kind: Expr {
@@ -85,53 +40,17 @@ Expr {
                                         kind: Identifier(
                                             "cleanup",
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 5,
-                                                column: 17,
-                                            },
-                                            end: Position {
-                                                line: 5,
-                                                column: 24,
-                                            },
-                                        },
+                                        span: 87..94,
                                     },
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 5,
-                                        column: 17,
-                                    },
-                                    end: Position {
-                                        line: 5,
-                                        column: 26,
-                                    },
-                                },
+                                span: 87..96,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 5,
-                                column: 17,
-                            },
-                            end: Position {
-                                line: 5,
-                                column: 26,
-                            },
-                        },
+                        span: 87..96,
                     },
                 ],
             },
         ),
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 2,
-            column: 13,
-        },
-        end: Position {
-            line: 6,
-            column: 14,
-        },
-    },
+    span: 13..111,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-2.snap
@@ -12,28 +12,10 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                    },
+                    span: 1..2,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 4,
-        },
-    },
+    span: 0..3,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-3.snap
@@ -12,16 +12,7 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                    },
+                    span: 1..2,
                 },
             ),
             Expr(
@@ -31,28 +22,10 @@ Expr {
                             "2",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-4.snap
@@ -12,16 +12,7 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                    },
+                    span: 1..2,
                 },
             ),
             Expr(
@@ -31,28 +22,10 @@ Expr {
                             "2",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-5.snap
@@ -12,16 +12,7 @@ Expr {
                             "1",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                    },
+                    span: 1..2,
                 },
             ),
             Expr(
@@ -31,16 +22,7 @@ Expr {
                             "two",
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 4..9,
                 },
             ),
             Expr(
@@ -54,42 +36,15 @@ Expr {
                                             "3",
                                         ),
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 13,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 14,
-                                        },
-                                    },
+                                    span: 12..13,
                                 },
                             ),
                         ],
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 15,
-                        },
-                    },
+                    span: 10..14,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 16,
-        },
-    },
+    span: 0..15,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-6.snap
@@ -10,16 +10,7 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 3,
-                        },
-                    },
+                    span: 1..2,
                 },
             ),
             Expr(
@@ -27,16 +18,7 @@ Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             ),
             Spread(
@@ -44,28 +26,10 @@ Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 12,
-                        },
-                    },
+                    span: 10..11,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 13,
-        },
-    },
+    span: 0..12,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals-7.snap
@@ -10,16 +10,7 @@ Expr {
                     kind: Identifier(
                         "a",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             ),
             Spread(
@@ -27,16 +18,7 @@ Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 12,
-                        },
-                    },
+                    span: 10..11,
                 },
             ),
             Spread(
@@ -44,28 +26,10 @@ Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 18,
-                        },
-                    },
+                    span: 16..17,
                 },
             ),
         ],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 19,
-        },
-    },
+    span: 0..18,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_tuple_literals.snap
@@ -6,14 +6,5 @@ Expr {
     kind: Tuple {
         elements: [],
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 3,
-        },
-    },
+    span: 0..2,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_unary_operators.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_unary_operators.snap
@@ -14,40 +14,13 @@ Expr {
                             kind: Identifier(
                                 "a",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 4,
-                                },
-                            },
+                            span: 2..3,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 1..3,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
         op: Minus,
         right: Expr {
@@ -57,38 +30,11 @@ Expr {
                     kind: Identifier(
                         "b",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                    },
+                    span: 7..8,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 6,
-                },
-                end: Position {
-                    line: 1,
-                    column: 9,
-                },
-            },
+            span: 5..8,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 9,
-        },
-    },
+    span: 0..8,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_valid_lvalues-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_valid_lvalues-2.snap
@@ -12,16 +12,7 @@ Expr {
                             kind: Identifier(
                                 "a",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                            },
+                            span: 0..1,
                         },
                         right: Expr {
                             kind: Literal(
@@ -29,81 +20,27 @@ Expr {
                                     "b",
                                 ),
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 2..5,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 0..5,
                 },
                 right: Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                    },
+                    span: 7..8,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 9,
-                },
-            },
+            span: 0..8,
         },
         op: Assign,
         right: Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 13,
-                },
-                end: Position {
-                    line: 1,
-                    column: 14,
-                },
-            },
+            span: 12..13,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 14,
-        },
-    },
+    span: 0..13,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_valid_lvalues.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_valid_lvalues.snap
@@ -12,96 +12,33 @@ Expr {
                             kind: Identifier(
                                 "a",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                            },
+                            span: 0..1,
                         },
                         property: Expr {
                             kind: Identifier(
                                 "b",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 4,
-                                },
-                            },
+                            span: 2..3,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                    },
+                    span: 0..3,
                 },
                 property: Expr {
                     kind: Identifier(
                         "c",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 6,
-                },
-            },
+            span: 0..5,
         },
         op: Assign,
         right: Expr {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 9,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 8..9,
         },
     },
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "Foo",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                },
+                span: 1..4,
             },
         ),
         attrs: [
@@ -41,16 +32,7 @@ JSXElement {
             name: Ident(
                 Ident {
                     name: "Foo",
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 22,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 25,
-                        },
-                    },
+                    span: 19..25,
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element_with_children_elements.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element_with_children_elements.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "ul",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                },
+                span: 1..3,
             },
         ),
         attrs: [],
@@ -29,16 +20,7 @@ JSXElement {
                     name: Ident(
                         Ident {
                             name: "li",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                            },
+                            span: 5..7,
                         },
                     ),
                     attrs: [],
@@ -47,6 +29,7 @@ JSXElement {
                 children: [
                     Text(
                         JSXText {
+                            span: 8..11,
                             value: "one",
                         },
                     ),
@@ -56,16 +39,7 @@ JSXElement {
                         name: Ident(
                             Ident {
                                 name: "li",
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 14,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 16,
-                                    },
-                                },
+                                span: 11..16,
                             },
                         ),
                     },
@@ -78,16 +52,7 @@ JSXElement {
                     name: Ident(
                         Ident {
                             name: "li",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 18,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 20,
-                                },
-                            },
+                            span: 17..19,
                         },
                     ),
                     attrs: [],
@@ -96,6 +61,7 @@ JSXElement {
                 children: [
                     Text(
                         JSXText {
+                            span: 20..23,
                             value: "two",
                         },
                     ),
@@ -105,16 +71,7 @@ JSXElement {
                         name: Ident(
                             Ident {
                                 name: "li",
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 26,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 28,
-                                    },
-                                },
+                                span: 23..28,
                             },
                         ),
                     },
@@ -127,16 +84,7 @@ JSXElement {
             name: Ident(
                 Ident {
                     name: "ul",
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 31,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 33,
-                        },
-                    },
+                    span: 28..33,
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element_with_children_text.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element_with_children_text.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "h1",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                },
+                span: 1..3,
             },
         ),
         attrs: [],
@@ -25,6 +16,7 @@ JSXElement {
     children: [
         Text(
             JSXText {
+                span: 4..17,
                 value: "Hello, world!",
             },
         ),
@@ -34,16 +26,7 @@ JSXElement {
             name: Ident(
                 Ident {
                     name: "h1",
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 20,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 22,
-                        },
-                    },
+                    span: 17..22,
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element_with_text_and_exprs.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_element_with_text_and_exprs.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "h1",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                },
+                span: 1..3,
             },
         ),
         attrs: [],
@@ -25,6 +16,7 @@ JSXElement {
     children: [
         Text(
             JSXText {
+                span: 4..11,
                 value: "Hello, ",
             },
         ),
@@ -34,21 +26,13 @@ JSXElement {
                     kind: Identifier(
                         "name",
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                    },
+                    span: 12..16,
                 },
             },
         ),
         Text(
             JSXText {
+                span: 17..18,
                 value: "!",
             },
         ),
@@ -58,16 +42,7 @@ JSXElement {
             name: Ident(
                 Ident {
                     name: "h1",
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 21,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 23,
-                        },
-                    },
+                    span: 18..23,
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_fragment.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_fragment.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                },
+                span: 1..1,
             },
         ),
         attrs: [],
@@ -29,16 +20,7 @@ JSXElement {
                     name: Ident(
                         Ident {
                             name: "span",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 4,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                            },
+                            span: 3..7,
                         },
                     ),
                     attrs: [],
@@ -47,6 +29,7 @@ JSXElement {
                 children: [
                     Text(
                         JSXText {
+                            span: 8..15,
                             value: "Hello, ",
                         },
                     ),
@@ -56,16 +39,7 @@ JSXElement {
                         name: Ident(
                             Ident {
                                 name: "span",
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 18,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 22,
-                                    },
-                                },
+                                span: 15..22,
                             },
                         ),
                     },
@@ -78,16 +52,7 @@ JSXElement {
                     name: Ident(
                         Ident {
                             name: "span",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 24,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 28,
-                                },
-                            },
+                            span: 23..27,
                         },
                     ),
                     attrs: [],
@@ -96,6 +61,7 @@ JSXElement {
                 children: [
                     Text(
                         JSXText {
+                            span: 28..34,
                             value: "world!",
                         },
                     ),
@@ -105,16 +71,7 @@ JSXElement {
                         name: Ident(
                             Ident {
                                 name: "span",
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 37,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 41,
-                                    },
-                                },
+                                span: 34..41,
                             },
                         ),
                     },
@@ -127,16 +84,7 @@ JSXElement {
             name: Ident(
                 Ident {
                     name: "",
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 44,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 44,
-                        },
-                    },
+                    span: 41..44,
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_nested_fragments.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_nested_fragments.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                },
+                span: 1..1,
             },
         ),
         attrs: [],
@@ -25,6 +16,7 @@ JSXElement {
     children: [
         Text(
             JSXText {
+                span: 2..3,
                 value: "a",
             },
         ),
@@ -38,16 +30,7 @@ JSXElement {
                                 kind: Identifier(
                                     "b",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 7,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 8,
-                                    },
-                                },
+                                span: 6..7,
                             },
                         },
                     ),
@@ -57,16 +40,7 @@ JSXElement {
                                 kind: Identifier(
                                     "c",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 10,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 11,
-                                    },
-                                },
+                                span: 9..10,
                             },
                         },
                     ),
@@ -76,6 +50,7 @@ JSXElement {
         ),
         Text(
             JSXText {
+                span: 14..15,
                 value: "d",
             },
         ),
@@ -85,16 +60,7 @@ JSXElement {
             name: Ident(
                 Ident {
                     name: "",
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 18,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 18,
-                        },
-                    },
+                    span: 15..18,
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_props_dot_children.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_jsx_props_dot_children.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "div",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                },
+                span: 1..4,
             },
         ),
         attrs: [],
@@ -31,44 +22,17 @@ JSXElement {
                             kind: Identifier(
                                 "a",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 7,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                            },
+                            span: 6..7,
                         },
                         op: Plus,
                         right: Expr {
                             kind: Identifier(
                                 "b",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 9,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 10,
-                                },
-                            },
+                            span: 8..9,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                    },
+                    span: 6..9,
                 },
             },
         ),
@@ -78,16 +42,7 @@ JSXElement {
             name: Ident(
                 Ident {
                     name: "div",
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                    },
+                    span: 10..16,
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_self_closing_jsx_element.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__jsx_parser__tests__parse_self_closing_jsx_element.snap
@@ -7,16 +7,7 @@ JSXElement {
         name: Ident(
             Ident {
                 name: "Foo",
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                },
+                span: 1..4,
             },
         ),
         attrs: [

--- a/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings.snap
@@ -8,31 +8,13 @@ StrTemplateLit {
             kind: StrLit(
                 "a",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 3,
-                },
-            },
+            span: 0..2,
         },
         Token {
             kind: StrLit(
                 "",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 13,
-                },
-                end: Position {
-                    line: 1,
-                    column: 14,
-                },
-            },
+            span: 12..13,
         },
     ],
     exprs: [
@@ -51,29 +33,11 @@ StrTemplateLit {
                         kind: Identifier(
                             "c",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 9,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 10,
-                            },
-                        },
+                        span: 8..9,
                     },
                 ],
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 5,
-                },
-                end: Position {
-                    line: 1,
-                    column: 12,
-                },
-            },
+            span: 4..11,
         },
     ],
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings_complex.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings_complex.snap
@@ -8,31 +8,13 @@ StrTemplateLit {
             kind: StrLit(
                 "ids = ",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 8,
-                },
-            },
+            span: 0..7,
         },
         Token {
             kind: StrLit(
                 "",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 50,
-                },
-                end: Position {
-                    line: 1,
-                    column: 51,
-                },
-            },
+            span: 49..50,
         },
     ],
     exprs: [
@@ -45,16 +27,7 @@ StrTemplateLit {
                                 ", ",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 44,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 48,
-                            },
-                        },
+                        span: 43..47,
                     },
                 ],
                 callee: Expr {
@@ -67,29 +40,11 @@ StrTemplateLit {
                                             params: [
                                                 FuncParam {
                                                     pattern: Pattern {
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 22,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 24,
-                                                            },
-                                                        },
+                                                        span: 21..23,
                                                         kind: Ident(
                                                             BindingIdent {
                                                                 name: "id",
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 22,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 24,
-                                                                    },
-                                                                },
+                                                                span: 21..23,
                                                                 mutable: false,
                                                             },
                                                         ),
@@ -114,43 +69,16 @@ StrTemplateLit {
                                                                 kind: Identifier(
                                                                     "id",
                                                                 ),
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 33,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 35,
-                                                                    },
-                                                                },
+                                                                span: 32..34,
                                                             },
                                                         ],
                                                     },
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 28,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 37,
-                                                        },
-                                                    },
+                                                    span: 27..36,
                                                 },
                                             ),
                                             type_ann: None,
                                         },
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 18,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 37,
-                                            },
-                                        },
+                                        span: 17..36,
                                     },
                                 ],
                                 callee: Expr {
@@ -159,94 +87,31 @@ StrTemplateLit {
                                             kind: Identifier(
                                                 "ids",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 10,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 13,
-                                                },
-                                            },
+                                            span: 9..12,
                                         },
                                         property: Expr {
                                             kind: Identifier(
                                                 "map",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 17,
-                                                },
-                                            },
+                                            span: 13..16,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 10,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 17,
-                                        },
-                                    },
+                                    span: 9..16,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 10,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 38,
-                                },
-                            },
+                            span: 9..37,
                         },
                         property: Expr {
                             kind: Identifier(
                                 "join",
                             ),
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 39,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 43,
-                                },
-                            },
+                            span: 38..42,
                         },
                     },
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 43,
-                        },
-                    },
+                    span: 9..42,
                 },
             },
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 10,
-                },
-                end: Position {
-                    line: 1,
-                    column: 49,
-                },
-            },
+            span: 9..48,
         },
     ],
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_template_string.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_template_string.snap
@@ -8,16 +8,7 @@ StrTemplateLit {
             kind: StrLit(
                 "abc",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 6,
-                },
-            },
+            span: 0..5,
         },
     ],
     exprs: [],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_template_string_with_exprs.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_template_string_with_exprs.snap
@@ -8,31 +8,13 @@ StrTemplateLit {
             kind: StrLit(
                 "abc",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 5,
-                },
-            },
+            span: 0..4,
         },
         Token {
             kind: StrLit(
                 "",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 9,
-                },
-                end: Position {
-                    line: 1,
-                    column: 10,
-                },
-            },
+            span: 8..9,
         },
     ],
     exprs: [
@@ -40,16 +22,7 @@ StrTemplateLit {
             kind: Identifier(
                 "x",
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 7,
-                },
-                end: Position {
-                    line: 1,
-                    column: 8,
-                },
-            },
+            span: 6..7,
         },
     ],
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-2.snap
@@ -3,16 +3,7 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"true\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 5,
-        },
-    },
+    span: 0..4,
     kind: Lit(
         LitPat {
             lit: Boolean(

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-3.snap
@@ -3,16 +3,7 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"false\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 6,
-        },
-    },
+    span: 0..5,
     kind: Lit(
         LitPat {
             lit: Boolean(

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-4.snap
@@ -3,16 +3,7 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"null\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 5,
-        },
-    },
+    span: 0..4,
     kind: Lit(
         LitPat {
             lit: Null,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-5.snap
@@ -3,16 +3,7 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"undefined\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
     kind: Lit(
         LitPat {
             lit: Undefined,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns-6.snap
@@ -3,16 +3,7 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(r#\"\"hello\"\"#)"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
     kind: Lit(
         LitPat {
             lit: String(

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_literal_patterns.snap
@@ -3,16 +3,7 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"123\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 4,
-        },
-    },
+    span: 0..3,
     kind: Lit(
         LitPat {
             lit: Number(

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_mixed_patterns.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_mixed_patterns.snap
@@ -3,55 +3,19 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(r#\"{type: \"foo\", bar: _, values: [head, ...tail]}\"#)"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 47,
-        },
-    },
+    span: 0..46,
     kind: Object(
         ObjectPat {
             props: [
                 KeyValue(
                     KeyValuePatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 2,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 13,
-                            },
-                        },
+                        span: 1..12,
                         key: Ident {
                             name: "type",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 1..5,
                         },
                         value: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 13,
-                                },
-                            },
+                            span: 7..12,
                             kind: Lit(
                                 LitPat {
                                     lit: String(
@@ -65,40 +29,13 @@ Pattern {
                 ),
                 KeyValue(
                     KeyValuePatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 15,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 21,
-                            },
-                        },
+                        span: 14..20,
                         key: Ident {
                             name: "bar",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 15,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 18,
-                                },
-                            },
+                            span: 14..17,
                         },
                         value: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 20,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 21,
-                                },
-                            },
+                            span: 19..20,
                             kind: Wildcard,
                         },
                         init: None,
@@ -106,69 +43,24 @@ Pattern {
                 ),
                 KeyValue(
                     KeyValuePatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 23,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 46,
-                            },
-                        },
+                        span: 22..45,
                         key: Ident {
                             name: "values",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 23,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 29,
-                                },
-                            },
+                            span: 22..28,
                         },
                         value: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 30,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 46,
-                                },
-                            },
+                            span: 29..45,
                             kind: Tuple(
                                 TuplePat {
                                     elems: [
                                         Some(
                                             TuplePatElem {
                                                 pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 32,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 36,
-                                                        },
-                                                    },
+                                                    span: 31..35,
                                                     kind: Ident(
                                                         BindingIdent {
                                                             name: "head",
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 1,
-                                                                    column: 32,
-                                                                },
-                                                                end: Position {
-                                                                    line: 1,
-                                                                    column: 36,
-                                                                },
-                                                            },
+                                                            span: 31..35,
                                                             mutable: false,
                                                         },
                                                     ),
@@ -179,42 +71,15 @@ Pattern {
                                         Some(
                                             TuplePatElem {
                                                 pattern: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 37,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 41,
-                                                        },
-                                                    },
+                                                    span: 36..40,
                                                     kind: Rest(
                                                         RestPat {
                                                             arg: Pattern {
-                                                                loc: SourceLocation {
-                                                                    start: Position {
-                                                                        line: 1,
-                                                                        column: 41,
-                                                                    },
-                                                                    end: Position {
-                                                                        line: 1,
-                                                                        column: 45,
-                                                                    },
-                                                                },
+                                                                span: 40..44,
                                                                 kind: Ident(
                                                                     BindingIdent {
                                                                         name: "tail",
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 41,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 45,
-                                                                            },
-                                                                        },
+                                                                        span: 40..44,
                                                                         mutable: false,
                                                                     },
                                                                 ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns-2.snap
@@ -3,43 +3,16 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"{x, y, ...z}\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 13,
-        },
-    },
+    span: 0..12,
     kind: Object(
         ObjectPat {
             props: [
                 Shorthand(
                     ShorthandPatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 2,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 3,
-                            },
-                        },
+                        span: 1..2,
                         ident: BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                            },
+                            span: 1..2,
                             mutable: false,
                         },
                         init: None,
@@ -47,28 +20,10 @@ Pattern {
                 ),
                 Shorthand(
                     ShorthandPatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                        },
+                        span: 4..5,
                         ident: BindingIdent {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                         init: None,
@@ -77,29 +32,11 @@ Pattern {
                 Rest(
                     RestPat {
                         arg: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 11,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 12,
-                                },
-                            },
+                            span: 10..11,
                             kind: Ident(
                                 BindingIdent {
                                     name: "z",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 11,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 12,
-                                        },
-                                    },
+                                    span: 10..11,
                                     mutable: false,
                                 },
                             ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns-3.snap
@@ -3,68 +3,23 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"{x: a, y: b, z: c}\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 19,
-        },
-    },
+    span: 0..18,
     kind: Object(
         ObjectPat {
             props: [
                 KeyValue(
                     KeyValuePatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 2,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                        },
+                        span: 1..5,
                         key: Ident {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                            },
+                            span: 1..2,
                         },
                         value: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             kind: Ident(
                                 BindingIdent {
                                     name: "a",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 5,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 6,
-                                        },
-                                    },
+                                    span: 4..5,
                                     mutable: false,
                                 },
                             ),
@@ -74,53 +29,17 @@ Pattern {
                 ),
                 KeyValue(
                     KeyValuePatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                        },
+                        span: 7..11,
                         key: Ident {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 9,
-                                },
-                            },
+                            span: 7..8,
                         },
                         value: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 11,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 12,
-                                },
-                            },
+                            span: 10..11,
                             kind: Ident(
                                 BindingIdent {
                                     name: "b",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 11,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 12,
-                                        },
-                                    },
+                                    span: 10..11,
                                     mutable: false,
                                 },
                             ),
@@ -130,53 +49,17 @@ Pattern {
                 ),
                 KeyValue(
                     KeyValuePatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 14,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 18,
-                            },
-                        },
+                        span: 13..17,
                         key: Ident {
                             name: "z",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 14,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 15,
-                                },
-                            },
+                            span: 13..14,
                         },
                         value: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 17,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 18,
-                                },
-                            },
+                            span: 16..17,
                             kind: Ident(
                                 BindingIdent {
                                     name: "c",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 18,
-                                        },
-                                    },
+                                    span: 16..17,
                                     mutable: false,
                                 },
                             ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns-4.snap
@@ -3,121 +3,40 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"{x: {y: {z}}}\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 14,
-        },
-    },
+    span: 0..13,
     kind: Object(
         ObjectPat {
             props: [
                 KeyValue(
                     KeyValuePatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 2,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 13,
-                            },
-                        },
+                        span: 1..12,
                         key: Ident {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                            },
+                            span: 1..2,
                         },
                         value: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 4,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 13,
-                                },
-                            },
+                            span: 3..12,
                             kind: Object(
                                 ObjectPat {
                                     props: [
                                         KeyValue(
                                             KeyValuePatProp {
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 6,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 12,
-                                                    },
-                                                },
+                                                span: 5..11,
                                                 key: Ident {
                                                     name: "y",
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 6,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 7,
-                                                        },
-                                                    },
+                                                    span: 5..6,
                                                 },
                                                 value: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 8,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 12,
-                                                        },
-                                                    },
+                                                    span: 7..11,
                                                     kind: Object(
                                                         ObjectPat {
                                                             props: [
                                                                 Shorthand(
                                                                     ShorthandPatProp {
-                                                                        loc: SourceLocation {
-                                                                            start: Position {
-                                                                                line: 1,
-                                                                                column: 10,
-                                                                            },
-                                                                            end: Position {
-                                                                                line: 1,
-                                                                                column: 11,
-                                                                            },
-                                                                        },
+                                                                        span: 9..10,
                                                                         ident: BindingIdent {
                                                                             name: "z",
-                                                                            loc: SourceLocation {
-                                                                                start: Position {
-                                                                                    line: 1,
-                                                                                    column: 10,
-                                                                                },
-                                                                                end: Position {
-                                                                                    line: 1,
-                                                                                    column: 11,
-                                                                                },
-                                                                            },
+                                                                            span: 9..10,
                                                                             mutable: false,
                                                                         },
                                                                         init: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_object_patterns.snap
@@ -3,43 +3,16 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"{x, y, z}\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
     kind: Object(
         ObjectPat {
             props: [
                 Shorthand(
                     ShorthandPatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 2,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 3,
-                            },
-                        },
+                        span: 1..2,
                         ident: BindingIdent {
                             name: "x",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                            },
+                            span: 1..2,
                             mutable: false,
                         },
                         init: None,
@@ -47,28 +20,10 @@ Pattern {
                 ),
                 Shorthand(
                     ShorthandPatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                        },
+                        span: 4..5,
                         ident: BindingIdent {
                             name: "y",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                         init: None,
@@ -76,28 +31,10 @@ Pattern {
                 ),
                 Shorthand(
                     ShorthandPatProp {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 9,
-                            },
-                        },
+                        span: 7..8,
                         ident: BindingIdent {
                             name: "z",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 9,
-                                },
-                            },
+                            span: 7..8,
                             mutable: false,
                         },
                         init: None,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_rest.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_rest.snap
@@ -3,42 +3,15 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"...rest\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 4,
-        },
-    },
+    span: 0..3,
     kind: Rest(
         RestPat {
             arg: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
+                span: 3..7,
                 kind: Ident(
                     BindingIdent {
                         name: "rest",
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 4,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 3..7,
                         mutable: false,
                     },
                 ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_tuple_patterns-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_tuple_patterns-2.snap
@@ -3,45 +3,18 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"[a, b, ...c]\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 13,
-        },
-    },
+    span: 0..12,
     kind: Tuple(
         TuplePat {
             elems: [
                 Some(
                     TuplePatElem {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                            },
+                            span: 1..2,
                             kind: Ident(
                                 BindingIdent {
                                     name: "a",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 2,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 3,
-                                        },
-                                    },
+                                    span: 1..2,
                                     mutable: false,
                                 },
                             ),
@@ -52,29 +25,11 @@ Pattern {
                 Some(
                     TuplePatElem {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             kind: Ident(
                                 BindingIdent {
                                     name: "b",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 5,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 6,
-                                        },
-                                    },
+                                    span: 4..5,
                                     mutable: false,
                                 },
                             ),
@@ -85,42 +40,15 @@ Pattern {
                 Some(
                     TuplePatElem {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 7,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 11,
-                                },
-                            },
+                            span: 6..10,
                             kind: Rest(
                                 RestPat {
                                     arg: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 11,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 12,
-                                            },
-                                        },
+                                        span: 10..11,
                                         kind: Ident(
                                             BindingIdent {
                                                 name: "c",
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 11,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 12,
-                                                    },
-                                                },
+                                                span: 10..11,
                                                 mutable: false,
                                             },
                                         ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_tuple_patterns.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_tuple_patterns.snap
@@ -3,45 +3,18 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"[a, b, c]\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
     kind: Tuple(
         TuplePat {
             elems: [
                 Some(
                     TuplePatElem {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 2,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 3,
-                                },
-                            },
+                            span: 1..2,
                             kind: Ident(
                                 BindingIdent {
                                     name: "a",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 2,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 3,
-                                        },
-                                    },
+                                    span: 1..2,
                                     mutable: false,
                                 },
                             ),
@@ -52,29 +25,11 @@ Pattern {
                 Some(
                     TuplePatElem {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             kind: Ident(
                                 BindingIdent {
                                     name: "b",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 5,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 6,
-                                        },
-                                    },
+                                    span: 4..5,
                                     mutable: false,
                                 },
                             ),
@@ -85,29 +40,11 @@ Pattern {
                 Some(
                     TuplePatElem {
                         pattern: Pattern {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 8,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 9,
-                                },
-                            },
+                            span: 7..8,
                             kind: Ident(
                                 BindingIdent {
                                     name: "c",
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 8,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 9,
-                                        },
-                                    },
+                                    span: 7..8,
                                     mutable: false,
                                 },
                             ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_wildcard.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__pattern_parser__tests__parse_wildcard.snap
@@ -3,15 +3,6 @@ source: crates/escalier_parser/src/pattern_parser.rs
 expression: "parse(\"_\")"
 ---
 Pattern {
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 2,
-        },
-    },
+    span: 0..1,
     kind: Wildcard,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_assignment-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_assignment-2.snap
@@ -13,43 +13,16 @@ expression: "parse(r#\"p.x = 5;\"#)"
                                 kind: Identifier(
                                     "p",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 2,
-                                    },
-                                },
+                                span: 0..1,
                             },
                             property: Expr {
                                 kind: Identifier(
                                     "x",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 3,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 4,
-                                    },
-                                },
+                                span: 2..3,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 4,
-                            },
-                        },
+                        span: 0..3,
                     },
                     op: Assign,
                     right: Expr {
@@ -58,39 +31,12 @@ expression: "parse(r#\"p.x = 5;\"#)"
                                 "5",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 7,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 6..7,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
+                span: 0..7,
             },
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 8,
-            },
-        },
+        span: 0..7,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_assignment-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_assignment-3.snap
@@ -13,16 +13,7 @@ expression: "parse(r#\"p[\"y\"] = 10;\"#)"
                                 kind: Identifier(
                                     "p",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 2,
-                                    },
-                                },
+                                span: 0..1,
                             },
                             right: Expr {
                                 kind: Literal(
@@ -30,28 +21,10 @@ expression: "parse(r#\"p[\"y\"] = 10;\"#)"
                                         "y",
                                     ),
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 3,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 6,
-                                    },
-                                },
+                                span: 2..5,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                        },
+                        span: 0..5,
                     },
                     op: Assign,
                     right: Expr {
@@ -60,39 +33,12 @@ expression: "parse(r#\"p[\"y\"] = 10;\"#)"
                                 "10",
                             ),
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 10,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                        },
+                        span: 9..11,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 12,
-                    },
-                },
+                span: 0..11,
             },
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 12,
-            },
-        },
+        span: 0..11,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_assignment.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_assignment.snap
@@ -11,16 +11,7 @@ expression: "parse(r#\"y = m*x + b;\"#)"
                         kind: Identifier(
                             "y",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 2,
-                            },
-                        },
+                        span: 0..1,
                     },
                     op: Assign,
                     right: Expr {
@@ -31,95 +22,32 @@ expression: "parse(r#\"y = m*x + b;\"#)"
                                         kind: Identifier(
                                             "m",
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 5,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                        },
+                                        span: 4..5,
                                     },
                                     op: Times,
                                     right: Expr {
                                         kind: Identifier(
                                             "x",
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 8,
-                                            },
-                                        },
+                                        span: 6..7,
                                     },
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 5,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 8,
-                                    },
-                                },
+                                span: 4..7,
                             },
                             op: Plus,
                             right: Expr {
                                 kind: Identifier(
                                     "b",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 12,
-                                    },
-                                },
+                                span: 10..11,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                        },
+                        span: 4..11,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 12,
-                    },
-                },
+                span: 0..11,
             },
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 12,
-            },
-        },
+        span: 0..11,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals-2.snap
@@ -11,28 +11,10 @@ expression: "parse(\"if (foo) { console.log(foo); };\")"
                         kind: Identifier(
                             "foo",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 4..7,
                     },
                     consequent: Block {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 9,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 31,
-                            },
-                        },
+                        span: 8..30,
                         stmts: [
                             Stmt {
                                 kind: Expr {
@@ -43,16 +25,7 @@ expression: "parse(\"if (foo) { console.log(foo); };\")"
                                                     kind: Identifier(
                                                         "foo",
                                                     ),
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 24,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 27,
-                                                        },
-                                                    },
+                                                    span: 23..26,
                                                 },
                                             ],
                                             callee: Expr {
@@ -61,93 +34,30 @@ expression: "parse(\"if (foo) { console.log(foo); };\")"
                                                         kind: Identifier(
                                                             "console",
                                                         ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 12,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 19,
-                                                            },
-                                                        },
+                                                        span: 11..18,
                                                     },
                                                     property: Expr {
                                                         kind: Identifier(
                                                             "log",
                                                         ),
-                                                        loc: SourceLocation {
-                                                            start: Position {
-                                                                line: 1,
-                                                                column: 20,
-                                                            },
-                                                            end: Position {
-                                                                line: 1,
-                                                                column: 23,
-                                                            },
-                                                        },
+                                                        span: 19..22,
                                                     },
                                                 },
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 12,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 23,
-                                                    },
-                                                },
+                                                span: 11..22,
                                             },
                                         },
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 12,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 28,
-                                            },
-                                        },
+                                        span: 11..27,
                                     },
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 12,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 28,
-                                    },
-                                },
+                                span: 11..27,
                             },
                         ],
                     },
                     alternate: None,
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 31,
-                    },
-                },
+                span: 0..30,
             },
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 31,
-            },
-        },
+        span: 0..30,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals.snap
@@ -6,29 +6,11 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
+                span: 4..7,
                 kind: Ident(
                     BindingIdent {
                         name: "max",
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 4..7,
                         mutable: false,
                     },
                 ),
@@ -41,56 +23,20 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
                                 kind: Identifier(
                                     "x",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 15,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 16,
-                                    },
-                                },
+                                span: 14..15,
                             },
                             op: GreaterThan,
                             right: Expr {
                                 kind: Identifier(
                                     "y",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 19,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 20,
-                                    },
-                                },
+                                span: 18..19,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 15,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 20,
-                            },
-                        },
+                        span: 14..19,
                     },
                     consequent: Block {
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 21,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 28,
-                            },
-                        },
+                        span: 20..27,
                         stmts: [
                             Stmt {
                                 kind: Expr {
@@ -98,43 +44,16 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
                                         kind: Identifier(
                                             "x",
                                         ),
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 24,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 25,
-                                            },
-                                        },
+                                        span: 23..24,
                                     },
                                 },
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 24,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 25,
-                                    },
-                                },
+                                span: 23..24,
                             },
                         ],
                     },
                     alternate: Some(
                         Block {
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 33,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 40,
-                                },
-                            },
+                            span: 32..39,
                             stmts: [
                                 Stmt {
                                     kind: Expr {
@@ -142,55 +61,19 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
                                             kind: Identifier(
                                                 "y",
                                             ),
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 36,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 37,
-                                                },
-                                            },
+                                            span: 35..36,
                                         },
                                     },
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 36,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 37,
-                                        },
-                                    },
+                                    span: 35..36,
                                 },
                             ],
                         },
                     ),
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 40,
-                    },
-                },
+                span: 10..39,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 40,
-            },
-        },
+        span: 0..39,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda-2.snap
@@ -6,29 +6,11 @@ expression: "parse(\"let add = fn (x) => fn (y) => x + y;\")"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
+                span: 4..7,
                 kind: Ident(
                     BindingIdent {
                         name: "add",
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 4..7,
                         mutable: false,
                     },
                 ),
@@ -38,29 +20,11 @@ expression: "parse(\"let add = fn (x) => fn (y) => x + y;\")"
                     params: [
                         FuncParam {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 15,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 16,
-                                    },
-                                },
+                                span: 14..15,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "x",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 15,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 16,
-                                            },
-                                        },
+                                        span: 14..15,
                                         mutable: false,
                                     },
                                 ),
@@ -75,29 +39,11 @@ expression: "parse(\"let add = fn (x) => fn (y) => x + y;\")"
                                 params: [
                                     FuncParam {
                                         pattern: Pattern {
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 26,
-                                                },
-                                            },
+                                            span: 24..25,
                                             kind: Ident(
                                                 BindingIdent {
                                                     name: "y",
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 25,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 26,
-                                                        },
-                                                    },
+                                                    span: 24..25,
                                                     mutable: false,
                                                 },
                                             ),
@@ -113,84 +59,30 @@ expression: "parse(\"let add = fn (x) => fn (y) => x + y;\")"
                                                 kind: Identifier(
                                                     "x",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 31,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 32,
-                                                    },
-                                                },
+                                                span: 30..31,
                                             },
                                             op: Plus,
                                             right: Expr {
                                                 kind: Identifier(
                                                     "y",
                                                 ),
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 35,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 36,
-                                                    },
-                                                },
+                                                span: 34..35,
                                             },
                                         },
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 31,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 36,
-                                            },
-                                        },
+                                        span: 30..35,
                                     },
                                 ),
                                 type_ann: None,
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 21,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 36,
-                                },
-                            },
+                            span: 20..35,
                         },
                     ),
                     type_ann: None,
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 36,
-                    },
-                },
+                span: 10..35,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 36,
-            },
-        },
+        span: 0..35,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda.snap
@@ -6,29 +6,11 @@ expression: "parse(\"let add = fn (x, y) => x + y;\")"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
+                span: 4..7,
                 kind: Ident(
                     BindingIdent {
                         name: "add",
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 4..7,
                         mutable: false,
                     },
                 ),
@@ -38,29 +20,11 @@ expression: "parse(\"let add = fn (x, y) => x + y;\")"
                     params: [
                         FuncParam {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 15,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 16,
-                                    },
-                                },
+                                span: 14..15,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "x",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 15,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 16,
-                                            },
-                                        },
+                                        span: 14..15,
                                         mutable: false,
                                     },
                                 ),
@@ -70,29 +34,11 @@ expression: "parse(\"let add = fn (x, y) => x + y;\")"
                         },
                         FuncParam {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 18,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 19,
-                                    },
-                                },
+                                span: 17..18,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "y",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 18,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 19,
-                                            },
-                                        },
+                                        span: 17..18,
                                         mutable: false,
                                     },
                                 ),
@@ -108,70 +54,25 @@ expression: "parse(\"let add = fn (x, y) => x + y;\")"
                                     kind: Identifier(
                                         "x",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 24,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 25,
-                                        },
-                                    },
+                                    span: 23..24,
                                 },
                                 op: Plus,
                                 right: Expr {
                                     kind: Identifier(
                                         "y",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 28,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 29,
-                                        },
-                                    },
+                                    span: 27..28,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 24,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 29,
-                                },
-                            },
+                            span: 23..28,
                         },
                     ),
                     type_ann: None,
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 29,
-                    },
-                },
+                span: 10..28,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 29,
-            },
-        },
+        span: 0..28,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let.snap
@@ -6,29 +6,11 @@ expression: "parse(r#\"let y = m*x + b;\"#)"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 6,
-                    },
-                },
+                span: 4..5,
                 kind: Ident(
                     BindingIdent {
                         name: "y",
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                        },
+                        span: 4..5,
                         mutable: false,
                     },
                 ),
@@ -41,84 +23,30 @@ expression: "parse(r#\"let y = m*x + b;\"#)"
                                 kind: Identifier(
                                     "m",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 9,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 10,
-                                    },
-                                },
+                                span: 8..9,
                             },
                             op: Times,
                             right: Expr {
                                 kind: Identifier(
                                     "x",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 11,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 12,
-                                    },
-                                },
+                                span: 10..11,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 9,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 12,
-                            },
-                        },
+                        span: 8..11,
                     },
                     op: Plus,
                     right: Expr {
                         kind: Identifier(
                             "b",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 15,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 16,
-                            },
-                        },
+                        span: 14..15,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 9,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 16,
-                    },
-                },
+                span: 8..15,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 16,
-            },
-        },
+        span: 0..15,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring-2.snap
@@ -6,68 +6,23 @@ expression: "parse(\"let {x: x1, y: y1} = p1;\")"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 19,
-                    },
-                },
+                span: 3..18,
                 kind: Object(
                     ObjectPat {
                         props: [
                             KeyValue(
                                 KeyValuePatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 6,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 11,
-                                        },
-                                    },
+                                    span: 5..10,
                                     key: Ident {
                                         name: "x",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                        },
+                                        span: 5..6,
                                     },
                                     value: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 11,
-                                            },
-                                        },
+                                        span: 8..10,
                                         kind: Ident(
                                             BindingIdent {
                                                 name: "x1",
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 9,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 11,
-                                                    },
-                                                },
+                                                span: 8..10,
                                                 mutable: false,
                                             },
                                         ),
@@ -77,53 +32,17 @@ expression: "parse(\"let {x: x1, y: y1} = p1;\")"
                             ),
                             KeyValue(
                                 KeyValuePatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 13,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 18,
-                                        },
-                                    },
+                                    span: 12..17,
                                     key: Ident {
                                         name: "y",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 13,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 14,
-                                            },
-                                        },
+                                        span: 12..13,
                                     },
                                     value: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 16,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 18,
-                                            },
-                                        },
+                                        span: 15..17,
                                         kind: Ident(
                                             BindingIdent {
                                                 name: "y1",
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 16,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 18,
-                                                    },
-                                                },
+                                                span: 15..17,
                                                 mutable: false,
                                             },
                                         ),
@@ -140,28 +59,10 @@ expression: "parse(\"let {x: x1, y: y1} = p1;\")"
                 kind: Identifier(
                     "p1",
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 22,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 24,
-                    },
-                },
+                span: 21..23,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 24,
-            },
-        },
+        span: 0..23,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring-3.snap
@@ -6,45 +6,18 @@ expression: "parse(\"let [p1, p2] = line;\")"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 13,
-                    },
-                },
+                span: 3..12,
                 kind: Tuple(
                     TuplePat {
                         elems: [
                             Some(
                                 TuplePatElem {
                                     pattern: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 8,
-                                            },
-                                        },
+                                        span: 5..7,
                                         kind: Ident(
                                             BindingIdent {
                                                 name: "p1",
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 6,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 8,
-                                                    },
-                                                },
+                                                span: 5..7,
                                                 mutable: false,
                                             },
                                         ),
@@ -55,29 +28,11 @@ expression: "parse(\"let [p1, p2] = line;\")"
                             Some(
                                 TuplePatElem {
                                     pattern: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 12,
-                                            },
-                                        },
+                                        span: 9..11,
                                         kind: Ident(
                                             BindingIdent {
                                                 name: "p2",
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 10,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 12,
-                                                    },
-                                                },
+                                                span: 9..11,
                                                 mutable: false,
                                             },
                                         ),
@@ -94,28 +49,10 @@ expression: "parse(\"let [p1, p2] = line;\")"
                 kind: Identifier(
                     "line",
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 16,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 20,
-                    },
-                },
+                span: 15..19,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 20,
-            },
-        },
+        span: 0..19,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring-4.snap
@@ -6,45 +6,18 @@ expression: "parse(\"let [head, ...tail] = polygon;\")"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 20,
-                    },
-                },
+                span: 3..19,
                 kind: Tuple(
                     TuplePat {
                         elems: [
                             Some(
                                 TuplePatElem {
                                     pattern: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                        },
+                                        span: 5..9,
                                         kind: Ident(
                                             BindingIdent {
                                                 name: "head",
-                                                loc: SourceLocation {
-                                                    start: Position {
-                                                        line: 1,
-                                                        column: 6,
-                                                    },
-                                                    end: Position {
-                                                        line: 1,
-                                                        column: 10,
-                                                    },
-                                                },
+                                                span: 5..9,
                                                 mutable: false,
                                             },
                                         ),
@@ -55,42 +28,15 @@ expression: "parse(\"let [head, ...tail] = polygon;\")"
                             Some(
                                 TuplePatElem {
                                     pattern: Pattern {
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 11,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 15,
-                                            },
-                                        },
+                                        span: 10..14,
                                         kind: Rest(
                                             RestPat {
                                                 arg: Pattern {
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 15,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 19,
-                                                        },
-                                                    },
+                                                    span: 14..18,
                                                     kind: Ident(
                                                         BindingIdent {
                                                             name: "tail",
-                                                            loc: SourceLocation {
-                                                                start: Position {
-                                                                    line: 1,
-                                                                    column: 15,
-                                                                },
-                                                                end: Position {
-                                                                    line: 1,
-                                                                    column: 19,
-                                                                },
-                                                            },
+                                                            span: 14..18,
                                                             mutable: false,
                                                         },
                                                     ),
@@ -110,28 +56,10 @@ expression: "parse(\"let [head, ...tail] = polygon;\")"
                 kind: Identifier(
                     "polygon",
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 23,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 30,
-                    },
-                },
+                span: 22..29,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 30,
-            },
-        },
+        span: 0..29,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_destructuring.snap
@@ -6,43 +6,16 @@ expression: "parse(\"let {x, y} = point;\")"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                },
+                span: 3..10,
                 kind: Object(
                     ObjectPat {
                         props: [
                             Shorthand(
                                 ShorthandPatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 6,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 7,
-                                        },
-                                    },
+                                    span: 5..6,
                                     ident: BindingIdent {
                                         name: "x",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                        },
+                                        span: 5..6,
                                         mutable: false,
                                     },
                                     init: None,
@@ -50,28 +23,10 @@ expression: "parse(\"let {x, y} = point;\")"
                             ),
                             Shorthand(
                                 ShorthandPatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 9,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 10,
-                                        },
-                                    },
+                                    span: 8..9,
                                     ident: BindingIdent {
                                         name: "y",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                        },
+                                        span: 8..9,
                                         mutable: false,
                                     },
                                     init: None,
@@ -86,28 +41,10 @@ expression: "parse(\"let {x, y} = point;\")"
                 kind: Identifier(
                     "point",
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 14,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 19,
-                    },
-                },
+                span: 13..18,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 19,
-            },
-        },
+        span: 0..18,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_fn_with_fn_type.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_fn_with_fn_type.snap
@@ -6,29 +6,11 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
+                span: 4..7,
                 kind: Ident(
                     BindingIdent {
                         name: "add",
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                        },
+                        span: 4..7,
                         mutable: false,
                     },
                 ),
@@ -38,29 +20,11 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
                     params: [
                         FuncParam {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 52,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 53,
-                                    },
-                                },
+                                span: 51..52,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "a",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 52,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 53,
-                                            },
-                                        },
+                                        span: 51..52,
                                         mutable: false,
                                     },
                                 ),
@@ -70,29 +34,11 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
                         },
                         FuncParam {
                             pattern: Pattern {
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 55,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 56,
-                                    },
-                                },
+                                span: 54..55,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "b",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 55,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 56,
-                                            },
-                                        },
+                                        span: 54..55,
                                         mutable: false,
                                     },
                                 ),
@@ -108,58 +54,22 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
                                     kind: Identifier(
                                         "a",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 61,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 62,
-                                        },
-                                    },
+                                    span: 60..61,
                                 },
                                 op: Plus,
                                 right: Expr {
                                     kind: Identifier(
                                         "b",
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 65,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 66,
-                                        },
-                                    },
+                                    span: 64..65,
                                 },
                             },
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 61,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 66,
-                                },
-                            },
+                            span: 60..65,
                         },
                     ),
                     type_ann: None,
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 48,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 66,
-                    },
-                },
+                span: 47..65,
             },
             type_ann: Some(
                 TypeAnn {
@@ -167,29 +77,11 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
                         [
                             FuncParam {
                                 pattern: Pattern {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 14,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 15,
-                                        },
-                                    },
+                                    span: 13..14,
                                     kind: Ident(
                                         BindingIdent {
                                             name: "a",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 14,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 15,
-                                                },
-                                            },
+                                            span: 13..14,
                                             mutable: false,
                                         },
                                     ),
@@ -197,45 +89,18 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
                                 type_ann: Some(
                                     TypeAnn {
                                         kind: Number,
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 17,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 23,
-                                            },
-                                        },
+                                        span: 16..22,
                                     },
                                 ),
                                 optional: false,
                             },
                             FuncParam {
                                 pattern: Pattern {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 25,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 26,
-                                        },
-                                    },
+                                    span: 24..25,
                                     kind: Ident(
                                         BindingIdent {
                                             name: "b",
-                                            loc: SourceLocation {
-                                                start: Position {
-                                                    line: 1,
-                                                    column: 25,
-                                                },
-                                                end: Position {
-                                                    line: 1,
-                                                    column: 26,
-                                                },
-                                            },
+                                            span: 24..25,
                                             mutable: false,
                                         },
                                     ),
@@ -243,16 +108,7 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
                                 type_ann: Some(
                                     TypeAnn {
                                         kind: Number,
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 28,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 34,
-                                            },
-                                        },
+                                        span: 27..33,
                                     },
                                 ),
                                 optional: false,
@@ -260,40 +116,13 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
                         ],
                         TypeAnn {
                             kind: Number,
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 39,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 45,
-                                },
-                            },
+                            span: 38..44,
                         },
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 10,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 12,
-                        },
-                    },
+                    span: 9..11,
                 },
             ),
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 66,
-            },
-        },
+        span: 0..65,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_with_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_with_destructuring.snap
@@ -6,43 +6,16 @@ expression: "parse(r#\"let {x, y} = point;\"#)"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                },
+                span: 3..10,
                 kind: Object(
                     ObjectPat {
                         props: [
                             Shorthand(
                                 ShorthandPatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 6,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 7,
-                                        },
-                                    },
+                                    span: 5..6,
                                     ident: BindingIdent {
                                         name: "x",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                        },
+                                        span: 5..6,
                                         mutable: false,
                                     },
                                     init: None,
@@ -50,28 +23,10 @@ expression: "parse(r#\"let {x, y} = point;\"#)"
                             ),
                             Shorthand(
                                 ShorthandPatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 9,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 10,
-                                        },
-                                    },
+                                    span: 8..9,
                                     ident: BindingIdent {
                                         name: "y",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                        },
+                                        span: 8..9,
                                         mutable: false,
                                     },
                                     init: None,
@@ -86,28 +41,10 @@ expression: "parse(r#\"let {x, y} = point;\"#)"
                 kind: Identifier(
                     "point",
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 14,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 19,
-                    },
-                },
+                span: 13..18,
             },
             type_ann: None,
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 19,
-            },
-        },
+        span: 0..18,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_with_destructuring_and_type_annotation.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_with_destructuring_and_type_annotation.snap
@@ -6,43 +6,16 @@ expression: "parse(r#\"let {x, y}: Point = point;\"#)"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 4,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 11,
-                    },
-                },
+                span: 3..10,
                 kind: Object(
                     ObjectPat {
                         props: [
                             Shorthand(
                                 ShorthandPatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 6,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 7,
-                                        },
-                                    },
+                                    span: 5..6,
                                     ident: BindingIdent {
                                         name: "x",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 6,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 7,
-                                            },
-                                        },
+                                        span: 5..6,
                                         mutable: false,
                                     },
                                     init: None,
@@ -50,28 +23,10 @@ expression: "parse(r#\"let {x, y}: Point = point;\"#)"
                             ),
                             Shorthand(
                                 ShorthandPatProp {
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 9,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 10,
-                                        },
-                                    },
+                                    span: 8..9,
                                     ident: BindingIdent {
                                         name: "y",
-                                        loc: SourceLocation {
-                                            start: Position {
-                                                line: 1,
-                                                column: 9,
-                                            },
-                                            end: Position {
-                                                line: 1,
-                                                column: 10,
-                                            },
-                                        },
+                                        span: 8..9,
                                         mutable: false,
                                     },
                                     init: None,
@@ -86,16 +41,7 @@ expression: "parse(r#\"let {x, y}: Point = point;\"#)"
                 kind: Identifier(
                     "point",
                 ),
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 21,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 26,
-                    },
-                },
+                span: 20..25,
             },
             type_ann: Some(
                 TypeAnn {
@@ -103,28 +49,10 @@ expression: "parse(r#\"let {x, y}: Point = point;\"#)"
                         "Point",
                         None,
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 13,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 18,
-                        },
-                    },
+                    span: 12..17,
                 },
             ),
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 26,
-            },
-        },
+        span: 0..25,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_with_type_annotation.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_with_type_annotation.snap
@@ -6,29 +6,11 @@ expression: "parse(r#\"let y: number = m*x + b;\"#)"
     Stmt {
         kind: Let {
             pattern: Pattern {
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 5,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 6,
-                    },
-                },
+                span: 4..5,
                 kind: Ident(
                     BindingIdent {
                         name: "y",
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 5,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 6,
-                            },
-                        },
+                        span: 4..5,
                         mutable: false,
                     },
                 ),
@@ -41,98 +23,35 @@ expression: "parse(r#\"let y: number = m*x + b;\"#)"
                                 kind: Identifier(
                                     "m",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 17,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 18,
-                                    },
-                                },
+                                span: 16..17,
                             },
                             op: Times,
                             right: Expr {
                                 kind: Identifier(
                                     "x",
                                 ),
-                                loc: SourceLocation {
-                                    start: Position {
-                                        line: 1,
-                                        column: 19,
-                                    },
-                                    end: Position {
-                                        line: 1,
-                                        column: 20,
-                                    },
-                                },
+                                span: 18..19,
                             },
                         },
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 17,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 20,
-                            },
-                        },
+                        span: 16..19,
                     },
                     op: Plus,
                     right: Expr {
                         kind: Identifier(
                             "b",
                         ),
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 23,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 24,
-                            },
-                        },
+                        span: 22..23,
                     },
                 },
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 17,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 24,
-                    },
-                },
+                span: 16..23,
             },
             type_ann: Some(
                 TypeAnn {
                     kind: Number,
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 14,
-                        },
-                    },
+                    span: 7..13,
                 },
             ),
         },
-        loc: SourceLocation {
-            start: Position {
-                line: 1,
-                column: 1,
-            },
-            end: Position {
-                line: 1,
-                column: 24,
-            },
-        },
+        span: 0..23,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_array_types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_array_types-2.snap
@@ -13,16 +13,7 @@ TypeAnn {
                         mutable: false,
                         type_ann: TypeAnn {
                             kind: Number,
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 11,
-                                },
-                            },
+                            span: 4..10,
                         },
                     },
                     ObjectProp {
@@ -31,40 +22,13 @@ TypeAnn {
                         mutable: false,
                         type_ann: TypeAnn {
                             kind: Number,
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 16,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 22,
-                                },
-                            },
+                            span: 15..21,
                         },
                     },
                 ],
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 23,
-                },
-            },
+            span: 0..22,
         },
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 25,
-        },
-    },
+    span: 0..24,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_array_types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_array_types-3.snap
@@ -11,38 +11,11 @@ TypeAnn {
                         "T",
                         None,
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 2,
-                        },
-                    },
+                    span: 0..1,
                 },
             ),
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 4,
-                },
-            },
+            span: 0..3,
         },
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 6,
-        },
-    },
+    span: 0..5,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_array_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_array_types.snap
@@ -6,26 +6,8 @@ TypeAnn {
     kind: Array(
         TypeAnn {
             kind: Number,
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 1,
-                },
-                end: Position {
-                    line: 1,
-                    column: 7,
-                },
-            },
+            span: 0..6,
         },
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 9,
-        },
-    },
+    span: 0..8,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_fn_type_ann.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_fn_type_ann.snap
@@ -7,29 +7,11 @@ TypeAnn {
         [
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                     kind: Ident(
                         BindingIdent {
                             name: "a",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 5,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 6,
-                                },
-                            },
+                            span: 4..5,
                             mutable: false,
                         },
                     ),
@@ -37,45 +19,18 @@ TypeAnn {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 8,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 14,
-                            },
-                        },
+                        span: 7..13,
                     },
                 ),
                 optional: false,
             },
             FuncParam {
                 pattern: Pattern {
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 16,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                    },
+                    span: 15..16,
                     kind: Ident(
                         BindingIdent {
                             name: "b",
-                            loc: SourceLocation {
-                                start: Position {
-                                    line: 1,
-                                    column: 16,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    column: 17,
-                                },
-                            },
+                            span: 15..16,
                             mutable: false,
                         },
                     ),
@@ -83,16 +38,7 @@ TypeAnn {
                 type_ann: Some(
                     TypeAnn {
                         kind: Number,
-                        loc: SourceLocation {
-                            start: Position {
-                                line: 1,
-                                column: 19,
-                            },
-                            end: Position {
-                                line: 1,
-                                column: 25,
-                            },
-                        },
+                        span: 18..24,
                     },
                 ),
                 optional: false,
@@ -100,26 +46,8 @@ TypeAnn {
         ],
         TypeAnn {
             kind: Number,
-            loc: SourceLocation {
-                start: Position {
-                    line: 1,
-                    column: 30,
-                },
-                end: Position {
-                    line: 1,
-                    column: 36,
-                },
-            },
+            span: 29..35,
         },
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 3,
-        },
-    },
+    span: 0..2,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-2.snap
@@ -6,14 +6,5 @@ TypeAnn {
     kind: BoolLit(
         true,
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 5,
-        },
-    },
+    span: 0..4,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-3.snap
@@ -6,14 +6,5 @@ TypeAnn {
     kind: BoolLit(
         false,
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 6,
-        },
-    },
+    span: 0..5,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-4.snap
@@ -4,14 +4,5 @@ expression: "parse(\"null\")"
 ---
 TypeAnn {
     kind: Null,
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 5,
-        },
-    },
+    span: 0..4,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-5.snap
@@ -4,14 +4,5 @@ expression: "parse(\"undefined\")"
 ---
 TypeAnn {
     kind: Undefined,
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types-6.snap
@@ -6,14 +6,5 @@ TypeAnn {
     kind: StrLit(
         "hello",
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_literal_types.snap
@@ -6,14 +6,5 @@ TypeAnn {
     kind: NumLit(
         "123",
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 4,
-        },
-    },
+    span: 0..3,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types-2.snap
@@ -25,56 +25,20 @@ TypeAnn {
                                                 mutable: false,
                                                 type_ann: TypeAnn {
                                                     kind: Boolean,
-                                                    loc: SourceLocation {
-                                                        start: Position {
-                                                            line: 1,
-                                                            column: 13,
-                                                        },
-                                                        end: Position {
-                                                            line: 1,
-                                                            column: 20,
-                                                        },
-                                                    },
+                                                    span: 12..19,
                                                 },
                                             },
                                         ],
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 8,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 21,
-                                        },
-                                    },
+                                    span: 7..20,
                                 },
                             },
                         ],
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 4,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 22,
-                        },
-                    },
+                    span: 3..21,
                 },
             },
         ],
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 23,
-        },
-    },
+    span: 0..22,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types-3.snap
@@ -11,16 +11,7 @@ TypeAnn {
                 mutable: false,
                 type_ann: TypeAnn {
                     kind: Number,
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 2,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 2,
-                            column: 12,
-                        },
-                    },
+                    span: 7..13,
                 },
             },
             ObjectProp {
@@ -29,16 +20,7 @@ TypeAnn {
                 mutable: false,
                 type_ann: TypeAnn {
                     kind: String,
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 3,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 3,
-                            column: 13,
-                        },
-                    },
+                    span: 21..27,
                 },
             },
             ObjectProp {
@@ -47,28 +29,10 @@ TypeAnn {
                 mutable: false,
                 type_ann: TypeAnn {
                     kind: Boolean,
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 4,
-                            column: 6,
-                        },
-                        end: Position {
-                            line: 4,
-                            column: 13,
-                        },
-                    },
+                    span: 34..41,
                 },
             },
         ],
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 5,
-            column: 2,
-        },
-    },
+    span: 0..44,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types.snap
@@ -11,16 +11,7 @@ TypeAnn {
                 mutable: false,
                 type_ann: TypeAnn {
                     kind: Number,
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 11,
-                        },
-                    },
+                    span: 4..10,
                 },
             },
             ObjectProp {
@@ -29,16 +20,7 @@ TypeAnn {
                 mutable: false,
                 type_ann: TypeAnn {
                     kind: String,
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 17,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 23,
-                        },
-                    },
+                    span: 16..22,
                 },
             },
             ObjectProp {
@@ -47,28 +29,10 @@ TypeAnn {
                 mutable: false,
                 type_ann: TypeAnn {
                     kind: Boolean,
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 28,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 35,
-                        },
-                    },
+                    span: 27..34,
                 },
             },
         ],
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 36,
-        },
-    },
+    span: 0..35,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types-2.snap
@@ -4,14 +4,5 @@ expression: "parse(\"string\")"
 ---
 TypeAnn {
     kind: String,
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types-3.snap
@@ -4,14 +4,5 @@ expression: "parse(\"boolean\")"
 ---
 TypeAnn {
     kind: Boolean,
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 8,
-        },
-    },
+    span: 0..7,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types-4.snap
@@ -4,14 +4,5 @@ expression: "parse(\"symbol\")"
 ---
 TypeAnn {
     kind: Symbol,
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_primitive_types.snap
@@ -4,14 +4,5 @@ expression: "parse(\"number\")"
 ---
 TypeAnn {
     kind: Number,
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 7,
-        },
-    },
+    span: 0..6,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_tuple_types-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_tuple_types-2.snap
@@ -7,53 +7,17 @@ TypeAnn {
         [
             TypeAnn {
                 kind: Number,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 2,
-                        column: 3,
-                    },
-                    end: Position {
-                        line: 2,
-                        column: 9,
-                    },
-                },
+                span: 4..10,
             },
             TypeAnn {
                 kind: String,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 3,
-                        column: 3,
-                    },
-                    end: Position {
-                        line: 3,
-                        column: 9,
-                    },
-                },
+                span: 14..20,
             },
             TypeAnn {
                 kind: Boolean,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 4,
-                        column: 3,
-                    },
-                    end: Position {
-                        line: 4,
-                        column: 10,
-                    },
-                },
+                span: 24..31,
             },
         ],
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 5,
-            column: 2,
-        },
-    },
+    span: 0..34,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_tuple_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_tuple_types.snap
@@ -7,53 +7,17 @@ TypeAnn {
         [
             TypeAnn {
                 kind: Number,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 2,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 8,
-                    },
-                },
+                span: 1..7,
             },
             TypeAnn {
                 kind: String,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 10,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 16,
-                    },
-                },
+                span: 9..15,
             },
             TypeAnn {
                 kind: Boolean,
-                loc: SourceLocation {
-                    start: Position {
-                        line: 1,
-                        column: 18,
-                    },
-                    end: Position {
-                        line: 1,
-                        column: 25,
-                    },
-                },
+                span: 17..24,
             },
         ],
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 26,
-        },
-    },
+    span: 0..25,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs-2.snap
@@ -12,44 +12,17 @@ TypeAnn {
                         "K",
                         None,
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 5,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 6,
-                        },
-                    },
+                    span: 4..5,
                 },
                 TypeAnn {
                     kind: TypeRef(
                         "V",
                         None,
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 9,
-                        },
-                    },
+                    span: 7..8,
                 },
             ],
         ),
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 10,
-        },
-    },
+    span: 0..9,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs-3.snap
@@ -17,42 +17,15 @@ TypeAnn {
                                         "T",
                                         None,
                                     ),
-                                    loc: SourceLocation {
-                                        start: Position {
-                                            line: 1,
-                                            column: 13,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 14,
-                                        },
-                                    },
+                                    span: 12..13,
                                 },
                             ],
                         ),
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 15,
-                        },
-                    },
+                    span: 6..14,
                 },
             ],
         ),
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 16,
-        },
-    },
+    span: 0..15,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs-4.snap
@@ -7,14 +7,5 @@ TypeAnn {
         "T",
         None,
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 2,
-        },
-    },
+    span: 0..1,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_type_refs.snap
@@ -12,28 +12,10 @@ TypeAnn {
                         "T",
                         None,
                     ),
-                    loc: SourceLocation {
-                        start: Position {
-                            line: 1,
-                            column: 7,
-                        },
-                        end: Position {
-                            line: 1,
-                            column: 8,
-                        },
-                    },
+                    span: 6..7,
                 },
             ],
         ),
     ),
-    loc: SourceLocation {
-        start: Position {
-            line: 1,
-            column: 1,
-        },
-        end: Position {
-            line: 1,
-            column: 9,
-        },
-    },
+    span: 0..8,
 }

--- a/crates/escalier_parser/src/source_location.rs
+++ b/crates/escalier_parser/src/source_location.rs
@@ -1,3 +1,6 @@
+use std::cmp::{max, min};
+use std::ops::Range;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Position {
     pub line: usize,
@@ -10,9 +13,13 @@ pub struct SourceLocation {
     pub end: Position,
 }
 
-pub fn merge_locations(left: &SourceLocation, right: &SourceLocation) -> SourceLocation {
-    SourceLocation {
-        start: left.start.clone(),
-        end: right.end.clone(),
+pub type Span = Range<usize>;
+
+pub const DUMMY_SPAN: Span = Span { start: 0, end: 0 };
+
+pub fn merge_spans(left: &Span, right: &Span) -> Span {
+    Span {
+        start: min(left.start, right.start),
+        end: max(left.end, right.end),
     }
 }

--- a/crates/escalier_parser/src/stmt.rs
+++ b/crates/escalier_parser/src/stmt.rs
@@ -1,6 +1,6 @@
 use crate::expr::Expr;
 use crate::pattern::Pattern;
-use crate::source_location::SourceLocation;
+use crate::source_location::Span;
 use crate::type_ann::TypeAnn;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -22,5 +22,5 @@ pub enum StmtKind {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Stmt {
     pub kind: StmtKind,
-    pub loc: SourceLocation,
+    pub span: Span,
 }

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -1,5 +1,5 @@
 use crate::parser::*;
-use crate::source_location::merge_locations;
+use crate::source_location::merge_spans;
 use crate::stmt::{Stmt, StmtKind};
 use crate::token::*;
 
@@ -27,14 +27,14 @@ impl<'a> Parser<'a> {
                     TokenKind::Semicolon
                 );
 
-                let loc = merge_locations(&token.loc, &expr.loc);
+                let span = merge_spans(&token.span, &expr.span);
                 Stmt {
                     kind: StmtKind::Let {
                         pattern,
                         expr,
                         type_ann,
                     },
-                    loc,
+                    span,
                 }
             }
             TokenKind::Return => {
@@ -45,7 +45,7 @@ impl<'a> Parser<'a> {
                         self.next().unwrap_or(EOF.clone());
                         Stmt {
                             kind: StmtKind::Return { arg: None },
-                            loc: merge_locations(&token.loc, &next.loc),
+                            span: merge_spans(&token.span, &next.span),
                         }
                     }
                     _ => {
@@ -55,10 +55,10 @@ impl<'a> Parser<'a> {
                             TokenKind::Semicolon
                         );
 
-                        let loc = merge_locations(&next.loc, &arg.loc);
+                        let span = merge_spans(&next.span, &arg.span);
                         Stmt {
                             kind: StmtKind::Return { arg: Some(arg) },
-                            loc,
+                            span,
                         }
                     }
                 }
@@ -72,10 +72,10 @@ impl<'a> Parser<'a> {
                 );
                 eprintln!("--- parse_stmt (assert semicolon) ---");
 
-                let loc = expr.loc.clone();
+                let span = expr.span.clone();
                 Stmt {
                     kind: StmtKind::Expr { expr },
-                    loc,
+                    span,
                 }
             }
         }

--- a/crates/escalier_parser/src/token.rs
+++ b/crates/escalier_parser/src/token.rs
@@ -85,13 +85,10 @@ pub enum TokenKind {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Token {
     pub kind: TokenKind,
-    pub loc: SourceLocation,
+    pub span: Span,
 }
 
 pub const EOF: Token = Token {
     kind: TokenKind::Eof,
-    loc: SourceLocation {
-        start: Position { line: 0, column: 0 },
-        end: Position { line: 0, column: 0 },
-    },
+    span: DUMMY_SPAN,
 };

--- a/crates/escalier_parser/src/type_ann.rs
+++ b/crates/escalier_parser/src/type_ann.rs
@@ -4,7 +4,7 @@
 // - conditional types
 
 use crate::func_param::FuncParam;
-use crate::source_location::SourceLocation;
+use crate::source_location::*;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ObjectProp {
@@ -35,5 +35,5 @@ pub enum TypeAnnKind {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypeAnn {
     pub kind: TypeAnnKind,
-    pub loc: SourceLocation,
+    pub span: Span,
 }

--- a/crates/escalier_parser/src/type_ann_parser.rs
+++ b/crates/escalier_parser/src/type_ann_parser.rs
@@ -1,11 +1,11 @@
 use crate::parser::*;
-use crate::source_location::merge_locations;
+use crate::source_location::merge_spans;
 use crate::token::*;
 use crate::type_ann::{ObjectProp, TypeAnn, TypeAnnKind};
 
 impl<'a> Parser<'a> {
     pub fn parse_type_ann(&mut self) -> TypeAnn {
-        let mut loc = self.peek().unwrap_or(&EOF).loc.clone();
+        let mut span = self.peek().unwrap_or(&EOF).span.clone();
         let mut kind = match self.next().unwrap_or(EOF.clone()).kind {
             TokenKind::BoolLit(value) => TypeAnnKind::BoolLit(value),
             TokenKind::Boolean => TypeAnnKind::Boolean,
@@ -47,7 +47,7 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                loc = merge_locations(&loc, &self.peek().unwrap_or(&EOF).loc);
+                span = merge_spans(&span, &self.peek().unwrap_or(&EOF).span);
                 assert_eq!(
                     self.next().unwrap_or(EOF.clone()).kind,
                     TokenKind::RightBrace
@@ -68,7 +68,7 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                loc = merge_locations(&loc, &self.peek().unwrap_or(&EOF).loc);
+                span = merge_spans(&span, &self.peek().unwrap_or(&EOF).span);
                 assert_eq!(
                     self.next().unwrap_or(EOF.clone()).kind,
                     TokenKind::RightBracket
@@ -91,7 +91,7 @@ impl<'a> Parser<'a> {
                         }
                     }
 
-                    loc = merge_locations(&loc, &self.peek().unwrap_or(&EOF).loc);
+                    span = merge_spans(&span, &self.peek().unwrap_or(&EOF).span);
                     assert_eq!(
                         self.next().unwrap_or(EOF.clone()).kind,
                         TokenKind::GreaterThan
@@ -116,17 +116,17 @@ impl<'a> Parser<'a> {
 
         while self.peek().unwrap_or(&EOF).kind == TokenKind::LeftBracket {
             self.next().unwrap_or(EOF.clone());
-            let right = self.peek().unwrap_or(&EOF).loc.clone();
-            let merged_loc = merge_locations(&loc, &right);
+            let right_span = self.peek().unwrap_or(&EOF).span.clone();
+            let merged_span = merge_spans(&span, &right_span);
             assert_eq!(
                 self.next().unwrap_or(EOF.clone()).kind,
                 TokenKind::RightBracket
             );
-            kind = TypeAnnKind::Array(Box::new(TypeAnn { kind, loc }));
-            loc = merged_loc;
+            kind = TypeAnnKind::Array(Box::new(TypeAnn { kind, span }));
+            span = merged_span;
         }
 
-        TypeAnn { kind, loc }
+        TypeAnn { kind, span }
     }
 }
 


### PR DESCRIPTION
`swc` needs `Span`s to compute sourcemaps.  We can always compute line/column locations if there's an error we want to report, but there's no reason to track that information for each node all the time.