### PR TITLE
Parse type params in functions

### DIFF
--- a/crates/escalier_parser/src/expr.rs
+++ b/crates/escalier_parser/src/expr.rs
@@ -109,8 +109,17 @@ pub struct Unary {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct TypeParam {
+    pub span: Span,
+    pub t: TypeAnn,
+    pub bound: Option<TypeAnn>,
+    pub default: Option<TypeAnn>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Function {
     pub span: Span,
+    pub type_params: Option<Vec<TypeParam>>,
     pub params: Vec<FuncParam>,
     pub body: BlockOrExpr,
     pub type_ann: Option<TypeAnn>, // return type

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_async_await.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_async_await.snap
@@ -5,6 +5,7 @@ expression: "parse(r#\"\n            async fn () => { \n                let x = 
 Function(
     Function {
         span: 13..105,
+        type_params: None,
         params: [],
         body: Block(
             Block {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_callback.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_callback.snap
@@ -23,6 +23,7 @@ Call(
                             Function(
                                 Function {
                                     span: 8..21,
+                                    type_params: None,
                                     params: [
                                         FuncParam {
                                             pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_with_type_params-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_with_type_params-2.snap
@@ -1,0 +1,102 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(\"fn <A, B> (a: A, b: B): A => a\")"
+---
+Function(
+    Function {
+        span: 0..30,
+        type_params: Some(
+            [
+                TypeParam {
+                    span: 5..6,
+                    t: TypeAnn {
+                        kind: TypeRef(
+                            "A",
+                            None,
+                        ),
+                        span: 4..5,
+                    },
+                    bound: None,
+                    default: None,
+                },
+                TypeParam {
+                    span: 8..9,
+                    t: TypeAnn {
+                        kind: TypeRef(
+                            "B",
+                            None,
+                        ),
+                        span: 7..8,
+                    },
+                    bound: None,
+                    default: None,
+                },
+            ],
+        ),
+        params: [
+            FuncParam {
+                pattern: Pattern {
+                    span: 11..12,
+                    kind: Ident(
+                        BindingIdent {
+                            name: "a",
+                            span: 11..12,
+                            mutable: false,
+                        },
+                    ),
+                },
+                type_ann: Some(
+                    TypeAnn {
+                        kind: TypeRef(
+                            "A",
+                            None,
+                        ),
+                        span: 14..15,
+                    },
+                ),
+                optional: false,
+            },
+            FuncParam {
+                pattern: Pattern {
+                    span: 17..18,
+                    kind: Ident(
+                        BindingIdent {
+                            name: "b",
+                            span: 17..18,
+                            mutable: false,
+                        },
+                    ),
+                },
+                type_ann: Some(
+                    TypeAnn {
+                        kind: TypeRef(
+                            "B",
+                            None,
+                        ),
+                        span: 20..21,
+                    },
+                ),
+                optional: false,
+            },
+        ],
+        body: Expr(
+            Ident(
+                Ident {
+                    name: "a",
+                    span: 29..30,
+                },
+            ),
+        ),
+        type_ann: Some(
+            TypeAnn {
+                kind: TypeRef(
+                    "A",
+                    None,
+                ),
+                span: 24..25,
+            },
+        ),
+        is_async: false,
+        is_gen: false,
+    },
+)

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_with_type_params-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_with_type_params-3.snap
@@ -1,0 +1,112 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(\"fn <A: number, B: number> (a: A, b: B): A => a\")"
+---
+Function(
+    Function {
+        span: 0..46,
+        type_params: Some(
+            [
+                TypeParam {
+                    span: 5..14,
+                    t: TypeAnn {
+                        kind: TypeRef(
+                            "A",
+                            None,
+                        ),
+                        span: 4..5,
+                    },
+                    bound: Some(
+                        TypeAnn {
+                            kind: Number,
+                            span: 7..13,
+                        },
+                    ),
+                    default: None,
+                },
+                TypeParam {
+                    span: 16..25,
+                    t: TypeAnn {
+                        kind: TypeRef(
+                            "B",
+                            None,
+                        ),
+                        span: 15..16,
+                    },
+                    bound: Some(
+                        TypeAnn {
+                            kind: Number,
+                            span: 18..24,
+                        },
+                    ),
+                    default: None,
+                },
+            ],
+        ),
+        params: [
+            FuncParam {
+                pattern: Pattern {
+                    span: 27..28,
+                    kind: Ident(
+                        BindingIdent {
+                            name: "a",
+                            span: 27..28,
+                            mutable: false,
+                        },
+                    ),
+                },
+                type_ann: Some(
+                    TypeAnn {
+                        kind: TypeRef(
+                            "A",
+                            None,
+                        ),
+                        span: 30..31,
+                    },
+                ),
+                optional: false,
+            },
+            FuncParam {
+                pattern: Pattern {
+                    span: 33..34,
+                    kind: Ident(
+                        BindingIdent {
+                            name: "b",
+                            span: 33..34,
+                            mutable: false,
+                        },
+                    ),
+                },
+                type_ann: Some(
+                    TypeAnn {
+                        kind: TypeRef(
+                            "B",
+                            None,
+                        ),
+                        span: 36..37,
+                    },
+                ),
+                optional: false,
+            },
+        ],
+        body: Expr(
+            Ident(
+                Ident {
+                    name: "a",
+                    span: 45..46,
+                },
+            ),
+        ),
+        type_ann: Some(
+            TypeAnn {
+                kind: TypeRef(
+                    "A",
+                    None,
+                ),
+                span: 40..41,
+            },
+        ),
+        is_async: false,
+        is_gen: false,
+    },
+)

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_with_type_params.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_with_type_params.snap
@@ -1,0 +1,60 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(\"fn <T> (x: T) => x\")"
+---
+Function(
+    Function {
+        span: 0..18,
+        type_params: Some(
+            [
+                TypeParam {
+                    span: 5..6,
+                    t: TypeAnn {
+                        kind: TypeRef(
+                            "T",
+                            None,
+                        ),
+                        span: 4..5,
+                    },
+                    bound: None,
+                    default: None,
+                },
+            ],
+        ),
+        params: [
+            FuncParam {
+                pattern: Pattern {
+                    span: 8..9,
+                    kind: Ident(
+                        BindingIdent {
+                            name: "x",
+                            span: 8..9,
+                            mutable: false,
+                        },
+                    ),
+                },
+                type_ann: Some(
+                    TypeAnn {
+                        kind: TypeRef(
+                            "T",
+                            None,
+                        ),
+                        span: 11..12,
+                    },
+                ),
+                optional: false,
+            },
+        ],
+        body: Expr(
+            Ident(
+                Ident {
+                    name: "x",
+                    span: 17..18,
+                },
+            ),
+        ),
+        type_ann: None,
+        is_async: false,
+        is_gen: false,
+    },
+)

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn () => { let x = 5 let y = 10 return x + y }\")"
 Function(
     Function {
         span: 0..46,
+        type_params: None,
         params: [],
         body: Block(
             Block {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring.snap
@@ -5,6 +5,7 @@ expression: "parse(r#\"fn ({x, y}) => { return x + y }\"#)"
 Function(
     Function {
         span: 0..31,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring_and_type_annotation.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_destructuring_and_type_annotation.snap
@@ -5,6 +5,7 @@ expression: "parse(r#\"fn ({x, y}: Point): number => { return x + y }\"#)"
 Function(
     Function {
         span: 0..46,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_optional_params.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_optional_params.snap
@@ -5,6 +5,7 @@ expression: "parse(r#\"fn (x: number, y: number, z?: number): number => { return
 Function(
     Function {
         span: 0..65,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_params.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_params.snap
@@ -5,6 +5,7 @@ expression: parse(src)
 Function(
     Function {
         span: 0..29,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_type_annotations.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_with_type_annotations.snap
@@ -5,6 +5,7 @@ expression: "parse(r#\"fn (x: number, y: number): number => { return x + y }\"#)
 Function(
     Function {
         span: 0..53,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (props) => <div>{props.children}</div>\")"
 Function(
     Function {
         span: 0..41,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component_with_fragment.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_functional_component_with_fragment.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (props) => <>{props.children}</>\")"
 Function(
     Function {
         span: 0..35,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_generator_function.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_generator_function.snap
@@ -5,6 +5,7 @@ expression: "parse(r#\"\n            gen fn () => { \n                yield 1\n 
 Function(
     Function {
         span: 13..114,
+        type_params: None,
         params: [],
         body: Block(
             Block {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-2.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (x) => fn (y) => x + y\")"
 Function(
     Function {
         span: 0..25,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {
@@ -25,6 +26,7 @@ Function(
             Function(
                 Function {
                     span: 10..25,
+                    type_params: None,
                     params: [
                         FuncParam {
                             pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas-3.snap
@@ -5,6 +5,7 @@ expression: "parse(r#\"fn (x: number, y: number): number => x + y\"#)"
 Function(
     Function {
         span: 0..42,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_lambdas.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (x, y) => x + y\")"
 Function(
     Function {
         span: 0..18,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring-2.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn ([head, ...tail]) => head\")"
 Function(
     Function {
         span: 0..28,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_param_destructuring.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn ({x, y}) => { return x + y }\")"
 Function(
     Function {
         span: 0..31,
+        type_params: None,
         params: [
             FuncParam {
                 pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings_complex.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings_complex.snap
@@ -39,6 +39,7 @@ StrTemplateLit {
                                     Function(
                                         Function {
                                             span: 17..36,
+                                            type_params: None,
                                             params: [
                                                 FuncParam {
                                                     pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda-2.snap
@@ -18,6 +18,7 @@ expression: "parse(\"let add = fn (x) => fn (y) => x + y\")"
             expr: Function(
                 Function {
                     span: 10..35,
+                    type_params: None,
                     params: [
                         FuncParam {
                             pattern: Pattern {
@@ -38,6 +39,7 @@ expression: "parse(\"let add = fn (x) => fn (y) => x + y\")"
                         Function(
                             Function {
                                 span: 20..35,
+                                type_params: None,
                                 params: [
                                     FuncParam {
                                         pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_lambda.snap
@@ -18,6 +18,7 @@ expression: "parse(\"let add = fn (x, y) => x + y\")"
             expr: Function(
                 Function {
                     span: 10..28,
+                    type_params: None,
                     params: [
                         FuncParam {
                             pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_fn_with_fn_type.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_fn_with_fn_type.snap
@@ -18,6 +18,7 @@ expression: "parse(r#\"let add: fn (a: number, b: number) => number = fn (a, b) 
             expr: Function(
                 Function {
                     span: 47..65,
+                    type_params: None,
                     params: [
                         FuncParam {
                             pattern: Pattern {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners-2.snap
@@ -18,6 +18,7 @@ expression: "parse(r#\"let add = fn(a, b) => a + b add(5, 10)\"#)"
             expr: Function(
                 Function {
                     span: 10..27,
+                    type_params: None,
                     params: [
                         FuncParam {
                             pattern: Pattern {


### PR DESCRIPTION
I'm punting on parsing type args on function calls for now since this requires back tracking and error handling.