### PR TITLE
use ':' instead of 'extends' everywhere

### DIFF
--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -759,6 +759,8 @@ pub fn infer_type_ann(
             let check_idx = infer_type_ann(arena, check, ctx)?;
             let extends_idx = infer_type_ann(arena, extends, ctx)?;
 
+            let mut true_ctx = ctx.clone();
+
             let infer_types = find_infer_types(arena, &extends_idx);
             for infer in infer_types {
                 let tp = new_var_type(arena, None);
@@ -766,12 +768,12 @@ pub fn infer_type_ann(
                     type_params: None,
                     t: tp,
                 };
-                ctx.schemes.insert(infer.name, scheme);
+                true_ctx.schemes.insert(infer.name, scheme);
                 // QUESTION: Do we need to do something with ctx.non_generic here?
-                // ctx.non_generic.insert(tp);
+                // true_ctx.non_generic.insert(tp);
             }
 
-            let true_idx = infer_type_ann(arena, true_type, ctx)?;
+            let true_idx = infer_type_ann(arena, true_type, &mut true_ctx)?;
             let false_idx = infer_type_ann(arena, false_type, ctx)?;
             new_conditional_type(arena, check_idx, extends_idx, true_idx, false_idx)
         }

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -759,6 +759,8 @@ pub fn infer_type_ann(
             let check_idx = infer_type_ann(arena, check, ctx)?;
             let extends_idx = infer_type_ann(arena, extends, ctx)?;
 
+            // Create a copy of `ctx` so that we can add type aliases to it
+            // without them leaking out of the conditional type.
             let mut true_ctx = ctx.clone();
 
             let infer_types = find_infer_types(arena, &extends_idx);

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -3808,7 +3808,7 @@ fn conditional_type_exclude() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 
     let src = r#"
-    type Exclude<T, U> = if (T extends U) { never } else { T }
+    type Exclude<T, U> = if (T: U) { never } else { T }
     type Result = Exclude<"a" | "b" | "c" | "d" | "e", "a" | "e">
     "#;
     let mut program = parse(src).unwrap();
@@ -3827,9 +3827,9 @@ fn chained_conditional_types() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 
     let src = r#"
-    type Foo<T> = if (T extends string) { 
+    type Foo<T> = if (T: string) { 
         "str"
-    } else if (T extends number) {
+    } else if (T: number) {
         "num"
     } else {
         "?"
@@ -3853,7 +3853,7 @@ fn conditional_type_with_placeholders() -> Result<(), Errors> {
 
     // TODO: introduce a placeholder type that will unify with anything
     let src = r#"
-        type IsArray<T> = if (T extends Array<_>) { true } else { false }
+        type IsArray<T> = if (T: Array<_>) { true } else { false }
         type T = IsArray<Array<number>>
         type F = IsArray<number>
     "#;
@@ -3878,7 +3878,7 @@ fn conditional_type_with_function_subtyping() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
 
     let src = r#"
-        type IsFunction<T> = if (T extends fn (...args: _) => _) { true } else { false }
+        type IsFunction<T> = if (T: fn (...args: _) => _) { true } else { false }
         type T = IsFunction<fn (a: number) => string>
         type F = IsFunction<number>
     "#;
@@ -3904,8 +3904,8 @@ fn return_type_rest_placeholder() -> Result<(), Errors> {
     // TODO: introduce a placeholder type that will unify with anything
     let src = r#"
         type ReturnType<
-            T : fn (...args: _) => _
-        > = if (T extends fn (...args: _) => infer R) { 
+            T: fn (...args: _) => _
+        > = if (T: fn (...args: _) => infer R) { 
             R 
         } else {
             never
@@ -3939,7 +3939,7 @@ fn parameters_utility_type() -> Result<(), Errors> {
 
     let src = r#"
     type Parameters<T : fn (...args: _) => _> = if (
-        T extends fn (...args: infer P) => _
+        T: fn (...args: infer P) => _
     ) { 
         P
     } else { 

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_type_alias-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_type_alias-3.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/stmt_parser.rs
-expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T extends fn (...args: Array<_>) => infer R) { R } else { never }\"#)"
+expression: "parse(r#\"\n            type ReturnType<T: fn (...args: Array<_>) => _> = if (\n                T: fn (...args: Array<_>) => infer R\n            ) { \n                R\n            } else {\n                never \n            }\"#)"
 ---
 [
     Stmt {
@@ -14,7 +14,7 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                 "T",
                                 None,
                             ),
-                            span: 55..56,
+                            span: 84..85,
                             inferred_type: None,
                         },
                         extends: TypeAnn {
@@ -30,16 +30,16 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                                             kind: Ident(
                                                                 BindingIdent {
                                                                     name: "args",
-                                                                    span: 72..76,
+                                                                    span: 94..98,
                                                                     mutable: false,
                                                                 },
                                                             ),
-                                                            span: 72..76,
+                                                            span: 94..98,
                                                             inferred_type: None,
                                                         },
                                                     },
                                                 ),
-                                                span: 69..72,
+                                                span: 91..94,
                                                 inferred_type: None,
                                             },
                                             type_ann: Some(
@@ -50,13 +50,13 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                                             [
                                                                 TypeAnn {
                                                                     kind: Wildcard,
-                                                                    span: 84..85,
+                                                                    span: 106..107,
                                                                     inferred_type: None,
                                                                 },
                                                             ],
                                                         ),
                                                     ),
-                                                    span: 78..86,
+                                                    span: 100..108,
                                                     inferred_type: None,
                                                 },
                                             ),
@@ -67,12 +67,12 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                         kind: Infer(
                                             "R",
                                         ),
-                                        span: 91..96,
+                                        span: 113..118,
                                         inferred_type: None,
                                     },
                                 },
                             ),
