### PR TITLE
Add 'Folder' to replace old types 'Visitor' for most use cases

### DIFF
--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -5,7 +5,7 @@ use im::hashset::HashSet;
 use crate::errors::*;
 use crate::folder::walk_index;
 use crate::folder::{self, Folder};
-use crate::key_value_store::KeyValueStore2;
+use crate::key_value_store::KeyValueStore;
 use crate::types::*;
 use crate::util::*;
 
@@ -57,7 +57,7 @@ struct Fresh<'a> {
     mapping: HashMap<Index, Index>,
 }
 
-impl<'a> KeyValueStore2<Index, Type> for Fresh<'a> {
+impl<'a> KeyValueStore<Index, Type> for Fresh<'a> {
     fn get_type(&mut self, index: &Index) -> Type {
         self.arena[*index].clone()
     }
@@ -116,7 +116,7 @@ pub struct Instantiate<'a> {
     pub mapping: &'a std::collections::HashMap<String, Index>,
 }
 
-impl<'a> KeyValueStore2<Index, Type> for Instantiate<'a> {
+impl<'a> KeyValueStore<Index, Type> for Instantiate<'a> {
     // NOTE: The reason we return both an Index and a Type is that
     // this method calls `prune` which maybe return a different Index
     // from the one passed to it. We need to ensure this method returns

--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -3,9 +3,11 @@ use im::hashmap::HashMap;
 use im::hashset::HashSet;
 
 use crate::errors::*;
+use crate::folder::walk_index;
+use crate::folder::{self, Folder};
+use crate::key_value_store::KeyValueStore2;
 use crate::types::*;
 use crate::util::*;
-use crate::visitor::{KeyValueStore, Visitor};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Binding {
@@ -55,30 +57,38 @@ struct Fresh<'a> {
     mapping: HashMap<Index, Index>,
 }
 
-impl<'a> KeyValueStore<Index, Type> for Fresh<'a> {
-    // NOTE: The reason we return both an Index and a Type is that
-    // this method calls `prune` which maybe return a different Index
-    // from the one passed to it. We need to ensure this method returns
-    // an Index that corresponds to the returned Type.
-    fn get_type(&mut self, idx: &Index) -> (Index, Type) {
-        let idx = prune(self.arena, *idx);
-        let t = self.arena[idx].clone();
-        (idx, t)
+impl<'a> KeyValueStore2<Index, Type> for Fresh<'a> {
+    fn get_type(&mut self, index: &Index) -> Type {
+        self.arena[*index].clone()
     }
     fn put_type(&mut self, t: Type) -> Index {
         self.arena.insert(t)
     }
 }
 
-impl<'a> Visitor for Fresh<'a> {
-    fn visit_type_var(&mut self, _: &Variable, idx: &Index) -> Index {
-        if is_generic(self.arena, *idx, self.ctx) {
-            self.mapping
-                .entry(*idx)
-                .or_insert_with(|| new_var_type(self.arena, None))
-                .to_owned()
-        } else {
-            *idx
+impl<'a> Folder for Fresh<'a> {
+    fn fold_index(&mut self, index: &Index) -> Index {
+        // QUESTION: Why do we need to `prune` here?  Maybe because we don't
+        // copy the `instance` when creating an new type variable.
+        let index = prune(self.arena, *index);
+        let t = self.get_type(&index);
+
+        match &t.kind {
+            TypeKind::Variable(Variable {
+                id: _,
+                instance: _,
+                constraint,
+            }) => {
+                if is_generic(self.arena, index, self.ctx) {
+                    self.mapping
+                        .entry(index)
+                        .or_insert_with(|| new_var_type(self.arena, *constraint))
+                        .to_owned()
+                } else {
+                    index
+                }
+            }
+            _ => walk_index(self, &index),
         }
     }
 }
@@ -98,7 +108,7 @@ pub fn fresh(arena: &mut Arena<Type>, index: Index, ctx: &Context) -> Index {
         mapping: HashMap::default(),
     };
 
-    fresh.visit_index(&index)
+    fresh.fold_index(&index)
 }
 
 pub struct Instantiate<'a> {
@@ -106,46 +116,45 @@ pub struct Instantiate<'a> {
     pub mapping: &'a std::collections::HashMap<String, Index>,
 }
 
-impl<'a> KeyValueStore<Index, Type> for Instantiate<'a> {
+impl<'a> KeyValueStore2<Index, Type> for Instantiate<'a> {
     // NOTE: The reason we return both an Index and a Type is that
     // this method calls `prune` which maybe return a different Index
     // from the one passed to it. We need to ensure this method returns
     // an Index that corresponds to the returned Type.
-    fn get_type(&mut self, idx: &Index) -> (Index, Type) {
-        let idx = prune(self.arena, *idx);
-        let t = self.arena[idx].clone();
-        (idx, t)
+    fn get_type(&mut self, idx: &Index) -> Type {
+        // let idx = prune(self.arena, *idx);
+        self.arena[*idx].clone()
     }
     fn put_type(&mut self, t: Type) -> Index {
         self.arena.insert(t)
     }
 }
 
-impl<'a> Visitor for Instantiate<'a> {
-    fn visit_type_var(&mut self, _: &Variable, idx: &Index) -> Index {
-        // We assume that any type variables were created by instantiate and
-        // thus there is no need to process them further.
-        *idx
-    }
-    // fn visit_wildcard(&mut self, wildcard: &Wildcard, _idx: Index) -> Index {
-    //     new_var_type(self.arena, wildcard.constraint)
-    // }
-    fn visit_type_ref(&mut self, tref: &Constructor, idx: &Index) -> Index {
-        let types = self.visit_indexes(&tref.types);
+impl<'a> Folder for Instantiate<'a> {
+    fn fold_index(&mut self, index: &Index) -> Index {
+        // let index = prune(self.arena, *index);
+        let t = self.get_type(index);
 
-        match self.mapping.get(&tref.name) {
-            Some(idx) => {
-                // What does it mean to replace the constructor name
-                // when it has type args?
-                *idx
-            }
-            None => {
-                if types != tref.types {
-                    new_constructor(self.arena, &tref.name, &types)
-                } else {
-                    *idx
+        match &t.kind {
+            TypeKind::Constructor(Constructor { name, types }) => {
+                let new_types = folder::walk_indexes(self, types);
+
+                match self.mapping.get(name) {
+                    Some(index) => {
+                        // What does it mean to replace the constructor name
+                        // when it has type args?
+                        *index
+                    }
+                    None => {
+                        if &new_types != types {
+                            new_constructor(self.arena, name, &new_types)
+                        } else {
+                            *index
+                        }
+                    }
                 }
             }
+            _ => walk_index(self, index),
         }
     }
 }
@@ -155,9 +164,10 @@ pub fn instantiate_scheme(
     t: Index,
     mapping: &std::collections::HashMap<String, Index>,
 ) -> Index {
-    let mut instantiate = Instantiate { arena, mapping };
-
-    instantiate.visit_index(&t)
+    let mut instantiate2 = Instantiate { arena, mapping };
+    instantiate2.fold_index(&t)
+    // let mut instantiate = Instantiate { arena, mapping };
+    // instantiate.visit_index(&t)
 }
 
 pub fn instantiate_func(
@@ -198,14 +208,14 @@ pub fn instantiate_func(
         .params
         .iter()
         .map(|param| FuncParam {
-            t: instantiate.visit_index(&param.t),
+            t: instantiate.fold_index(&param.t),
             ..param.to_owned()
         })
         .collect::<Vec<_>>();
 
-    let ret = instantiate.visit_index(&func.ret);
+    let ret = instantiate.fold_index(&func.ret);
 
-    let throws = func.throws.map(|t| instantiate.visit_index(&t));
+    let throws = func.throws.map(|t| instantiate.fold_index(&t));
 
     Ok(Function {
         params,

--- a/crates/escalier_hm/src/folder.rs
+++ b/crates/escalier_hm/src/folder.rs
@@ -1,9 +1,9 @@
 use generational_arena::Index;
 
-use crate::key_value_store::KeyValueStore2;
+use crate::key_value_store::KeyValueStore;
 use crate::types::*;
 
-pub trait Folder: KeyValueStore2<Index, Type> + Sized {
+pub trait Folder: KeyValueStore<Index, Type> + Sized {
     fn fold_index(&mut self, index: &Index) -> Index {
         walk_index(self, index)
     }

--- a/crates/escalier_hm/src/folder.rs
+++ b/crates/escalier_hm/src/folder.rs
@@ -1,0 +1,265 @@
+use generational_arena::Index;
+
+use crate::key_value_store::KeyValueStore2;
+use crate::types::*;
+
+pub trait Folder: KeyValueStore2<Index, Type> + Sized {
+    fn fold_index(&mut self, index: &Index) -> Index {
+        walk_index(self, index)
+    }
+}
+
+pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
+    let t = folder.get_type(index);
+
+    let kind = match &t.kind {
+        TypeKind::Variable(Variable {
+            id,
+            instance,
+            constraint,
+        }) => {
+            let new_instance = instance.map(|instance| folder.fold_index(&instance));
+            let new_constraint = constraint.map(|constraint| folder.fold_index(&constraint));
+
+            if new_instance == *instance && new_constraint == *constraint {
+                return *index;
+            }
+
+            // This doesn't seem right. We're creating a new type here, but
+            // the `id` is the same.
+            TypeKind::Variable(Variable {
+                id: *id,
+                instance: new_instance,
+                constraint: new_constraint,
+            })
+        }
+        TypeKind::Constructor(Constructor { name, types }) => {
+            let new_types = walk_indexes(folder, types);
+
+            if new_types == *types {
+                return *index;
+            }
+
+            TypeKind::Constructor(Constructor {
+                name: name.to_owned(),
+                types: new_types,
+            })
+        }
+        TypeKind::Union(Union { types }) => {
+            let new_types = walk_indexes(folder, types);
+
+            if new_types == *types {
+                return *index;
+            }
+
+            TypeKind::Union(Union { types: new_types })
+        }
+        TypeKind::Intersection(Intersection { types }) => {
+            let new_types = walk_indexes(folder, types);
+
+            if new_types == *types {
+                return *index;
+            }
+
+            TypeKind::Intersection(Intersection { types: new_types })
+        }
+        TypeKind::Tuple(Tuple { types }) => {
+            let new_types = walk_indexes(folder, types);
+
+            if new_types == *types {
+                return *index;
+            }
+
+            TypeKind::Tuple(Tuple { types: new_types })
+        }
+        TypeKind::Keyword(_) => return *index,
+        TypeKind::Primitive(_) => return *index,
+        TypeKind::Literal(_) => return *index,
+        TypeKind::Function(Function {
+            params,
+            ret,
+            type_params,
+            throws,
+        }) => {
+            let new_params = walk_func_params(folder, params);
+            let new_ret = folder.fold_index(ret);
+            let new_type_params = walk_type_params(folder, type_params);
+            let new_throws = throws.map(|throws| folder.fold_index(&throws));
+
+            if new_params == *params
+                && new_ret == *ret
+                && new_type_params == *type_params
+                && new_throws == *throws
+            {
+                return *index;
+            }
+
+            TypeKind::Function(Function {
+                params: new_params,
+                ret: new_ret,
+                type_params: new_type_params,
+                throws: new_throws,
+            })
+        }
+        TypeKind::Object(Object { elems }) => {
+            let elems: Vec<_> = elems
+                .iter()
+                .map(|elem| match elem {
+                    TObjElem::Constructor(TCallable {
+                        params,
+                        ret,
+                        type_params,
+                    }) => TObjElem::Constructor(TCallable {
+                        params: walk_func_params(folder, params),
+                        ret: folder.fold_index(ret),
+                        type_params: walk_type_params(folder, type_params),
+                    }),
+                    TObjElem::Call(TCallable {
+                        params,
+                        ret,
+                        type_params,
+                    }) => TObjElem::Call(TCallable {
+                        params: walk_func_params(folder, params),
+                        ret: folder.fold_index(ret),
+                        type_params: walk_type_params(folder, type_params),
+                    }),
+                    TObjElem::Index(index) => TObjElem::Index(TIndex {
+                        t: folder.fold_index(&index.t),
+                        ..index.clone()
+                    }),
+                    TObjElem::Prop(prop) => TObjElem::Prop(TProp {
+                        t: folder.fold_index(&prop.t),
+                        ..prop.clone()
+                    }),
+                })
+                .collect();
+
+            TypeKind::Object(Object { elems })
+        }
+        TypeKind::Rest(Rest { arg }) => {
+            let new_arg = folder.fold_index(arg);
+
+            if new_arg == *arg {
+                return *index;
+            }
+
+            TypeKind::Rest(Rest { arg: new_arg })
+        }
+        TypeKind::KeyOf(KeyOf { t }) => {
+            let new_t = folder.fold_index(t);
+
+            if new_t == *t {
+                return *index;
+            }
+
+            TypeKind::KeyOf(KeyOf { t: new_t })
+        }
+        TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
+            let new_obj = folder.fold_index(obj);
+            let new_index = folder.fold_index(index);
+
+            if new_obj == *obj && new_index == *index {
+                return *index;
+            }
+
+            TypeKind::IndexedAccess(IndexedAccess {
+                obj: new_obj,
+                index: new_index,
+            })
+        }
+        TypeKind::Conditional(Conditional {
+            check,
+            extends,
+            true_type,
+            false_type,
+        }) => {
+            let new_check = folder.fold_index(check);
+            let new_extends = folder.fold_index(extends);
+            let new_true_type = folder.fold_index(true_type);
+            let new_false_type = folder.fold_index(false_type);
+
+            if new_check == *check
+                && new_extends == *extends
+                && new_true_type == *true_type
+                && new_false_type == *false_type
+            {
+                return *index;
+            }
+
+            TypeKind::Conditional(Conditional {
+                check: new_check,
+                extends: new_extends,
+                true_type: new_true_type,
+                false_type: new_false_type,
+            })
+        }
+        TypeKind::Infer(_) => return *index,
+        TypeKind::Wildcard => return *index,
+        TypeKind::Binary(BinaryT { op, left, right }) => {
+            let new_left = folder.fold_index(left);
+            let new_right = folder.fold_index(right);
+
+            if new_left == *left && new_right == *right {
+                return *index;
+            }
+
+            TypeKind::Binary(BinaryT {
+                op: *op,
+                left: new_left,
+                right: new_right,
+            })
+        }
+    };
+
+    folder.put_type(Type {
+        kind,
+        provenance: t.provenance,
+    })
+}
+
+pub fn walk_indexes<F: Folder>(folder: &mut F, indexes: &[Index]) -> Vec<Index> {
+    indexes
+        .iter()
+        .map(|index| folder.fold_index(index))
+        .collect::<Vec<_>>()
+}
+
+fn walk_func_params<F: Folder>(folder: &mut F, params: &[FuncParam]) -> Vec<FuncParam> {
+    params
+        .iter()
+        .map(|param| walk_func_param(folder, param))
+        .collect::<Vec<_>>()
+}
+
+fn walk_func_param<F: Folder>(folder: &mut F, func_param: &FuncParam) -> FuncParam {
+    FuncParam {
+        t: folder.fold_index(&func_param.t),
+        ..func_param.to_owned()
+    }
+}
+
+fn walk_type_params<F: Folder>(
+    folder: &mut F,
+    type_params: &Option<Vec<TypeParam>>,
+) -> Option<Vec<TypeParam>> {
+    type_params.as_ref().map(|type_params| {
+        type_params
+            .iter()
+            .map(|type_param| walk_type_param(folder, type_param))
+            .collect::<Vec<_>>()
+    })
+}
+
+fn walk_type_param<F: Folder>(folder: &mut F, type_param: &TypeParam) -> TypeParam {
+    TypeParam {
+        name: type_param.name.to_owned(),
+        constraint: type_param
+            .constraint
+            .as_ref()
+            .map(|constraint| folder.fold_index(constraint)),
+        default: type_param
+            .default
+            .as_ref()
+            .map(|default| folder.fold_index(default)),
+    }
+}

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -10,7 +10,7 @@ use crate::context::*;
 use crate::errors::*;
 use crate::folder::{self, Folder};
 use crate::infer_pattern::*;
-use crate::key_value_store::KeyValueStore2;
+use crate::key_value_store::KeyValueStore;
 use crate::provenance::Provenance;
 use crate::types::{self, *};
 use crate::unify::*;
@@ -1186,7 +1186,7 @@ struct Generalize<'a> {
     mapping: &'a mut BTreeMap<Index, String>,
 }
 
-impl<'a> KeyValueStore2<Index, Type> for Generalize<'a> {
+impl<'a> KeyValueStore<Index, Type> for Generalize<'a> {
     fn get_type(&mut self, index: &Index) -> Type {
         self.arena[*index].clone()
     }

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -8,12 +8,13 @@ use crate::ast_utils::find_returns;
 use crate::ast_utils::{find_throws, find_throws_in_block};
 use crate::context::*;
 use crate::errors::*;
+use crate::folder::{self, Folder};
 use crate::infer_pattern::*;
+use crate::key_value_store::KeyValueStore2;
 use crate::provenance::Provenance;
 use crate::types::{self, *};
 use crate::unify::*;
 use crate::util::*;
-use crate::visitor::{KeyValueStore, Visitor};
 
 /// Computes the type of the expression given by node.
 ///
@@ -1185,37 +1186,44 @@ struct Generalize<'a> {
     mapping: &'a mut BTreeMap<Index, String>,
 }
 
-impl<'a> KeyValueStore<Index, Type> for Generalize<'a> {
-    // NOTE: The reason we return both an Index and a Type is that
-    // this method calls `prune` which maybe return a different Index
-    // from the one passed to it. We need to ensure this method returns
-    // an Index that corresponds to the returned Type.
-    fn get_type(&mut self, idx: &Index) -> (Index, Type) {
-        let idx = prune(self.arena, *idx);
-        let t = self.arena[idx].clone();
-        (idx, t)
+impl<'a> KeyValueStore2<Index, Type> for Generalize<'a> {
+    fn get_type(&mut self, index: &Index) -> Type {
+        self.arena[*index].clone()
     }
     fn put_type(&mut self, t: Type) -> Index {
         self.arena.insert(t)
     }
 }
 
-impl<'a> Visitor for Generalize<'a> {
-    fn visit_type_var(&mut self, _: &Variable, idx: &Index) -> Index {
-        // Replace with a type reference/constructor
-        let name = match self.mapping.get(idx) {
-            Some(name) => name.clone(),
-            None => {
-                // TODO: create a name generator that can avoid duplicating
-                // names of explicitly provided type params.
-                let name = ((self.mapping.len() as u8) + 65) as char;
-                let name = format!("{}", name);
-                // let name = format!("'{}", mappings.len());
-                self.mapping.insert(*idx, name.clone());
-                name
+impl<'a> Folder for Generalize<'a> {
+    fn fold_index(&mut self, index: &Index) -> Index {
+        // QUESTION: Why do we need to `prune` here?  Maybe because we don't
+        // copy the `instance` when creating an new type variable.
+        let index = prune(self.arena, *index);
+        let t = self.get_type(&index);
+
+        match &t.kind {
+            TypeKind::Variable(Variable {
+                id: _,
+                instance: _,
+                constraint: _,
+            }) => {
+                let name = match self.mapping.get(&index) {
+                    Some(name) => name.clone(),
+                    None => {
+                        // TODO: create a name generator that can avoid duplicating
+                        // names of explicitly provided type params.
+                        let name = ((self.mapping.len() as u8) + 65) as char;
+                        let name = format!("{}", name);
+                        // let name = format!("'{}", mappings.len());
+                        self.mapping.insert(index, name.clone());
+                        name
+                    }
+                };
+                new_constructor(self.arena, &name, &[])
             }
-        };
-        new_constructor(self.arena, &name, &[])
+            _ => folder::walk_index(self, &index),
+        }
     }
 }
 
@@ -1231,12 +1239,12 @@ pub fn generalize_func(arena: &'_ mut Arena<Type>, func: &types::Function) -> In
         .params
         .iter()
         .map(|param| types::FuncParam {
-            t: generalize.visit_index(&param.t),
+            t: generalize.fold_index(&param.t),
             ..param.to_owned()
         })
         .collect::<Vec<_>>();
-    let ret = generalize.visit_index(&func.ret);
-    let throws = func.throws.map(|throws| generalize.visit_index(&throws));
+    let ret = generalize.fold_index(&func.ret);
+    let throws = func.throws.map(|throws| generalize.fold_index(&throws));
 
     let mut type_params: Vec<types::TypeParam> = vec![];
 

--- a/crates/escalier_hm/src/key_value_store.rs
+++ b/crates/escalier_hm/src/key_value_store.rs
@@ -1,9 +1,4 @@
 pub trait KeyValueStore<K, V> {
-    fn get_type(&mut self, idx: &K) -> (K, V);
-    fn put_type(&mut self, t: V) -> K;
-}
-
-pub trait KeyValueStore2<K, V> {
     fn get_type(&mut self, idx: &K) -> V;
     fn put_type(&mut self, t: V) -> K;
 }

--- a/crates/escalier_hm/src/key_value_store.rs
+++ b/crates/escalier_hm/src/key_value_store.rs
@@ -1,0 +1,9 @@
+pub trait KeyValueStore<K, V> {
+    fn get_type(&mut self, idx: &K) -> (K, V);
+    fn put_type(&mut self, t: V) -> K;
+}
+
+pub trait KeyValueStore2<K, V> {
+    fn get_type(&mut self, idx: &K) -> V;
+    fn put_type(&mut self, t: V) -> K;
+}

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -2,8 +2,10 @@
 mod ast_utils;
 pub mod context;
 pub mod errors;
+mod folder;
 pub mod infer;
 mod infer_pattern;
+mod key_value_store;
 mod provenance;
 pub mod types;
 mod unify;

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -590,7 +590,7 @@ impl Type {
                 )
             }
             TypeKind::Infer(Infer { name }) => format!("infer {}", name),
-            TypeKind::Wildcard => format!("_"),
+            TypeKind::Wildcard => "_".to_string(),
             TypeKind::Binary(BinaryT { op, left, right }) => {
                 let op = match op {
                     TBinaryOp::Add => "+",

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -2,12 +2,8 @@ use generational_arena::Index;
 
 use escalier_ast::Literal as Lit;
 
+use crate::key_value_store::KeyValueStore;
 use crate::types::*;
-
-pub trait KeyValueStore<K, V> {
-    fn get_type(&mut self, idx: &K) -> (K, V);
-    fn put_type(&mut self, t: V) -> K;
-}
 
 pub trait Visitor: KeyValueStore<Index, Type> {
     fn visit_type_var(&mut self, _: &Variable, idx: &Index) -> Index;

--- a/crates/escalier_hm/tests/exceptions_test.rs
+++ b/crates/escalier_hm/tests/exceptions_test.rs
@@ -276,7 +276,7 @@ fn throws_coalesces_duplicate_exceptions() -> Result<(), Errors> {
     assert_eq!(
         arena[binding.index].as_string(&arena),
         // TODO: dedupe this
-        r#"(a: number, b: number) -> number throws "DIV_BY_ZERO" | "DIV_BY_ZERO""#
+        r#"(a: number, b: number) -> number throws "DIV_BY_ZERO""#
     );
 
     Ok(())


### PR DESCRIPTION
This PR also updates the `Visitor` in `escalier_hm` to follow the same pattern as the one in `escalier_ast`.