### PR TITLE
Adding for getters, setters, and callables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,25 @@
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file"
-  }
+  },
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#d78ab0",
+    "activityBar.background": "#d78ab0",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#4f7729",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#d78ab0",
+    "statusBar.background": "#ca6496",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#bb407c",
+    "statusBarItem.remoteBackground": "#ca6496",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#ca6496",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#ca649699",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#ca6496"
 }

--- a/crates/escalier_ast/src/type_ann.rs
+++ b/crates/escalier_ast/src/type_ann.rs
@@ -7,8 +7,48 @@ use crate::type_param::TypeParam;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ObjectProp {
+    Call(ObjCallable),
+    Constructor(ObjCallable),
+    Method(ObjMethod),
+    Getter(ObjGetter),
+    Setter(ObjSetter),
     Indexer(Indexer),
     Prop(Prop),
+}
+
+// TODO: dedupe with `FunctionType` below
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ObjCallable {
+    pub span: Span,
+    pub type_params: Option<Vec<TypeParam>>,
+    pub params: Vec<FuncParam>,
+    pub ret: Box<TypeAnn>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ObjMethod {
+    pub span: Span,
+    pub name: String, // TODO: allow computed names, e.g. `Symbol.iterator`
+    pub type_params: Option<Vec<TypeParam>>,
+    pub params: Vec<FuncParam>,
+    pub ret: Box<TypeAnn>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ObjGetter {
+    pub span: Span,
+    pub name: String, // TODO: allow computed names, e.g. `Symbol.iterator`
+    // The first param must always be self and there should only be a single param
+    pub params: Vec<FuncParam>,
+    pub ret: Box<TypeAnn>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ObjSetter {
+    pub span: Span,
+    pub name: String, // TODO: allow computed names, e.g. `Symbol.iterator`
+    // The first param must always be self and there should only be two params
+    pub params: Vec<FuncParam>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -216,9 +216,9 @@ pub fn infer_expression(
                     // the type params added to sig_ctx.schemes so that they can
                     // be looked up.
                     unify(arena, &sig_ctx, body_t, ret_t)?;
-                    new_func_type(arena, &func_params, ret_t, type_params)
+                    new_func_type(arena, &func_params, ret_t, &type_params)
                 }
-                None => new_func_type(arena, &func_params, body_t, type_params),
+                None => new_func_type(arena, &func_params, body_t, &type_params),
             }
         }
         ExprKind::IfElse(IfElse {
@@ -445,7 +445,7 @@ pub fn infer_type_ann(
 
             let ret_idx = infer_type_ann(arena, ret.as_mut(), &mut sig_ctx)?;
 
-            new_func_type(arena, &func_params, ret_idx, type_params)
+            new_func_type(arena, &func_params, ret_idx, &type_params)
         }
         TypeAnnKind::NumLit(value) => {
             arena.insert(Type::from(TypeKind::Literal(syntax::Literal::Number(value.to_owned()))))
@@ -848,9 +848,9 @@ pub fn generalize_func(arena: &'_ mut Arena<Type>, func: &types::Function) -> In
     }
 
     if type_params.is_empty() {
-        new_func_type(arena, &params, ret, None)
+        new_func_type(arena, &params, ret, &None)
     } else {
-        new_func_type(arena, &params, ret, Some(type_params))
+        new_func_type(arena, &params, ret, &Some(type_params))
     }
 }
 

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -379,7 +379,7 @@ impl Type {
                                 _ => (),
                             };
                             result.push_str(&format!(
-                                "(self, {}): {}",
+                                "({}): {}",
                                 params_to_strings(arena, params).join(", "),
                                 arena[*ret].as_string(arena)
                             ));
@@ -426,14 +426,20 @@ impl Type {
                                 TPropKey::StringKey(s) => s,
                                 TPropKey::NumberKey(n) => n,
                             };
-                            fields.push(format!("get {name}():{}", arena[*ret].as_string(arena)))
+                            fields.push(format!(
+                                "get {name}(self): {}",
+                                arena[*ret].as_string(arena)
+                            ))
                         }
                         TObjElem::Setter(TSetter { name, param }) => {
                             let name = match name {
                                 TPropKey::StringKey(s) => s,
                                 TPropKey::NumberKey(n) => n,
                             };
-                            fields.push(format!("set {name}({})", param_to_string(arena, param)))
+                            fields.push(format!(
+                                "set {name}(self, {}): undefined",
+                                param_to_string(arena, param)
+                            ))
                         }
                         TObjElem::Index(TIndex { key, mutable, t }) => {
                             let t = arena[*t].as_string(arena);

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -148,6 +148,15 @@ pub enum TPropKey {
     NumberKey(String),
 }
 
+impl fmt::Display for TPropKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TPropKey::StringKey(key) => write!(f, "{key}"),
+            TPropKey::NumberKey(key) => write!(f, "{key}"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TProp {
     pub name: TPropKey,
@@ -574,12 +583,12 @@ pub fn new_func_type(
     arena: &mut Arena<Type>,
     params: &[FuncParam],
     ret: Index,
-    type_params: Option<Vec<TypeParam>>,
+    type_params: &Option<Vec<TypeParam>>,
 ) -> Index {
     arena.insert(Type::from(TypeKind::Function(Function {
         params: params.to_vec(),
         ret: ret.to_owned(),
-        type_params,
+        type_params: type_params.to_owned(),
     })))
 }
 
@@ -705,6 +714,8 @@ impl Type {
                 let t2 = &arena[m2.t];
                 t1.equals(t2, arena)
             }
+            // TODO:
+            // - unification of object and intersection
             _ => false,
         }
     }

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -157,12 +157,32 @@ pub struct TProp {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TCallable {
+    pub params: Vec<FuncParam>,
+    pub ret: Index,
+    pub type_params: Option<Vec<TypeParam>>,
+    // TODO: support mutating callables? ...they'd still need have the same type
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TGetter {
+    pub name: TPropKey,
+    pub ret: Index,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TSetter {
+    pub name: TPropKey,
+    pub param: FuncParam,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TObjElem {
-    // Call(TCallable),
-    // Constructor(TCallable),
+    Call(TCallable),
+    Constructor(TCallable),
     Method(TMethod),
-    // Getter(TGetter),
-    // Setter(TSetter),
+    Getter(TGetter),
+    Setter(TSetter),
     Index(TIndex),
     Prop(TProp),
     // RestSpread - we can use this instead of converting {a, ...x} to {a} & tvar
@@ -294,6 +314,20 @@ impl Type {
                 let mut fields = vec![];
                 for prop in &object.props {
                     match prop {
+                        TObjElem::Constructor(TCallable {
+                            params,
+                            ret,
+                            type_params,
+                        }) => {
+                            todo!()
+                        }
+                        TObjElem::Call(TCallable {
+                            params,
+                            ret,
+                            type_params,
+                        }) => {
+                            todo!()
+                        }
                         TObjElem::Method(TMethod {
                             name,
                             params,
@@ -328,6 +362,12 @@ impl Type {
                                 params_to_strings(arena, params).join(", "),
                                 arena[*ret].as_string(arena)
                             ));
+                        }
+                        TObjElem::Getter(TGetter { name, ret }) => {
+                            todo!()
+                        }
+                        TObjElem::Setter(TSetter { name, param }) => {
+                            todo!()
                         }
                         TObjElem::Index(TIndex { key, mutable, t }) => {
                             let t = arena[*t].as_string(arena);

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -219,6 +219,10 @@ pub fn unify(arena: &mut Arena<Type>, ctx: &Context, t1: Index, t2: Index) -> Re
         (TypeKind::Literal(Lit::Boolean(_)), TypeKind::Keyword(Keyword::Boolean)) => Ok(()),
         (TypeKind::Object(object1), TypeKind::Object(object2)) => {
             // object1 must have atleast as the same properties as object2
+            // This is pretyt inefficient... we should have some way of hashing
+            // each object element so that we can look them.  The problem comes
+            // in with functions where different signatures can expand to be the
+            // same.  Do these kinds of checks is going to be really slow.
             'outer: for prop2 in &object2.props {
                 for prop1 in &object1.props {
                     match (prop1, prop2) {
@@ -249,6 +253,8 @@ pub fn unify(arena: &mut Arena<Type>, ctx: &Context, t1: Index, t2: Index) -> Re
                 // If we haven't found a matching property, then we report an
                 // appropriate type error.
                 match prop2 {
+                    TObjElem::Constructor(_) => todo!(),
+                    TObjElem::Call(_) => todo!(),
                     TObjElem::Method(method) => {
                         let name = match &method.name {
                             TPropKey::NumberKey(name) => name.to_string(),
@@ -259,6 +265,8 @@ pub fn unify(arena: &mut Arena<Type>, ctx: &Context, t1: Index, t2: Index) -> Re
                             a_t.as_string(arena),
                         )));
                     }
+                    TObjElem::Getter(_) => todo!(),
+                    TObjElem::Setter(_) => todo!(),
                     TObjElem::Index(_) => todo!(),
                     TObjElem::Prop(prop) => {
                         let name = match &prop.name {
@@ -570,11 +578,11 @@ pub fn simplify_intersection(arena: &mut Arena<Type>, in_types: &[Index]) -> Ind
         for elem in &obj.props {
             match elem {
                 // What do we do with Call and Index signatures
-                // TObjElem::Call(_) => todo!(),
-                // TObjElem::Constructor(_) => todo!(),
+                TObjElem::Call(_) => todo!(),
+                TObjElem::Constructor(_) => todo!(),
                 TObjElem::Method(_) => todo!(),
-                // TObjElem::Getter(_) => todo!(),
-                // TObjElem::Setter(_) => todo!(),
+                TObjElem::Getter(_) => todo!(),
+                TObjElem::Setter(_) => todo!(),
                 TObjElem::Index(_) => todo!(),
                 TObjElem::Prop(prop) => {
                     let key = match &prop.name {
@@ -610,11 +618,11 @@ pub fn simplify_intersection(arena: &mut Arena<Type>, in_types: &[Index]) -> Ind
         .collect();
     // How do we sort call and index signatures?
     elems.sort_by_key(|elem| match elem {
-        // TObjElem::Call(_) => todo!(),
-        // TObjElem::Constructor(_) => todo!(),
+        TObjElem::Call(_) => todo!(),
+        TObjElem::Constructor(_) => todo!(),
         TObjElem::Method(_) => todo!(),
-        // TObjElem::Getter(_) => todo!(),
-        // TObjElem::Setter(_) => todo!(),
+        TObjElem::Getter(_) => todo!(),
+        TObjElem::Setter(_) => todo!(),
         TObjElem::Index(_) => todo!(),
         TObjElem::Prop(prop) => prop.name.clone(),
     }); // ensure a stable order

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -1,4 +1,5 @@
 use defaultmap::*;
+use escalier_ast::Getter;
 use generational_arena::{Arena, Index};
 use itertools::Itertools;
 use std::collections::BTreeSet;
@@ -219,67 +220,194 @@ pub fn unify(arena: &mut Arena<Type>, ctx: &Context, t1: Index, t2: Index) -> Re
         (TypeKind::Literal(Lit::Boolean(_)), TypeKind::Keyword(Keyword::Boolean)) => Ok(()),
         (TypeKind::Object(object1), TypeKind::Object(object2)) => {
             // object1 must have atleast as the same properties as object2
-            // This is pretyt inefficient... we should have some way of hashing
+            // This is pretty inefficient... we should have some way of hashing
             // each object element so that we can look them.  The problem comes
             // in with functions where different signatures can expand to be the
             // same.  Do these kinds of checks is going to be really slow.
-            'outer: for prop2 in &object2.props {
-                for prop1 in &object1.props {
-                    match (prop1, prop2) {
-                        (TObjElem::Prop(prop1), TObjElem::Prop(prop2))
-                            if prop1.name == prop2.name =>
-                        {
-                            let p1_t = match prop1.optional {
-                                true => {
-                                    let undefined = new_keyword(arena, Keyword::Undefined);
-                                    new_union_type(arena, &[prop1.t, undefined])
-                                }
-                                false => prop1.t,
-                            };
-                            let p2_t = match prop2.optional {
-                                true => {
-                                    let undefined = new_keyword(arena, Keyword::Undefined);
-                                    new_union_type(arena, &[prop2.t, undefined])
-                                }
-                                false => prop2.t,
-                            };
-                            unify(arena, ctx, p1_t, p2_t)?;
-                            continue 'outer;
-                        }
-                        _ => (),
+            // We could also try bucketing the different object element types
+            // to reduce the size of the n^2.
+
+            let mut calls_1: Vec<&TCallable> = vec![];
+            let mut constructors_1: Vec<&TCallable> = vec![];
+            let mut methods_1: Vec<&TMethod> = vec![];
+            let mut getters_1: Vec<&TGetter> = vec![];
+            let mut setters_1: Vec<&TSetter> = vec![];
+            let mut indexes_1: Vec<&TIndex> = vec![];
+            let mut props_1: Vec<&TProp> = vec![];
+
+            let mut calls_2: Vec<&TCallable> = vec![];
+            let mut constructors_2: Vec<&TCallable> = vec![];
+            let mut methods_2: Vec<&TMethod> = vec![];
+            let mut getters_2: Vec<&TGetter> = vec![];
+            let mut setters_2: Vec<&TSetter> = vec![];
+            let mut indexes_2: Vec<&TIndex> = vec![];
+            let mut props_2: Vec<&TProp> = vec![];
+
+            for prop1 in &object1.props {
+                match prop1 {
+                    TObjElem::Call(call) => calls_1.push(call),
+                    TObjElem::Constructor(constructor) => constructors_1.push(constructor),
+                    TObjElem::Method(method) => methods_1.push(method),
+                    TObjElem::Getter(getter) => getters_1.push(getter),
+                    TObjElem::Setter(setter) => setters_1.push(setter),
+                    TObjElem::Index(indexer) => indexes_1.push(indexer),
+                    TObjElem::Prop(prop) => props_1.push(prop),
+                }
+            }
+
+            for prop2 in &object2.props {
+                match prop2 {
+                    TObjElem::Call(call) => calls_2.push(call),
+                    TObjElem::Constructor(constructor) => constructors_2.push(constructor),
+                    TObjElem::Method(method) => methods_2.push(method),
+                    TObjElem::Getter(getter) => getters_2.push(getter),
+                    TObjElem::Setter(setter) => setters_2.push(setter),
+                    TObjElem::Index(indexer) => indexes_2.push(indexer),
+                    TObjElem::Prop(prop) => props_2.push(prop),
+                }
+            }
+
+            // TODO: what about unifying properties with getters, setters, and
+            // methods?
+
+            // object1 must have at least as the same properties as object2
+            'outer: for prop2 in &props_2 {
+                for prop1 in &props_1 {
+                    if prop1.name == prop2.name {
+                        let p1_t = match prop1.optional {
+                            true => {
+                                let undefined = new_keyword(arena, Keyword::Undefined);
+                                new_union_type(arena, &[prop1.t, undefined])
+                            }
+                            false => prop1.t,
+                        };
+                        let p2_t = match prop2.optional {
+                            true => {
+                                let undefined = new_keyword(arena, Keyword::Undefined);
+                                new_union_type(arena, &[prop2.t, undefined])
+                            }
+                            false => prop2.t,
+                        };
+                        unify(arena, ctx, p1_t, p2_t)?;
+                        continue 'outer;
                     }
                 }
 
                 // If we haven't found a matching property, then we report an
                 // appropriate type error.
-                match prop2 {
-                    TObjElem::Constructor(_) => todo!(),
-                    TObjElem::Call(_) => todo!(),
-                    TObjElem::Method(method) => {
-                        let name = match &method.name {
-                            TPropKey::NumberKey(name) => name.to_string(),
-                            TPropKey::StringKey(name) => name.to_string(),
-                        };
-                        return Err(Errors::InferenceError(format!(
-                            "'{name}' is missing in {}",
-                            a_t.as_string(arena),
-                        )));
-                    }
-                    TObjElem::Getter(_) => todo!(),
-                    TObjElem::Setter(_) => todo!(),
-                    TObjElem::Index(_) => todo!(),
-                    TObjElem::Prop(prop) => {
-                        let name = match &prop.name {
-                            TPropKey::NumberKey(name) => name.to_string(),
-                            TPropKey::StringKey(name) => name.to_string(),
-                        };
-                        return Err(Errors::InferenceError(format!(
-                            "'{name}' is missing in {}",
-                            a_t.as_string(arena),
-                        )));
-                    }
-                };
+                return Err(Errors::InferenceError(format!(
+                    "'{}' is missing in {}",
+                    prop2.name,
+                    a_t.as_string(arena),
+                )));
             }
+
+            // object1 must have at least as the same methods as object2
+            'outer: for method2 in &methods_2 {
+                for method1 in &methods_1 {
+                    if method1.name == method2.name {
+                        let fn1 = new_func_type(
+                            arena,
+                            &method1.params,
+                            method1.ret,
+                            &method1.type_params,
+                        );
+                        let fn2 = new_func_type(
+                            arena,
+                            &method2.params,
+                            method2.ret,
+                            &method2.type_params,
+                        );
+                        unify(arena, ctx, fn1, fn2)?;
+                        continue 'outer;
+                    }
+                }
+
+                // If we haven't found a matching property, then we report an
+                // appropriate type error.
+                return Err(Errors::InferenceError(format!(
+                    "'{}' is missing in {}", // TODO: write out the full method
+                    method2.name,
+                    a_t.as_string(arena),
+                )));
+            }
+
+            // object1 must have at least as the same getters as object2
+            'outer: for getter2 in &getters_2 {
+                for getter1 in &getters_1 {
+                    if getter1.name == getter2.name {
+                        unify(arena, ctx, getter1.ret, getter2.ret)?;
+                        continue 'outer;
+                    }
+                }
+
+                // If we haven't found a matching getter, then we report an
+                // appropriate type error.
+                return Err(Errors::InferenceError(format!(
+                    "get '{}' is missing in {}",
+                    getter2.name,
+                    a_t.as_string(arena),
+                )));
+            }
+
+            // object1 must have at least as the same getters as object2
+            'outer: for setter2 in &setters_2 {
+                for setter1 in &setters_1 {
+                    if setter1.name == setter2.name {
+                        // NOTE: the order is reverse here because setter1
+                        // needs to accept at least everything that setter2
+                        // accepts, but could accept more.
+                        unify(arena, ctx, setter2.param.t, setter1.param.t)?;
+                        continue 'outer;
+                    }
+                }
+
+                // If we haven't found a matching getter, then we report an
+                // appropriate type error.
+                return Err(Errors::InferenceError(format!(
+                    "get '{}' is missing in {}",
+                    setter2.name,
+                    a_t.as_string(arena),
+                )));
+            }
+
+            match indexes_2.len() {
+                0 => (),
+                1 => {
+                    match indexes_1.len() {
+                        0 => {
+                            return Err(Errors::InferenceError(format!(
+                                "{} has no indexers but should",
+                                a_t.as_string(arena)
+                            )))
+                        }
+                        1 => {
+                            unify(arena, ctx, indexes_1[0].t, indexes_2[0].t)?;
+                            // NOTE: the order is reverse here because object1
+                            // has to have at least the same keys as object2,
+                            // but it can have more.
+                            unify(arena, ctx, indexes_2[0].key.t, indexes_1[0].key.t)?;
+                        }
+                        _ => {
+                            return Err(Errors::InferenceError(format!(
+                                "{} has multiple indexers",
+                                a_t.as_string(arena)
+                            )))
+                        }
+                    }
+                }
+                _ => {
+                    return Err(Errors::InferenceError(format!(
+                        "{} has multiple indexers",
+                        b_t.as_string(arena)
+                    )))
+                }
+            }
+
+            // TODO:
+            // - call (all calls in object1 must cover the calls in object2)
+            // - constructor (all constructors in object1 must cover the
+            //   constructors in object2)
             Ok(())
         }
         (TypeKind::Object(object1), TypeKind::Intersection(intersection)) => {
@@ -436,7 +564,7 @@ pub fn unify_call(
                     optional: false,
                 })
                 .collect();
-            let call_type = new_func_type(arena, &arg_types, ret_type, None);
+            let call_type = new_func_type(arena, &arg_types, ret_type, &None);
             bind(arena, ctx, b, call_type)?
         }
         TypeKind::Union(Union { types }) => {

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -559,7 +559,6 @@ fn bind(arena: &mut Arena<Type>, ctx: &Context, a: Index, b: Index) -> Result<()
     Ok(())
 }
 
-// TODO: make this recursive
 // TODO: handle optional properties correctly
 // Maybe we can have a function that will canonicalize objects by converting
 // `x: T | undefined` to `x?: T`

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -320,6 +320,7 @@ pub fn get_computed_member(
     }
 }
 
+// TODO(#624) - to behave differently when used to look up an lvalue vs a rvalue
 pub fn get_prop(
     arena: &mut Arena<Type>,
     ctx: &Context,

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -53,6 +53,8 @@ pub trait Visitor: KeyValueStore<Index, Type> {
             .props
             .iter()
             .map(|prop| match prop {
+                TObjElem::Constructor(_) => todo!(),
+                TObjElem::Call(_) => todo!(),
                 TObjElem::Method(method) => {
                     let params = method
                         .params
@@ -68,6 +70,8 @@ pub trait Visitor: KeyValueStore<Index, Type> {
                         ..method.to_owned()
                     })
                 }
+                TObjElem::Getter(_) => todo!(),
+                TObjElem::Setter(_) => todo!(),
                 TObjElem::Index(index) => TObjElem::Index(TIndex {
                     t: self.visit_index(&index.t),
                     ..index.clone()

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -48,30 +48,90 @@ pub trait Visitor: KeyValueStore<Index, Type> {
         lit.clone()
     }
 
+    fn visit_type_param(&mut self, type_param: &TypeParam) -> TypeParam {
+        TypeParam {
+            name: type_param.name.to_owned(),
+            constraint: type_param
+                .constraint
+                .as_ref()
+                .map(|constraint| self.visit_index(constraint)),
+            default: type_param
+                .default
+                .as_ref()
+                .map(|default| self.visit_index(default)),
+        }
+    }
+
+    fn visit_type_params(
+        &mut self,
+        type_params: &Option<Vec<TypeParam>>,
+    ) -> Option<Vec<TypeParam>> {
+        type_params.as_ref().map(|type_params| {
+            type_params
+                .iter()
+                .map(|type_param| self.visit_type_param(type_param))
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn visit_func_param(&mut self, func_param: &FuncParam) -> FuncParam {
+        FuncParam {
+            t: self.visit_index(&func_param.t),
+            ..func_param.to_owned()
+        }
+    }
+
+    fn visit_func_params(&mut self, params: &[FuncParam]) -> Vec<FuncParam> {
+        params
+            .iter()
+            .map(|param| self.visit_func_param(param))
+            .collect::<Vec<_>>()
+    }
+
     fn visit_object(&mut self, obj: &Object) -> Object {
         let props: Vec<_> = obj
             .props
             .iter()
             .map(|prop| match prop {
-                TObjElem::Constructor(_) => todo!(),
-                TObjElem::Call(_) => todo!(),
-                TObjElem::Method(method) => {
-                    let params = method
-                        .params
-                        .iter()
-                        .map(|param| FuncParam {
-                            t: self.visit_index(&param.t),
-                            ..param.to_owned()
-                        })
-                        .collect::<Vec<_>>();
-                    TObjElem::Method(TMethod {
-                        params,
-                        ret: self.visit_index(&method.ret),
-                        ..method.to_owned()
-                    })
-                }
-                TObjElem::Getter(_) => todo!(),
-                TObjElem::Setter(_) => todo!(),
+                TObjElem::Constructor(TCallable {
+                    params,
+                    ret,
+                    type_params,
+                }) => TObjElem::Constructor(TCallable {
+                    params: self.visit_func_params(params),
+                    ret: self.visit_index(ret),
+                    type_params: self.visit_type_params(type_params),
+                }),
+                TObjElem::Call(TCallable {
+                    params,
+                    ret,
+                    type_params,
+                }) => TObjElem::Call(TCallable {
+                    params: self.visit_func_params(params),
+                    ret: self.visit_index(ret),
+                    type_params: self.visit_type_params(type_params),
+                }),
+                TObjElem::Method(TMethod {
+                    name,
+                    params,
+                    ret,
+                    type_params,
+                    is_mutating,
+                }) => TObjElem::Method(TMethod {
+                    name: name.to_owned(),
+                    params: self.visit_func_params(params),
+                    ret: self.visit_index(ret),
+                    type_params: self.visit_type_params(type_params),
+                    is_mutating: *is_mutating,
+                }),
+                TObjElem::Getter(TGetter { name, ret }) => TObjElem::Getter(TGetter {
+                    name: name.to_owned(),
+                    ret: self.visit_index(ret),
+                }),
+                TObjElem::Setter(TSetter { name, param }) => TObjElem::Setter(TSetter {
+                    name: name.to_owned(),
+                    param: self.visit_func_param(param),
+                }),
                 TObjElem::Index(index) => TObjElem::Index(TIndex {
                     t: self.visit_index(&index.t),
                     ..index.clone()
@@ -90,15 +150,14 @@ pub trait Visitor: KeyValueStore<Index, Type> {
         let params = func
             .params
             .iter()
-            .map(|param| FuncParam {
-                t: self.visit_index(&param.t),
-                ..param.to_owned()
-            })
+            .map(|param| self.visit_func_param(param))
             .collect::<Vec<_>>();
+        let ret = self.visit_index(&func.ret);
+        let type_params = self.visit_type_params(&func.type_params);
         Function {
             params,
-            ret: self.visit_index(&func.ret),
-            ..func.clone()
+            ret,
+            type_params,
         }
     }
 

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -838,6 +838,36 @@ fn object_subtyping() -> Result<(), Errors> {
 }
 
 #[test]
+fn object_signatures() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    // Each prop must be a subtype of the expected element type
+    // It's okay to pass an object with extra props
+    let src = r#"
+    declare let obj: {
+        fn (a: number): string,
+        fn foo(a: number): string,
+        fn bar(self, a: number): string,
+        get baz(self): string,
+        set baz(self, value: string): undefined,
+        [key: string]: number,
+        qux: string,
+    }
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    let binding = my_ctx.values.get("obj").unwrap();
+
+    assert_eq!(
+        arena[binding.index].as_string(&arena),
+        "{fn(a: number): string, fn foo(a: number): string, fn bar(self: t9, a: number): string, get baz(self): string, set baz(self, value: string): undefined, [key: string]: number, qux: string}".to_string(),
+    );
+
+    Ok(())
+}
+
+#[test]
 fn object_subtyping_missing_prop() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -503,8 +503,8 @@ fn test_calling_a_union() -> Result<(), Errors> {
 
     let bool = new_keyword(&mut arena, Keyword::Boolean);
     let str = new_keyword(&mut arena, Keyword::String);
-    let fn1 = new_func_type(&mut arena, &[], bool, None);
-    let fn2 = new_func_type(&mut arena, &[], str, None);
+    let fn1 = new_func_type(&mut arena, &[], bool, &None);
+    let fn2 = new_func_type(&mut arena, &[], str, &None);
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -868,6 +868,217 @@ fn object_signatures() -> Result<(), Errors> {
 }
 
 #[test]
+fn object_callable_subtyping() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        fn (self, a: number | string): string,
+    }
+    let bar: {
+        fn (self, a: number): number | string,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+// TODO: This fail, we need to check unify callable siagntures in
+// object types
+#[test]
+#[ignore]
+fn object_callable_subtyping_failure_case() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        fn (self, a: string): string,
+    }
+    let bar: {
+        fn (self, a: number): number,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Err(Errors::InferenceError(
+        "Expected type number, found type string".to_string(),
+    ))
+}
+
+#[test]
+fn object_method_subtyping() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        fn method(self, a: number | string): string,
+    }
+    let bar: {
+        fn method(self, a: number): number | string,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+#[test]
+fn object_property_subtyping() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        fn method(self, a: number): string,
+        x: number,
+        y: boolean,
+    }
+    let bar: {
+        fn method(self, a: number): string,
+        x: number | string,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+#[test]
+fn object_indexer_subtyping() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        [key: string | number]: number,
+    }
+    let bar: {
+        [key: string]: number | string,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+// TODO
+#[test]
+#[ignore]
+fn object_methods_and_properties_should_unify() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        fn foo(self, a: number): string,
+    }
+    let bar: {
+        foo: fn (a: number) => string,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+// TODO
+#[test]
+#[ignore]
+fn object_indexers_and_properties_should_unify() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        x: number,
+        y: number,
+    };
+    let bar: {
+        [key: string]: number,
+    } = foo;
+    "#;
+
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+// TODO
+#[test]
+#[ignore]
+fn object_properties_and_getter_should_unify() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: {
+        fn foo(self, a: number): string,
+    }
+    let bar: {
+        foo: (self, a: number) => string,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+#[test]
+fn mutable_object_properties_unify() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: mut {
+        a: number,
+        b: string,
+    }
+    let bar: mut {
+        a: number,
+        b: string,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+// TODO
+#[test]
+#[ignore]
+fn mutable_object_properties_unify_with_getters_setters() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    declare let foo: mut {
+        x: number,
+    }
+    let bar: mut {
+        get x(self): number,
+        set x(self, value: number): undefined,
+    } = foo
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+#[test]
 fn object_subtyping_missing_prop() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_type_all_sig_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_type_all_sig_types.snap
@@ -1,0 +1,204 @@
+---
+source: crates/escalier_parser/src/type_ann_parser.rs
+expression: result
+---
+TypeAnn {
+    kind: Object(
+        [
+            Call(
+                ObjCallable {
+                    span: 0..0,
+                    type_params: None,
+                    params: [
+                        FuncParam {
+                            pattern: Pattern {
+                                kind: Ident(
+                                    BindingIdent {
+                                        name: "a",
+                                        span: 35..36,
+                                        mutable: false,
+                                    },
+                                ),
+                                span: 35..36,
+                                inferred_type: None,
+                            },
+                            type_ann: Some(
+                                TypeAnn {
+                                    kind: Number,
+                                    span: 38..44,
+                                    inferred_type: None,
+                                },
+                            ),
+                            optional: false,
+                        },
+                    ],
+                    ret: TypeAnn {
+                        kind: String,
+                        span: 47..53,
+                        inferred_type: None,
+                    },
+                },
+            ),
+            Method(
+                ObjMethod {
+                    span: 0..0,
+                    name: "foo",
+                    type_params: None,
+                    params: [
+                        FuncParam {
+                            pattern: Pattern {
+                                kind: Ident(
+                                    BindingIdent {
+                                        name: "a",
+                                        span: 78..79,
+                                        mutable: false,
+                                    },
+                                ),
+                                span: 78..79,
+                                inferred_type: None,
+                            },
+                            type_ann: Some(
+                                TypeAnn {
+                                    kind: Number,
+                                    span: 81..87,
+                                    inferred_type: None,
+                                },
+                            ),
+                            optional: false,
+                        },
+                    ],
+                    ret: TypeAnn {
+                        kind: String,
+                        span: 90..96,
+                        inferred_type: None,
+                    },
+                },
+            ),
+            Method(
+                ObjMethod {
+                    span: 0..0,
+                    name: "bar",
+                    type_params: None,
+                    params: [
+                        FuncParam {
+                            pattern: Pattern {
+                                kind: Ident(
+                                    BindingIdent {
+                                        name: "self",
+                                        span: 121..125,
+                                        mutable: false,
+                                    },
+                                ),
+                                span: 121..125,
+                                inferred_type: None,
+                            },
+                            type_ann: None,
+                            optional: false,
+                        },
+                        FuncParam {
+                            pattern: Pattern {
+                                kind: Ident(
+                                    BindingIdent {
+                                        name: "a",
+                                        span: 127..128,
+                                        mutable: false,
+                                    },
+                                ),
+                                span: 127..128,
+                                inferred_type: None,
+                            },
+                            type_ann: Some(
+                                TypeAnn {
+                                    kind: Number,
+                                    span: 130..136,
+                                    inferred_type: None,
+                                },
+                            ),
+                            optional: false,
+                        },
+                    ],
+                    ret: TypeAnn {
+                        kind: String,
+                        span: 139..145,
+                        inferred_type: None,
+                    },
+                },
+            ),
+            Getter(
+                ObjGetter {
+                    span: 0..0,
+                    name: "baz",
+                    params: [],
+                    ret: TypeAnn {
+                        kind: String,
+                        span: 174..180,
+                        inferred_type: None,
+                    },
+                },
+            ),
+            Setter(
+                ObjSetter {
+                    span: 0..0,
+                    name: "baz",
+                    params: [
+                        FuncParam {
+                            pattern: Pattern {
+                                kind: Ident(
+                                    BindingIdent {
+                                        name: "value",
+                                        span: 206..211,
+                                        mutable: false,
+                                    },
+                                ),
+                                span: 206..211,
+                                inferred_type: None,
+                            },
+                            type_ann: Some(
+                                TypeAnn {
+                                    kind: String,
+                                    span: 213..219,
+                                    inferred_type: None,
+                                },
+                            ),
+                            optional: false,
+                        },
+                    ],
+                },
+            ),
+            Indexer(
+                Indexer {
+                    span: 0..0,
+                    key: IndexerKey {
+                        name: "key",
+                        type_ann: TypeAnn {
+                            kind: String,
+                            span: 255..261,
+                            inferred_type: None,
+                        },
+                    },
+                    mutable: false,
+                    type_ann: TypeAnn {
+                        kind: Number,
+                        span: 264..270,
+                        inferred_type: None,
+                    },
+                },
+            ),
+            Prop(
+                Prop {
+                    span: 0..0,
+                    name: "qux",
+                    optional: false,
+                    mutable: false,
+                    type_ann: TypeAnn {
+                        kind: String,
+                        span: 293..299,
+                        inferred_type: None,
+                    },
+                },
+            ),
+        ],
+    ),
+    span: 0..314,
+    inferred_type: None,
+}


### PR DESCRIPTION
TODO:
- [x] visitors
- [ ] ~simplify_intersection~
- [x] as_string
- [ ] ~(object, object) unification~ this is partially done but there's more edge cases to take care of.  I'll do this in a future PR
- [ ] ~(object, function) unification~
- etc.

I'm going to move (object, function) unification and updating `simplify_intersection` in future PRs