### PR TITLE
Parse type args in function calls

### DIFF
--- a/crates/escalier_parser/src/expr.rs
+++ b/crates/escalier_parser/src/expr.rs
@@ -130,8 +130,9 @@ pub struct Function {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Call {
     pub span: Span,
-    pub args: Vec<Expr>,
     pub callee: Box<Expr>,
+    pub type_args: Option<Vec<TypeAnn>>,
+    pub args: Vec<Expr>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/escalier_parser/src/parser.rs
+++ b/crates/escalier_parser/src/parser.rs
@@ -7,10 +7,11 @@ use crate::scanner::Scanner;
 use crate::span::*;
 use crate::token::*;
 
+#[derive(Debug, Clone)]
 pub struct Parser<'a> {
     pub scanner: Scanner<'a>,
     pub brace_counts: Vec<usize>,
-    peeked: Option<Token>,
+    pub peeked: Option<Token>,
 }
 
 impl<'a> Iterator for Parser<'a> {
@@ -33,6 +34,12 @@ impl<'a> Parser<'a> {
             brace_counts: vec![0], // we need separate brace counts for each mode
             peeked: None,
         }
+    }
+
+    pub fn restore(&mut self, backup: Parser<'a>) {
+        self.scanner = backup.scanner;
+        self.brace_counts = backup.brace_counts;
+        self.peeked = backup.peeked;
     }
 
     pub fn peek(&mut self) -> Option<&Token> {

--- a/crates/escalier_parser/src/scanner.rs
+++ b/crates/escalier_parser/src/scanner.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Scanner<'a> {
     cursor: usize,
     column: usize,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_async_await.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_async_await.snap
@@ -29,13 +29,14 @@ Function(
                                     arg: Call(
                                         Call {
                                             span: 61..66,
-                                            args: [],
                                             callee: Ident(
                                                 Ident {
                                                     name: "foo",
                                                     span: 61..64,
                                                 },
                                             ),
+                                            type_args: None,
+                                            args: [],
                                         },
                                     ),
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_call_expr.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_call_expr.snap
@@ -5,20 +5,6 @@ expression: parse(src)
 Call(
     Call {
         span: 0..15,
-        args: [
-            Num(
-                Num {
-                    span: 9..10,
-                    value: "5",
-                },
-            ),
-            Num(
-                Num {
-                    span: 12..14,
-                    value: "10",
-                },
-            ),
-        ],
         callee: Index(
             Index {
                 span: 0..7,
@@ -36,5 +22,20 @@ Call(
                 ),
             },
         ),
+        type_args: None,
+        args: [
+            Num(
+                Num {
+                    span: 9..10,
+                    value: "5",
+                },
+            ),
+            Num(
+                Num {
+                    span: 12..14,
+                    value: "10",
+                },
+            ),
+        ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_callback.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_callback.snap
@@ -5,20 +5,30 @@ expression: "parse(r#\"ids.map(fn (id) => id).join(\", \")\"#)"
 Call(
     Call {
         span: 0..33,
-        args: [
-            Str(
-                Str {
-                    span: 28..32,
-                    value: ", ",
-                },
-            ),
-        ],
         callee: Member(
             Member {
                 span: 0..27,
                 object: Call(
                     Call {
                         span: 0..22,
+                        callee: Member(
+                            Member {
+                                span: 0..7,
+                                object: Ident(
+                                    Ident {
+                                        name: "ids",
+                                        span: 0..3,
+                                    },
+                                ),
+                                property: Ident(
+                                    Ident {
+                                        name: "map",
+                                        span: 4..7,
+                                    },
+                                ),
+                            },
+                        ),
+                        type_args: None,
                         args: [
                             Function(
                                 Function {
@@ -54,23 +64,6 @@ Call(
                                 },
                             ),
                         ],
-                        callee: Member(
-                            Member {
-                                span: 0..7,
-                                object: Ident(
-                                    Ident {
-                                        name: "ids",
-                                        span: 0..3,
-                                    },
-                                ),
-                                property: Ident(
-                                    Ident {
-                                        name: "map",
-                                        span: 4..7,
-                                    },
-                                ),
-                            },
-                        ),
                     },
                 ),
                 property: Ident(
@@ -81,5 +74,14 @@ Call(
                 ),
             },
         ),
+        type_args: None,
+        args: [
+            Str(
+                Str {
+                    span: 28..32,
+                    value: ", ",
+                },
+            ),
+        ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_calls_with_type_args-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_calls_with_type_args-2.snap
@@ -1,0 +1,41 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(r#\"fst<number, string>(5, \"hello\")\"#)"
+---
+Call(
+    Call {
+        span: 0..31,
+        callee: Ident(
+            Ident {
+                name: "fst",
+                span: 0..3,
+            },
+        ),
+        type_args: Some(
+            [
+                TypeAnn {
+                    kind: Number,
+                    span: 4..10,
+                },
+                TypeAnn {
+                    kind: String,
+                    span: 12..18,
+                },
+            ],
+        ),
+        args: [
+            Num(
+                Num {
+                    span: 20..21,
+                    value: "5",
+                },
+            ),
+            Str(
+                Str {
+                    span: 23..30,
+                    value: "hello",
+                },
+            ),
+        ],
+    },
+)

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_calls_with_type_args.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_func_calls_with_type_args.snap
@@ -1,0 +1,31 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(\"id<number>(5)\")"
+---
+Call(
+    Call {
+        span: 0..13,
+        callee: Ident(
+            Ident {
+                name: "id",
+                span: 0..2,
+            },
+        ),
+        type_args: Some(
+            [
+                TypeAnn {
+                    kind: Number,
+                    span: 3..9,
+                },
+            ],
+        ),
+        args: [
+            Num(
+                Num {
+                    span: 11..12,
+                    value: "5",
+                },
+            ),
+        ],
+    },
+)

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-2.snap
@@ -5,17 +5,16 @@ expression: "parse(\"add(5)(10)\")"
 Call(
     Call {
         span: 0..10,
-        args: [
-            Num(
-                Num {
-                    span: 7..9,
-                    value: "10",
-                },
-            ),
-        ],
         callee: Call(
             Call {
                 span: 0..6,
+                callee: Ident(
+                    Ident {
+                        name: "add",
+                        span: 0..3,
+                    },
+                ),
+                type_args: None,
                 args: [
                     Num(
                         Num {
@@ -24,13 +23,16 @@ Call(
                         },
                     ),
                 ],
-                callee: Ident(
-                    Ident {
-                        name: "add",
-                        span: 0..3,
-                    },
-                ),
             },
         ),
+        type_args: None,
+        args: [
+            Num(
+                Num {
+                    span: 7..9,
+                    value: "10",
+                },
+            ),
+        ],
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call-3.snap
@@ -5,6 +5,13 @@ expression: "parse(\"add(obj.x, obj.y)\")"
 Call(
     Call {
         span: 0..17,
+        callee: Ident(
+            Ident {
+                name: "add",
+                span: 0..3,
+            },
+        ),
+        type_args: None,
         args: [
             Member(
                 Member {
@@ -41,11 +48,5 @@ Call(
                 },
             ),
         ],
-        callee: Ident(
-            Ident {
-                name: "add",
-                span: 0..3,
-            },
-        ),
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_function_call.snap
@@ -5,6 +5,13 @@ expression: "parse(\"add(5, 10)\")"
 Call(
     Call {
         span: 0..10,
+        callee: Ident(
+            Ident {
+                name: "add",
+                span: 0..3,
+            },
+        ),
+        type_args: None,
         args: [
             Num(
                 Num {
@@ -19,11 +26,5 @@ Call(
                 },
             ),
         ],
-        callee: Ident(
-            Ident {
-                name: "add",
-                span: 0..3,
-            },
-        ),
     },
 )

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_multiple_application.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_multiple_application.snap
@@ -8,6 +8,20 @@ Binary(
         left: Call(
             Call {
                 span: 0..11,
+                callee: Call(
+                    Call {
+                        span: 0..5,
+                        callee: Ident(
+                            Ident {
+                                name: "foo",
+                                span: 0..3,
+                            },
+                        ),
+                        type_args: None,
+                        args: [],
+                    },
+                ),
+                type_args: None,
                 args: [
                     Binary(
                         Binary {
@@ -28,18 +42,6 @@ Binary(
                         },
                     ),
                 ],
-                callee: Call(
-                    Call {
-                        span: 0..5,
-                        args: [],
-                        callee: Ident(
-                            Ident {
-                                name: "foo",
-                                span: 0..3,
-                            },
-                        ),
-                    },
-                ),
             },
         ),
         op: Times,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_optional_chaining-3.snap
@@ -8,13 +8,14 @@ OptionalChain(
         base: Call(
             Call {
                 span: 0..7,
-                args: [],
                 callee: Ident(
                     Ident {
                         name: "foo",
                         span: 0..3,
                     },
                 ),
+                type_args: None,
+                args: [],
             },
         ),
     },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch.snap
@@ -13,13 +13,14 @@ Try(
                         expr: Call(
                             Call {
                                 span: 35..45,
-                                args: [],
                                 callee: Ident(
                                     Ident {
                                         name: "canThrow",
                                         span: 35..43,
                                     },
                                 ),
+                                type_args: None,
+                                args: [],
                             },
                         ),
                     },
@@ -49,6 +50,24 @@ Try(
                                 expr: Call(
                                     Call {
                                         span: 88..114,
+                                        callee: Member(
+                                            Member {
+                                                span: 88..99,
+                                                object: Ident(
+                                                    Ident {
+                                                        name: "console",
+                                                        span: 88..95,
+                                                    },
+                                                ),
+                                                property: Ident(
+                                                    Ident {
+                                                        name: "log",
+                                                        span: 96..99,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        type_args: None,
                                         args: [
                                             Binary(
                                                 Binary {
@@ -69,23 +88,6 @@ Try(
                                                 },
                                             ),
                                         ],
-                                        callee: Member(
-                                            Member {
-                                                span: 88..99,
-                                                object: Ident(
-                                                    Ident {
-                                                        name: "console",
-                                                        span: 88..95,
-                                                    },
-                                                ),
-                                                property: Ident(
-                                                    Ident {
-                                                        name: "log",
-                                                        span: 96..99,
-                                                    },
-                                                ),
-                                            },
-                                        ),
                                     },
                                 ),
                             },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_catch_finally.snap
@@ -13,13 +13,14 @@ Try(
                         expr: Call(
                             Call {
                                 span: 35..45,
-                                args: [],
                                 callee: Ident(
                                     Ident {
                                         name: "canThrow",
                                         span: 35..43,
                                     },
                                 ),
+                                type_args: None,
+                                args: [],
                             },
                         ),
                     },
@@ -49,6 +50,24 @@ Try(
                                 expr: Call(
                                     Call {
                                         span: 88..114,
+                                        callee: Member(
+                                            Member {
+                                                span: 88..99,
+                                                object: Ident(
+                                                    Ident {
+                                                        name: "console",
+                                                        span: 88..95,
+                                                    },
+                                                ),
+                                                property: Ident(
+                                                    Ident {
+                                                        name: "log",
+                                                        span: 96..99,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        type_args: None,
                                         args: [
                                             Binary(
                                                 Binary {
@@ -69,23 +88,6 @@ Try(
                                                 },
                                             ),
                                         ],
-                                        callee: Member(
-                                            Member {
-                                                span: 88..99,
-                                                object: Ident(
-                                                    Ident {
-                                                        name: "console",
-                                                        span: 88..95,
-                                                    },
-                                                ),
-                                                property: Ident(
-                                                    Ident {
-                                                        name: "log",
-                                                        span: 96..99,
-                                                    },
-                                                ),
-                                            },
-                                        ),
                                     },
                                 ),
                             },
@@ -104,13 +106,14 @@ Try(
                             expr: Call(
                                 Call {
                                     span: 155..164,
-                                    args: [],
                                     callee: Ident(
                                         Ident {
                                             name: "cleanup",
                                             span: 155..162,
                                         },
                                     ),
+                                    type_args: None,
+                                    args: [],
                                 },
                             ),
                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_finally.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_try_finally.snap
@@ -13,13 +13,14 @@ Try(
                         expr: Call(
                             Call {
                                 span: 35..45,
-                                args: [],
                                 callee: Ident(
                                     Ident {
                                         name: "canThrow",
                                         span: 35..43,
                                     },
                                 ),
+                                type_args: None,
+                                args: [],
                             },
                         ),
                     },
@@ -37,13 +38,14 @@ Try(
                             expr: Call(
                                 Call {
                                     span: 86..95,
-                                    args: [],
                                     callee: Ident(
                                         Ident {
                                             name: "cleanup",
                                             span: 86..93,
                                         },
                                     ),
+                                    type_args: None,
+                                    args: [],
                                 },
                             ),
                         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings_complex.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__parser__tests__lex_nested_template_strings_complex.snap
@@ -21,20 +21,30 @@ StrTemplateLit {
         Call(
             Call {
                 span: 9..48,
-                args: [
-                    Str(
-                        Str {
-                            span: 43..47,
-                            value: ", ",
-                        },
-                    ),
-                ],
                 callee: Member(
                     Member {
                         span: 9..42,
                         object: Call(
                             Call {
                                 span: 9..37,
+                                callee: Member(
+                                    Member {
+                                        span: 9..16,
+                                        object: Ident(
+                                            Ident {
+                                                name: "ids",
+                                                span: 9..12,
+                                            },
+                                        ),
+                                        property: Ident(
+                                            Ident {
+                                                name: "map",
+                                                span: 13..16,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                type_args: None,
                                 args: [
                                     Function(
                                         Function {
@@ -87,23 +97,6 @@ StrTemplateLit {
                                         },
                                     ),
                                 ],
-                                callee: Member(
-                                    Member {
-                                        span: 9..16,
-                                        object: Ident(
-                                            Ident {
-                                                name: "ids",
-                                                span: 9..12,
-                                            },
-                                        ),
-                                        property: Ident(
-                                            Ident {
-                                                name: "map",
-                                                span: 13..16,
-                                            },
-                                        ),
-                                    },
-                                ),
                             },
                         ),
                         property: Ident(
@@ -114,6 +107,15 @@ StrTemplateLit {
                         ),
                     },
                 ),
+                type_args: None,
+                args: [
+                    Str(
+                        Str {
+                            span: 43..47,
+                            value: ", ",
+                        },
+                    ),
+                ],
             },
         ),
     ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_conditionals-2.snap
@@ -22,14 +22,6 @@ expression: "parse(\"if (foo) { console.log(foo) }\")"
                                     expr: Call(
                                         Call {
                                             span: 11..27,
-                                            args: [
-                                                Ident(
-                                                    Ident {
-                                                        name: "foo",
-                                                        span: 23..26,
-                                                    },
-                                                ),
-                                            ],
                                             callee: Member(
                                                 Member {
                                                     span: 11..22,
@@ -47,6 +39,15 @@ expression: "parse(\"if (foo) { console.log(foo) }\")"
                                                     ),
                                                 },
                                             ),
+                                            type_args: None,
+                                            args: [
+                                                Ident(
+                                                    Ident {
+                                                        name: "foo",
+                                                        span: 23..26,
+                                                    },
+                                                ),
+                                            ],
                                         },
                                     ),
                                 },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-3.snap
@@ -8,7 +8,6 @@ expression: "parse(\"foo\\n.bar()\")"
             expr: Call(
                 Call {
                     span: 0..10,
-                    args: [],
                     callee: Member(
                         Member {
                             span: 0..8,
@@ -26,6 +25,8 @@ expression: "parse(\"foo\\n.bar()\")"
                             ),
                         },
                     ),
+                    type_args: None,
+                    args: [],
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_new_line_inference-4.snap
@@ -9,13 +9,14 @@ expression: "parse(\"return\\nfoo()\")"
                 Call(
                     Call {
                         span: 7..12,
-                        args: [],
                         callee: Ident(
                             Ident {
                                 name: "foo",
                                 span: 7..10,
                             },
                         ),
+                        type_args: None,
+                        args: [],
                     },
                 ),
             ),

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners-2.snap
@@ -83,6 +83,13 @@ expression: "parse(r#\"let add = fn(a, b) => a + b add(5, 10)\"#)"
             expr: Call(
                 Call {
                     span: 28..38,
+                    callee: Ident(
+                        Ident {
+                            name: "add",
+                            span: 28..31,
+                        },
+                    ),
+                    type_args: None,
                     args: [
                         Num(
                             Num {
@@ -97,12 +104,6 @@ expression: "parse(r#\"let add = fn(a, b) => a + b add(5, 10)\"#)"
                             },
                         ),
                     ],
-                    callee: Ident(
-                        Ident {
-                            name: "add",
-                            span: 28..31,
-                        },
-                    ),
                 },
             ),
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_one_liners.snap
@@ -8,13 +8,14 @@ expression: "parse(r#\"foo() bar()\"#)"
             expr: Call(
                 Call {
                     span: 0..5,
-                    args: [],
                     callee: Ident(
                         Ident {
                             name: "foo",
                             span: 0..3,
                         },
                     ),
+                    type_args: None,
+                    args: [],
                 },
             ),
         },
@@ -25,13 +26,14 @@ expression: "parse(r#\"foo() bar()\"#)"
             expr: Call(
                 Call {
                     span: 6..11,
-                    args: [],
                     callee: Ident(
                         Ident {
                             name: "bar",
                             span: 6..9,
                         },
                     ),
+                    type_args: None,
+                    args: [],
                 },
             ),
         },


### PR DESCRIPTION
This required storing (and restoring) the state of the parser when to resolve conflicts between expression involving less-than and function calls with explicit type args.