### PR TITLE
Drop the requirement that statements need to be separated by semi-colons

### DIFF
--- a/crates/escalier_parser/src/expr_parser.rs
+++ b/crates/escalier_parser/src/expr_parser.rs
@@ -78,10 +78,10 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            assert_eq!(
-                self.next().unwrap_or(EOF.clone()).kind,
-                TokenKind::Semicolon
-            );
+            // assert_eq!(
+            //     self.next().unwrap_or(EOF.clone()).kind,
+            //     TokenKind::Semicolon
+            // );
         }
         let close = self.next().unwrap_or(EOF.clone());
         assert_eq!(close.kind, TokenKind::RightBrace);
@@ -811,57 +811,57 @@ mod tests {
 
     #[test]
     fn parse_function() {
-        insta::assert_debug_snapshot!(parse("fn () => { let x = 5; let y = 10; return x + y; }"));
+        insta::assert_debug_snapshot!(parse("fn () => { let x = 5 let y = 10 return x + y }"));
     }
 
     #[test]
     fn parse_function_with_params() {
-        let src = r#"fn (x, y) => { return x + y; }"#;
+        let src = r#"fn (x, y) => { return x + y }"#;
         insta::assert_debug_snapshot!(parse(src));
     }
 
     #[test]
     fn parse_function_with_type_annotations() {
         insta::assert_debug_snapshot!(parse(
-            r#"fn (x: number, y: number): number => { return x + y; }"#
+            r#"fn (x: number, y: number): number => { return x + y }"#
         ));
     }
 
     #[test]
     fn parse_function_with_optional_params() {
         insta::assert_debug_snapshot!(parse(
-            r#"fn (x: number, y: number, z?: number): number => { return x + y; }"#
+            r#"fn (x: number, y: number, z?: number): number => { return x + y }"#
         ));
     }
 
     #[test]
     fn parse_function_with_destructuring() {
-        insta::assert_debug_snapshot!(parse(r#"fn ({x, y}) => { return x + y; }"#));
+        insta::assert_debug_snapshot!(parse(r#"fn ({x, y}) => { return x + y }"#));
     }
 
     #[test]
     fn parse_function_with_destructuring_and_type_annotation() {
-        insta::assert_debug_snapshot!(parse(r#"fn ({x, y}: Point): number => { return x + y; }"#));
+        insta::assert_debug_snapshot!(parse(r#"fn ({x, y}: Point): number => { return x + y }"#));
     }
 
     #[test]
     fn parse_lambdas() {
-        insta::assert_debug_snapshot!(parse("fn (x, y) => x + y;"));
-        insta::assert_debug_snapshot!(parse("fn (x) => fn (y) => x + y;"));
-        insta::assert_debug_snapshot!(parse(r#"fn (x: number, y: number): number => x + y;"#));
+        insta::assert_debug_snapshot!(parse("fn (x, y) => x + y"));
+        insta::assert_debug_snapshot!(parse("fn (x) => fn (y) => x + y"));
+        insta::assert_debug_snapshot!(parse(r#"fn (x: number, y: number): number => x + y"#));
     }
 
     #[test]
     #[should_panic]
     fn parse_function_expected_comma_or_left_brace() {
-        let src = r#"fn (x, y { return x + y; }"#;
+        let src = r#"fn (x, y { return x + y }"#;
         parse(src);
     }
 
     #[test]
     #[should_panic]
     fn parse_function_expected_identifier() {
-        let src = r#"fn (, y) { return x + y; }"#;
+        let src = r#"fn (, y) { return x + y }"#;
         parse(src);
     }
 
@@ -906,11 +906,11 @@ mod tests {
     #[test]
     fn parse_conditionals() {
         insta::assert_debug_snapshot!(parse(r#"if (cond) { x }"#));
-        insta::assert_debug_snapshot!(parse(r#"if (cond) { x } else { y; }"#));
+        insta::assert_debug_snapshot!(parse(r#"if (cond) { x } else { y }"#));
         insta::assert_debug_snapshot!(parse(
             r#"
             if (cond) {
-                {x: 5, y: 10};
+                {x: 5, y: 10}
             } else {
                 {a: 1, b: 2}
             }
@@ -944,9 +944,9 @@ mod tests {
         insta::assert_debug_snapshot!(parse(
             r#"
             try {
-                canThrow();
+                canThrow()
             } catch (e) {
-                console.log("Error: " + e);
+                console.log("Error: " + e)
             }
             "#
         ));
@@ -957,9 +957,9 @@ mod tests {
         insta::assert_debug_snapshot!(parse(
             r#"
             try {
-                canThrow();
+                canThrow()
             } finally {
-                cleanup();
+                cleanup()
             }
             "#
         ));
@@ -972,7 +972,7 @@ mod tests {
             try {
                 canThrow()
             } catch (e) {
-                console.log("Error: " + e);
+                console.log("Error: " + e)
             } finally {
                 cleanup()
             }
@@ -985,8 +985,8 @@ mod tests {
         insta::assert_debug_snapshot!(parse(
             r#"
             do {
-                let x = 5;
-                let y = 10;
+                let x = 5
+                let y = 10
                 x + y
             }
             "#

--- a/crates/escalier_parser/src/expr_parser.rs
+++ b/crates/escalier_parser/src/expr_parser.rs
@@ -1037,4 +1037,9 @@ mod tests {
     fn parse_invalid_fn_should_error() {
         insta::assert_debug_snapshot!(parse("(x) => x"));
     }
+
+    #[test]
+    fn parse_multiple_application() {
+        insta::assert_debug_snapshot!(parse("foo()\n(3+4) * 5"));
+    }
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-2.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"if (cond) { x } else { y; }\"#)"
+expression: "parse(r#\"if (cond) { x } else { y }\"#)"
 ---
 IfElse(
     IfElse {
-        span: 0..27,
+        span: 0..26,
         cond: Ident(
             Ident {
                 name: "cond",
@@ -29,7 +29,7 @@ IfElse(
         },
         alternate: Some(
             Block {
-                span: 20..27,
+                span: 20..26,
                 stmts: [
                     Stmt {
                         kind: Expr {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-2.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"if (cond) { x; } else { y; }\"#)"
+expression: "parse(r#\"if (cond) { x } else { y; }\"#)"
 ---
 IfElse(
     IfElse {
-        span: 0..28,
+        span: 0..27,
         cond: Ident(
             Ident {
                 name: "cond",
@@ -12,7 +12,7 @@ IfElse(
             },
         ),
         consequent: Block {
-            span: 9..16,
+            span: 9..15,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -29,18 +29,18 @@ IfElse(
         },
         alternate: Some(
             Block {
-                span: 21..28,
+                span: 20..27,
                 stmts: [
                     Stmt {
                         kind: Expr {
                             expr: Ident(
                                 Ident {
                                     name: "y",
-                                    span: 24..25,
+                                    span: 23..24,
                                 },
                             ),
                         },
-                        span: 24..25,
+                        span: 23..24,
                     },
                 ],
             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-3.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            if (cond) {\n                {x: 5, y: 10};\n            } else {\n                {a: 1, b: 2};\n            }\n            \"#)"
+expression: "parse(r#\"\n            if (cond) {\n                {x: 5, y: 10};\n            } else {\n                {a: 1, b: 2}\n            }\n            \"#)"
 ---
 IfElse(
     IfElse {
-        span: 13..120,
+        span: 13..119,
         cond: Ident(
             Ident {
                 name: "cond",
@@ -62,7 +62,7 @@ IfElse(
         },
         alternate: Some(
             Block {
-                span: 74..120,
+                span: 74..119,
                 stmts: [
                     Stmt {
                         kind: Expr {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals-3.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            if (cond) {\n                {x: 5, y: 10};\n            } else {\n                {a: 1, b: 2}\n            }\n            \"#)"
+expression: "parse(r#\"\n            if (cond) {\n                {x: 5, y: 10}\n            } else {\n                {a: 1, b: 2}\n            }\n            \"#)"
 ---
 IfElse(
     IfElse {
-        span: 13..119,
+        span: 13..118,
         cond: Ident(
             Ident {
                 name: "cond",
@@ -12,7 +12,7 @@ IfElse(
             },
         ),
         consequent: Block {
-            span: 22..69,
+            span: 22..68,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -62,25 +62,25 @@ IfElse(
         },
         alternate: Some(
             Block {
-                span: 74..119,
+                span: 73..118,
                 stmts: [
                     Stmt {
                         kind: Expr {
                             expr: Object(
                                 Object {
-                                    span: 76..105,
+                                    span: 75..104,
                                     properties: [
                                         Prop(
                                             Property {
                                                 key: Ident(
                                                     Ident {
                                                         name: "a",
-                                                        span: 94..95,
+                                                        span: 93..94,
                                                     },
                                                 ),
                                                 value: Num(
                                                     Num {
-                                                        span: 97..98,
+                                                        span: 96..97,
                                                         value: "1",
                                                     },
                                                 ),
@@ -91,12 +91,12 @@ IfElse(
                                                 key: Ident(
                                                     Ident {
                                                         name: "b",
-                                                        span: 100..101,
+                                                        span: 99..100,
                                                     },
                                                 ),
                                                 value: Num(
                                                     Num {
-                                                        span: 103..104,
+                                                        span: 102..103,
                                                         value: "2",
                                                     },
                                                 ),
@@ -106,7 +106,7 @@ IfElse(
                                 },
                             ),
                         },
-                        span: 76..105,
+                        span: 75..104,
                     },
                 ],
             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_conditionals.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"if (cond) { x; }\"#)"
+expression: "parse(r#\"if (cond) { x }\"#)"
 ---
 IfElse(
     IfElse {
-        span: 0..16,
+        span: 0..15,
         cond: Ident(
             Ident {
                 name: "cond",
@@ -12,7 +12,7 @@ IfElse(
             },
         ),
         consequent: Block {
-            span: 9..16,
+            span: 9..15,
             stmts: [
                 Stmt {
                     kind: Expr {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_do_expr.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_do_expr.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            do {\n                let x = 5;\n                let y = 10;\n                x + y\n            }\n            \"#)"
+expression: "parse(r#\"\n            do {\n                let x = 5\n                let y = 10\n                x + y\n            }\n            \"#)"
 ---
 Do(
     Do {
-        span: 13..108,
+        span: 13..106,
         body: Block {
-            span: 15..108,
+            span: 15..106,
             stmts: [
                 Stmt {
                     kind: Let {
@@ -33,47 +33,47 @@ Do(
                 Stmt {
                     kind: Let {
                         pattern: Pattern {
-                            span: 65..66,
+                            span: 64..65,
                             kind: Ident(
                                 BindingIdent {
                                     name: "y",
-                                    span: 65..66,
+                                    span: 64..65,
                                     mutable: false,
                                 },
                             ),
                         },
                         expr: Num(
                             Num {
-                                span: 69..71,
+                                span: 68..70,
                                 value: "10",
                             },
                         ),
                         type_ann: None,
                     },
-                    span: 61..71,
+                    span: 60..70,
                 },
                 Stmt {
                     kind: Expr {
                         expr: Binary(
                             Binary {
-                                span: 89..94,
+                                span: 87..92,
                                 left: Ident(
                                     Ident {
                                         name: "x",
-                                        span: 89..90,
+                                        span: 87..88,
                                     },
                                 ),
                                 op: Plus,
                                 right: Ident(
                                     Ident {
                                         name: "y",
-                                        span: 93..94,
+                                        span: 91..92,
                                     },
                                 ),
                             },
                         ),
                     },
-                    span: 89..94,
+                    span: 87..92,
                 },
             ],
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_do_expr.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_do_expr.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            do {\n                let x = 5;\n                let y = 10;\n                x + y;\n            }\n            \"#)"
+expression: "parse(r#\"\n            do {\n                let x = 5;\n                let y = 10;\n                x + y\n            }\n            \"#)"
 ---
 Do(
     Do {
-        span: 13..109,
+        span: 13..108,
         body: Block {
-            span: 15..109,
+            span: 15..108,
             stmts: [
                 Stmt {
                     kind: Let {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"fn () => { let x = 5; let y = 10; return x + y; }\")"
+expression: "parse(\"fn () => { let x = 5 let y = 10 return x + y }\")"
 ---
 Function(
     Function {
-        span: 0..49,
+        span: 0..46,
         params: [],
         body: Block(
             Block {
-                span: 8..49,
+                span: 8..46,
                 stmts: [
                     Stmt {
                         kind: Let {
@@ -35,49 +35,49 @@ Function(
                     Stmt {
                         kind: Let {
                             pattern: Pattern {
-                                span: 26..27,
+                                span: 25..26,
                                 kind: Ident(
                                     BindingIdent {
                                         name: "y",
-                                        span: 26..27,
+                                        span: 25..26,
                                         mutable: false,
                                     },
                                 ),
                             },
                             expr: Num(
                                 Num {
-                                    span: 30..32,
+                                    span: 29..31,
                                     value: "10",
                                 },
                             ),
                             type_ann: None,
                         },
-                        span: 22..32,
+                        span: 21..31,
                     },
                     Stmt {
                         kind: Return {
                             arg: Some(
                                 Binary(
                                     Binary {
-                                        span: 41..46,
+                                        span: 39..44,
                                         left: Ident(
                                             Ident {
                                                 name: "x",
-                                                span: 41..42,
+                                                span: 39..40,
                                             },
                                         ),
                                         op: Plus,
                                         right: Ident(
                                             Ident {
                                                 name: "y",
-                                                span: 45..46,
+                                                span: 43..44,
                                             },
                                         ),
                                     },
                                 ),
                             ),
                         },
-                        span: 41..46,
+                        span: 39..44,
                     },
                 ],
             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"fn ({x, y}) => { return x + y; }\"#)"
+expression: "parse(r#\"fn ({x, y}) => { return x + y }\"#)"
 ---
 Function(
     Function {
-        span: 0..32,
+        span: 0..31,
         params: [
             FuncParam {
                 pattern: Pattern {
@@ -45,7 +45,7 @@ Function(
         ],
         body: Block(
             Block {
-                span: 14..32,
+                span: 14..31,
                 stmts: [
                     Stmt {
                         kind: Return {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring_and_type_annotation.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring_and_type_annotation.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"fn ({x, y}: Point): number => { return x + y; }\"#)"
+expression: "parse(r#\"fn ({x, y}: Point): number => { return x + y }\"#)"
 ---
 Function(
     Function {
-        span: 0..47,
+        span: 0..46,
         params: [
             FuncParam {
                 pattern: Pattern {
@@ -53,7 +53,7 @@ Function(
         ],
         body: Block(
             Block {
-                span: 29..47,
+                span: 29..46,
                 stmts: [
                     Stmt {
                         kind: Return {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_optional_params.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_optional_params.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"fn (x: number, y: number, z?: number): number => { return x + y; }\"#)"
+expression: "parse(r#\"fn (x: number, y: number, z?: number): number => { return x + y }\"#)"
 ---
 Function(
     Function {
-        span: 0..66,
+        span: 0..65,
         params: [
             FuncParam {
                 pattern: Pattern {
@@ -66,7 +66,7 @@ Function(
         ],
         body: Block(
             Block {
-                span: 48..66,
+                span: 48..65,
                 stmts: [
                     Stmt {
                         kind: Return {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_params.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_params.snap
@@ -4,7 +4,7 @@ expression: parse(src)
 ---
 Function(
     Function {
-        span: 0..30,
+        span: 0..29,
         params: [
             FuncParam {
                 pattern: Pattern {
@@ -37,7 +37,7 @@ Function(
         ],
         body: Block(
             Block {
-                span: 12..30,
+                span: 12..29,
                 stmts: [
                     Stmt {
                         kind: Return {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_type_annotations.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_type_annotations.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"fn (x: number, y: number): number => { return x + y; }\"#)"
+expression: "parse(r#\"fn (x: number, y: number): number => { return x + y }\"#)"
 ---
 Function(
     Function {
-        span: 0..54,
+        span: 0..53,
         params: [
             FuncParam {
                 pattern: Pattern {
@@ -47,7 +47,7 @@ Function(
         ],
         body: Block(
             Block {
-                span: 36..54,
+                span: 36..53,
                 stmts: [
                     Stmt {
                         kind: Return {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_multiple_application.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_multiple_application.snap
@@ -1,0 +1,53 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(\"foo()\\n(3+4) * 5\")"
+---
+Binary(
+    Binary {
+        span: 0..15,
+        left: Call(
+            Call {
+                span: 0..11,
+                args: [
+                    Binary(
+                        Binary {
+                            span: 7..10,
+                            left: Num(
+                                Num {
+                                    span: 7..8,
+                                    value: "3",
+                                },
+                            ),
+                            op: Plus,
+                            right: Num(
+                                Num {
+                                    span: 9..10,
+                                    value: "4",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                callee: Call(
+                    Call {
+                        span: 0..5,
+                        args: [],
+                        callee: Ident(
+                            Ident {
+                                name: "foo",
+                                span: 0..3,
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        op: Times,
+        right: Num(
+            Num {
+                span: 14..15,
+                value: "5",
+            },
+        ),
+    },
+)

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"fn ({x, y}) => { return x + y; }\")"
+expression: "parse(\"fn ({x, y}) => { return x + y }\")"
 ---
 Function(
     Function {
-        span: 0..32,
+        span: 0..31,
         params: [
             FuncParam {
                 pattern: Pattern {
@@ -45,7 +45,7 @@ Function(
         ],
         body: Block(
             Block {
-                span: 14..32,
+                span: 14..31,
                 stmts: [
                     Stmt {
                         kind: Return {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_pattern_matching.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_pattern_matching.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            match (obj.type) {\n                \"foo\" => obj.foo,\n                \"bar\" => {\n                    obj.bar;\n                },\n                _ => \"default\",\n            };\n            \"#)"
+expression: "parse(r#\"\n            match (obj.type) {\n                \"foo\" => obj.foo,\n                \"bar\" => {\n                    obj.bar\n                },\n                _ => \"default\",\n            };\n            \"#)"
 ---
 Match(
     Match {
-        span: 13..186,
+        span: 13..185,
         expr: Member(
             Member {
                 span: 20..28,
@@ -57,7 +57,7 @@ Match(
                 ),
             },
             MatchArm {
-                span: 82..139,
+                span: 82..138,
                 pattern: Pattern {
                     span: 82..87,
                     kind: Lit(
@@ -71,7 +71,7 @@ Match(
                 guard: None,
                 body: Block(
                     Block {
-                        span: 90..139,
+                        span: 90..138,
                         stmts: [
                             Stmt {
                                 kind: Expr {
@@ -100,16 +100,16 @@ Match(
                 ),
             },
             MatchArm {
-                span: 157..171,
+                span: 156..170,
                 pattern: Pattern {
-                    span: 157..158,
+                    span: 156..157,
                     kind: Wildcard,
                 },
                 guard: None,
                 body: Expr(
                     Str(
                         Str {
-                            span: 162..171,
+                            span: 161..170,
                             value: "default",
                         },
                     ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            try {\n                canThrow();\n            } catch (e) {\n                console.log(\"Error: \" + e);\n            }\n            \"#)"
+expression: "parse(r#\"\n            try {\n                canThrow()\n            } catch (e) {\n                console.log(\"Error: \" + e)\n            }\n            \"#)"
 ---
 Try(
     Try {
-        span: 13..130,
+        span: 13..128,
         body: Block {
-            span: 16..60,
+            span: 16..59,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -31,31 +31,31 @@ Try(
             CatchClause {
                 param: Some(
                     Pattern {
-                        span: 68..69,
+                        span: 67..68,
                         kind: Ident(
                             BindingIdent {
                                 name: "e",
-                                span: 68..69,
+                                span: 67..68,
                                 mutable: false,
                             },
                         ),
                     },
                 ),
                 body: Block {
-                    span: 70..130,
+                    span: 69..128,
                     stmts: [
                         Stmt {
                             kind: Expr {
                                 expr: Call(
                                     Call {
-                                        span: 89..115,
+                                        span: 88..114,
                                         args: [
                                             Binary(
                                                 Binary {
-                                                    span: 101..114,
+                                                    span: 100..113,
                                                     left: Str(
                                                         Str {
-                                                            span: 101..110,
+                                                            span: 100..109,
                                                             value: "Error: ",
                                                         },
                                                     ),
@@ -63,7 +63,7 @@ Try(
                                                     right: Ident(
                                                         Ident {
                                                             name: "e",
-                                                            span: 113..114,
+                                                            span: 112..113,
                                                         },
                                                     ),
                                                 },
@@ -71,17 +71,17 @@ Try(
                                         ],
                                         callee: Member(
                                             Member {
-                                                span: 89..100,
+                                                span: 88..99,
                                                 object: Ident(
                                                     Ident {
                                                         name: "console",
-                                                        span: 89..96,
+                                                        span: 88..95,
                                                     },
                                                 ),
                                                 property: Ident(
                                                     Ident {
                                                         name: "log",
-                                                        span: 97..100,
+                                                        span: 96..99,
                                                     },
                                                 ),
                                             },
@@ -89,7 +89,7 @@ Try(
                                     },
                                 ),
                             },
-                            span: 89..115,
+                            span: 88..114,
                         },
                     ],
                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            try {\n                canThrow()\n            } catch (e) {\n                console.log(\"Error: \" + e);\n            } finally {\n                cleanup()\n            }\n            \"#)"
+expression: "parse(r#\"\n            try {\n                canThrow()\n            } catch (e) {\n                console.log(\"Error: \" + e)\n            } finally {\n                cleanup()\n            }\n            \"#)"
 ---
 Try(
     Try {
-        span: 13..179,
+        span: 13..178,
         body: Block {
             span: 16..59,
             stmts: [
@@ -42,7 +42,7 @@ Try(
                     },
                 ),
                 body: Block {
-                    span: 69..129,
+                    span: 69..128,
                     stmts: [
                         Stmt {
                             kind: Expr {
@@ -97,24 +97,24 @@ Try(
         ),
         finally: Some(
             Block {
-                span: 137..179,
+                span: 136..178,
                 stmts: [
                     Stmt {
                         kind: Expr {
                             expr: Call(
                                 Call {
-                                    span: 156..165,
+                                    span: 155..164,
                                     args: [],
                                     callee: Ident(
                                         Ident {
                                             name: "cleanup",
-                                            span: 156..163,
+                                            span: 155..162,
                                         },
                                     ),
                                 },
                             ),
                         },
-                        span: 156..165,
+                        span: 155..164,
                     },
                 ],
             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            try {\n                canThrow();\n            } catch (e) {\n                console.log(\"Error: \" + e);\n            } finally {\n                cleanup();\n            }\n            \"#)"
+expression: "parse(r#\"\n            try {\n                canThrow()\n            } catch (e) {\n                console.log(\"Error: \" + e);\n            } finally {\n                cleanup()\n            }\n            \"#)"
 ---
 Try(
     Try {
-        span: 13..181,
+        span: 13..179,
         body: Block {
-            span: 16..60,
+            span: 16..59,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -31,31 +31,31 @@ Try(
             CatchClause {
                 param: Some(
                     Pattern {
-                        span: 68..69,
+                        span: 67..68,
                         kind: Ident(
                             BindingIdent {
                                 name: "e",
-                                span: 68..69,
+                                span: 67..68,
                                 mutable: false,
                             },
                         ),
                     },
                 ),
                 body: Block {
-                    span: 70..130,
+                    span: 69..129,
                     stmts: [
                         Stmt {
                             kind: Expr {
                                 expr: Call(
                                     Call {
-                                        span: 89..115,
+                                        span: 88..114,
                                         args: [
                                             Binary(
                                                 Binary {
-                                                    span: 101..114,
+                                                    span: 100..113,
                                                     left: Str(
                                                         Str {
-                                                            span: 101..110,
+                                                            span: 100..109,
                                                             value: "Error: ",
                                                         },
                                                     ),
@@ -63,7 +63,7 @@ Try(
                                                     right: Ident(
                                                         Ident {
                                                             name: "e",
-                                                            span: 113..114,
+                                                            span: 112..113,
                                                         },
                                                     ),
                                                 },
@@ -71,17 +71,17 @@ Try(
                                         ],
                                         callee: Member(
                                             Member {
-                                                span: 89..100,
+                                                span: 88..99,
                                                 object: Ident(
                                                     Ident {
                                                         name: "console",
-                                                        span: 89..96,
+                                                        span: 88..95,
                                                     },
                                                 ),
                                                 property: Ident(
                                                     Ident {
                                                         name: "log",
-                                                        span: 97..100,
+                                                        span: 96..99,
                                                     },
                                                 ),
                                             },
@@ -89,7 +89,7 @@ Try(
                                     },
                                 ),
                             },
-                            span: 89..115,
+                            span: 88..114,
                         },
                     ],
                 },
@@ -97,24 +97,24 @@ Try(
         ),
         finally: Some(
             Block {
-                span: 138..181,
+                span: 137..179,
                 stmts: [
                     Stmt {
                         kind: Expr {
                             expr: Call(
                                 Call {
-                                    span: 157..166,
+                                    span: 156..165,
                                     args: [],
                                     callee: Ident(
                                         Ident {
                                             name: "cleanup",
-                                            span: 157..164,
+                                            span: 156..163,
                                         },
                                     ),
                                 },
                             ),
                         },
-                        span: 157..166,
+                        span: 156..165,
                     },
                 ],
             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_finally.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_finally.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(r#\"\n            try {\n                canThrow();\n            } finally {\n                cleanup();\n            }\n            \"#)"
+expression: "parse(r#\"\n            try {\n                canThrow()\n            } finally {\n                cleanup()\n            }\n            \"#)"
 ---
 Try(
     Try {
-        span: 13..111,
+        span: 13..109,
         body: Block {
-            span: 16..60,
+            span: 16..59,
             stmts: [
                 Stmt {
                     kind: Expr {
@@ -30,24 +30,24 @@ Try(
         catch: None,
         finally: Some(
             Block {
-                span: 68..111,
+                span: 67..109,
                 stmts: [
                     Stmt {
                         kind: Expr {
                             expr: Call(
                                 Call {
-                                    span: 87..96,
+                                    span: 86..95,
                                     args: [],
                                     callee: Ident(
                                         Ident {
                                             name: "cleanup",
-                                            span: 87..94,
+                                            span: 86..93,
                                         },
                                     ),
                                 },
                             ),
                         },
-                        span: 87..96,
+                        span: 86..95,
                     },
                 ],
             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals-2.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/escalier_parser/src/stmt_parser.rs
-expression: "parse(\"if (foo) { console.log(foo); };\")"
+expression: "parse(\"if (foo) { console.log(foo) }\")"
 ---
 [
     Stmt {
         kind: Expr {
             expr: IfElse(
                 IfElse {
-                    span: 0..30,
+                    span: 0..29,
                     cond: Ident(
                         Ident {
                             name: "foo",
@@ -15,7 +15,7 @@ expression: "parse(\"if (foo) { console.log(foo); };\")"
                         },
                     ),
                     consequent: Block {
-                        span: 8..30,
+                        span: 8..29,
                         stmts: [
                             Stmt {
                                 kind: Expr {
@@ -58,6 +58,6 @@ expression: "parse(\"if (foo) { console.log(foo); };\")"
                 },
             ),
         },
-        span: 0..30,
+        span: 0..29,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/stmt_parser.rs
-expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
+expression: "parse(\"let max = if (x > y) { x } else { y }\")"
 ---
 [
     Stmt {
@@ -17,7 +17,7 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
             },
             expr: IfElse(
                 IfElse {
-                    span: 10..39,
+                    span: 10..37,
                     cond: Binary(
                         Binary {
                             span: 14..19,
@@ -37,7 +37,7 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
                         },
                     ),
                     consequent: Block {
-                        span: 20..27,
+                        span: 20..26,
                         stmts: [
                             Stmt {
                                 kind: Expr {
@@ -54,18 +54,18 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
                     },
                     alternate: Some(
                         Block {
-                            span: 32..39,
+                            span: 31..37,
                             stmts: [
                                 Stmt {
                                     kind: Expr {
                                         expr: Ident(
                                             Ident {
                                                 name: "y",
-                                                span: 35..36,
+                                                span: 34..35,
                                             },
                                         ),
                                     },
-                                    span: 35..36,
+                                    span: 34..35,
                                 },
                             ],
                         },
@@ -74,6 +74,6 @@ expression: "parse(\"let max = if (x > y) { x; } else { y; };\")"
             ),
             type_ann: None,
         },
-        span: 0..39,
+        span: 0..37,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-2.snap
@@ -1,0 +1,29 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(\"1 \\n+ 2\")"
+---
+[
+    Stmt {
+        kind: Expr {
+            expr: Binary(
+                Binary {
+                    span: 0..6,
+                    left: Num(
+                        Num {
+                            span: 0..1,
+                            value: "1",
+                        },
+                    ),
+                    op: Plus,
+                    right: Num(
+                        Num {
+                            span: 5..6,
+                            value: "2",
+                        },
+                    ),
+                },
+            ),
+        },
+        span: 0..6,
+    },
+]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-3.snap
@@ -1,0 +1,34 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(\"foo\\n.bar()\")"
+---
+[
+    Stmt {
+        kind: Expr {
+            expr: Call(
+                Call {
+                    span: 0..10,
+                    args: [],
+                    callee: Member(
+                        Member {
+                            span: 0..8,
+                            object: Ident(
+                                Ident {
+                                    name: "foo",
+                                    span: 0..3,
+                                },
+                            ),
+                            property: Ident(
+                                Ident {
+                                    name: "bar",
+                                    span: 5..8,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        },
+        span: 0..10,
+    },
+]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-4.snap
@@ -1,0 +1,25 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(\"return\\nfoo()\")"
+---
+[
+    Stmt {
+        kind: Return {
+            arg: Some(
+                Call(
+                    Call {
+                        span: 7..12,
+                        args: [],
+                        callee: Ident(
+                            Ident {
+                                name: "foo",
+                                span: 7..10,
+                            },
+                        ),
+                    },
+                ),
+            ),
+        },
+        span: 7..12,
+    },
+]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference.snap
@@ -1,0 +1,29 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(\"1 + \\n2\")"
+---
+[
+    Stmt {
+        kind: Expr {
+            expr: Binary(
+                Binary {
+                    span: 0..6,
+                    left: Num(
+                        Num {
+                            span: 0..1,
+                            value: "1",
+                        },
+                    ),
+                    op: Plus,
+                    right: Num(
+                        Num {
+                            span: 5..6,
+                            value: "2",
+                        },
+                    ),
+                },
+            ),
+        },
+        span: 0..6,
+    },
+]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners-2.snap
@@ -1,0 +1,108 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(r#\"let add = fn(a, b) => a + b add(5, 10)\"#)"
+---
+[
+    Stmt {
+        kind: Let {
+            pattern: Pattern {
+                span: 4..7,
+                kind: Ident(
+                    BindingIdent {
+                        name: "add",
+                        span: 4..7,
+                        mutable: false,
+                    },
+                ),
+            },
+            expr: Function(
+                Function {
+                    span: 10..27,
+                    params: [
+                        FuncParam {
+                            pattern: Pattern {
+                                span: 13..14,
+                                kind: Ident(
+                                    BindingIdent {
+                                        name: "a",
+                                        span: 13..14,
+                                        mutable: false,
+                                    },
+                                ),
+                            },
+                            type_ann: None,
+                            optional: false,
+                        },
+                        FuncParam {
+                            pattern: Pattern {
+                                span: 16..17,
+                                kind: Ident(
+                                    BindingIdent {
+                                        name: "b",
+                                        span: 16..17,
+                                        mutable: false,
+                                    },
+                                ),
+                            },
+                            type_ann: None,
+                            optional: false,
+                        },
+                    ],
+                    body: Expr(
+                        Binary(
+                            Binary {
+                                span: 22..27,
+                                left: Ident(
+                                    Ident {
+                                        name: "a",
+                                        span: 22..23,
+                                    },
+                                ),
+                                op: Plus,
+                                right: Ident(
+                                    Ident {
+                                        name: "b",
+                                        span: 26..27,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                    type_ann: None,
+                },
+            ),
+            type_ann: None,
+        },
+        span: 0..27,
+    },
+    Stmt {
+        kind: Expr {
+            expr: Call(
+                Call {
+                    span: 28..38,
+                    args: [
+                        Num(
+                            Num {
+                                span: 32..33,
+                                value: "5",
+                            },
+                        ),
+                        Num(
+                            Num {
+                                span: 35..37,
+                                value: "10",
+                            },
+                        ),
+                    ],
+                    callee: Ident(
+                        Ident {
+                            name: "add",
+                            span: 28..31,
+                        },
+                    ),
+                },
+            ),
+        },
+        span: 28..38,
+    },
+]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners.snap
@@ -1,0 +1,40 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(r#\"foo() bar()\"#)"
+---
+[
+    Stmt {
+        kind: Expr {
+            expr: Call(
+                Call {
+                    span: 0..5,
+                    args: [],
+                    callee: Ident(
+                        Ident {
+                            name: "foo",
+                            span: 0..3,
+                        },
+                    ),
+                },
+            ),
+        },
+        span: 0..5,
+    },
+    Stmt {
+        kind: Expr {
+            expr: Call(
+                Call {
+                    span: 6..11,
+                    args: [],
+                    callee: Ident(
+                        Ident {
+                            name: "bar",
+                            span: 6..9,
+                        },
+                    ),
+                },
+            ),
+        },
+        span: 6..11,
+    },
+]

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -43,6 +43,10 @@ impl<'a> Parser<'a> {
                         kind: StmtKind::Return { arg: None },
                         span: merge_spans(&token.span, &next.span),
                     },
+                    TokenKind::Eof => Stmt {
+                        kind: StmtKind::Return { arg: None },
+                        span: token.span,
+                    },
                     _ => {
                         let arg = self.parse_expr();
 
@@ -69,10 +73,6 @@ impl<'a> Parser<'a> {
         let mut stmts = Vec::new();
         while self.peek().unwrap_or(&EOF).kind != TokenKind::Eof {
             stmts.push(self.parse_stmt());
-            assert_eq!(
-                self.next().unwrap_or(EOF.clone()).kind,
-                TokenKind::Semicolon
-            );
         }
         stmts
     }
@@ -89,14 +89,14 @@ mod tests {
 
     #[test]
     fn single_statement() {
-        let input = "let x = 5;";
+        let input = "let x = 5";
         let stmts = parse(input);
         assert_eq!(stmts.len(), 1);
     }
 
     #[test]
     fn single_variable_expression() {
-        let input = "x;";
+        let input = "x";
         let stmts = parse(input);
         assert_eq!(stmts.len(), 1);
     }
@@ -104,10 +104,10 @@ mod tests {
     #[test]
     fn multiple_statements() {
         let input = r#"
-        let x = 5;
-        let y = 10;
-        x + y;
-        return; 
+        let x = 5
+        let y = 10
+        x + y
+        return
         "#;
 
         let stmts = parse(input);
@@ -117,55 +117,69 @@ mod tests {
 
     #[test]
     fn parse_let() {
-        insta::assert_debug_snapshot!(parse(r#"let y = m*x + b;"#));
+        insta::assert_debug_snapshot!(parse(r#"let y = m*x + b"#));
     }
 
     #[test]
     fn parse_let_with_type_annotation() {
-        insta::assert_debug_snapshot!(parse(r#"let y: number = m*x + b;"#));
+        insta::assert_debug_snapshot!(parse(r#"let y: number = m*x + b"#));
     }
 
     #[test]
     fn parse_let_with_destructuring() {
-        insta::assert_debug_snapshot!(parse(r#"let {x, y} = point;"#));
+        insta::assert_debug_snapshot!(parse(r#"let {x, y} = point"#));
     }
 
     #[test]
     fn parse_let_with_destructuring_and_type_annotation() {
-        insta::assert_debug_snapshot!(parse(r#"let {x, y}: Point = point;"#));
+        insta::assert_debug_snapshot!(parse(r#"let {x, y}: Point = point"#));
     }
 
     #[test]
     fn parse_assignment() {
-        insta::assert_debug_snapshot!(parse(r#"y = m*x + b;"#));
-        insta::assert_debug_snapshot!(parse(r#"p.x = 5;"#));
-        insta::assert_debug_snapshot!(parse(r#"p["y"] = 10;"#));
+        insta::assert_debug_snapshot!(parse(r#"y = m*x + b"#));
+        insta::assert_debug_snapshot!(parse(r#"p.x = 5"#));
+        insta::assert_debug_snapshot!(parse(r#"p["y"] = 10"#));
     }
 
     #[test]
     fn parse_conditionals() {
-        insta::assert_debug_snapshot!(parse("let max = if (x > y) { x; } else { y; };"));
-        insta::assert_debug_snapshot!(parse("if (foo) { console.log(foo); };"));
+        insta::assert_debug_snapshot!(parse("let max = if (x > y) { x } else { y }"));
+        insta::assert_debug_snapshot!(parse("if (foo) { console.log(foo) }"));
     }
 
     #[test]
     fn parse_lambda() {
-        insta::assert_debug_snapshot!(parse("let add = fn (x, y) => x + y;"));
-        insta::assert_debug_snapshot!(parse("let add = fn (x) => fn (y) => x + y;"));
+        insta::assert_debug_snapshot!(parse("let add = fn (x, y) => x + y"));
+        insta::assert_debug_snapshot!(parse("let add = fn (x) => fn (y) => x + y"));
     }
 
     #[test]
     fn parse_let_destructuring() {
-        insta::assert_debug_snapshot!(parse("let {x, y} = point;"));
-        insta::assert_debug_snapshot!(parse("let {x: x1, y: y1} = p1;"));
-        insta::assert_debug_snapshot!(parse("let [p1, p2] = line;"));
-        insta::assert_debug_snapshot!(parse("let [head, ...tail] = polygon;"));
+        insta::assert_debug_snapshot!(parse("let {x, y} = point"));
+        insta::assert_debug_snapshot!(parse("let {x: x1, y: y1} = p1"));
+        insta::assert_debug_snapshot!(parse("let [p1, p2] = line"));
+        insta::assert_debug_snapshot!(parse("let [head, ...tail] = polygon"));
     }
 
     #[test]
     fn parse_let_fn_with_fn_type() {
         insta::assert_debug_snapshot!(parse(
-            r#"let add: fn (a: number, b: number) => number = fn (a, b) => a + b;"#
+            r#"let add: fn (a: number, b: number) => number = fn (a, b) => a + b"#
         ));
+    }
+
+    #[test]
+    fn parse_one_liners() {
+        insta::assert_debug_snapshot!(parse(r#"foo() bar()"#));
+        insta::assert_debug_snapshot!(parse(r#"let add = fn(a, b) => a + b add(5, 10)"#));
+    }
+
+    #[test]
+    fn parse_new_line_inference() {
+        insta::assert_debug_snapshot!(parse("1 + \n2"));
+        insta::assert_debug_snapshot!(parse("1 \n+ 2"));
+        insta::assert_debug_snapshot!(parse("foo\n.bar()"));
+        insta::assert_debug_snapshot!(parse("return\nfoo()"));
     }
 }

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -37,12 +37,6 @@ impl<'a> Parser<'a> {
                 self.next(); // consumes 'return'
                 let next = self.peek().unwrap_or(&EOF).clone();
                 match next.kind {
-                    // NOTE: The caller is responsible for consuming the
-                    // semicolon.
-                    TokenKind::Semicolon => Stmt {
-                        kind: StmtKind::Return { arg: None },
-                        span: merge_spans(&token.span, &next.span),
-                    },
                     TokenKind::Eof => Stmt {
                         kind: StmtKind::Return { arg: None },
                         span: token.span,


### PR DESCRIPTION
This will make inline usage of things like `if-else` more ergonomic, e.g.
```
if (cond) { x } else { y }
```

One-liners look a little weird, e.g.
```
foo() bar() baz()
```
instead of
```
foo(); bar(); baz()
```
but that's okay because I don't really use one-liners.