### PR TITLE
Add provenance to Type from TypeAnn and Expr AST nodes

### DIFF
--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -3,6 +3,7 @@ pub mod context;
 pub mod errors;
 pub mod infer;
 mod infer_pattern;
+mod provenance;
 pub mod types;
 mod unify;
 pub mod util;

--- a/crates/escalier_hm/src/provenance.rs
+++ b/crates/escalier_hm/src/provenance.rs
@@ -1,0 +1,13 @@
+use escalier_ast::{Expr, TypeAnn};
+
+use crate::types::Type;
+
+#[derive(Debug, Clone)]
+pub enum Provenance {
+    // from AST
+    Expr(Box<Expr>),
+    TypeAnn(Box<TypeAnn>),
+
+    // from other types
+    Type(Box<Type>),
+}

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -7,6 +7,8 @@ use std::fmt;
 // with source locations when doing type-level stuff.
 use escalier_ast::{BindingIdent, Literal as Lit};
 
+use crate::provenance::Provenance;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Variable {
     pub id: usize,
@@ -285,12 +287,15 @@ pub enum TypeKind {
 #[derive(Debug, Clone)]
 pub struct Type {
     pub kind: TypeKind,
-    // TODO: add `provenance` to support error reporting
+    pub provenance: Option<Provenance>,
 }
 
 impl From<TypeKind> for Type {
     fn from(kind: TypeKind) -> Self {
-        Self { kind }
+        Self {
+            kind,
+            provenance: None,
+        }
     }
 }
 
@@ -793,12 +798,3 @@ fn obj_elem_equals(arena: &Arena<Type>, elem1: &TObjElem, elem2: &TObjElem) -> b
         _ => false,
     }
 }
-
-//impl fmt::Debug for Type {
-//    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-//        match self {
-//            write!(f, "TypeVariable(id = {})", self.id)
-//            write!(f, "TypeOperator(name, )", self.id)
-//        }
-//    }
-//}

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -7,6 +7,7 @@ use escalier_ast::{BindingIdent, Expr, ExprKind, Literal as Lit, Span};
 
 use crate::context::*;
 use crate::errors::*;
+use crate::provenance;
 use crate::types::*;
 use crate::util::*;
 
@@ -676,11 +677,16 @@ pub fn unify_call(
 }
 
 fn bind(arena: &mut Arena<Type>, ctx: &Context, a: Index, b: Index) -> Result<(), Errors> {
-    eprintln!(
-        "bind({:#?}, {:#?})",
-        arena[a].as_string(arena),
-        arena[b].as_string(arena)
-    );
+    eprint!("bind(");
+    eprint!("{:#?}", arena[a].as_string(arena));
+    if let Some(provenance) = &arena[a].provenance {
+        eprint!(" : {:#?}", provenance);
+    }
+    eprint!(", {:#?}", arena[b].as_string(arena));
+    if let Some(provenance) = &arena[b].provenance {
+        eprint!(" : {:#?}", provenance);
+    }
+    eprintln!(")");
 
     if a != b {
         if occurs_in_type(arena, a, b) {

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -12,12 +12,14 @@ pub trait KeyValueStore<K, V> {
 pub trait Visitor: KeyValueStore<Index, Type> {
     fn visit_type_var(&mut self, _: &Variable, idx: &Index) -> Index;
 
-    fn visit_type_ref(&mut self, tref: &Constructor, _: &Index) -> Index {
+    fn visit_type_ref(&mut self, tref: &Constructor, idx: &Index) -> Index {
+        let t = self.get_type(idx).1;
         let t = Type {
             kind: TypeKind::Constructor(Constructor {
                 types: self.visit_indexes(&tref.types),
                 ..tref.to_owned()
             }),
+            provenance: t.provenance,
         };
         self.put_type(t)
     }
@@ -219,7 +221,10 @@ pub trait Visitor: KeyValueStore<Index, Type> {
                 TypeKind::Conditional(self.visit_conditional(conditional))
             }
         };
-        let new_t = Type { kind };
+        let new_t = Type {
+            kind,
+            provenance: t.provenance,
+        };
         self.put_type(new_t)
     }
 


### PR DESCRIPTION
This should come in handy debugging issues with the im(mutable) binding work.  Later it can be used for error reporting and other diagnostics.