-                            span: 65..67,
+                            span: 87..89,
                             inferred_type: None,
                         },
                         true_type: TypeAnn {
@@ -80,23 +80,23 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                 "R",
                                 None,
                             ),
-                            span: 102..103,
+                            span: 154..155,
                             inferred_type: None,
                         },
                         false_type: TypeAnn {
                             kind: Never,
-                            span: 113..118,
+                            span: 193..198,
                             inferred_type: None,
                         },
                     },
                 ),
-                span: 51..53,
+                span: 63..65,
                 inferred_type: None,
             },
             type_params: Some(
                 [
                     TypeParam {
-                        span: 17..48,
+                        span: 30..60,
                         name: "T",
                         bound: Some(
                             TypeAnn {
@@ -112,16 +112,16 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                                                 kind: Ident(
                                                                     BindingIdent {
                                                                         name: "args",
-                                                                        span: 27..31,
+                                                                        span: 39..43,
                                                                         mutable: false,
                                                                     },
                                                                 ),
-                                                                span: 27..31,
+                                                                span: 39..43,
                                                                 inferred_type: None,
                                                             },
                                                         },
                                                     ),
-                                                    span: 24..27,
+                                                    span: 36..39,
                                                     inferred_type: None,
                                                 },
                                                 type_ann: Some(
@@ -132,13 +132,13 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                                                 [
                                                                     TypeAnn {
                                                                         kind: Wildcard,
-                                                                        span: 39..40,
+                                                                        span: 51..52,
                                                                         inferred_type: None,
                                                                     },
                                                                 ],
                                                             ),
                                                         ),
-                                                        span: 33..41,
+                                                        span: 45..53,
                                                         inferred_type: None,
                                                     },
                                                 ),
@@ -147,12 +147,12 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                                         ],
                                         ret: TypeAnn {
                                             kind: Wildcard,
-                                            span: 46..47,
+                                            span: 58..59,
                                             inferred_type: None,
                                         },
                                     },
                                 ),
-                                span: 20..22,
+                                span: 32..34,
                                 inferred_type: None,
                             },
                         ),
@@ -161,7 +161,7 @@ expression: "parse(r#\"type ReturnType<T : fn (...args: Array<_>) => _> = if (T 
                 ],
             ),
         },
-        span: 0..53,
+        span: 13..65,
         inferred_type: None,
     },
 ]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_conditional_type.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_conditional_type.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/type_ann_parser.rs
-expression: "parse(\"if (T extends U) { never } else { T }\")"
+expression: "parse(\"if (T: U) { never } else { T }\")"
 ---
 TypeAnn {
     kind: Condition(
@@ -18,12 +18,12 @@ TypeAnn {
                     "U",
                     None,
                 ),
-                span: 14..15,
+                span: 7..8,
                 inferred_type: None,
             },
             true_type: TypeAnn {
                 kind: Never,
-                span: 19..24,
+                span: 12..17,
                 inferred_type: None,
             },
             false_type: TypeAnn {
@@ -31,7 +31,7 @@ TypeAnn {
                     "T",
                     None,
                 ),
-                span: 34..35,
+                span: 27..28,
                 inferred_type: None,
             },
         },

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -260,7 +260,14 @@ mod tests {
         insta::assert_debug_snapshot!(parse(r#"type Foo = Bar"#));
         insta::assert_debug_snapshot!(parse(r#"type Point<T> = {x: T, y: T}"#));
         insta::assert_debug_snapshot!(parse(
-            r#"type ReturnType<T : fn (...args: Array<_>) => _> = if (T extends fn (...args: Array<_>) => infer R) { R } else { never }"#
+            r#"
+            type ReturnType<T: fn (...args: Array<_>) => _> = if (
+                T: fn (...args: Array<_>) => infer R
+            ) { 
+                R
+            } else {
+                never 
+            }"#
         ))
     }
 

--- a/crates/escalier_parser/src/type_ann_parser.rs
+++ b/crates/escalier_parser/src/type_ann_parser.rs
@@ -517,7 +517,7 @@ impl<'a> Parser<'a> {
             TokenKind::LeftParen
         );
         let check = self.parse_type_ann()?;
-        assert_eq!(self.next().unwrap_or(EOF.clone()).kind, TokenKind::Extends);
+        assert_eq!(self.next().unwrap_or(EOF.clone()).kind, TokenKind::Colon);
         let extends = self.parse_type_ann()?;
         assert_eq!(
             self.next().unwrap_or(EOF.clone()).kind,
@@ -716,7 +716,7 @@ mod tests {
 
     #[test]
     fn parse_conditional_type() {
-        insta::assert_debug_snapshot!(parse("if (T extends U) { never } else { T }"));
+        insta::assert_debug_snapshot!(parse("if (T: U) { never } else { T }"));
     }
 
     #[test]


### PR DESCRIPTION
This PR also makes a minor to how we infer conditional types to preference new type aliases without them leaking out of the conditional type into the surrounding context.