### PR TITLE
Initial support for rest elements in tuple types

### DIFF
--- a/crates/escalier_ast/src/type_ann.rs
+++ b/crates/escalier_ast/src/type_ann.rs
@@ -112,6 +112,7 @@ pub enum TypeAnnKind {
     Intersection(Vec<TypeAnn>),
     IndexedAccess(Box<TypeAnn>, Box<TypeAnn>),
     KeyOf(Box<TypeAnn>),
+    Rest(Box<TypeAnn>),
     TypeOf(Box<Expr>),
     Condition(ConditionType),
     Wildcard,

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -732,6 +732,10 @@ pub fn infer_type_ann(
             }
             new_tuple_type(arena, &idxs)
         }
+        TypeAnnKind::Rest(rest) => {
+            let idx = infer_type_ann(arena, rest, ctx)?;
+            new_rest_type(arena, idx)
+        }
         TypeAnnKind::Array(elem_type) => {
             let idx = infer_type_ann(arena, elem_type, ctx)?;
             new_constructor(arena, "Array", &[idx])

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -749,6 +749,24 @@ fn tuple_subtyping() -> Result<(), Errors> {
     Ok(())
 }
 
+// TODO(#654): update how we unify tuples with arrays and other tuples
+#[test]
+#[ignore]
+fn more_tuple_subtyping() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    let tuple1: [number, ...string[]] = [5]
+    let tuple2: [number, ...string[]] = [5, "hello"]
+    let tuple3: [number, ...string[]] = [5, "hello", "world"]
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+
+    Ok(())
+}
+
 #[test]
 fn tuple_subtyping_not_enough_elements() -> Result<(), Errors> {
     let (mut arena, mut my_ctx) = test_env();
@@ -3948,6 +3966,7 @@ fn parameters_utility_type() -> Result<(), Errors> {
     type P1 = Parameters<fn (a: string, b: number) => boolean>
     type P2 = Parameters<fn (a: string, ...rest: Array<number>) => boolean>
     type P3 = Parameters<fn (a: string, ...rest: [number, boolean]) => boolean>
+    type P4 = Parameters<fn (a: string, ...rest: [number, boolean, ...string[]]) => boolean>
     "#;
 
     let mut program = parse(src).unwrap();
@@ -3966,6 +3985,13 @@ fn parameters_utility_type() -> Result<(), Errors> {
     let t = expand_type(&mut arena, &my_ctx, result.t)?;
     assert_eq!(arena[t].as_string(&arena), r#"[string, number, boolean]"#);
 
+    let result = my_ctx.schemes.get("P4").unwrap();
+    let t = expand_type(&mut arena, &my_ctx, result.t)?;
+    assert_eq!(
+        arena[t].as_string(&arena),
+        r#"[string, number, boolean, ...Array<string>]"#
+    );
+
     Ok(())
 }
 
@@ -3979,6 +4005,9 @@ fn function_subtyping_with_rest_placeholder() -> Result<(), Errors> {
     let many: fn (...args: _) => boolean = fn (a: string, b: number) => true
     let one_req: fn (a: string, ...args: _) => boolean = fn (a: string, b: number) => true
     let array: fn (...args: Array<_>) => boolean = fn (...args: Array<number>) => true
+    let tuple1: fn (...args: [_, _]) => boolean = fn (...args: [number, string]) => true
+    let tuple2: fn (...args: [_, _]) => boolean = fn (a: string, b: number) => true
+    let tuple3: fn (...args: [string, number]) => boolean = fn (a: string, b: number) => true
     "#;
     let mut program = parse(src).unwrap();
 
@@ -4046,6 +4075,24 @@ fn function_multiple_rest_params_function_fails() -> Result<(), Errors> {
             "multiple rest params in function".to_string()
         ))
     );
+
+    Ok(())
+}
+
+// TODO(#653): rest args in function calls
+#[test]
+#[ignore]
+fn function_call_with_spread_args() -> Result<(), Errors> {
+    let (mut arena, mut my_ctx) = test_env();
+
+    let src = r#"
+    let foo = fn (a: number, b: string) => true
+    let args = [5, "hello"]
+    let result = foo(...args)
+    "#;
+    let mut program = parse(src).unwrap();
+
+    infer_program(&mut arena, &mut program, &mut my_ctx)?;
 
     Ok(())
 }

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -3947,6 +3947,7 @@ fn parameters_utility_type() -> Result<(), Errors> {
     }
     type P1 = Parameters<fn (a: string, b: number) => boolean>
     type P2 = Parameters<fn (a: string, ...rest: Array<number>) => boolean>
+    type P3 = Parameters<fn (a: string, ...rest: [number, boolean]) => boolean>
     "#;
 
     let mut program = parse(src).unwrap();
@@ -3959,8 +3960,11 @@ fn parameters_utility_type() -> Result<(), Errors> {
 
     let result = my_ctx.schemes.get("P2").unwrap();
     let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    // TODO: add support for spread types within tuple types
-    assert_eq!(arena[t].as_string(&arena), r#"[string, Array<number>]"#);
+    assert_eq!(arena[t].as_string(&arena), r#"[string, ...Array<number>]"#);
+
+    let result = my_ctx.schemes.get("P3").unwrap();
+    let t = expand_type(&mut arena, &my_ctx, result.t)?;
+    assert_eq!(arena[t].as_string(&arena), r#"[string, number, boolean]"#);
 
     Ok(())
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_tuple_types-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_tuple_types-3.snap
@@ -1,0 +1,34 @@
+---
+source: crates/escalier_parser/src/type_ann_parser.rs
+expression: "parse(\"[number, ...number[]]\")"
+---
+TypeAnn {
+    kind: Tuple(
+        [
+            TypeAnn {
+                kind: Number,
+                span: 1..7,
+                inferred_type: None,
+            },
+            TypeAnn {
+                kind: Rest(
+                    TypeAnn {
+                        kind: Array(
+                            TypeAnn {
+                                kind: Number,
+                                span: 12..18,
+                                inferred_type: None,
+                            },
+                        ),
+                        span: 12..20,
+                        inferred_type: None,
+                    },
+                ),
+                span: 8..20,
+                inferred_type: None,
+            },
+        ],
+    ),
+    span: 0..21,
+    inferred_type: None,
+}


### PR DESCRIPTION
This PR updates the parser to handle rest elements in tuple types and updates `unify()` to handle unifying functions that have rest elements.  It also allows unification of `..._` in a param list with any number of params.  This is used in utility types such as `Parameters<T>` which returns the type of each parameter inside a tuple.