### PR TITLE
Add proper mutability checking

### DIFF
--- a/crates/escalier_ast/src/identifier.rs
+++ b/crates/escalier_ast/src/identifier.rs
@@ -1,6 +1,6 @@
 use crate::span::*;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ident {
     pub name: String,
     pub span: Span,

--- a/crates/escalier_ast/src/literal.rs
+++ b/crates/escalier_ast/src/literal.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Literal {
     Number(String),
     String(String),

--- a/crates/escalier_ast/src/type_ann.rs
+++ b/crates/escalier_ast/src/type_ann.rs
@@ -105,7 +105,6 @@ pub enum TypeAnnKind {
     IndexedAccess(Box<TypeAnn>, Box<TypeAnn>),
     KeyOf(Box<TypeAnn>),
     TypeOf(Box<Expr>),
-    Mutable(Box<TypeAnn>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -427,11 +427,7 @@ pub fn infer_type_ann(
                     };
 
                     Ok(types::FuncParam {
-                        pattern: TPat::Ident(BindingIdent {
-                            name: param.pattern.get_name(&i),
-                            mutable: false,
-                            span: Span { start: 0, end: 0 },
-                        }),
+                        pattern: pattern_to_tpat(&param.pattern, true),
                         t,
                         optional: param.optional,
                     })
@@ -769,9 +765,6 @@ pub fn infer_statement(
                         TypeKind::Function(func) if top_level => generalize_func(arena, func),
                         _ => init_idx,
                     };
-
-                    let can_be_mutable =
-                        matches!(&init.kind, ExprKind::Object(_) | ExprKind::Tuple(_));
 
                     let idx = match type_ann {
                         Some(type_ann) => {

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -419,8 +419,7 @@ pub fn infer_type_ann(
 
             let func_params = params
                 .iter_mut()
-                .enumerate()
-                .map(|(i, param)| {
+                .map(|param| {
                     let t = match &mut param.type_ann {
                         Some(type_ann) => infer_type_ann(arena, type_ann, &mut sig_ctx)?,
                         None => new_var_type(arena, None),

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -724,10 +724,6 @@ pub fn infer_type_ann(
             new_indexed_access_type(arena, obj_idx, index_idx)
         }
         TypeAnnKind::TypeOf(expr) => infer_expression(arena, expr, ctx)?,
-        TypeAnnKind::Mutable(type_ann) => {
-            let t = infer_type_ann(arena, type_ann, ctx)?;
-            new_mutable_type(arena, t)
-        }
 
         // TODO: Create types for all of these
         TypeAnnKind::KeyOf(type_ann) => {
@@ -783,15 +779,8 @@ pub fn infer_statement(
 
                             // The initializer must conform to the type annotation's
                             // inferred type.
-                            if can_be_mutable {
-                                let type_ann_idx = match &arena[type_ann_idx].kind {
-                                    TypeKind::Mutable(Mutable { t }) => *t,
-                                    _ => type_ann_idx,
-                                };
-                                unify(arena, ctx, init_idx, type_ann_idx)?;
-                            } else {
-                                unify(arena, ctx, init_idx, type_ann_idx)?;
-                            }
+                            unify(arena, ctx, init_idx, type_ann_idx)?;
+
                             // Results in bindings introduced by the LHS pattern
                             // having their types inferred.
                             // It's okay for pat_type to be the super type here
@@ -1087,10 +1076,6 @@ fn get_ident_member(
                 "Can't find type alias for Array".to_string(),
             )),
         },
-        TypeKind::Mutable(types::Mutable { t, .. }) => {
-            let idx = get_ident_member(arena, ctx, *t, key_idx)?;
-            Ok(new_mutable_type(arena, idx))
-        }
         _ => Err(Errors::InferenceError(format!(
             "Can't access properties on {}",
             obj_type.as_string(arena)

--- a/crates/escalier_hm/src/infer_pattern.rs
+++ b/crates/escalier_hm/src/infer_pattern.rs
@@ -223,25 +223,30 @@ pub fn pattern_to_tpat(pattern: &Pattern, is_func_param: bool) -> TPat {
                     .collect(),
             })
         }
-        PatternKind::Lit(_) => {
+        PatternKind::Lit(LitPat { lit }) => {
             if is_func_param {
                 panic!("Literal patterns not allowed in function params")
             } else {
-                todo!()
+                TPat::Lit(TLitPat {
+                    lit: lit.to_owned(),
+                })
             }
         }
-        PatternKind::Is(_) => {
+        PatternKind::Is(IsPat { ident, is_id }) => {
             if is_func_param {
                 panic!("'is' patterns not allowed in function params")
             } else {
-                todo!()
+                TPat::Is(TIsPat {
+                    ident: ident.name.to_owned(),
+                    is_id: is_id.name.to_owned(),
+                })
             }
         }
         PatternKind::Wildcard => {
             if is_func_param {
                 panic!("Wildcard patterns not allowed in function params")
             } else {
-                todo!()
+                TPat::Wildcard
             }
         }
     }

--- a/crates/escalier_hm/src/infer_pattern.rs
+++ b/crates/escalier_hm/src/infer_pattern.rs
@@ -171,7 +171,7 @@ pub fn infer_pattern(
     Ok((assump, pat_type))
 }
 
-pub fn pattern_to_tpat(pattern: &Pattern) -> TPat {
+pub fn pattern_to_tpat(pattern: &Pattern, is_func_param: bool) -> TPat {
     match &pattern.kind {
         PatternKind::Ident(binding_ident) => TPat::Ident(ast::BindingIdent {
             name: binding_ident.name.to_owned(),
@@ -179,7 +179,7 @@ pub fn pattern_to_tpat(pattern: &Pattern) -> TPat {
             span: Span { start: 0, end: 0 },
         }),
         PatternKind::Rest(e_rest) => TPat::Rest(types::RestPat {
-            arg: Box::from(pattern_to_tpat(e_rest.arg.as_ref())),
+            arg: Box::from(pattern_to_tpat(e_rest.arg.as_ref(), is_func_param)),
         }),
         PatternKind::Object(e_obj) => {
             // TODO: replace TProp with the type equivalent of EFnParamObjectPatProp
@@ -191,7 +191,7 @@ pub fn pattern_to_tpat(pattern: &Pattern) -> TPat {
                         ObjectPatProp::KeyValue(kv) => {
                             types::TObjectPatProp::KeyValue(types::TObjectKeyValuePatProp {
                                 key: kv.key.name.to_owned(),
-                                value: pattern_to_tpat(&kv.value),
+                                value: pattern_to_tpat(&kv.value, is_func_param),
                             })
                         }
                         ObjectPatProp::Shorthand(ShorthandPatProp { ident, .. }) => {
@@ -202,7 +202,7 @@ pub fn pattern_to_tpat(pattern: &Pattern) -> TPat {
                             })
                         }
                         ObjectPatProp::Rest(rest) => types::TObjectPatProp::Rest(types::RestPat {
-                            arg: Box::from(pattern_to_tpat(rest.arg.as_ref())),
+                            arg: Box::from(pattern_to_tpat(rest.arg.as_ref(), is_func_param)),
                         }),
                     }
                 })
@@ -216,12 +216,33 @@ pub fn pattern_to_tpat(pattern: &Pattern) -> TPat {
                 elems: e_array
                     .elems
                     .iter()
-                    .map(|elem| elem.as_ref().map(|elem| pattern_to_tpat(&elem.pattern)))
+                    .map(|elem| {
+                        elem.as_ref()
+                            .map(|elem| pattern_to_tpat(&elem.pattern, is_func_param))
+                    })
                     .collect(),
             })
         }
-        PatternKind::Lit(_) => panic!("Literal patterns not allowed in function params"),
-        PatternKind::Is(_) => panic!("'is' patterns not allowed in function params"),
-        PatternKind::Wildcard => panic!("Wildcard patterns not allowed in function params"),
+        PatternKind::Lit(_) => {
+            if is_func_param {
+                panic!("Literal patterns not allowed in function params")
+            } else {
+                todo!()
+            }
+        }
+        PatternKind::Is(_) => {
+            if is_func_param {
+                panic!("'is' patterns not allowed in function params")
+            } else {
+                todo!()
+            }
+        }
+        PatternKind::Wildcard => {
+            if is_func_param {
+                panic!("Wildcard patterns not allowed in function params")
+            } else {
+                todo!()
+            }
+        }
     }
 }

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 // TODO: create type versions of these so that we don't have to bother
 // with source locations when doing type-level stuff.
-use escalier_ast::{BindingIdent, Ident, Literal as Lit};
+use escalier_ast::{BindingIdent, Literal as Lit};
 
 use crate::provenance::Provenance;
 

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 // TODO: create type versions of these so that we don't have to bother
 // with source locations when doing type-level stuff.
-use escalier_ast::{BindingIdent, Literal as Lit};
+use escalier_ast::{BindingIdent, Ident, Literal as Lit};
 
 use crate::provenance::Provenance;
 
@@ -72,6 +72,9 @@ pub enum TPat {
     Rest(RestPat),
     Tuple(TuplePat),
     Object(TObjectPat),
+    Lit(TLitPat),
+    Is(TIsPat),
+    Wildcard,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -107,6 +110,17 @@ pub struct TObjectKeyValuePatProp {
 pub struct TObjectAssignPatProp {
     pub key: String,
     pub value: Option<Index>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TLitPat {
+    pub lit: Lit,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TIsPat {
+    pub ident: String,
+    pub is_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -599,6 +613,11 @@ fn tpat_to_string(_arena: &Arena<Type>, pattern: &TPat) -> String {
                 .collect();
             format!("{{{}}}", props.join(", "))
         }
+        TPat::Lit(TLitPat { lit }) => lit.to_string(),
+        TPat::Is(TIsPat { ident, is_id }) => {
+            format!("{ident} is {is_id}")
+        }
+        TPat::Wildcard => "_".to_string(),
     }
 }
 

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -277,8 +277,6 @@ pub enum TypeKind {
     Function(Function),
     Object(Object),
     Rest(Rest), // Why is this its own type?
-    // Utility(Utility),
-    Mutable(Mutable), // Should this be moved to `Type` as a field?
     KeyOf(KeyOf),
     IndexedAccess(IndexedAccess),
     Conditional(Conditional),
@@ -515,7 +513,6 @@ impl Type {
                     arena[func.ret].as_string(arena),
                 )
             }
-            TypeKind::Mutable(Mutable { t }) => format!("mut {}", arena[*t].as_string(arena)),
             TypeKind::KeyOf(KeyOf { t }) => format!("keyof {}", arena[*t].as_string(arena)),
             TypeKind::IndexedAccess(IndexedAccess { obj, index }) => format!(
                 "{}[{}]",
@@ -672,10 +669,6 @@ pub fn new_lit_type(arena: &mut Arena<Type>, lit: &Lit) -> Index {
     arena.insert(Type::from(TypeKind::Literal(lit.clone())))
 }
 
-pub fn new_mutable_type(arena: &mut Arena<Type>, t: Index) -> Index {
-    arena.insert(Type::from(TypeKind::Mutable(Mutable { t })))
-}
-
 pub fn new_keyof_type(arena: &mut Arena<Type>, t: Index) -> Index {
     arena.insert(Type::from(TypeKind::KeyOf(KeyOf { t })))
 }
@@ -750,11 +743,6 @@ impl Type {
             (TypeKind::Rest(r1), TypeKind::Rest(r2)) => {
                 let t1 = &arena[r1.arg];
                 let t2 = &arena[r2.arg];
-                t1.equals(t2, arena)
-            }
-            (TypeKind::Mutable(m1), TypeKind::Mutable(m2)) => {
-                let t1 = &arena[m1.t];
-                let t2 = &arena[m2.t];
                 t1.equals(t2, arena)
             }
             // TODO:

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -38,19 +38,6 @@ pub fn unify(arena: &mut Arena<Type>, ctx: &Context, t1: Index, t2: Index) -> Re
         (TypeKind::Variable(_), _) => bind(arena, ctx, a, b),
         (_, TypeKind::Variable(_)) => bind(arena, ctx, b, a),
 
-        (TypeKind::Mutable(Mutable { t: t1 }), TypeKind::Mutable(Mutable { t: t2 })) => {
-            unify_mut(arena, ctx, *t1, *t2)
-        }
-
-        // It's okay to use a mutable reference as if it were immutable
-        (TypeKind::Mutable(Mutable { t: t1 }), _) => unify(arena, ctx, *t1, b),
-
-        (_, TypeKind::Mutable(_)) => Err(Errors::InferenceError(format!(
-            "type mismatch: unify({}, {}) failed",
-            a_t.as_string(arena),
-            b_t.as_string(arena)
-        ))),
-
         (TypeKind::Keyword(kw1), TypeKind::Keyword(kw2)) => {
             if kw1 == kw2 {
                 Ok(())
@@ -654,9 +641,6 @@ pub fn unify_call(
             }
 
             unify(arena, ctx, ret_type, func.ret)?;
-        }
-        TypeKind::Mutable(Mutable { t }) => {
-            unify_call(arena, ctx, args, type_args, t)?;
         }
         TypeKind::KeyOf(KeyOf { t }) => {
             return Err(Errors::InferenceError(format!(

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -3,11 +3,11 @@ use generational_arena::{Arena, Index};
 use itertools::Itertools;
 use std::collections::{BTreeSet, HashMap};
 
-use escalier_ast::{BindingIdent, Expr, ExprKind, Literal as Lit, Span};
+use escalier_ast::{BindingIdent, Expr, Literal as Lit, Span};
 
 use crate::context::*;
 use crate::errors::*;
-use crate::provenance;
+use crate::infer::{check_mutability, infer_expression};
 use crate::types::*;
 use crate::util::*;
 
@@ -539,8 +539,8 @@ fn unify_mut(arena: &mut Arena<Type>, ctx: &Context, t1: Index, t2: Index) -> Re
 // This function unifies and infers the return type of a function call.
 pub fn unify_call(
     arena: &mut Arena<Type>,
-    ctx: &Context,
-    arg_types: &[(&Expr, Index)],
+    ctx: &mut Context,
+    args: &mut [Expr],
     type_args: Option<&[Index]>,
     t2: Index,
 ) -> Result<Index, Errors> {
@@ -551,28 +551,32 @@ pub fn unify_call(
 
     match b_t.kind {
         TypeKind::Variable(_) => {
-            let arg_types: Vec<FuncParam> = arg_types
-                .iter()
+            let arg_types: Vec<FuncParam> = args
+                .iter_mut()
                 .enumerate()
-                .map(|(i, (_, t))| FuncParam {
-                    pattern: TPat::Ident(BindingIdent {
-                        name: format!("arg{i}"),
-                        mutable: false,
-                        // loc: DUMMY_LOC,
-                        span: Span { start: 0, end: 0 },
-                    }),
-                    // name: format!("arg{i}"),
-                    t: *t,
-                    optional: false,
+                .map(|(i, arg)| {
+                    let t = infer_expression(arena, arg, ctx)?;
+                    let param = FuncParam {
+                        pattern: TPat::Ident(BindingIdent {
+                            name: format!("arg{i}"),
+                            mutable: false,
+                            // loc: DUMMY_LOC,
+                            span: Span { start: 0, end: 0 },
+                        }),
+                        // name: format!("arg{i}"),
+                        t,
+                        optional: false,
+                    };
+                    Ok(param)
                 })
-                .collect();
+                .collect::<Result<Vec<_>, _>>()?;
             let call_type = new_func_type(arena, &arg_types, ret_type, &None);
             bind(arena, ctx, b, call_type)?
         }
         TypeKind::Union(Union { types }) => {
             let mut ret_types = vec![];
             for t in types.iter() {
-                let ret_type = unify_call(arena, ctx, arg_types, type_args, *t)?;
+                let ret_type = unify_call(arena, ctx, args, type_args, *t)?;
                 ret_types.push(ret_type);
             }
 
@@ -585,7 +589,7 @@ pub fn unify_call(
             for t in types.iter() {
                 // TODO: if there are multiple overloads that unify, pick the
                 // best one.
-                let result = unify_call(arena, ctx, arg_types, type_args, *t);
+                let result = unify_call(arena, ctx, args, type_args, *t);
                 match result {
                     Ok(ret_type) => return Ok(ret_type),
                     Err(_) => continue,
@@ -624,30 +628,35 @@ pub fn unify_call(
                 func
             };
 
-            if arg_types.len() < func.params.len() {
+            if args.len() < func.params.len() {
                 return Err(Errors::InferenceError(format!(
                     "too few arguments to function: expected {}, got {}",
                     func.params.len(),
-                    arg_types.len()
+                    args.len()
                 )));
             }
 
-            for ((expr, p), q) in arg_types.iter().zip(func.params.iter()) {
-                let can_be_mutable = matches!(&expr.kind, ExprKind::Object(_) | ExprKind::Tuple(_));
-                if can_be_mutable {
-                    let q_t = match &arena[q.t].kind {
-                        TypeKind::Mutable(Mutable { t }) => *t,
-                        _ => q.t,
-                    };
-                    unify(arena, ctx, *p, q_t)?;
-                } else {
-                    unify(arena, ctx, *p, q.t)?;
-                }
+            let arg_types = args
+                .iter_mut()
+                .map(|arg| {
+                    // TODO: handle spreads
+                    let t = infer_expression(arena, arg, ctx)?;
+                    Ok(t)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            for (p, q) in arg_types.iter().zip(func.params.iter()) {
+                unify(arena, ctx, *p, q.t)?;
             }
+
+            for (arg, param) in args.iter().zip(func.params.iter()) {
+                check_mutability(ctx, &param.pattern, arg)?;
+            }
+
             unify(arena, ctx, ret_type, func.ret)?;
         }
         TypeKind::Mutable(Mutable { t }) => {
-            unify_call(arena, ctx, arg_types, type_args, t)?;
+            unify_call(arena, ctx, args, type_args, t)?;
         }
         TypeKind::KeyOf(KeyOf { t }) => {
             return Err(Errors::InferenceError(format!(
@@ -657,7 +666,7 @@ pub fn unify_call(
         }
         TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
             let t = get_prop(arena, ctx, obj, index)?;
-            unify_call(arena, ctx, arg_types, type_args, t)?;
+            unify_call(arena, ctx, args, type_args, t)?;
         }
         TypeKind::Conditional(Conditional {
             check,
@@ -666,8 +675,8 @@ pub fn unify_call(
             false_type,
         }) => {
             match unify(arena, ctx, check, extends) {
-                Ok(_) => unify_call(arena, ctx, arg_types, type_args, true_type)?,
-                Err(_) => unify_call(arena, ctx, arg_types, type_args, false_type)?,
+                Ok(_) => unify_call(arena, ctx, args, type_args, true_type)?,
+                Err(_) => unify_call(arena, ctx, args, type_args, false_type)?,
             };
         }
     }

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -677,16 +677,16 @@ pub fn unify_call(
 }
 
 fn bind(arena: &mut Arena<Type>, ctx: &Context, a: Index, b: Index) -> Result<(), Errors> {
-    eprint!("bind(");
-    eprint!("{:#?}", arena[a].as_string(arena));
-    if let Some(provenance) = &arena[a].provenance {
-        eprint!(" : {:#?}", provenance);
-    }
-    eprint!(", {:#?}", arena[b].as_string(arena));
-    if let Some(provenance) = &arena[b].provenance {
-        eprint!(" : {:#?}", provenance);
-    }
-    eprintln!(")");
+    // eprint!("bind(");
+    // eprint!("{:#?}", arena[a].as_string(arena));
+    // if let Some(provenance) = &arena[a].provenance {
+    //     eprint!(" : {:#?}", provenance);
+    // }
+    // eprint!(", {:#?}", arena[b].as_string(arena));
+    // if let Some(provenance) = &arena[b].provenance {
+    //     eprint!(" : {:#?}", provenance);
+    // }
+    // eprintln!(")");
 
     if a != b {
         if occurs_in_type(arena, a, b) {

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -65,7 +65,6 @@ pub fn occurs_in_type(arena: &mut Arena<Type>, v: Index, type2: Index) -> bool {
         TypeKind::Intersection(Intersection { types }) => occurs_in(arena, v, &types),
         TypeKind::Tuple(Tuple { types }) => occurs_in(arena, v, &types),
         TypeKind::Constructor(Constructor { types, .. }) => occurs_in(arena, v, &types),
-        TypeKind::Mutable(Mutable { t }) => occurs_in_type(arena, v, t),
         TypeKind::KeyOf(KeyOf { t }) => occurs_in_type(arena, v, t),
         TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
             occurs_in_type(arena, v, obj) || occurs_in_type(arena, v, index)
@@ -311,10 +310,6 @@ pub fn get_computed_member(
                 "Can't find type alias for {alias_name}"
             ))),
         },
-        TypeKind::Mutable(Mutable { t, .. }) => {
-            let idx = get_computed_member(arena, ctx, *t, key_idx)?;
-            Ok(new_mutable_type(arena, idx))
-        }
         _ => {
             // TODO: provide a more specific error message for type variables
             Err(Errors::InferenceError(

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -169,12 +169,6 @@ pub trait Visitor: KeyValueStore<Index, Type> {
         }
     }
 
-    fn visit_mutable(&mut self, mutable: &Mutable) -> Mutable {
-        Mutable {
-            t: self.visit_index(&mutable.t),
-        }
-    }
-
     fn visit_keyof(&mut self, keyof: &KeyOf) -> KeyOf {
         KeyOf {
             t: self.visit_index(&keyof.t),
@@ -212,7 +206,6 @@ pub trait Visitor: KeyValueStore<Index, Type> {
             TypeKind::Function(func) => TypeKind::Function(self.visit_function(func)),
             TypeKind::Object(obj) => TypeKind::Object(self.visit_object(obj)),
             TypeKind::Rest(rest) => TypeKind::Rest(self.visit_rest(rest)),
-            TypeKind::Mutable(mutable) => TypeKind::Mutable(self.visit_mutable(mutable)),
             TypeKind::KeyOf(keyof) => TypeKind::KeyOf(self.visit_keyof(keyof)),
             TypeKind::IndexedAccess(indexed_access) => {
                 TypeKind::IndexedAccess(self.visit_indexed_access(indexed_access))

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -3310,6 +3310,54 @@ fn test_mutable_error() -> Result<(), Errors> {
 }
 
 #[test]
+fn test_mutable_error_assignment() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    type Point = {x: number, y: number}
+    let p: Point = {x: 5, y: 10}
+    let mut q = p
+    "#;
+    let mut program = parse(src).unwrap();
+
+    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+
+    assert_eq!(
+        result,
+        Err(Errors::InferenceError(
+            "Can't assign immutable value to mutable binding".to_string()
+        ))
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_mutable_ok_assignments() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    type Point = {x: number, y: number}
+    
+    let main = fn () => {
+        let mut p: Point = {x: 5, y: 10}
+        let mut q = p
+    
+        let p: Point = {x: 5, y: 10}
+        let q = p
+
+        let mut p: Point = {x: 5, y: 10}
+        let q = p
+    }
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
+#[test]
 fn test_sub_objects_are_mutable() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -1998,7 +1998,6 @@ fn test_array_destructuring_assignment_with_rest() -> Result<(), Errors> {
 }
 
 #[test]
-#[ignore = "TODO: make this test pass by update TPat to handle all patterns"]
 fn test_tuple_nested_destrcuturing_assignment() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_var_decls-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_var_decls-4.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/stmt_parser.rs
-expression: "parse(r#\"declare let scale: fn (p: mut Point, scale: number) => void\"#)"
+expression: "parse(r#\"declare let scale: fn (mut p: Point, scale: number) => void\"#)"
 ---
 [
     Stmt {
@@ -30,26 +30,20 @@ expression: "parse(r#\"declare let scale: fn (p: mut Point, scale: number) => vo
                                         kind: Ident(
                                             BindingIdent {
                                                 name: "p",
-                                                span: 23..24,
-                                                mutable: false,
+                                                span: 23..26,
+                                                mutable: true,
                                             },
                                         ),
-                                        span: 23..24,
+                                        span: 23..26,
                                         inferred_type: None,
                                     },
                                     type_ann: Some(
                                         TypeAnn {
-                                            kind: Mutable(
-                                                TypeAnn {
-                                                    kind: TypeRef(
-                                                        "Point",
-                                                        None,
-                                                    ),
-                                                    span: 30..35,
-                                                    inferred_type: None,
-                                                },
+                                            kind: TypeRef(
+                                                "Point",
+                                                None,
                                             ),
-                                            span: 26..29,
+                                            span: 30..35,
                                             inferred_type: None,
                                         },
                                     ),

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -267,7 +267,7 @@ mod tests {
         insta::assert_debug_snapshot!(parse(r#"var i = 0"#));
         insta::assert_debug_snapshot!(parse(r#"var mut p = {x: 5, y: 10}"#));
         insta::assert_debug_snapshot!(parse(
-            r#"declare let scale: fn (p: mut Point, scale: number) => void"#
+            r#"declare let scale: fn (mut p: Point, scale: number) => void"#
         ));
     }
 }

--- a/crates/escalier_parser/src/type_ann_parser.rs
+++ b/crates/escalier_parser/src/type_ann_parser.rs
@@ -317,13 +317,6 @@ impl<'a> Parser<'a> {
 
                 TypeAnnKind::KeyOf(Box::new(type_ann))
             }
-            TokenKind::Mut => {
-                self.next(); // consumes 'mut'
-
-                let type_ann = self.parse_type_ann()?;
-
-                TypeAnnKind::Mutable(Box::new(type_ann))
-            }
             TokenKind::TypeOf => {
                 self.next(); // consumes 'typeof'
 


### PR DESCRIPTION
We only track the mutability of bindings.  Checks are done when inferring `let` statements and unifying function calls.  In the future we'll also check non-let assignments, e.g. `a.x = "foo"`.

TODO:
- [x] expand `TPat` to handle all patterns
- [x] when inferring `declare let`, make sure we handle `mut` modifiers on params in function types