### PR TITLE
Add Checker struct and make existing functions methods on it

### DIFF
--- a/crates/escalier_ast/src/type_ann.rs
+++ b/crates/escalier_ast/src/type_ann.rs
@@ -9,7 +9,6 @@ use crate::type_param::TypeParam;
 pub enum ObjectProp {
     Call(ObjCallable),
     Constructor(ObjCallable),
-    // Indexer(Indexer),
     Prop(Prop),
     Mapped(Mapped),
 }
@@ -39,20 +38,6 @@ pub struct Prop {
     pub mutable: bool,
     pub type_ann: Box<TypeAnn>,
 }
-
-// #[derive(Debug, PartialEq, Eq, Clone)]
-// pub struct IndexerKey {
-//     pub name: String, // TODO: change to Ident
-//     pub type_ann: Box<TypeAnn>,
-// }
-
-// #[derive(Debug, PartialEq, Eq, Clone)]
-// pub struct Indexer {
-//     pub span: Span,
-//     pub key: IndexerKey,
-//     pub mutable: bool,
-//     pub type_ann: Box<TypeAnn>,
-// }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Mapped {

--- a/crates/escalier_hm/src/checker.rs
+++ b/crates/escalier_hm/src/checker.rs
@@ -1,0 +1,7 @@
+use generational_arena::Arena;
+
+use crate::types::Type;
+
+pub struct Checker {
+    pub arena: Arena<Type>,
+}

--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -42,7 +42,7 @@ impl Checker {
     ///         environment.
     pub fn get_type(&mut self, name: &str, ctx: &Context) -> Result<Index, Errors> {
         if let Some(value) = ctx.values.get(name) {
-            let result = fresh(self, value.index, ctx);
+            let result = self.fresh(&value.index, ctx);
             Ok(result)
         } else {
             Err(Errors::InferenceError(format!(
@@ -50,6 +50,92 @@ impl Checker {
                 name
             )))
         }
+    }
+
+    /// Makes a copy of a type expression.
+    ///
+    /// The type t is copied. The the generic variables are duplicated and the
+    /// non_generic variables are shared.
+    ///
+    /// Args:
+    ///     t: A type to be copied.
+    ///     non_generic: A set of non-generic TypeVariables
+    fn fresh(&mut self, index: &Index, ctx: &Context) -> Index {
+        let mut fresh = Fresh {
+            checker: self,
+            ctx,
+            mapping: HashMap::default(),
+        };
+
+        fresh.fold_index(index)
+    }
+
+    // TODO: rename this to `replace_type_vars` or something like that
+    pub fn instantiate_scheme(
+        &mut self,
+        t: &Index,
+        mapping: &std::collections::HashMap<String, Index>,
+    ) -> Index {
+        let mut instantiate = Instantiate {
+            checker: self,
+            mapping,
+        };
+        instantiate.fold_index(t)
+    }
+
+    pub fn instantiate_func(
+        &mut self,
+        func: &Function,
+        type_args: Option<&[Index]>,
+    ) -> Result<Function, Errors> {
+        // A mapping of TypeVariables to TypeVariables
+        let mut mapping = std::collections::HashMap::default();
+
+        if let Some(type_params) = &func.type_params {
+            match type_args {
+                Some(type_args) => {
+                    if type_args.len() != type_params.len() {
+                        return Err(Errors::InferenceError(
+                            "wrong number of type args".to_string(),
+                        ));
+                    }
+
+                    for (tp, ta) in type_params.iter().zip(type_args.iter()) {
+                        mapping.insert(tp.name.to_owned(), *ta);
+                    }
+                }
+                None => {
+                    for tp in type_params {
+                        mapping.insert(tp.name.to_owned(), self.new_var_type(tp.constraint));
+                    }
+                }
+            }
+        }
+
+        let mut instantiate = Instantiate {
+            checker: self,
+            mapping: &mut mapping,
+        };
+
+        let params = func
+            .params
+            .iter()
+            .map(|param| FuncParam {
+                t: instantiate.fold_index(&param.t),
+                ..param.to_owned()
+            })
+            .collect::<Vec<_>>();
+
+        let ret = instantiate.fold_index(&func.ret);
+
+        let throws = func.throws.map(|t| instantiate.fold_index(&t));
+
+        Ok(Function {
+            params,
+            ret,
+            type_params: None,
+            throws,
+        })
     }
 }
 
@@ -86,7 +172,7 @@ impl<'a, 'b> Folder for Fresh<'a, 'b> {
                 if is_generic(self.checker, index, self.ctx) {
                     self.mapping
                         .entry(index)
-                        .or_insert_with(|| new_var_type(&mut self.checker.arena, *constraint))
+                        .or_insert_with(|| self.checker.new_var_type(*constraint))
                         .to_owned()
                 } else {
                     index
@@ -97,26 +183,8 @@ impl<'a, 'b> Folder for Fresh<'a, 'b> {
     }
 }
 
-/// Makes a copy of a type expression.
-///
-/// The type t is copied. The the generic variables are duplicated and the
-/// non_generic variables are shared.
-///
-/// Args:
-///     t: A type to be copied.
-///     non_generic: A set of non-generic TypeVariables
-pub fn fresh(checker: &mut Checker, index: Index, ctx: &Context) -> Index {
-    let mut fresh = Fresh {
-        checker,
-        ctx,
-        mapping: HashMap::default(),
-    };
-
-    fresh.fold_index(&index)
-}
-
 pub struct Instantiate<'a> {
-    pub arena: &'a mut Arena<Type>,
+    pub checker: &'a mut Checker,
     pub mapping: &'a std::collections::HashMap<String, Index>,
 }
 
@@ -127,10 +195,10 @@ impl<'a> KeyValueStore<Index, Type> for Instantiate<'a> {
     // an Index that corresponds to the returned Type.
     fn get_type(&mut self, idx: &Index) -> Type {
         // let idx = prune(self.arena, *idx);
-        self.arena[*idx].clone()
+        self.checker.arena[*idx].clone()
     }
     fn put_type(&mut self, t: Type) -> Index {
-        self.arena.insert(t)
+        self.checker.arena.insert(t)
     }
 }
 
@@ -151,7 +219,7 @@ impl<'a> Folder for Instantiate<'a> {
                     }
                     None => {
                         if &new_types != types {
-                            new_constructor(self.arena, name, &new_types)
+                            self.checker.new_constructor(name, &new_types)
                         } else {
                             *index
                         }
@@ -161,73 +229,6 @@ impl<'a> Folder for Instantiate<'a> {
             _ => walk_index(self, index),
         }
     }
-}
-
-// TODO: rename this to `replace_type_vars` or something like that
-pub fn instantiate_scheme(
-    arena: &mut Arena<Type>,
-    t: Index,
-    mapping: &std::collections::HashMap<String, Index>,
-) -> Index {
-    let mut instantiate2 = Instantiate { arena, mapping };
-    instantiate2.fold_index(&t)
-    // let mut instantiate = Instantiate { arena, mapping };
-    // instantiate.visit_index(&t)
-}
-
-pub fn instantiate_func(
-    arena: &mut Arena<Type>,
-    func: &Function,
-    type_args: Option<&[Index]>,
-) -> Result<Function, Errors> {
-    // A mapping of TypeVariables to TypeVariables
-    let mut mapping = std::collections::HashMap::default();
-
-    if let Some(type_params) = &func.type_params {
-        match type_args {
-            Some(type_args) => {
-                if type_args.len() != type_params.len() {
-                    return Err(Errors::InferenceError(
-                        "wrong number of type args".to_string(),
-                    ));
-                }
-
-                for (tp, ta) in type_params.iter().zip(type_args.iter()) {
-                    mapping.insert(tp.name.to_owned(), *ta);
-                }
-            }
-            None => {
-                for tp in type_params {
-                    mapping.insert(tp.name.to_owned(), new_var_type(arena, tp.constraint));
-                }
-            }
-        }
-    }
-
-    let mut instantiate = Instantiate {
-        arena,
-        mapping: &mut mapping,
-    };
-
-    let params = func
-        .params
-        .iter()
-        .map(|param| FuncParam {
-            t: instantiate.fold_index(&param.t),
-            ..param.to_owned()
-        })
-        .collect::<Vec<_>>();
-
-    let ret = instantiate.fold_index(&func.ret);
-
-    let throws = func.throws.map(|t| instantiate.fold_index(&t));
-
-    Ok(Function {
-        params,
-        ret,
-        type_params: None,
-        throws,
-    })
 }
 
 /// Checks whether a given variable occurs in a list of non-generic variables

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -1234,9 +1234,7 @@ impl Checker {
         key_idx: Index,
     ) -> Result<Index, Errors> {
         // NOTE: cloning is fine here because we aren't mutating `obj_type`
-        let obj_type = self.arena[obj_idx].clone();
-
-        match &obj_type.kind {
+        match &self.arena[obj_idx].kind.clone() {
             TypeKind::Object(_) => self.get_prop(ctx, obj_idx, key_idx),
             // declare let obj: {x: number} | {x: string}
             // obj.x; // number | string
@@ -1291,7 +1289,7 @@ impl Checker {
             },
             _ => Err(Errors::InferenceError(format!(
                 "Can't access properties on {}",
-                obj_type.as_string(&self.arena)
+                self.print_type(&obj_idx)
             ))),
         }
     }

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -1,4 +1,4 @@
-use generational_arena::{Arena, Index};
+use generational_arena::Index;
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashSet};
 
@@ -6,6 +6,7 @@ use escalier_ast::{self as syntax, *};
 
 use crate::ast_utils::find_returns;
 use crate::ast_utils::{find_throws, find_throws_in_block};
+use crate::checker::Checker;
 use crate::context::*;
 use crate::errors::*;
 use crate::folder::{self, Folder};
@@ -13,616 +14,1345 @@ use crate::infer_pattern::*;
 use crate::key_value_store::KeyValueStore;
 use crate::provenance::Provenance;
 use crate::types::{self, *};
-use crate::unify::*;
 use crate::util::*;
 
-/// Computes the type of the expression given by node.
-///
-/// The type of the node is computed in the context of the
-/// supplied type environment env. Data types can be introduced into the
-/// language simply by having a predefined set of identifiers in the initial
-/// environment. environment; this way there is no need to change the syntax or, more
-/// importantly, the type-checking program when extending the language.
-///
-/// Args:
-///     node: The root of the abstract syntax tree.
-///     env: The type environment is a mapping of expression identifier names
-///         to type assignments.
-///     non_generic: A set of non-generic variables, or None
-///
-/// Returns:
-///     The computed type of the expression.
-///
-/// Raises:
-///     InferenceError: The type of the expression could not be inferred, for example
-///         if it is not possible to unify two types such as Integer and Bool
-///     ParseError: The abstract syntax tree rooted at node could not be parsed
-pub fn infer_expression(
-    arena: &mut Arena<Type>,
-    node: &mut Expr,
-    ctx: &mut Context,
-) -> Result<Index, Errors> {
-    let idx: Index = match &mut node.kind {
-        ExprKind::Ident(Ident { name, .. }) => get_type(arena, name, ctx)?,
-        ExprKind::Str(str) => arena.insert(Type::from(TypeKind::Literal(syntax::Literal::String(
-            str.value.to_owned(),
-        )))),
-        ExprKind::Num(num) => arena.insert(Type::from(TypeKind::Literal(syntax::Literal::Number(
-            num.value.to_owned(),
-        )))),
-        ExprKind::Bool(bool) => arena.insert(Type::from(TypeKind::Literal(
-            syntax::Literal::Boolean(bool.value),
-        ))),
-        ExprKind::Null(_) => arena.insert(Type::from(TypeKind::Literal(syntax::Literal::Null))),
-        ExprKind::Undefined(_) => {
-            arena.insert(Type::from(TypeKind::Literal(syntax::Literal::Undefined)))
-        }
-        ExprKind::Tuple(syntax::Tuple {
-            elements: elems, ..
-        }) => {
-            let mut element_types = vec![];
-            for element in elems.iter_mut() {
-                let t = match element {
-                    ExprOrSpread::Expr(expr) => infer_expression(arena, expr, ctx)?,
-                    ExprOrSpread::Spread(_) => todo!(), // TODO: handle spreads
-                };
-                element_types.push(t);
+impl Checker {
+    /// Computes the type of the expression given by node.
+    ///
+    /// The type of the node is computed in the context of the
+    /// supplied type environment env. Data types can be introduced into the
+    /// language simply by having a predefined set of identifiers in the initial
+    /// environment. environment; this way there is no need to change the syntax or, more
+    /// importantly, the type-checking program when extending the language.
+    ///
+    /// Args:
+    ///     node: The root of the abstract syntax tree.
+    ///     env: The type environment is a mapping of expression identifier names
+    ///         to type assignments.
+    ///     non_generic: A set of non-generic variables, or None
+    ///
+    /// Returns:
+    ///     The computed type of the expression.
+    ///
+    /// Raises:
+    ///     InferenceError: The type of the expression could not be inferred, for example
+    ///         if it is not possible to unify two types such as Integer and Bool
+    ///     ParseError: The abstract syntax tree rooted at node could not be parsed
+    pub fn infer_expression(
+        &mut self,
+        node: &mut Expr,
+        ctx: &mut Context,
+    ) -> Result<Index, Errors> {
+        let idx: Index = match &mut node.kind {
+            ExprKind::Ident(Ident { name, .. }) => self.get_type(name, ctx)?,
+            ExprKind::Str(str) => {
+                self.arena
+                    .insert(Type::from(TypeKind::Literal(syntax::Literal::String(
+                        str.value.to_owned(),
+                    ))))
             }
-            new_tuple_type(arena, &element_types)
-        }
-        ExprKind::Object(syntax::Object {
-            properties: props, ..
-        }) => {
-            let mut prop_types: Vec<types::TObjElem> = vec![];
-            for prop_or_spread in props.iter_mut() {
-                match prop_or_spread {
-                    PropOrSpread::Spread(_) => todo!(),
-                    PropOrSpread::Prop(prop) => match prop {
-                        expr::Prop::Shorthand(ident) => {
-                            prop_types.push(types::TObjElem::Prop(types::TProp {
-                                name: TPropKey::StringKey(ident.to_owned()),
-                                modifier: None,
-                                t: get_type(arena, ident, ctx)?,
-                                mutable: false,
-                                optional: false,
-                            }));
-                        }
-                        expr::Prop::Property { key, value } => {
-                            let prop = match key {
-                                ObjectKey::Ident(ident) => types::TProp {
-                                    name: TPropKey::StringKey(ident.name.to_owned()),
+            ExprKind::Num(num) => {
+                self.arena
+                    .insert(Type::from(TypeKind::Literal(syntax::Literal::Number(
+                        num.value.to_owned(),
+                    ))))
+            }
+            ExprKind::Bool(bool) => {
+                self.arena
+                    .insert(Type::from(TypeKind::Literal(syntax::Literal::Boolean(
+                        bool.value,
+                    ))))
+            }
+            ExprKind::Null(_) => self
+                .arena
+                .insert(Type::from(TypeKind::Literal(syntax::Literal::Null))),
+            ExprKind::Undefined(_) => self
+                .arena
+                .insert(Type::from(TypeKind::Literal(syntax::Literal::Undefined))),
+            ExprKind::Tuple(syntax::Tuple {
+                elements: elems, ..
+            }) => {
+                let mut element_types = vec![];
+                for element in elems.iter_mut() {
+                    let t = match element {
+                        ExprOrSpread::Expr(expr) => self.infer_expression(expr, ctx)?,
+                        ExprOrSpread::Spread(_) => todo!(), // TODO: handle spreads
+                    };
+                    element_types.push(t);
+                }
+                new_tuple_type(&mut self.arena, &element_types)
+            }
+            ExprKind::Object(syntax::Object {
+                properties: props, ..
+            }) => {
+                let mut prop_types: Vec<types::TObjElem> = vec![];
+                for prop_or_spread in props.iter_mut() {
+                    match prop_or_spread {
+                        PropOrSpread::Spread(_) => todo!(),
+                        PropOrSpread::Prop(prop) => match prop {
+                            expr::Prop::Shorthand(ident) => {
+                                prop_types.push(types::TObjElem::Prop(types::TProp {
+                                    name: TPropKey::StringKey(ident.to_owned()),
                                     modifier: None,
-                                    t: infer_expression(arena, value, ctx)?,
+                                    t: self.get_type(ident, ctx)?,
                                     mutable: false,
                                     optional: false,
-                                },
-                                ObjectKey::String(name) => types::TProp {
-                                    name: TPropKey::StringKey(name.to_owned()),
-                                    modifier: None,
-                                    t: infer_expression(arena, value, ctx)?,
-                                    mutable: false,
-                                    optional: false,
-                                },
-                                ObjectKey::Number(name) => types::TProp {
-                                    name: TPropKey::StringKey(name.to_owned()),
-                                    modifier: None,
-                                    t: infer_expression(arena, value, ctx)?,
-                                    mutable: false,
-                                    optional: false,
-                                },
-                                ObjectKey::Computed(_) => todo!(),
-                            };
-                            prop_types.push(types::TObjElem::Prop(prop));
-                        }
-                    },
-                }
-            }
-            new_object_type(arena, &prop_types)
-        }
-        ExprKind::Call(syntax::Call {
-            callee: func,
-            args,
-            type_args,
-            opt_chain,
-            throws,
-        }) => {
-            let mut func_idx = infer_expression(arena, func, ctx)?;
-            let mut has_undefined = false;
-            if *opt_chain {
-                if let TypeKind::Union(union) = &arena[func_idx].kind {
-                    let types = filter_nullables(arena, &union.types);
-                    has_undefined = types.len() != union.types.len();
-                    func_idx = new_union_type(arena, &types);
-                }
-            }
-
-            let (result, new_throws) = match type_args {
-                Some(type_args) => {
-                    let type_args = type_args
-                        .iter_mut()
-                        .map(|type_arg| infer_type_ann(arena, type_arg, ctx))
-                        .collect::<Result<Vec<_>, _>>()?;
-
-                    unify_call(arena, ctx, args, Some(&type_args), func_idx)?
-                }
-                None => unify_call(arena, ctx, args, None, func_idx)?,
-            };
-
-            if let Some(new_throws) = new_throws {
-                throws.replace(new_throws);
-            }
-
-            match *opt_chain && has_undefined {
-                true => {
-                    let undefined = new_keyword(arena, Keyword::Undefined);
-
-                    if let TypeKind::Union(union) = &arena[result].kind {
-                        let mut types = filter_nullables(arena, &union.types);
-
-                        if types.len() != union.types.len() {
-                            // If we didn't end up removing any `undefined`s then
-                            // itmeans that `result` already contains `undefined`
-                            // and we can return it as is.
-                            result
-                        } else {
-                            types.push(undefined);
-                            new_union_type(arena, &types)
-                        }
-                    } else {
-                        new_union_type(arena, &[result, undefined])
+                                }));
+                            }
+                            expr::Prop::Property { key, value } => {
+                                let prop = match key {
+                                    ObjectKey::Ident(ident) => types::TProp {
+                                        name: TPropKey::StringKey(ident.name.to_owned()),
+                                        modifier: None,
+                                        t: self.infer_expression(value, ctx)?,
+                                        mutable: false,
+                                        optional: false,
+                                    },
+                                    ObjectKey::String(name) => types::TProp {
+                                        name: TPropKey::StringKey(name.to_owned()),
+                                        modifier: None,
+                                        t: self.infer_expression(value, ctx)?,
+                                        mutable: false,
+                                        optional: false,
+                                    },
+                                    ObjectKey::Number(name) => types::TProp {
+                                        name: TPropKey::StringKey(name.to_owned()),
+                                        modifier: None,
+                                        t: self.infer_expression(value, ctx)?,
+                                        mutable: false,
+                                        optional: false,
+                                    },
+                                    ObjectKey::Computed(_) => todo!(),
+                                };
+                                prop_types.push(types::TObjElem::Prop(prop));
+                            }
+                        },
                     }
                 }
-                false => result,
+                new_object_type(&mut self.arena, &prop_types)
             }
-        }
-        ExprKind::Function(syntax::Function {
-            params,
-            body,
-            is_async,
-            is_gen: _,
-            type_params,
-            type_ann: return_type,
-            throws: sig_throws,
-        }) => {
-            let mut func_params: Vec<types::FuncParam> = vec![];
-            let mut sig_ctx = ctx.clone();
-
-            let type_params = infer_type_params(arena, type_params, &mut sig_ctx)?;
-
-            for syntax::FuncParam {
-                pattern,
-                type_ann,
-                optional,
-            } in params.iter_mut()
-            {
-                let type_ann_t = match type_ann {
-                    Some(type_ann) => infer_type_ann(arena, type_ann, &mut sig_ctx)?,
-                    None => new_var_type(arena, None),
-                };
-                pattern.inferred_type = Some(type_ann_t);
-
-                let (assumps, param_t) = infer_pattern(arena, pattern, &sig_ctx)?;
-                unify(arena, &sig_ctx, param_t, type_ann_t)?;
-
-                for (name, binding) in assumps {
-                    sig_ctx.non_generic.insert(binding.index);
-                    sig_ctx.values.insert(name.to_owned(), binding);
+            ExprKind::Call(syntax::Call {
+                callee: func,
+                args,
+                type_args,
+                opt_chain,
+                throws,
+            }) => {
+                let mut func_idx = self.infer_expression(func, ctx)?;
+                let mut has_undefined = false;
+                if *opt_chain {
+                    if let TypeKind::Union(union) = &self.arena[func_idx].kind {
+                        let types = filter_nullables(&self.arena, &union.types);
+                        has_undefined = types.len() != union.types.len();
+                        func_idx = new_union_type(&mut self.arena, &types);
+                    }
                 }
 
-                func_params.push(types::FuncParam {
-                    pattern: pattern_to_tpat(pattern, true),
-                    t: type_ann_t,
-                    optional: *optional,
-                });
+                let (result, new_throws) = match type_args {
+                    Some(type_args) => {
+                        let type_args = type_args
+                            .iter_mut()
+                            .map(|type_arg| self.infer_type_ann(type_arg, ctx))
+                            .collect::<Result<Vec<_>, _>>()?;
+
+                        self.unify_call(ctx, args, Some(&type_args), func_idx)?
+                    }
+                    None => self.unify_call(ctx, args, None, func_idx)?,
+                };
+
+                if let Some(new_throws) = new_throws {
+                    throws.replace(new_throws);
+                }
+
+                match *opt_chain && has_undefined {
+                    true => {
+                        let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+
+                        if let TypeKind::Union(union) = &self.arena[result].kind.clone() {
+                            let mut types = filter_nullables(&self.arena, &union.types);
+
+                            if types.len() != union.types.len() {
+                                // If we didn't end up removing any `undefined`s then
+                                // itmeans that `result` already contains `undefined`
+                                // and we can return it as is.
+                                result
+                            } else {
+                                types.push(undefined);
+                                new_union_type(&mut self.arena, &types)
+                            }
+                        } else {
+                            new_union_type(&mut self.arena, &[result, undefined])
+                        }
+                    }
+                    false => result,
+                }
             }
+            ExprKind::Function(syntax::Function {
+                params,
+                body,
+                is_async,
+                is_gen: _,
+                type_params,
+                type_ann: return_type,
+                throws: sig_throws,
+            }) => {
+                let mut func_params: Vec<types::FuncParam> = vec![];
+                let mut sig_ctx = ctx.clone();
 
-            let mut body_ctx = sig_ctx.clone();
-            body_ctx.is_async = *is_async;
+                let type_params = self.infer_type_params(type_params, &mut sig_ctx)?;
 
-            let mut body_t = 'outer: {
-                match body {
-                    BlockOrExpr::Block(Block { stmts, .. }) => {
-                        for stmt in stmts.iter_mut() {
-                            body_ctx = body_ctx.clone();
-                            infer_statement(arena, stmt, &mut body_ctx, false)?;
-                            if let StmtKind::Return { arg: _ } = stmt.kind {
-                                let ret_types: Vec<Index> = find_returns(body)
-                                    .iter()
-                                    .filter_map(|ret| ret.inferred_type)
-                                    .collect();
+                for syntax::FuncParam {
+                    pattern,
+                    type_ann,
+                    optional,
+                } in params.iter_mut()
+                {
+                    let type_ann_t = match type_ann {
+                        Some(type_ann) => self.infer_type_ann(type_ann, &mut sig_ctx)?,
+                        None => new_var_type(&mut self.arena, None),
+                    };
+                    pattern.inferred_type = Some(type_ann_t);
 
-                                // TODO: warn about unreachable code.
-                                break 'outer new_union_type(arena, &ret_types);
+                    let (assumps, param_t) = self.infer_pattern(pattern, &sig_ctx)?;
+                    self.unify(&sig_ctx, param_t, type_ann_t)?;
+
+                    for (name, binding) in assumps {
+                        sig_ctx.non_generic.insert(binding.index);
+                        sig_ctx.values.insert(name.to_owned(), binding);
+                    }
+
+                    func_params.push(types::FuncParam {
+                        pattern: pattern_to_tpat(pattern, true),
+                        t: type_ann_t,
+                        optional: *optional,
+                    });
+                }
+
+                let mut body_ctx = sig_ctx.clone();
+                body_ctx.is_async = *is_async;
+
+                let mut body_t = 'outer: {
+                    match body {
+                        BlockOrExpr::Block(Block { stmts, .. }) => {
+                            for stmt in stmts.iter_mut() {
+                                body_ctx = body_ctx.clone();
+                                self.infer_statement(stmt, &mut body_ctx, false)?;
+                                if let StmtKind::Return { arg: _ } = stmt.kind {
+                                    let ret_types: Vec<Index> = find_returns(body)
+                                        .iter()
+                                        .filter_map(|ret| ret.inferred_type)
+                                        .collect();
+
+                                    // TODO: warn about unreachable code.
+                                    break 'outer new_union_type(&mut self.arena, &ret_types);
+                                }
+                            }
+
+                            // If we don't encounter a return statement, we assume
+                            // the return type is `undefined`.
+                            new_keyword(&mut self.arena, Keyword::Undefined)
+                        }
+                        BlockOrExpr::Expr(expr) => {
+                            // TODO: use `find_returns` here as well
+                            self.infer_expression(expr, &mut body_ctx)?
+                        }
+                    }
+                };
+
+                // TODO: search for `throw` expressions in the body and include
+                // them in the throws type.
+
+                let body_throws = find_throws(body);
+                let body_throws = if body_throws.is_empty() {
+                    None
+                } else {
+                    Some(new_union_type(
+                        &mut self.arena,
+                        // TODO: compare string reps of the types for deduplication
+                        &body_throws.into_iter().unique().collect_vec(),
+                    ))
+                };
+
+                let sig_throws = sig_throws
+                    .as_mut()
+                    .map(|t| self.infer_type_ann(t, &mut sig_ctx))
+                    .transpose()?;
+
+                let throws = match (body_throws, sig_throws) {
+                    (Some(call_throws), Some(sig_throws)) => {
+                        self.unify(&sig_ctx, call_throws, sig_throws)?;
+                        Some(sig_throws)
+                    }
+                    (Some(call_throws), None) => Some(call_throws),
+                    // This should probably be a warning.  If the function doesn't
+                    // throw anything, then it shouldn't be marked as such.
+                    (None, Some(sig_throws)) => Some(sig_throws),
+                    (None, None) => None,
+                };
+
+                // TODO: Make the return type `Promise<body_t, throws>` if the function
+                // is async.  Async functions cannot throw.  They can only return a
+                // rejected promise.
+                if *is_async && !is_promise(&self.arena[body_t]) {
+                    let never = new_keyword(&mut self.arena, Keyword::Never);
+                    let throws_t = throws.unwrap_or(never);
+                    body_t = new_constructor(&mut self.arena, "Promise", &[body_t, throws_t]);
+
+                    match return_type {
+                        Some(return_type) => {
+                            let ret_t = self.infer_type_ann(return_type, &mut sig_ctx)?;
+                            // TODO: add sig_ctx which is a copy of ctx but with all of
+                            // the type params added to sig_ctx.schemes so that they can
+                            // be looked up.
+                            self.unify(&sig_ctx, body_t, ret_t)?;
+                            self.new_func_type(&func_params, ret_t, &type_params, None)
+                        }
+                        None => self.new_func_type(&func_params, body_t, &type_params, None),
+                    }
+                } else {
+                    match return_type {
+                        Some(return_type) => {
+                            let ret_t = self.infer_type_ann(return_type, &mut sig_ctx)?;
+                            // TODO: add sig_ctx which is a copy of ctx but with all of
+                            // the type params added to sig_ctx.schemes so that they can
+                            // be looked up.
+                            self.unify(&sig_ctx, body_t, ret_t)?;
+                            self.new_func_type(&func_params, ret_t, &type_params, throws)
+                        }
+                        None => self.new_func_type(&func_params, body_t, &type_params, throws),
+                    }
+                }
+            }
+            ExprKind::IfElse(IfElse {
+                cond,
+                consequent,
+                alternate,
+            }) => {
+                let cond_type = self.infer_expression(cond, ctx)?;
+                let bool_type = new_primitive(&mut self.arena, Primitive::Boolean);
+                self.unify(ctx, cond_type, bool_type)?;
+                let consequent_type = self.infer_block(consequent, ctx)?;
+                let alternate_type = match alternate {
+                    Some(alternate) => match alternate {
+                        BlockOrExpr::Block(block) => self.infer_block(block, ctx)?,
+                        BlockOrExpr::Expr(expr) => self.infer_expression(expr, ctx)?,
+                    },
+                    None => new_keyword(&mut self.arena, Keyword::Undefined),
+                };
+                new_union_type(&mut self.arena, &[consequent_type, alternate_type])
+            }
+            ExprKind::Member(Member {
+                object: obj,
+                property: prop,
+                opt_chain,
+            }) => {
+                let mut obj_idx = self.infer_expression(obj, ctx)?;
+                let mut has_undefined = false;
+                if *opt_chain {
+                    if let TypeKind::Union(union) = &self.arena[obj_idx].kind {
+                        let types = filter_nullables(&self.arena, &union.types);
+                        has_undefined = types.len() != union.types.len();
+                        obj_idx = new_union_type(&mut self.arena, &types);
+                    }
+                }
+
+                let result = match prop {
+                    MemberProp::Ident(Ident { name, .. }) => {
+                        let key_idx =
+                            new_lit_type(&mut self.arena, &Literal::String(name.to_owned()));
+                        self.get_ident_member(ctx, obj_idx, key_idx)?
+                    }
+                    MemberProp::Computed(ComputedPropName { expr, .. }) => {
+                        let prop_type = self.infer_expression(expr, ctx)?;
+                        self.get_computed_member(ctx, obj_idx, prop_type)?
+                    }
+                };
+
+                match *opt_chain && has_undefined {
+                    true => {
+                        let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+
+                        if let TypeKind::Union(union) = &self.arena[result].kind {
+                            let mut types = filter_nullables(&self.arena, &union.types);
+
+                            if types.len() != union.types.len() {
+                                // If we didn't end up removing any `undefined`s then
+                                // itmeans that `result` already contains `undefined`
+                                // and we can return it as is.
+                                result
+                            } else {
+                                types.push(undefined);
+                                new_union_type(&mut self.arena, &types)
+                            }
+                        } else {
+                            new_union_type(&mut self.arena, &[result, undefined])
+                        }
+                    }
+                    false => result,
+                }
+            }
+            ExprKind::JSXElement(_) => todo!(),
+            ExprKind::Assign(Assign { left, op: _, right }) => {
+                if !lvalue_mutability(ctx, left)? {
+                    return Err(Errors::InferenceError(
+                        "Cannot assign to immutable lvalue".to_string(),
+                    ));
+                }
+
+                let l_t = self.infer_expression(left, ctx)?;
+                let r_t = self.infer_expression(right, ctx)?;
+                self.unify(ctx, r_t, l_t)?;
+
+                r_t
+            }
+            ExprKind::Binary(Binary { op, left, right }) => {
+                let number = new_primitive(&mut self.arena, Primitive::Number);
+                let boolean = new_primitive(&mut self.arena, Primitive::Boolean);
+                let left_type = self.infer_expression(left, ctx)?;
+                let right_type = self.infer_expression(right, ctx)?;
+
+                match op {
+                    BinaryOp::Plus
+                    | BinaryOp::Minus
+                    | BinaryOp::Times
+                    | BinaryOp::Divide
+                    | BinaryOp::Modulo => {
+                        match (&self.arena[left_type].kind, &self.arena[right_type].kind) {
+                            (
+                                TypeKind::Literal(Literal::Number(left)),
+                                TypeKind::Literal(Literal::Number(right)),
+                            ) => {
+                                let left = left.parse::<f64>().unwrap();
+                                let right = right.parse::<f64>().unwrap();
+
+                                let result = match op {
+                                    BinaryOp::Plus => left + right,
+                                    BinaryOp::Minus => left - right,
+                                    BinaryOp::Times => left * right,
+                                    BinaryOp::Divide => left / right,
+                                    BinaryOp::Modulo => left % right,
+                                    _ => unreachable!(),
+                                };
+
+                                new_lit_type(&mut self.arena, &Literal::Number(result.to_string()))
+                            }
+                            (_, _) => {
+                                self.unify(ctx, left_type, number)?;
+                                self.unify(ctx, right_type, number)?;
+                                number
                             }
                         }
-
-                        // If we don't encounter a return statement, we assume
-                        // the return type is `undefined`.
-                        new_keyword(arena, Keyword::Undefined)
                     }
-                    BlockOrExpr::Expr(expr) => {
-                        // TODO: use `find_returns` here as well
-                        infer_expression(arena, expr, &mut body_ctx)?
-                    }
-                }
-            };
+                    BinaryOp::GreaterThan
+                    | BinaryOp::GreaterThanOrEqual
+                    | BinaryOp::LessThan
+                    | BinaryOp::LessThanOrEqual => {
+                        match (&self.arena[left_type].kind, &self.arena[right_type].kind) {
+                            (
+                                TypeKind::Literal(Literal::Number(left)),
+                                TypeKind::Literal(Literal::Number(right)),
+                            ) => {
+                                let left = left.parse::<f64>().unwrap();
+                                let right = right.parse::<f64>().unwrap();
 
-            // TODO: search for `throw` expressions in the body and include
-            // them in the throws type.
+                                let result = match op {
+                                    BinaryOp::GreaterThan => left > right,
+                                    BinaryOp::GreaterThanOrEqual => left >= right,
+                                    BinaryOp::LessThan => left < right,
+                                    BinaryOp::LessThanOrEqual => left <= right,
+                                    _ => unreachable!(),
+                                };
 
-            let body_throws = find_throws(body);
-            let body_throws = if body_throws.is_empty() {
-                None
-            } else {
-                Some(new_union_type(
-                    arena,
-                    // TODO: compare string reps of the types for deduplication
-                    &body_throws.into_iter().unique().collect_vec(),
-                ))
-            };
-
-            let sig_throws = sig_throws
-                .as_mut()
-                .map(|t| infer_type_ann(arena, t, &mut sig_ctx))
-                .transpose()?;
-
-            let throws = match (body_throws, sig_throws) {
-                (Some(call_throws), Some(sig_throws)) => {
-                    unify(arena, &sig_ctx, call_throws, sig_throws)?;
-                    Some(sig_throws)
-                }
-                (Some(call_throws), None) => Some(call_throws),
-                // This should probably be a warning.  If the function doesn't
-                // throw anything, then it shouldn't be marked as such.
-                (None, Some(sig_throws)) => Some(sig_throws),
-                (None, None) => None,
-            };
-
-            // TODO: Make the return type `Promise<body_t, throws>` if the function
-            // is async.  Async functions cannot throw.  They can only return a
-            // rejected promise.
-            if *is_async && !is_promise(&arena[body_t]) {
-                let never = new_keyword(arena, Keyword::Never);
-                let throws_t = throws.unwrap_or(never);
-                body_t = new_constructor(arena, "Promise", &[body_t, throws_t]);
-
-                match return_type {
-                    Some(return_type) => {
-                        let ret_t = infer_type_ann(arena, return_type, &mut sig_ctx)?;
-                        // TODO: add sig_ctx which is a copy of ctx but with all of
-                        // the type params added to sig_ctx.schemes so that they can
-                        // be looked up.
-                        unify(arena, &sig_ctx, body_t, ret_t)?;
-                        new_func_type(arena, &func_params, ret_t, &type_params, None)
-                    }
-                    None => new_func_type(arena, &func_params, body_t, &type_params, None),
-                }
-            } else {
-                match return_type {
-                    Some(return_type) => {
-                        let ret_t = infer_type_ann(arena, return_type, &mut sig_ctx)?;
-                        // TODO: add sig_ctx which is a copy of ctx but with all of
-                        // the type params added to sig_ctx.schemes so that they can
-                        // be looked up.
-                        unify(arena, &sig_ctx, body_t, ret_t)?;
-                        new_func_type(arena, &func_params, ret_t, &type_params, throws)
-                    }
-                    None => new_func_type(arena, &func_params, body_t, &type_params, throws),
-                }
-            }
-        }
-        ExprKind::IfElse(IfElse {
-            cond,
-            consequent,
-            alternate,
-        }) => {
-            let cond_type = infer_expression(arena, cond, ctx)?;
-            let bool_type = new_primitive(arena, Primitive::Boolean);
-            unify(arena, ctx, cond_type, bool_type)?;
-            let consequent_type = infer_block(arena, consequent, ctx)?;
-            let alternate_type = match alternate {
-                Some(alternate) => match alternate {
-                    BlockOrExpr::Block(block) => infer_block(arena, block, ctx)?,
-                    BlockOrExpr::Expr(expr) => infer_expression(arena, expr, ctx)?,
-                },
-                None => new_keyword(arena, Keyword::Undefined),
-            };
-            new_union_type(arena, &[consequent_type, alternate_type])
-        }
-        ExprKind::Member(Member {
-            object: obj,
-            property: prop,
-            opt_chain,
-        }) => {
-            let mut obj_idx = infer_expression(arena, obj, ctx)?;
-            let mut has_undefined = false;
-            if *opt_chain {
-                if let TypeKind::Union(union) = &arena[obj_idx].kind {
-                    let types = filter_nullables(arena, &union.types);
-                    has_undefined = types.len() != union.types.len();
-                    obj_idx = new_union_type(arena, &types);
-                }
-            }
-
-            let result = match prop {
-                MemberProp::Ident(Ident { name, .. }) => {
-                    let key_idx = new_lit_type(arena, &Literal::String(name.to_owned()));
-                    get_ident_member(arena, ctx, obj_idx, key_idx)?
-                }
-                MemberProp::Computed(ComputedPropName { expr, .. }) => {
-                    let prop_type = infer_expression(arena, expr, ctx)?;
-                    get_computed_member(arena, ctx, obj_idx, prop_type)?
-                }
-            };
-
-            match *opt_chain && has_undefined {
-                true => {
-                    let undefined = new_keyword(arena, Keyword::Undefined);
-
-                    if let TypeKind::Union(union) = &arena[result].kind {
-                        let mut types = filter_nullables(arena, &union.types);
-
-                        if types.len() != union.types.len() {
-                            // If we didn't end up removing any `undefined`s then
-                            // itmeans that `result` already contains `undefined`
-                            // and we can return it as is.
-                            result
-                        } else {
-                            types.push(undefined);
-                            new_union_type(arena, &types)
+                                new_lit_type(&mut self.arena, &Literal::Boolean(result))
+                            }
+                            (_, _) => {
+                                self.unify(ctx, left_type, number)?;
+                                self.unify(ctx, right_type, number)?;
+                                boolean
+                            }
                         }
-                    } else {
-                        new_union_type(arena, &[result, undefined])
+                    }
+                    BinaryOp::And | BinaryOp::Or => {
+                        self.unify(ctx, left_type, boolean)?;
+                        self.unify(ctx, right_type, boolean)?;
+                        boolean
+                    }
+                    BinaryOp::Equals | BinaryOp::NotEquals => {
+                        match (&self.arena[left_type].kind, &self.arena[right_type].kind) {
+                            (
+                                TypeKind::Literal(Literal::Number(left)),
+                                TypeKind::Literal(Literal::Number(right)),
+                            ) => {
+                                let result = match op {
+                                    BinaryOp::Equals => left == right,
+                                    BinaryOp::NotEquals => left != right,
+                                    _ => unreachable!(),
+                                };
+
+                                new_lit_type(&mut self.arena, &Literal::Boolean(result))
+                            }
+                            (
+                                TypeKind::Literal(Literal::String(left)),
+                                TypeKind::Literal(Literal::String(right)),
+                            ) => {
+                                let result = match op {
+                                    BinaryOp::Equals => left == right,
+                                    BinaryOp::NotEquals => left != right,
+                                    _ => unreachable!(),
+                                };
+
+                                new_lit_type(&mut self.arena, &Literal::Boolean(result))
+                            }
+                            (_, _) => {
+                                let var_a = new_var_type(&mut self.arena, None);
+                                let var_b = new_var_type(&mut self.arena, None);
+                                self.unify(ctx, left_type, var_a)?;
+                                self.unify(ctx, right_type, var_b)?;
+                                boolean
+                            }
+                        }
                     }
                 }
-                false => result,
             }
-        }
-        ExprKind::JSXElement(_) => todo!(),
-        ExprKind::Assign(Assign { left, op: _, right }) => {
-            if !lvalue_mutability(ctx, left)? {
-                return Err(Errors::InferenceError(
-                    "Cannot assign to immutable lvalue".to_string(),
-                ));
-            }
+            ExprKind::Unary(Unary {
+                op,
+                right: arg, // TODO: rename `right` to `arg`
+            }) => {
+                let number = new_primitive(&mut self.arena, Primitive::Number);
+                let boolean = new_primitive(&mut self.arena, Primitive::Boolean);
+                let arg_type = self.infer_expression(arg, ctx)?;
 
-            let l_t = infer_expression(arena, left, ctx)?;
-            let r_t = infer_expression(arena, right, ctx)?;
-            unify(arena, ctx, r_t, l_t)?;
-
-            r_t
-        }
-        ExprKind::Binary(Binary { op, left, right }) => {
-            let number = new_primitive(arena, Primitive::Number);
-            let boolean = new_primitive(arena, Primitive::Boolean);
-            let left_type = infer_expression(arena, left, ctx)?;
-            let right_type = infer_expression(arena, right, ctx)?;
-
-            match op {
-                BinaryOp::Plus
-                | BinaryOp::Minus
-                | BinaryOp::Times
-                | BinaryOp::Divide
-                | BinaryOp::Modulo => match (&arena[left_type].kind, &arena[right_type].kind) {
-                    (
-                        TypeKind::Literal(Literal::Number(left)),
-                        TypeKind::Literal(Literal::Number(right)),
-                    ) => {
-                        let left = left.parse::<f64>().unwrap();
-                        let right = right.parse::<f64>().unwrap();
-
-                        let result = match op {
-                            BinaryOp::Plus => left + right,
-                            BinaryOp::Minus => left - right,
-                            BinaryOp::Times => left * right,
-                            BinaryOp::Divide => left / right,
-                            BinaryOp::Modulo => left % right,
-                            _ => unreachable!(),
-                        };
-
-                        new_lit_type(arena, &Literal::Number(result.to_string()))
-                    }
-                    (_, _) => {
-                        unify(arena, ctx, left_type, number)?;
-                        unify(arena, ctx, right_type, number)?;
+                match op {
+                    UnaryOp::Minus => {
+                        self.unify(ctx, arg_type, number)?;
                         number
                     }
-                },
-                BinaryOp::GreaterThan
-                | BinaryOp::GreaterThanOrEqual
-                | BinaryOp::LessThan
-                | BinaryOp::LessThanOrEqual => {
-                    match (&arena[left_type].kind, &arena[right_type].kind) {
-                        (
-                            TypeKind::Literal(Literal::Number(left)),
-                            TypeKind::Literal(Literal::Number(right)),
-                        ) => {
-                            let left = left.parse::<f64>().unwrap();
-                            let right = right.parse::<f64>().unwrap();
-
-                            let result = match op {
-                                BinaryOp::GreaterThan => left > right,
-                                BinaryOp::GreaterThanOrEqual => left >= right,
-                                BinaryOp::LessThan => left < right,
-                                BinaryOp::LessThanOrEqual => left <= right,
-                                _ => unreachable!(),
-                            };
-
-                            new_lit_type(arena, &Literal::Boolean(result))
-                        }
-                        (_, _) => {
-                            unify(arena, ctx, left_type, number)?;
-                            unify(arena, ctx, right_type, number)?;
-                            boolean
-                        }
+                    UnaryOp::Plus => {
+                        self.unify(ctx, arg_type, number)?;
+                        number
                     }
-                }
-                BinaryOp::And | BinaryOp::Or => {
-                    unify(arena, ctx, left_type, boolean)?;
-                    unify(arena, ctx, right_type, boolean)?;
-                    boolean
-                }
-                BinaryOp::Equals | BinaryOp::NotEquals => {
-                    match (&arena[left_type].kind, &arena[right_type].kind) {
-                        (
-                            TypeKind::Literal(Literal::Number(left)),
-                            TypeKind::Literal(Literal::Number(right)),
-                        ) => {
-                            let result = match op {
-                                BinaryOp::Equals => left == right,
-                                BinaryOp::NotEquals => left != right,
-                                _ => unreachable!(),
-                            };
-
-                            new_lit_type(arena, &Literal::Boolean(result))
-                        }
-                        (
-                            TypeKind::Literal(Literal::String(left)),
-                            TypeKind::Literal(Literal::String(right)),
-                        ) => {
-                            let result = match op {
-                                BinaryOp::Equals => left == right,
-                                BinaryOp::NotEquals => left != right,
-                                _ => unreachable!(),
-                            };
-
-                            new_lit_type(arena, &Literal::Boolean(result))
-                        }
-                        (_, _) => {
-                            let var_a = new_var_type(arena, None);
-                            let var_b = new_var_type(arena, None);
-                            unify(arena, ctx, left_type, var_a)?;
-                            unify(arena, ctx, right_type, var_b)?;
-                            boolean
-                        }
+                    UnaryOp::Not => {
+                        self.unify(ctx, arg_type, boolean)?;
+                        boolean
                     }
                 }
             }
-        }
-        ExprKind::Unary(Unary {
-            op,
-            right: arg, // TODO: rename `right` to `arg`
-        }) => {
-            let number = new_primitive(arena, Primitive::Number);
-            let boolean = new_primitive(arena, Primitive::Boolean);
-            let arg_type = infer_expression(arena, arg, ctx)?;
+            ExprKind::Await(Await { arg: expr, throws }) => {
+                if !ctx.is_async {
+                    return Err(Errors::InferenceError(
+                        "Can't use await outside of an async function".to_string(),
+                    ));
+                }
 
-            match op {
-                UnaryOp::Minus => {
-                    unify(arena, ctx, arg_type, number)?;
-                    number
+                let expr_t = self.infer_expression(expr, ctx)?;
+                let inner_t = new_var_type(&mut self.arena, None);
+                let throws_t = new_var_type(&mut self.arena, None);
+                // TODO: Merge Constructor and TypeRef
+                // NOTE: This isn't quite right because we can await non-promise values.
+                // That being said, we should avoid doing so.
+                let promise_t = new_constructor(&mut self.arena, "Promise", &[inner_t, throws_t]);
+                self.unify(ctx, expr_t, promise_t)?;
+                *throws = Some(throws_t);
+
+                inner_t
+            }
+            // ExprKind::Empty => todo!(),
+            ExprKind::TemplateLiteral(_) => todo!(),
+            // ExprKind::TaggedTemplateLiteral(_) => todo!(),
+            ExprKind::Match(Match { expr, arms }) => {
+                let expr_idx = self.infer_expression(expr, ctx)?;
+                let mut body_types: Vec<Index> = vec![];
+
+                for arm in arms.iter_mut() {
+                    let (pat_bindings, pat_idx) = self.infer_pattern(&mut arm.pattern, ctx)?;
+
+                    // Checks that the pattern is a sub-type of expr
+                    self.unify(ctx, pat_idx, expr_idx)?;
+
+                    let mut new_ctx = ctx.clone();
+                    for (name, binding) in pat_bindings {
+                        // TODO: Update .env to store bindings so that we can handle
+                        // mutability correctly
+                        new_ctx.values.insert(name, binding);
+                    }
+
+                    let body_type = match arm.body {
+                        BlockOrExpr::Block(ref mut block) => {
+                            self.infer_block(block, &mut new_ctx)?
+                        }
+                        BlockOrExpr::Expr(ref mut expr) => {
+                            self.infer_expression(expr, &mut new_ctx)?
+                        }
+                    };
+                    body_types.push(body_type);
                 }
-                UnaryOp::Plus => {
-                    unify(arena, ctx, arg_type, number)?;
-                    number
-                }
-                UnaryOp::Not => {
-                    unify(arena, ctx, arg_type, boolean)?;
-                    boolean
+
+                let t0 = self.prune(body_types[0]);
+                eprintln!("t0 = {}", self.print_type(&t0));
+
+                let t1 = self.prune(body_types[1]);
+                eprintln!("t1 = {}", self.print_type(&t1));
+
+                new_union_type(&mut self.arena, &body_types)
+            }
+            ExprKind::Class(_) => todo!(),
+            ExprKind::Do(Do { body }) => self.infer_block(body, ctx)?,
+            ExprKind::Try(Try {
+                body,
+                catch,
+                finally: _, // Don't include this in the result
+            }) => {
+                let body_t = self.infer_block(body, ctx)?;
+
+                match catch {
+                    Some(catch) => {
+                        let throws = find_throws_in_block(body);
+
+                        let init_idx = new_union_type(&mut self.arena, &throws);
+
+                        if let Some(pattern) = &mut catch.param {
+                            let (pat_bindings, pat_type) = self.infer_pattern(pattern, ctx)?;
+
+                            self.unify(ctx, init_idx, pat_type)?;
+
+                            for (name, binding) in pat_bindings {
+                                ctx.values.insert(name.clone(), binding);
+                            }
+
+                            pattern.inferred_type = Some(init_idx);
+                        }
+
+                        let catch_t = self.infer_block(&mut catch.body, ctx)?;
+                        new_union_type(&mut self.arena, &[body_t, catch_t])
+                    }
+                    None => body_t,
                 }
             }
+            ExprKind::Yield(_) => todo!(),
+            ExprKind::Throw(Throw { arg, throws }) => {
+                throws.replace(self.infer_expression(arg, ctx)?);
+                new_keyword(&mut self.arena, Keyword::Never)
+            }
+            ExprKind::JSXFragment(_) => todo!(),
+        };
+
+        let t = &mut self.arena[idx];
+        t.provenance = Some(Provenance::Expr(Box::new(node.to_owned())));
+
+        node.inferred_type = Some(idx);
+
+        Ok(idx)
+    }
+
+    pub fn infer_block(&mut self, block: &mut Block, ctx: &mut Context) -> Result<Index, Errors> {
+        let mut new_ctx = ctx.clone();
+        let mut result_t = new_keyword(&mut self.arena, Keyword::Undefined);
+
+        for stmt in &mut block.stmts.iter_mut() {
+            result_t = self.infer_statement(stmt, &mut new_ctx, false)?;
         }
-        ExprKind::Await(Await { arg: expr, throws }) => {
-            if !ctx.is_async {
-                return Err(Errors::InferenceError(
-                    "Can't use await outside of an async function".to_string(),
-                ));
+
+        Ok(result_t)
+    }
+
+    pub fn infer_type_ann(
+        &mut self,
+        type_ann: &mut TypeAnn,
+        ctx: &mut Context,
+    ) -> Result<Index, Errors> {
+        let idx = match &mut type_ann.kind {
+            TypeAnnKind::Function(FunctionType {
+                params,
+                ret,
+                type_params,
+                throws,
+            }) => {
+                // NOTE: We clone `ctx` so that type params don't escape the signature
+                let mut sig_ctx = ctx.clone();
+
+                let type_params = self.infer_type_params(type_params, &mut sig_ctx)?;
+
+                let func_params = params
+                    .iter_mut()
+                    .map(|param| {
+                        let t = match &mut param.type_ann {
+                            Some(type_ann) => self.infer_type_ann(type_ann, &mut sig_ctx)?,
+                            None => new_var_type(&mut self.arena, None),
+                        };
+
+                        Ok(types::FuncParam {
+                            pattern: pattern_to_tpat(&param.pattern, true),
+                            t,
+                            optional: param.optional,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let ret_idx = self.infer_type_ann(ret.as_mut(), &mut sig_ctx)?;
+
+                let throws = throws
+                    .as_mut()
+                    .map(|throws| self.infer_type_ann(throws, &mut sig_ctx))
+                    .transpose()?;
+
+                self.new_func_type(&func_params, ret_idx, &type_params, throws)
             }
 
-            let expr_t = infer_expression(arena, expr, ctx)?;
-            let inner_t = new_var_type(arena, None);
-            let throws_t = new_var_type(arena, None);
-            // TODO: Merge Constructor and TypeRef
-            // NOTE: This isn't quite right because we can await non-promise values.
-            // That being said, we should avoid doing so.
-            let promise_t = new_constructor(arena, "Promise", &[inner_t, throws_t]);
-            unify(arena, ctx, expr_t, promise_t)?;
-            *throws = Some(throws_t);
+            TypeAnnKind::NumLit(value) => {
+                self.arena
+                    .insert(Type::from(TypeKind::Literal(syntax::Literal::Number(
+                        value.to_owned(),
+                    ))))
+            }
+            TypeAnnKind::StrLit(value) => {
+                self.arena
+                    .insert(Type::from(TypeKind::Literal(syntax::Literal::String(
+                        value.to_owned(),
+                    ))))
+            }
+            TypeAnnKind::BoolLit(value) => {
+                self.arena
+                    .insert(Type::from(TypeKind::Literal(syntax::Literal::Boolean(
+                        value.to_owned(),
+                    ))))
+            }
 
-            inner_t
-        }
-        // ExprKind::Empty => todo!(),
-        ExprKind::TemplateLiteral(_) => todo!(),
-        // ExprKind::TaggedTemplateLiteral(_) => todo!(),
-        ExprKind::Match(Match { expr, arms }) => {
-            let expr_idx = infer_expression(arena, expr, ctx)?;
-            let mut body_types: Vec<Index> = vec![];
+            TypeAnnKind::Number => new_primitive(&mut self.arena, Primitive::Number),
+            TypeAnnKind::Boolean => new_primitive(&mut self.arena, Primitive::Boolean),
+            TypeAnnKind::String => new_primitive(&mut self.arena, Primitive::String),
+            TypeAnnKind::Symbol => new_primitive(&mut self.arena, Primitive::Symbol),
 
-            for arm in arms.iter_mut() {
-                let (pat_bindings, pat_idx) = infer_pattern(arena, &mut arm.pattern, ctx)?;
+            TypeAnnKind::Null => new_keyword(&mut self.arena, Keyword::Null),
+            TypeAnnKind::Undefined => new_keyword(&mut self.arena, Keyword::Undefined),
+            TypeAnnKind::Unknown => new_keyword(&mut self.arena, Keyword::Unknown),
+            TypeAnnKind::Never => new_keyword(&mut self.arena, Keyword::Never),
 
-                // Checks that the pattern is a sub-type of expr
-                unify(arena, ctx, pat_idx, expr_idx)?;
+            // TODO: How we make sure that create a fresh type variable for this
+            // whenever it's used?  Maybe we can have an actual TypeKind::Wildcard
+            // instead of creating a type variable here.
+            TypeAnnKind::Wildcard => new_wildcard_type(&mut self.arena),
+            TypeAnnKind::Infer(name) => new_infer_type(&mut self.arena, name),
 
-                let mut new_ctx = ctx.clone();
-                for (name, binding) in pat_bindings {
-                    // TODO: Update .env to store bindings so that we can handle
-                    // mutability correctly
-                    new_ctx.values.insert(name, binding);
+            TypeAnnKind::Object(obj) => {
+                let mut props: Vec<types::TObjElem> = Vec::new();
+                for elem in obj.iter_mut() {
+                    match elem {
+                        ObjectProp::Mapped(Mapped {
+                            key,
+                            value,
+                            target,
+                            source,
+                            check,
+                            extends,
+                        }) => {
+                            let mut type_ctx = ctx.clone();
+
+                            let source = self.infer_type_ann(source, &mut type_ctx)?;
+                            let scheme = Scheme {
+                                type_params: None,
+                                t: source,
+                            };
+                            type_ctx.schemes.insert(target.to_owned(), scheme);
+
+                            let key = self.infer_type_ann(key, &mut type_ctx)?;
+                            // let mut mapping: HashMap<String, Index> = HashMap::new();
+                            // mapping.insert(target.to_owned(), source);
+                            // let key = instantiate_scheme(self.arena, key, &mapping);
+
+                            let value = self.infer_type_ann(value, &mut type_ctx)?;
+                            let check = match check {
+                                Some(check) => Some(self.infer_type_ann(check, &mut type_ctx)?),
+                                None => None,
+                            };
+                            let extends = match extends {
+                                Some(extends) => Some(self.infer_type_ann(extends, &mut type_ctx)?),
+                                None => None,
+                            };
+
+                            props.push(types::TObjElem::Mapped(types::MappedType {
+                                key,
+                                value,
+                                target: target.to_owned(),
+                                source,
+                                check,
+                                extends,
+                            }));
+                        }
+                        ObjectProp::Prop(prop) => {
+                            let modifier = prop.modifier.as_ref().map(|modifier| match modifier {
+                                PropModifier::Getter => TPropModifier::Getter,
+                                PropModifier::Setter => TPropModifier::Setter,
+                            });
+                            props.push(types::TObjElem::Prop(types::TProp {
+                                name: TPropKey::StringKey(prop.name.to_owned()),
+                                modifier,
+                                t: self.infer_type_ann(&mut prop.type_ann, ctx)?,
+                                mutable: prop.mutable,
+                                optional: prop.optional,
+                            }));
+                        }
+                        ObjectProp::Call(ObjCallable {
+                            span: _,
+                            type_params,
+                            params,
+                            ret,
+                        }) => {
+                            // TODO: dedupe with `Function` inference code above
+                            // NOTE: We clone `ctx` so that type params don't escape the signature
+                            let mut sig_ctx = ctx.clone();
+
+                            let type_params = self.infer_type_params(type_params, &mut sig_ctx)?;
+
+                            let func_params = params
+                                .iter_mut()
+                                .enumerate()
+                                .map(|(i, param)| {
+                                    let t = match &mut param.type_ann {
+                                        Some(type_ann) => {
+                                            self.infer_type_ann(type_ann, &mut sig_ctx)?
+                                        }
+                                        None => new_var_type(&mut self.arena, None),
+                                    };
+
+                                    Ok(types::FuncParam {
+                                        pattern: TPat::Ident(BindingIdent {
+                                            name: param.pattern.get_name(&i),
+                                            mutable: false,
+                                            span: Span { start: 0, end: 0 },
+                                        }),
+                                        t,
+                                        optional: param.optional,
+                                    })
+                                })
+                                .collect::<Result<Vec<_>, _>>()?;
+
+                            let ret_idx = self.infer_type_ann(ret.as_mut(), &mut sig_ctx)?;
+
+                            props.push(TObjElem::Call(TCallable {
+                                params: func_params,
+                                ret: ret_idx,
+                                type_params,
+                            }))
+                        }
+                        ObjectProp::Constructor(ObjCallable {
+                            span: _,
+                            type_params,
+                            params,
+                            ret,
+                        }) => {
+                            // TODO: dedupe with `Function` inference code above
+                            // NOTE: We clone `ctx` so that type params don't escape the signature
+                            let mut sig_ctx = ctx.clone();
+
+                            let type_params = self.infer_type_params(type_params, &mut sig_ctx)?;
+
+                            let func_params = params
+                                .iter_mut()
+                                .enumerate()
+                                .map(|(i, param)| {
+                                    let t = match &mut param.type_ann {
+                                        Some(type_ann) => {
+                                            self.infer_type_ann(type_ann, &mut sig_ctx)?
+                                        }
+                                        None => new_var_type(&mut self.arena, None),
+                                    };
+
+                                    Ok(types::FuncParam {
+                                        pattern: TPat::Ident(BindingIdent {
+                                            name: param.pattern.get_name(&i),
+                                            mutable: false,
+                                            span: Span { start: 0, end: 0 },
+                                        }),
+                                        t,
+                                        optional: param.optional,
+                                    })
+                                })
+                                .collect::<Result<Vec<_>, _>>()?;
+
+                            let ret_idx = self.infer_type_ann(ret.as_mut(), &mut sig_ctx)?;
+
+                            props.push(TObjElem::Constructor(TCallable {
+                                params: func_params,
+                                ret: ret_idx,
+                                type_params,
+                            }))
+                        }
+                    }
+                }
+                new_object_type(&mut self.arena, &props)
+            }
+            TypeAnnKind::TypeRef(name, type_args) => {
+                if ctx.schemes.get(name).is_none() {
+                    return Err(Errors::InferenceError(format!("{} is not in scope", name)));
                 }
 
-                let body_type = match arm.body {
-                    BlockOrExpr::Block(ref mut block) => infer_block(arena, block, &mut new_ctx)?,
-                    BlockOrExpr::Expr(ref mut expr) => infer_expression(arena, expr, &mut new_ctx)?,
+                match type_args {
+                    Some(type_args) => {
+                        let mut type_args_idxs = Vec::new();
+                        for type_arg in type_args.iter_mut() {
+                            type_args_idxs.push(self.infer_type_ann(type_arg, ctx)?);
+                        }
+                        // TODO: check that the type args conform to any constraints
+                        // present in the type params.
+                        new_constructor(&mut self.arena, name, &type_args_idxs)
+                    }
+                    None => new_constructor(&mut self.arena, name, &[]),
+                }
+            }
+            TypeAnnKind::Union(types) => {
+                let mut idxs = Vec::new();
+                for type_ann in types.iter_mut() {
+                    idxs.push(self.infer_type_ann(type_ann, ctx)?);
+                }
+                new_union_type(&mut self.arena, &idxs)
+            }
+            TypeAnnKind::Intersection(types) => {
+                let mut idxs = Vec::new();
+                for type_ann in types.iter_mut() {
+                    idxs.push(self.infer_type_ann(type_ann, ctx)?);
+                }
+                new_intersection_type(&mut self.arena, &idxs)
+            }
+            TypeAnnKind::Tuple(types) => {
+                let mut idxs = Vec::new();
+                for type_ann in types.iter_mut() {
+                    idxs.push(self.infer_type_ann(type_ann, ctx)?);
+                }
+                new_tuple_type(&mut self.arena, &idxs)
+            }
+            TypeAnnKind::Rest(rest) => {
+                let idx = self.infer_type_ann(rest, ctx)?;
+                new_rest_type(&mut self.arena, idx)
+            }
+            TypeAnnKind::Array(elem_type) => {
+                let idx = self.infer_type_ann(elem_type, ctx)?;
+                new_constructor(&mut self.arena, "Array", &[idx])
+            }
+            TypeAnnKind::IndexedAccess(obj_type, index_type) => {
+                let obj_idx = self.infer_type_ann(obj_type, ctx)?;
+                let index_idx = self.infer_type_ann(index_type, ctx)?;
+                new_indexed_access_type(&mut self.arena, obj_idx, index_idx)
+            }
+            TypeAnnKind::TypeOf(expr) => self.infer_expression(expr, ctx)?,
+
+            // TODO: Create types for all of these
+            TypeAnnKind::KeyOf(type_ann) => {
+                let t = self.infer_type_ann(type_ann, ctx)?;
+                new_keyof_type(&mut self.arena, t)
+                // expand_type(self.arena, ctx, t)?
+            }
+            // TypeAnnKind::Mapped(_) => todo!(),
+            TypeAnnKind::Condition(ConditionType {
+                check,
+                extends,
+                true_type,
+                false_type,
+            }) => {
+                let mut cond_ctx = ctx.clone();
+                let check_idx = self.infer_type_ann(check, &mut cond_ctx)?;
+                let extends_idx = self.infer_type_ann(extends, &mut cond_ctx)?;
+
+                // Create a copy of `ctx` so that we can add type aliases to it
+                // without them leaking out of the conditional type.
+                // let mut true_ctx = ctx.clone();
+
+                let infer_types = find_infer_types(&mut self.arena, &extends_idx);
+                for infer in infer_types {
+                    let tp = new_var_type(&mut self.arena, None);
+                    let scheme = Scheme {
+                        type_params: None,
+                        t: tp,
+                    };
+                    cond_ctx.schemes.insert(infer.name, scheme);
+                    // QUESTION: Do we need to do something with ctx.non_generic here?
+                    // true_ctx.non_generic.insert(tp);
+                }
+
+                let true_idx = self.infer_type_ann(true_type, &mut cond_ctx)?;
+                let false_idx = self.infer_type_ann(false_type, &mut cond_ctx)?;
+                new_conditional_type(&mut self.arena, check_idx, extends_idx, true_idx, false_idx)
+            }
+            TypeAnnKind::Match(MatchType { matchable, cases }) => {
+                let check_idx = self.infer_type_ann(matchable, ctx)?;
+
+                let case = cases.last_mut().unwrap();
+
+                let extends_idx = self.infer_type_ann(&mut case.extends, ctx)?;
+                let true_idx = self.infer_type_ann(&mut case.true_type, ctx)?;
+                let false_idx = new_keyword(&mut self.arena, Keyword::Never);
+
+                let mut cond_type = new_conditional_type(
+                    &mut self.arena,
+                    check_idx,
+                    extends_idx,
+                    true_idx,
+                    false_idx,
+                );
+
+                for case in cases.iter_mut().rev().skip(1) {
+                    let extends_idx = self.infer_type_ann(&mut case.extends, ctx)?;
+                    let true_idx = self.infer_type_ann(&mut case.true_type, ctx)?;
+                    let false_idx = cond_type;
+
+                    cond_type = new_conditional_type(
+                        &mut self.arena,
+                        check_idx,
+                        extends_idx,
+                        true_idx,
+                        false_idx,
+                    );
+                }
+
+                cond_type
+            }
+            // TODO: move this logic to `expand_type`.
+            TypeAnnKind::Binary(BinaryTypeAnn { left, op, right }) => {
+                let left = self.infer_type_ann(left, ctx)?;
+                let right = self.infer_type_ann(right, ctx)?;
+
+                let op = match op {
+                    BinaryOp::Plus => TBinaryOp::Add,
+                    BinaryOp::Minus => TBinaryOp::Sub,
+                    BinaryOp::Times => TBinaryOp::Mul,
+                    BinaryOp::Divide => TBinaryOp::Div,
+                    BinaryOp::Modulo => TBinaryOp::Mod,
+                    BinaryOp::Equals => todo!(),
+                    BinaryOp::NotEquals => todo!(),
+                    BinaryOp::LessThan => todo!(),
+                    BinaryOp::LessThanOrEqual => todo!(),
+                    BinaryOp::GreaterThan => todo!(),
+                    BinaryOp::GreaterThanOrEqual => todo!(),
+                    BinaryOp::Or => todo!(),
+                    BinaryOp::And => todo!(),
                 };
-                body_types.push(body_type);
+
+                self.arena
+                    .insert(Type::from(TypeKind::Binary(BinaryT { op, left, right })))
             }
+        };
 
-            let t0 = prune(arena, body_types[0]);
-            eprintln!("t0 = {}", arena[t0].as_string(arena));
+        let t = &mut self.arena[idx];
+        t.provenance = Some(Provenance::TypeAnn(Box::new(type_ann.to_owned())));
 
-            let t1 = prune(arena, body_types[1]);
-            eprintln!("t1 = {}", arena[t1].as_string(arena));
+        type_ann.inferred_type = Some(idx);
 
-            new_union_type(arena, &body_types)
-        }
-        ExprKind::Class(_) => todo!(),
-        ExprKind::Do(Do { body }) => infer_block(arena, body, ctx)?,
-        ExprKind::Try(Try {
-            body,
-            catch,
-            finally: _, // Don't include this in the result
-        }) => {
-            let body_t = infer_block(arena, body, ctx)?;
+        Ok(idx)
+    }
 
-            match catch {
-                Some(catch) => {
-                    let throws = find_throws_in_block(body);
+    pub fn infer_statement(
+        &mut self,
+        statement: &mut Stmt,
+        ctx: &mut Context,
+        top_level: bool,
+    ) -> Result<Index, Errors> {
+        let t = match &mut statement.kind {
+            StmtKind::Let {
+                is_declare,
+                pattern,
+                expr: init,
+                type_ann,
+                ..
+            } => {
+                let (pat_bindings, pat_type) = self.infer_pattern(pattern, ctx)?;
 
-                    let init_idx = new_union_type(arena, &throws);
+                match (is_declare, init, type_ann) {
+                    (false, Some(init), type_ann) => {
+                        let init_idx = self.infer_expression(init, ctx)?;
 
-                    if let Some(pattern) = &mut catch.param {
-                        let (pat_bindings, pat_type) = infer_pattern(arena, pattern, ctx)?;
+                        let init_type = self.arena.get(init_idx).unwrap().clone();
+                        let init_idx = match &init_type.kind {
+                            TypeKind::Function(func) if top_level => generalize_func(self, func),
+                            _ => init_idx,
+                        };
 
-                        unify(arena, ctx, init_idx, pat_type)?;
+                        let tpat = pattern_to_tpat(pattern, false);
+                        let mutability = check_mutability(ctx, &tpat, init)?;
+
+                        let idx = match type_ann {
+                            Some(type_ann) => {
+                                let type_ann_idx = self.infer_type_ann(type_ann, ctx)?;
+
+                                // The initializer must conform to the type annotation's
+                                // inferred type.
+                                match mutability {
+                                    true => self.unify_mut(ctx, init_idx, type_ann_idx)?,
+                                    false => self.unify(ctx, init_idx, type_ann_idx)?,
+                                };
+
+                                // Results in bindings introduced by the LHS pattern
+                                // having their types inferred.
+                                // It's okay for pat_type to be the super type here
+                                // because all initializers it introduces are type
+                                // variables.  It also prevents patterns from including
+                                // variables that don't exist in the type annotation.
+                                self.unify(ctx, type_ann_idx, pat_type)?;
+
+                                type_ann_idx
+                            }
+                            None => {
+                                // Results in bindings introduced by the LHS pattern
+                                // having their types inferred.
+                                // It's okay for pat_type to be the super type here
+                                // because all initializers it introduces are type
+                                // variables.  It also prevents patterns from including
+                                // variables that don't exist in the initializer.
+                                self.unify(ctx, init_idx, pat_type)?;
+
+                                init_idx
+                            }
+                        };
 
                         for (name, binding) in pat_bindings {
                             ctx.values.insert(name.clone(), binding);
                         }
 
-                        pattern.inferred_type = Some(init_idx);
-                    }
+                        pattern.inferred_type = Some(idx);
 
-                    let catch_t = infer_block(arena, &mut catch.body, ctx)?;
-                    new_union_type(arena, &[body_t, catch_t])
+                        idx // TODO: Should this be unit?
+                    }
+                    (false, None, _) => {
+                        return Err(Errors::InferenceError(
+                            "Variable declarations not using `declare` must have an initializer"
+                                .to_string(),
+                        ))
+                    }
+                    (true, None, Some(type_ann)) => {
+                        let idx = self.infer_type_ann(type_ann, ctx)?;
+
+                        self.unify(ctx, idx, pat_type)?;
+
+                        for (name, binding) in pat_bindings {
+                            ctx.values.insert(name.clone(), binding);
+                        }
+
+                        idx
+                    }
+                    (true, Some(_), _) => {
+                        return Err(Errors::InferenceError(
+                            "Variable declarations using `declare` cannot have an initializer"
+                                .to_string(),
+                        ))
+                    }
+                    (true, None, None) => {
+                        return Err(Errors::InferenceError(
+                            "Variable declarations using `declare` must have a type annotation"
+                                .to_string(),
+                        ))
+                    }
                 }
-                None => body_t,
+            }
+            StmtKind::Expr { expr } => self.infer_expression(expr, ctx)?,
+            StmtKind::Return { arg: expr } => {
+                // TODO: handle multiple return statements
+                // TODO: warn about unreachable code after a return statement
+                match expr {
+                    Some(expr) => self.infer_expression(expr, ctx)?,
+                    None => {
+                        // TODO: return `undefined` or `void`.
+                        todo!()
+                    }
+                }
+            }
+            // StmtKind::ClassDecl(_) => todo!(),
+            StmtKind::TypeDecl {
+                name,
+                type_ann,
+                type_params,
+            } => {
+                // NOTE: We clone `ctx` so that type params don't escape the signature
+                let mut sig_ctx = ctx.clone();
+
+                let type_params = self.infer_type_params(type_params, &mut sig_ctx)?;
+                let t = self.infer_type_ann(type_ann, &mut sig_ctx)?;
+
+                // TODO: generalize type `t` into a scheme
+                let scheme = Scheme { t, type_params };
+
+                ctx.schemes.insert(name.to_owned(), scheme);
+
+                t
+            } // StmtKind::ForStmt(_) => todo!(),
+        };
+
+        statement.inferred_type = Some(t);
+
+        Ok(t)
+    }
+
+    // TODO: introduce `infer_script` which has the same semantics as those used
+    // to infer the body of a function.
+    // TODO: rename to `infer_module`
+    pub fn infer_program(&mut self, node: &mut Program, ctx: &mut Context) -> Result<(), Errors> {
+        for stmt in &node.stmts {
+            if let StmtKind::TypeDecl { name, .. } = &stmt.kind {
+                let placeholder_scheme = Scheme {
+                    t: new_keyword(&mut self.arena, Keyword::Unknown),
+                    type_params: None,
+                };
+                let name = name.to_owned();
+                if ctx
+                    .schemes
+                    .insert(name.clone(), placeholder_scheme)
+                    .is_some()
+                {
+                    return Err(Errors::InferenceError(format!(
+                        "{name} cannot be redeclared at the top-level"
+                    )));
+                }
             }
         }
-        ExprKind::Yield(_) => todo!(),
-        ExprKind::Throw(Throw { arg, throws }) => {
-            throws.replace(infer_expression(arena, arg, ctx)?);
-            new_keyword(arena, Keyword::Never)
+
+        for stmt in &mut node.stmts {
+            if let StmtKind::Let { pattern, .. } = &mut stmt.kind {
+                let (bindings, _) = self.infer_pattern(pattern, ctx)?;
+
+                for (name, binding) in bindings {
+                    ctx.non_generic.insert(binding.index);
+                    if ctx.values.insert(name.to_owned(), binding).is_some() {
+                        return Err(Errors::InferenceError(format!(
+                            "{name} cannot be redeclared at the top-level"
+                        )));
+                    }
+                }
+            }
         }
-        ExprKind::JSXFragment(_) => todo!(),
-    };
 
-    let t = &mut arena[idx];
-    t.provenance = Some(Provenance::Expr(Box::new(node.to_owned())));
+        // TODO: capture all type decls and do a second pass to valid them
 
-    node.inferred_type = Some(idx);
+        // TODO: figure out how to avoid parsing patterns twice
+        for stmt in &mut node.stmts.iter_mut() {
+            self.infer_statement(stmt, ctx, true)?;
+        }
 
-    Ok(idx)
+        Ok(())
+    }
+
+    fn get_ident_member(
+        &mut self,
+        ctx: &mut Context,
+        obj_idx: Index,
+        key_idx: Index,
+    ) -> Result<Index, Errors> {
+        // NOTE: cloning is fine here because we aren't mutating `obj_type`
+        let obj_type = self.arena[obj_idx].clone();
+
+        match &obj_type.kind {
+            TypeKind::Object(_) => self.get_prop(ctx, obj_idx, key_idx),
+            // declare let obj: {x: number} | {x: string}
+            // obj.x; // number | string
+            TypeKind::Union(union) => {
+                let mut result_types = vec![];
+                let mut undefined_count = 0;
+                for idx in &union.types {
+                    match self.get_prop(ctx, *idx, key_idx) {
+                        Ok(t) => result_types.push(t),
+                        Err(_) => {
+                            // TODO: check what the error is, we may want to propagate
+                            // certain errors
+                            if undefined_count == 0 {
+                                let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+                                result_types.push(undefined);
+                            }
+                            undefined_count += 1;
+                        }
+                    }
+                }
+                if undefined_count == union.types.len() {
+                    Err(Errors::InferenceError(format!(
+                        "Couldn't find property {} on object",
+                        self.print_type(&key_idx),
+                    )))
+                } else {
+                    Ok(new_union_type(&mut self.arena, &result_types))
+                }
+            }
+            TypeKind::Constructor(types::Constructor {
+                name: alias_name,
+                types,
+                ..
+            }) => match ctx.schemes.get(alias_name) {
+                Some(scheme) => {
+                    let obj_idx = self.expand_alias(ctx, alias_name, scheme, types)?;
+                    self.get_ident_member(ctx, obj_idx, key_idx)
+                }
+                None => Err(Errors::InferenceError(format!(
+                    "Can't find type alias for {alias_name}"
+                ))),
+            },
+            TypeKind::Tuple(types::Tuple { types }) => match ctx.schemes.get("Array") {
+                Some(scheme) => {
+                    let t = new_union_type(&mut self.arena, types);
+                    let obj_idx = self.expand_alias(ctx, "Array", scheme, &[t])?;
+                    self.get_ident_member(ctx, obj_idx, key_idx)
+                }
+                None => Err(Errors::InferenceError(
+                    "Can't find type alias for Array".to_string(),
+                )),
+            },
+            _ => Err(Errors::InferenceError(format!(
+                "Can't access properties on {}",
+                obj_type.as_string(&self.arena)
+            ))),
+        }
+    }
+
+    fn infer_type_params(
+        &mut self,
+        type_params: &mut Option<Vec<syntax::TypeParam>>,
+        sig_ctx: &mut Context,
+    ) -> Result<Option<Vec<types::TypeParam>>, Errors> {
+        if let Some(type_params) = type_params {
+            for tp in type_params.iter_mut() {
+                let constraint = match &mut tp.bound {
+                    Some(constraint) => Some(self.infer_type_ann(constraint, sig_ctx)?),
+                    None => None,
+                };
+
+                // Adds the param to the context and set its type to the constraint
+                // or `unknown` if there is no constraint.
+                let scheme = Scheme {
+                    t: match constraint {
+                        Some(constraint) => constraint,
+                        None => new_keyword(&mut self.arena, Keyword::Unknown),
+                    },
+                    type_params: None,
+                };
+                sig_ctx.schemes.insert(tp.name.to_owned(), scheme);
+            }
+        }
+
+        // TODO: move this up and do this at the same time we do the other
+        // processing of `type_params`.
+        let mut type_param_names: HashSet<String> = HashSet::new();
+        let type_params = match type_params {
+            Some(type_params) => Some(
+                type_params
+                    .iter_mut()
+                    .map(|tp| {
+                        if !type_param_names.insert(tp.name.to_owned()) {
+                            return Err(Errors::InferenceError(
+                                "type param identifiers must be unique".to_string(),
+                            ));
+                        }
+                        Ok(types::TypeParam {
+                            name: tp.name.to_owned(),
+                            constraint: match &mut tp.bound {
+                                Some(constraint) => Some(self.infer_type_ann(constraint, sig_ctx)?),
+                                None => None,
+                            },
+                            default: match &mut tp.default {
+                                Some(default) => Some(self.infer_type_ann(default, sig_ctx)?),
+                                None => None,
+                            },
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            None => None,
+        };
+
+        Ok(type_params)
+    }
 }
 
 fn is_promise(t: &Type) -> bool {
@@ -633,795 +1363,6 @@ fn is_promise(t: &Type) -> bool {
             provenance: _,
         } if name == "Promise"
     )
-}
-
-pub fn infer_block(
-    arena: &mut Arena<Type>,
-    block: &mut Block,
-    ctx: &mut Context,
-) -> Result<Index, Errors> {
-    let mut new_ctx = ctx.clone();
-    let mut result_t = new_keyword(arena, Keyword::Undefined);
-
-    for stmt in &mut block.stmts.iter_mut() {
-        result_t = infer_statement(arena, stmt, &mut new_ctx, false)?;
-    }
-
-    Ok(result_t)
-}
-
-pub fn infer_type_ann(
-    arena: &mut Arena<Type>,
-    type_ann: &mut TypeAnn,
-    ctx: &mut Context,
-) -> Result<Index, Errors> {
-    let idx = match &mut type_ann.kind {
-        TypeAnnKind::Function(FunctionType {
-            params,
-            ret,
-            type_params,
-            throws,
-        }) => {
-            // NOTE: We clone `ctx` so that type params don't escape the signature
-            let mut sig_ctx = ctx.clone();
-
-            let type_params = infer_type_params(arena, type_params, &mut sig_ctx)?;
-
-            let func_params = params
-                .iter_mut()
-                .map(|param| {
-                    let t = match &mut param.type_ann {
-                        Some(type_ann) => infer_type_ann(arena, type_ann, &mut sig_ctx)?,
-                        None => new_var_type(arena, None),
-                    };
-
-                    Ok(types::FuncParam {
-                        pattern: pattern_to_tpat(&param.pattern, true),
-                        t,
-                        optional: param.optional,
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let ret_idx = infer_type_ann(arena, ret.as_mut(), &mut sig_ctx)?;
-
-            let throws = throws
-                .as_mut()
-                .map(|throws| infer_type_ann(arena, throws, &mut sig_ctx))
-                .transpose()?;
-
-            new_func_type(arena, &func_params, ret_idx, &type_params, throws)
-        }
-        TypeAnnKind::NumLit(value) => arena.insert(Type::from(TypeKind::Literal(
-            syntax::Literal::Number(value.to_owned()),
-        ))),
-        TypeAnnKind::StrLit(value) => arena.insert(Type::from(TypeKind::Literal(
-            syntax::Literal::String(value.to_owned()),
-        ))),
-        TypeAnnKind::BoolLit(value) => arena.insert(Type::from(TypeKind::Literal(
-            syntax::Literal::Boolean(value.to_owned()),
-        ))),
-        // TypeAnnKind::Null => arena.insert(Type {
-        //     kind: TypeKind::Literal(syntax::Literal::Null),
-        // }),
-        // TypeAnnKind::Undefined => arena.insert(Type {
-        //     kind: TypeKind::Literal(syntax::Literal::Undefined),
-        // }),
-        // TypeAnnKind::Lit(lit) => new_lit_type(arena, lit),
-        TypeAnnKind::Number => new_primitive(arena, Primitive::Number),
-        TypeAnnKind::Boolean => new_primitive(arena, Primitive::Boolean),
-        TypeAnnKind::String => new_primitive(arena, Primitive::String),
-        TypeAnnKind::Symbol => new_primitive(arena, Primitive::Symbol),
-
-        TypeAnnKind::Null => new_keyword(arena, Keyword::Null),
-        TypeAnnKind::Undefined => new_keyword(arena, Keyword::Undefined),
-        TypeAnnKind::Unknown => new_keyword(arena, Keyword::Unknown),
-        TypeAnnKind::Never => new_keyword(arena, Keyword::Never),
-
-        // TODO: How we make sure that create a fresh type variable for this
-        // whenever it's used?  Maybe we can have an actual TypeKind::Wildcard
-        // instead of creating a type variable here.
-        TypeAnnKind::Wildcard => new_wildcard_type(arena),
-        TypeAnnKind::Infer(name) => new_infer_type(arena, name),
-
-        TypeAnnKind::Object(obj) => {
-            let mut props: Vec<types::TObjElem> = Vec::new();
-            for elem in obj.iter_mut() {
-                match elem {
-                    ObjectProp::Mapped(Mapped {
-                        key,
-                        value,
-                        target,
-                        source,
-                        check,
-                        extends,
-                    }) => {
-                        let mut type_ctx = ctx.clone();
-
-                        let source = infer_type_ann(arena, source, &mut type_ctx)?;
-                        let scheme = Scheme {
-                            type_params: None,
-                            t: source,
-                        };
-                        type_ctx.schemes.insert(target.to_owned(), scheme);
-
-                        let key = infer_type_ann(arena, key, &mut type_ctx)?;
-                        // let mut mapping: HashMap<String, Index> = HashMap::new();
-                        // mapping.insert(target.to_owned(), source);
-                        // let key = instantiate_scheme(arena, key, &mapping);
-
-                        let value = infer_type_ann(arena, value, &mut type_ctx)?;
-                        let check = match check {
-                            Some(check) => Some(infer_type_ann(arena, check, &mut type_ctx)?),
-                            None => None,
-                        };
-                        let extends = match extends {
-                            Some(extends) => Some(infer_type_ann(arena, extends, &mut type_ctx)?),
-                            None => None,
-                        };
-
-                        props.push(types::TObjElem::Mapped(types::MappedType {
-                            key,
-                            value,
-                            target: target.to_owned(),
-                            source,
-                            check,
-                            extends,
-                        }));
-                    }
-                    ObjectProp::Prop(prop) => {
-                        let modifier = prop.modifier.as_ref().map(|modifier| match modifier {
-                            PropModifier::Getter => TPropModifier::Getter,
-                            PropModifier::Setter => TPropModifier::Setter,
-                        });
-                        props.push(types::TObjElem::Prop(types::TProp {
-                            name: TPropKey::StringKey(prop.name.to_owned()),
-                            modifier,
-                            t: infer_type_ann(arena, &mut prop.type_ann, ctx)?,
-                            mutable: prop.mutable,
-                            optional: prop.optional,
-                        }));
-                    }
-                    ObjectProp::Call(ObjCallable {
-                        span: _,
-                        type_params,
-                        params,
-                        ret,
-                    }) => {
-                        // TODO: dedupe with `Function` inference code above
-                        // NOTE: We clone `ctx` so that type params don't escape the signature
-                        let mut sig_ctx = ctx.clone();
-
-                        let type_params = infer_type_params(arena, type_params, &mut sig_ctx)?;
-
-                        let func_params = params
-                            .iter_mut()
-                            .enumerate()
-                            .map(|(i, param)| {
-                                let t = match &mut param.type_ann {
-                                    Some(type_ann) => {
-                                        infer_type_ann(arena, type_ann, &mut sig_ctx)?
-                                    }
-                                    None => new_var_type(arena, None),
-                                };
-
-                                Ok(types::FuncParam {
-                                    pattern: TPat::Ident(BindingIdent {
-                                        name: param.pattern.get_name(&i),
-                                        mutable: false,
-                                        span: Span { start: 0, end: 0 },
-                                    }),
-                                    t,
-                                    optional: param.optional,
-                                })
-                            })
-                            .collect::<Result<Vec<_>, _>>()?;
-
-                        let ret_idx = infer_type_ann(arena, ret.as_mut(), &mut sig_ctx)?;
-
-                        props.push(TObjElem::Call(TCallable {
-                            params: func_params,
-                            ret: ret_idx,
-                            type_params,
-                        }))
-                    }
-                    ObjectProp::Constructor(ObjCallable {
-                        span: _,
-                        type_params,
-                        params,
-                        ret,
-                    }) => {
-                        // TODO: dedupe with `Function` inference code above
-                        // NOTE: We clone `ctx` so that type params don't escape the signature
-                        let mut sig_ctx = ctx.clone();
-
-                        let type_params = infer_type_params(arena, type_params, &mut sig_ctx)?;
-
-                        let func_params = params
-                            .iter_mut()
-                            .enumerate()
-                            .map(|(i, param)| {
-                                let t = match &mut param.type_ann {
-                                    Some(type_ann) => {
-                                        infer_type_ann(arena, type_ann, &mut sig_ctx)?
-                                    }
-                                    None => new_var_type(arena, None),
-                                };
-
-                                Ok(types::FuncParam {
-                                    pattern: TPat::Ident(BindingIdent {
-                                        name: param.pattern.get_name(&i),
-                                        mutable: false,
-                                        span: Span { start: 0, end: 0 },
-                                    }),
-                                    t,
-                                    optional: param.optional,
-                                })
-                            })
-                            .collect::<Result<Vec<_>, _>>()?;
-
-                        let ret_idx = infer_type_ann(arena, ret.as_mut(), &mut sig_ctx)?;
-
-                        props.push(TObjElem::Constructor(TCallable {
-                            params: func_params,
-                            ret: ret_idx,
-                            type_params,
-                        }))
-                    }
-                }
-            }
-            new_object_type(arena, &props)
-        }
-        TypeAnnKind::TypeRef(name, type_args) => {
-            if ctx.schemes.get(name).is_none() {
-                return Err(Errors::InferenceError(format!("{} is not in scope", name)));
-            }
-
-            match type_args {
-                Some(type_args) => {
-                    let mut type_args_idxs = Vec::new();
-                    for type_arg in type_args.iter_mut() {
-                        type_args_idxs.push(infer_type_ann(arena, type_arg, ctx)?);
-                    }
-                    // TODO: check that the type args conform to any constraints
-                    // present in the type params.
-                    new_constructor(arena, name, &type_args_idxs)
-                }
-                None => new_constructor(arena, name, &[]),
-            }
-        }
-        TypeAnnKind::Union(types) => {
-            let mut idxs = Vec::new();
-            for type_ann in types.iter_mut() {
-                idxs.push(infer_type_ann(arena, type_ann, ctx)?);
-            }
-            new_union_type(arena, &idxs)
-        }
-        TypeAnnKind::Intersection(types) => {
-            let mut idxs = Vec::new();
-            for type_ann in types.iter_mut() {
-                idxs.push(infer_type_ann(arena, type_ann, ctx)?);
-            }
-            new_intersection_type(arena, &idxs)
-        }
-        TypeAnnKind::Tuple(types) => {
-            let mut idxs = Vec::new();
-            for type_ann in types.iter_mut() {
-                idxs.push(infer_type_ann(arena, type_ann, ctx)?);
-            }
-            new_tuple_type(arena, &idxs)
-        }
-        TypeAnnKind::Rest(rest) => {
-            let idx = infer_type_ann(arena, rest, ctx)?;
-            new_rest_type(arena, idx)
-        }
-        TypeAnnKind::Array(elem_type) => {
-            let idx = infer_type_ann(arena, elem_type, ctx)?;
-            new_constructor(arena, "Array", &[idx])
-        }
-        TypeAnnKind::IndexedAccess(obj_type, index_type) => {
-            let obj_idx = infer_type_ann(arena, obj_type, ctx)?;
-            let index_idx = infer_type_ann(arena, index_type, ctx)?;
-            new_indexed_access_type(arena, obj_idx, index_idx)
-        }
-        TypeAnnKind::TypeOf(expr) => infer_expression(arena, expr, ctx)?,
-
-        // TODO: Create types for all of these
-        TypeAnnKind::KeyOf(type_ann) => {
-            let t = infer_type_ann(arena, type_ann, ctx)?;
-            new_keyof_type(arena, t)
-            // expand_type(arena, ctx, t)?
-        }
-        // TypeAnnKind::Mapped(_) => todo!(),
-        TypeAnnKind::Condition(ConditionType {
-            check,
-            extends,
-            true_type,
-            false_type,
-        }) => {
-            let mut cond_ctx = ctx.clone();
-            let check_idx = infer_type_ann(arena, check, &mut cond_ctx)?;
-            let extends_idx = infer_type_ann(arena, extends, &mut cond_ctx)?;
-
-            // Create a copy of `ctx` so that we can add type aliases to it
-            // without them leaking out of the conditional type.
-            // let mut true_ctx = ctx.clone();
-
-            let infer_types = find_infer_types(arena, &extends_idx);
-            for infer in infer_types {
-                let tp = new_var_type(arena, None);
-                let scheme = Scheme {
-                    type_params: None,
-                    t: tp,
-                };
-                cond_ctx.schemes.insert(infer.name, scheme);
-                // QUESTION: Do we need to do something with ctx.non_generic here?
-                // true_ctx.non_generic.insert(tp);
-            }
-
-            let true_idx = infer_type_ann(arena, true_type, &mut cond_ctx)?;
-            let false_idx = infer_type_ann(arena, false_type, &mut cond_ctx)?;
-            new_conditional_type(arena, check_idx, extends_idx, true_idx, false_idx)
-        }
-        TypeAnnKind::Match(MatchType { matchable, cases }) => {
-            let check_idx = infer_type_ann(arena, matchable, ctx)?;
-
-            let case = cases.last_mut().unwrap();
-
-            let extends_idx = infer_type_ann(arena, &mut case.extends, ctx)?;
-            let true_idx = infer_type_ann(arena, &mut case.true_type, ctx)?;
-            let false_idx = new_keyword(arena, Keyword::Never);
-
-            let mut cond_type =
-                new_conditional_type(arena, check_idx, extends_idx, true_idx, false_idx);
-
-            for case in cases.iter_mut().rev().skip(1) {
-                let extends_idx = infer_type_ann(arena, &mut case.extends, ctx)?;
-                let true_idx = infer_type_ann(arena, &mut case.true_type, ctx)?;
-                let false_idx = cond_type;
-
-                cond_type =
-                    new_conditional_type(arena, check_idx, extends_idx, true_idx, false_idx);
-            }
-
-            cond_type
-        }
-        // TODO: move this logic to `expand_type`.
-        TypeAnnKind::Binary(BinaryTypeAnn { left, op, right }) => {
-            let left = infer_type_ann(arena, left, ctx)?;
-            let right = infer_type_ann(arena, right, ctx)?;
-
-            let op = match op {
-                BinaryOp::Plus => TBinaryOp::Add,
-                BinaryOp::Minus => TBinaryOp::Sub,
-                BinaryOp::Times => TBinaryOp::Mul,
-                BinaryOp::Divide => TBinaryOp::Div,
-                BinaryOp::Modulo => TBinaryOp::Mod,
-                BinaryOp::Equals => todo!(),
-                BinaryOp::NotEquals => todo!(),
-                BinaryOp::LessThan => todo!(),
-                BinaryOp::LessThanOrEqual => todo!(),
-                BinaryOp::GreaterThan => todo!(),
-                BinaryOp::GreaterThanOrEqual => todo!(),
-                BinaryOp::Or => todo!(),
-                BinaryOp::And => todo!(),
-            };
-
-            arena.insert(Type::from(TypeKind::Binary(BinaryT { op, left, right })))
-        }
-    };
-
-    let t = &mut arena[idx];
-    t.provenance = Some(Provenance::TypeAnn(Box::new(type_ann.to_owned())));
-
-    type_ann.inferred_type = Some(idx);
-
-    Ok(idx)
-}
-
-pub fn infer_statement(
-    arena: &mut Arena<Type>,
-    statement: &mut Stmt,
-    ctx: &mut Context,
-    top_level: bool,
-) -> Result<Index, Errors> {
-    let t = match &mut statement.kind {
-        StmtKind::Let {
-            is_declare,
-            pattern,
-            expr: init,
-            type_ann,
-            ..
-        } => {
-            let (pat_bindings, pat_type) = infer_pattern(arena, pattern, ctx)?;
-
-            match (is_declare, init, type_ann) {
-                (false, Some(init), type_ann) => {
-                    let init_idx = infer_expression(arena, init, ctx)?;
-
-                    let init_type = arena.get(init_idx).unwrap().clone();
-                    let init_idx = match &init_type.kind {
-                        TypeKind::Function(func) if top_level => generalize_func(arena, func),
-                        _ => init_idx,
-                    };
-
-                    let tpat = pattern_to_tpat(pattern, false);
-                    let mutability = check_mutability(ctx, &tpat, init)?;
-
-                    let idx = match type_ann {
-                        Some(type_ann) => {
-                            let type_ann_idx = infer_type_ann(arena, type_ann, ctx)?;
-
-                            // The initializer must conform to the type annotation's
-                            // inferred type.
-                            match mutability {
-                                true => unify_mut(arena, ctx, init_idx, type_ann_idx)?,
-                                false => unify(arena, ctx, init_idx, type_ann_idx)?,
-                            };
-
-                            // Results in bindings introduced by the LHS pattern
-                            // having their types inferred.
-                            // It's okay for pat_type to be the super type here
-                            // because all initializers it introduces are type
-                            // variables.  It also prevents patterns from including
-                            // variables that don't exist in the type annotation.
-                            unify(arena, ctx, type_ann_idx, pat_type)?;
-
-                            type_ann_idx
-                        }
-                        None => {
-                            // Results in bindings introduced by the LHS pattern
-                            // having their types inferred.
-                            // It's okay for pat_type to be the super type here
-                            // because all initializers it introduces are type
-                            // variables.  It also prevents patterns from including
-                            // variables that don't exist in the initializer.
-                            unify(arena, ctx, init_idx, pat_type)?;
-
-                            init_idx
-                        }
-                    };
-
-                    for (name, binding) in pat_bindings {
-                        ctx.values.insert(name.clone(), binding);
-                    }
-
-                    pattern.inferred_type = Some(idx);
-
-                    idx // TODO: Should this be unit?
-                }
-                (false, None, _) => {
-                    return Err(Errors::InferenceError(
-                        "Variable declarations not using `declare` must have an initializer"
-                            .to_string(),
-                    ))
-                }
-                (true, None, Some(type_ann)) => {
-                    let idx = infer_type_ann(arena, type_ann, ctx)?;
-
-                    unify(arena, ctx, idx, pat_type)?;
-
-                    for (name, binding) in pat_bindings {
-                        ctx.values.insert(name.clone(), binding);
-                    }
-
-                    idx
-                }
-                (true, Some(_), _) => {
-                    return Err(Errors::InferenceError(
-                        "Variable declarations using `declare` cannot have an initializer"
-                            .to_string(),
-                    ))
-                }
-                (true, None, None) => {
-                    return Err(Errors::InferenceError(
-                        "Variable declarations using `declare` must have a type annotation"
-                            .to_string(),
-                    ))
-                }
-            }
-        }
-        StmtKind::Expr { expr } => infer_expression(arena, expr, ctx)?,
-        StmtKind::Return { arg: expr } => {
-            // TODO: handle multiple return statements
-            // TODO: warn about unreachable code after a return statement
-            match expr {
-                Some(expr) => infer_expression(arena, expr, ctx)?,
-                None => {
-                    // TODO: return `undefined` or `void`.
-                    todo!()
-                }
-            }
-        }
-        // StmtKind::ClassDecl(_) => todo!(),
-        StmtKind::TypeDecl {
-            name,
-            type_ann,
-            type_params,
-        } => {
-            // NOTE: We clone `ctx` so that type params don't escape the signature
-            let mut sig_ctx = ctx.clone();
-
-            let type_params = infer_type_params(arena, type_params, &mut sig_ctx)?;
-            let t = infer_type_ann(arena, type_ann, &mut sig_ctx)?;
-
-            // TODO: generalize type `t` into a scheme
-            let scheme = Scheme { t, type_params };
-
-            ctx.schemes.insert(name.to_owned(), scheme);
-
-            t
-        } // StmtKind::ForStmt(_) => todo!(),
-    };
-
-    statement.inferred_type = Some(t);
-
-    Ok(t)
-}
-
-// TODO: introduce `infer_script` which has the same semantics as those used
-// to infer the body of a function.
-// TODO: rename to `infer_module`
-pub fn infer_program(
-    arena: &mut Arena<Type>,
-    node: &mut Program,
-    ctx: &mut Context,
-) -> Result<(), Errors> {
-    for stmt in &node.stmts {
-        if let StmtKind::TypeDecl { name, .. } = &stmt.kind {
-            let placeholder_scheme = Scheme {
-                t: new_keyword(arena, Keyword::Unknown),
-                type_params: None,
-            };
-            let name = name.to_owned();
-            if ctx
-                .schemes
-                .insert(name.clone(), placeholder_scheme)
-                .is_some()
-            {
-                return Err(Errors::InferenceError(format!(
-                    "{name} cannot be redeclared at the top-level"
-                )));
-            }
-        }
-    }
-
-    for stmt in &mut node.stmts {
-        if let StmtKind::Let { pattern, .. } = &mut stmt.kind {
-            let (bindings, _) = infer_pattern(arena, pattern, ctx)?;
-
-            for (name, binding) in bindings {
-                ctx.non_generic.insert(binding.index);
-                if ctx.values.insert(name.to_owned(), binding).is_some() {
-                    return Err(Errors::InferenceError(format!(
-                        "{name} cannot be redeclared at the top-level"
-                    )));
-                }
-            }
-        }
-    }
-
-    // TODO: capture all type decls and do a second pass to valid them
-
-    // TODO: figure out how to avoid parsing patterns twice
-    for stmt in &mut node.stmts.iter_mut() {
-        infer_statement(arena, stmt, ctx, true)?;
-    }
-
-    Ok(())
-}
-
-struct Generalize<'a> {
-    arena: &'a mut Arena<Type>,
-    mapping: &'a mut BTreeMap<Index, String>,
-}
-
-impl<'a> KeyValueStore<Index, Type> for Generalize<'a> {
-    fn get_type(&mut self, index: &Index) -> Type {
-        self.arena[*index].clone()
-    }
-    fn put_type(&mut self, t: Type) -> Index {
-        self.arena.insert(t)
-    }
-}
-
-impl<'a> Folder for Generalize<'a> {
-    fn fold_index(&mut self, index: &Index) -> Index {
-        // QUESTION: Why do we need to `prune` here?  Maybe because we don't
-        // copy the `instance` when creating an new type variable.
-        let index = prune(self.arena, *index);
-        let t = self.get_type(&index);
-
-        match &t.kind {
-            TypeKind::Variable(Variable {
-                id: _,
-                instance: _,
-                constraint: _,
-            }) => {
-                let name = match self.mapping.get(&index) {
-                    Some(name) => name.clone(),
-                    None => {
-                        // TODO: create a name generator that can avoid duplicating
-                        // names of explicitly provided type params.
-                        let name = ((self.mapping.len() as u8) + 65) as char;
-                        let name = format!("{}", name);
-                        // let name = format!("'{}", mappings.len());
-                        self.mapping.insert(index, name.clone());
-                        name
-                    }
-                };
-                new_constructor(self.arena, &name, &[])
-            }
-            _ => folder::walk_index(self, &index),
-        }
-    }
-}
-
-pub fn generalize_func(arena: &'_ mut Arena<Type>, func: &types::Function) -> Index {
-    // A mapping of TypeVariables to TypeVariables
-    let mut mapping = BTreeMap::default();
-    let mut generalize = Generalize {
-        arena,
-        mapping: &mut mapping,
-    };
-
-    let params = func
-        .params
-        .iter()
-        .map(|param| types::FuncParam {
-            t: generalize.fold_index(&param.t),
-            ..param.to_owned()
-        })
-        .collect::<Vec<_>>();
-    let ret = generalize.fold_index(&func.ret);
-    let throws = func.throws.map(|throws| generalize.fold_index(&throws));
-
-    let mut type_params: Vec<types::TypeParam> = vec![];
-
-    if let Some(explicit_type_params) = &func.type_params {
-        type_params.extend(explicit_type_params.to_owned());
-    }
-
-    for (_, name) in mapping {
-        type_params.push(types::TypeParam {
-            name: name.clone(),
-            constraint: None,
-            default: None,
-        });
-    }
-
-    if type_params.is_empty() {
-        new_func_type(arena, &params, ret, &None, throws)
-    } else {
-        new_func_type(arena, &params, ret, &Some(type_params), throws)
-    }
-}
-
-fn get_ident_member(
-    arena: &mut Arena<Type>,
-    ctx: &mut Context,
-    obj_idx: Index,
-    key_idx: Index,
-) -> Result<Index, Errors> {
-    // NOTE: cloning is fine here because we aren't mutating `obj_type`
-    let obj_type = arena[obj_idx].clone();
-
-    match &obj_type.kind {
-        TypeKind::Object(_) => get_prop(arena, ctx, obj_idx, key_idx),
-        // declare let obj: {x: number} | {x: string}
-        // obj.x; // number | string
-        TypeKind::Union(union) => {
-            let mut result_types = vec![];
-            let mut undefined_count = 0;
-            for idx in &union.types {
-                match get_prop(arena, ctx, *idx, key_idx) {
-                    Ok(t) => result_types.push(t),
-                    Err(_) => {
-                        // TODO: check what the error is, we may want to propagate
-                        // certain errors
-                        if undefined_count == 0 {
-                            let undefined = new_keyword(arena, Keyword::Undefined);
-                            result_types.push(undefined);
-                        }
-                        undefined_count += 1;
-                    }
-                }
-            }
-            if undefined_count == union.types.len() {
-                Err(Errors::InferenceError(format!(
-                    "Couldn't find property {} on object",
-                    arena[key_idx].as_string(arena)
-                )))
-            } else {
-                Ok(new_union_type(arena, &result_types))
-            }
-        }
-        TypeKind::Constructor(types::Constructor {
-            name: alias_name,
-            types,
-            ..
-        }) => match ctx.schemes.get(alias_name) {
-            Some(scheme) => {
-                let obj_idx = expand_alias(arena, ctx, alias_name, scheme, types)?;
-                get_ident_member(arena, ctx, obj_idx, key_idx)
-            }
-            None => Err(Errors::InferenceError(format!(
-                "Can't find type alias for {alias_name}"
-            ))),
-        },
-        TypeKind::Tuple(types::Tuple { types }) => match ctx.schemes.get("Array") {
-            Some(scheme) => {
-                let t = new_union_type(arena, types);
-                let obj_idx = expand_alias(arena, ctx, "Array", scheme, &[t])?;
-                get_ident_member(arena, ctx, obj_idx, key_idx)
-            }
-            None => Err(Errors::InferenceError(
-                "Can't find type alias for Array".to_string(),
-            )),
-        },
-        _ => Err(Errors::InferenceError(format!(
-            "Can't access properties on {}",
-            obj_type.as_string(arena)
-        ))),
-    }
-}
-
-fn infer_type_params(
-    arena: &mut Arena<Type>,
-    type_params: &mut Option<Vec<syntax::TypeParam>>,
-    sig_ctx: &mut Context,
-) -> Result<Option<Vec<types::TypeParam>>, Errors> {
-    if let Some(type_params) = type_params {
-        for tp in type_params.iter_mut() {
-            let constraint = match &mut tp.bound {
-                Some(constraint) => Some(infer_type_ann(arena, constraint, sig_ctx)?),
-                None => None,
-            };
-
-            // Adds the param to the context and set its type to the constraint
-            // or `unknown` if there is no constraint.
-            let scheme = Scheme {
-                t: match constraint {
-                    Some(constraint) => constraint,
-                    None => new_keyword(arena, Keyword::Unknown),
-                },
-                type_params: None,
-            };
-            sig_ctx.schemes.insert(tp.name.to_owned(), scheme);
-        }
-    }
-
-    // TODO: move this up and do this at the same time we do the other
-    // processing of `type_params`.
-    let mut type_param_names: HashSet<String> = HashSet::new();
-    let type_params = match type_params {
-        Some(type_params) => Some(
-            type_params
-                .iter_mut()
-                .map(|tp| {
-                    if !type_param_names.insert(tp.name.to_owned()) {
-                        return Err(Errors::InferenceError(
-                            "type param identifiers must be unique".to_string(),
-                        ));
-                    }
-                    Ok(types::TypeParam {
-                        name: tp.name.to_owned(),
-                        constraint: match &mut tp.bound {
-                            Some(constraint) => Some(infer_type_ann(arena, constraint, sig_ctx)?),
-                            None => None,
-                        },
-                        default: match &mut tp.default {
-                            Some(default) => Some(infer_type_ann(arena, default, sig_ctx)?),
-                            None => None,
-                        },
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-        ),
-        None => None,
-    };
-
-    Ok(type_params)
 }
 
 // NOTE: It's possible to have a mix of mutable and immutable bindings be
@@ -1478,5 +1419,92 @@ fn lvalue_mutability(ctx: &Context, expr: &Expr) -> Result<bool, Errors> {
         _ => Err(Errors::InferenceError(
             "Can't assign to non-lvalue".to_string(),
         )),
+    }
+}
+
+struct Generalize<'a, 'b> {
+    checker: &'a mut Checker,
+    mapping: &'b mut BTreeMap<Index, String>,
+}
+
+// TODO: have `Checker` implement this trait
+impl<'a, 'b> KeyValueStore<Index, Type> for Generalize<'a, 'b> {
+    fn get_type(&mut self, index: &Index) -> Type {
+        self.checker.arena[*index].clone()
+    }
+    fn put_type(&mut self, t: Type) -> Index {
+        self.checker.arena.insert(t)
+    }
+}
+
+impl<'a, 'b> Folder for Generalize<'a, 'b> {
+    fn fold_index(&mut self, index: &Index) -> Index {
+        // QUESTION: Why do we need to `prune` here?  Maybe because we don't
+        // copy the `instance` when creating an new type variable.
+        let index = self.checker.prune(*index);
+        let t = self.get_type(&index);
+
+        match &t.kind {
+            TypeKind::Variable(Variable {
+                id: _,
+                instance: _,
+                constraint: _,
+            }) => {
+                let name = match self.mapping.get(&index) {
+                    Some(name) => name.clone(),
+                    None => {
+                        // TODO: create a name generator that can avoid duplicating
+                        // names of explicitly provided type params.
+                        let name = ((self.mapping.len() as u8) + 65) as char;
+                        let name = format!("{}", name);
+                        // let name = format!("'{}", mappings.len());
+                        self.mapping.insert(index, name.clone());
+                        name
+                    }
+                };
+                new_constructor(&mut self.checker.arena, &name, &[])
+            }
+            _ => folder::walk_index(self, &index),
+        }
+    }
+}
+
+pub fn generalize_func(checker: &mut Checker, func: &types::Function) -> Index {
+    // A mapping of TypeVariables to TypeVariables
+    let mut mapping = BTreeMap::default();
+    let mut generalize = Generalize {
+        checker,
+        mapping: &mut mapping,
+    };
+
+    let params = func
+        .params
+        .iter()
+        .map(|param| types::FuncParam {
+            t: generalize.fold_index(&param.t),
+            ..param.to_owned()
+        })
+        .collect::<Vec<_>>();
+    let ret = generalize.fold_index(&func.ret);
+    let throws = func.throws.map(|throws| generalize.fold_index(&throws));
+
+    let mut type_params: Vec<types::TypeParam> = vec![];
+
+    if let Some(explicit_type_params) = &func.type_params {
+        type_params.extend(explicit_type_params.to_owned());
+    }
+
+    for (_, name) in mapping {
+        type_params.push(types::TypeParam {
+            name: name.clone(),
+            constraint: None,
+            default: None,
+        });
+    }
+
+    if type_params.is_empty() {
+        checker.new_func_type(&params, ret, &None, throws)
+    } else {
+        checker.new_func_type(&params, ret, &Some(type_params), throws)
     }
 }

--- a/crates/escalier_hm/src/lib.rs
+++ b/crates/escalier_hm/src/lib.rs
@@ -1,5 +1,6 @@
 // Based on https://github.com/tcr/rust-hindley-milner/blob/master/src/lib.rs
 mod ast_utils;
+pub mod checker;
 pub mod context;
 pub mod errors;
 mod folder;
@@ -11,5 +12,3 @@ pub mod types;
 mod unify;
 pub mod util;
 mod visitor;
-
-pub use infer::{infer_expression, infer_program};

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -5,861 +5,880 @@ use std::collections::{BTreeSet, HashMap};
 
 use escalier_ast::{BindingIdent, Expr, Literal as Lit, Span};
 
+use crate::checker::Checker;
 use crate::context::*;
 use crate::errors::*;
-use crate::infer::{check_mutability, infer_expression};
+use crate::infer::check_mutability;
 use crate::types::*;
-use crate::util::*;
 
-/// Unify the two types t1 and t2.
-///
-/// Makes the types t1 and t2 the same.
-///
-/// Args:
-///     t1: The first type to be made equivalent (subtype)
-///     t2: The second type to be be equivalent (supertype)
-///
-/// Returns:
-///     None
-///
-/// Raises:
-///     InferenceError: Raised if the types cannot be unified.
-pub fn unify(arena: &mut Arena<Type>, ctx: &Context, t1: Index, t2: Index) -> Result<(), Errors> {
-    let a = prune(arena, t1);
-    let b = prune(arena, t2);
+impl Checker {
+    /// Unify the two types t1 and t2.
+    ///
+    /// Makes the types t1 and t2 the same.
+    ///
+    /// Args:
+    ///     t1: The first type to be made equivalent (subtype)
+    ///     t2: The second type to be be equivalent (supertype)
+    ///
+    /// Returns:
+    ///     None
+    ///
+    /// Raises:
+    ///     InferenceError: Raised if the types cannot be unified.
+    pub fn unify(&mut self, ctx: &Context, t1: Index, t2: Index) -> Result<(), Errors> {
+        let a = self.prune(t1);
+        let b = self.prune(t2);
 
-    // TODO: only expand if unification fails since it's expensive
-    let a = expand(arena, ctx, a)?;
-    let b = expand(arena, ctx, b)?;
+        // TODO: only expand if unification fails since it's expensive
+        let a = self.expand(ctx, a)?;
+        let b = self.expand(ctx, b)?;
 
-    let a_t = arena[a].clone();
-    let b_t = arena[b].clone();
+        let a_t = self.arena[a].clone();
+        let b_t = self.arena[b].clone();
 
-    match (&a_t.kind, &b_t.kind) {
-        (TypeKind::Variable(_), _) => bind(arena, ctx, a, b),
-        (_, TypeKind::Variable(_)) => bind(arena, ctx, b, a),
+        match (&a_t.kind, &b_t.kind) {
+            (TypeKind::Variable(_), _) => self.bind(ctx, a, b),
+            (_, TypeKind::Variable(_)) => self.bind(ctx, b, a),
 
-        // Wildcards are always unifiable
-        (TypeKind::Wildcard, _) => Ok(()),
-        (_, TypeKind::Wildcard) => Ok(()),
+            // Wildcards are always unifiable
+            (TypeKind::Wildcard, _) => Ok(()),
+            (_, TypeKind::Wildcard) => Ok(()),
 
-        (TypeKind::Keyword(kw1), TypeKind::Keyword(kw2)) => {
-            if kw1 == kw2 {
-                Ok(())
-            } else {
-                Err(Errors::InferenceError(format!(
-                    "type mismatch: {} != {}",
-                    a_t.as_string(arena),
-                    b_t.as_string(arena)
-                )))
-            }
-        }
-
-        (_, TypeKind::Keyword(Keyword::Unknown)) => {
-            // All types are assignable to `unknown`
-            Ok(())
-        }
-
-        (TypeKind::Union(union), _) => {
-            // All types in the union must be subtypes of t2
-            for t in union.types.iter() {
-                unify(arena, ctx, *t, b)?;
-            }
-            Ok(())
-        }
-        (_, TypeKind::Union(union)) => {
-            // If t1 is a subtype of any of the types in the union, then it is a
-            // subtype of the union.
-            for t2 in union.types.iter() {
-                if unify(arena, ctx, a, *t2).is_ok() {
-                    return Ok(());
-                }
-            }
-
-            Err(Errors::InferenceError(format!(
-                "type mismatch: unify({}, {}) failed",
-                a_t.as_string(arena),
-                b_t.as_string(arena)
-            )))
-        }
-        (TypeKind::Tuple(tuple1), TypeKind::Tuple(tuple2)) => {
-            'outer: {
-                if tuple1.types.len() < tuple2.types.len() {
-                    // If there's a rest pattern in tuple1, then it can unify
-                    // with the reamining elements of tuple2.
-                    if let Some(last) = tuple1.types.last() {
-                        if let TypeKind::Rest(_) = arena[*last].kind {
-                            break 'outer;
-                        }
-                    }
-
-                    return Err(Errors::InferenceError(format!(
-                        "Expected tuple of length {}, got tuple of length {}",
-                        tuple2.types.len(),
-                        tuple1.types.len()
-                    )));
-                }
-            }
-
-            for (i, (p, q)) in tuple1.types.iter().zip(tuple2.types.iter()).enumerate() {
-                // let q_t = arena[*q];
-                match (&arena[*p].kind, &arena[*q].kind) {
-                    (TypeKind::Rest(_), TypeKind::Rest(_)) => {
-                        return Err(Errors::InferenceError(
-                            "Can't unify two rest elements".to_string(),
-                        ))
-                    }
-                    (TypeKind::Rest(_), _) => {
-                        let rest_q = new_tuple_type(arena, &tuple2.types[i..]);
-                        unify(arena, ctx, *p, rest_q)?;
-                    }
-                    (_, TypeKind::Rest(_)) => {
-                        let rest_p = new_tuple_type(arena, &tuple1.types[i..]);
-                        unify(arena, ctx, rest_p, *q)?;
-                    }
-                    (_, _) => unify(arena, ctx, *p, *q)?,
-                }
-            }
-            Ok(())
-        }
-        (TypeKind::Tuple(tuple), TypeKind::Constructor(array)) if array.name == "Array" => {
-            let q = array.types[0];
-            for p in &tuple.types {
-                match &arena[*p].kind {
-                    TypeKind::Constructor(Constructor { name, types }) if name == "Array" => {
-                        unify(arena, ctx, types[0], q)?;
-                    }
-                    TypeKind::Rest(_) => unify(arena, ctx, *p, b)?,
-                    _ => unify(arena, ctx, *p, q)?,
-                }
-            }
-            Ok(())
-        }
-        (TypeKind::Constructor(array), TypeKind::Tuple(tuple)) if array.name == "Array" => {
-            let p = array.types[0];
-            for q in &tuple.types {
-                let undefined = new_keyword(arena, Keyword::Undefined);
-                let p_or_undefined = new_union_type(arena, &[p, undefined]);
-
-                match &arena[*q].kind {
-                    TypeKind::Rest(_) => unify(arena, ctx, a, *q)?,
-                    _ => unify(arena, ctx, p_or_undefined, *q)?,
-                }
-            }
-            Ok(())
-        }
-        (TypeKind::Rest(rest), TypeKind::Constructor(array)) if (array.name == "Array") => {
-            unify(arena, ctx, rest.arg, b)
-        }
-        (TypeKind::Rest(rest), TypeKind::Tuple(_)) => unify(arena, ctx, rest.arg, b),
-        (TypeKind::Constructor(array), TypeKind::Rest(rest)) if (array.name == "Array") => {
-            unify(arena, ctx, a, rest.arg)
-        }
-        (TypeKind::Tuple(_), TypeKind::Rest(rest)) => unify(arena, ctx, a, rest.arg),
-        (TypeKind::Constructor(con_a), TypeKind::Constructor(con_b)) => {
-            // TODO: support type constructors with optional and default type params
-            if con_a.name != con_b.name || con_a.types.len() != con_b.types.len() {
-                return Err(Errors::InferenceError(format!(
-                    "type mismatch: {} != {}",
-                    a_t.as_string(arena),
-                    b_t.as_string(arena),
-                )));
-            }
-            for (p, q) in con_a.types.iter().zip(con_b.types.iter()) {
-                unify(arena, ctx, *p, *q)?;
-            }
-            Ok(())
-        }
-        (TypeKind::Function(func_a), TypeKind::Function(func_b)) => {
-            // Is this the right place to instantiate the function types?
-            let func_a = instantiate_func(arena, func_a, None)?;
-            let func_b = instantiate_func(arena, func_b, None)?;
-
-            let mut params_a = func_a.params;
-            let mut params_b = func_b.params;
-
-            if let Some(param) = params_a.get(0) {
-                if param.is_self() {
-                    params_a.remove(0);
-                }
-            }
-
-            if let Some(param) = params_b.get(0) {
-                if param.is_self() {
-                    params_b.remove(0);
-                }
-            }
-
-            let mut rest_a = None;
-            let mut rest_b = None;
-
-            for param in &params_a {
-                if let TPat::Rest(rest) = &param.pattern {
-                    if rest_a.is_some() {
-                        return Err(Errors::InferenceError(
-                            "multiple rest params in function".to_string(),
-                        ));
-                    }
-                    rest_a = Some((rest, param.t));
-                }
-            }
-
-            for param in &params_b {
-                if let TPat::Rest(rest) = &param.pattern {
-                    if rest_b.is_some() {
-                        return Err(Errors::InferenceError(
-                            "multiple rest params in function".to_string(),
-                        ));
-                    }
-                    rest_b = Some((rest, param.t));
-                }
-            }
-
-            // TODO: remove leading `self` or `mut self` param before proceding
-
-            let min_params_a = params_a.len() - rest_a.is_some() as usize;
-            let min_params_b = params_b.len() - rest_b.is_some() as usize;
-
-            if min_params_a > min_params_b {
-                if let Some(rest_b) = rest_b {
-                    for i in 0..min_params_b {
-                        let p = &params_a[i];
-                        let q = &params_b[i];
-                        // NOTE: We reverse the order of the params here because func_a
-                        // should be able to accept any params that func_b can accept,
-                        // its params may be more lenient.
-                        unify(arena, ctx, q.t, p.t)?;
-                    }
-
-                    let mut remaining_args_a = vec![];
-
-                    for p in &params_a[min_params_b..] {
-                        let arg = match &p.pattern {
-                            TPat::Rest(_) => match &arena[p.t].kind {
-                                TypeKind::Tuple(tuple) => {
-                                    for t in &tuple.types {
-                                        remaining_args_a.push(*t);
-                                    }
-                                    continue;
-                                }
-                                TypeKind::Constructor(array) if array.name == "Array" => {
-                                    new_rest_type(arena, p.t)
-                                }
-                                TypeKind::Constructor(_) => todo!(),
-                                _ => {
-                                    return Err(Errors::InferenceError(format!(
-                                        "rest param must be an array or tuple, got {}",
-                                        arena[p.t].as_string(arena)
-                                    )))
-                                }
-                            },
-                            _ => p.t,
-                        };
-
-                        remaining_args_a.push(arg);
-                    }
-
-                    let remaining_args_a = new_tuple_type(arena, &remaining_args_a);
-
-                    // NOTE: We reverse the order of the params here because func_a
-                    // should be able to accept any params that func_b can accept,
-                    // its params may be more lenient.
-                    unify(arena, ctx, rest_b.1, remaining_args_a)?;
-
-                    unify(arena, ctx, func_a.ret, func_b.ret)?;
-
-                    return Ok(());
-                }
-
-                return Err(Errors::InferenceError(format!(
-                    "{} is not a subtype of {} since it requires more params",
-                    a_t.as_string(arena),
-                    b_t.as_string(arena),
-                )));
-            }
-
-            for i in 0..min_params_a {
-                let p = &params_a[i];
-                let q = &params_b[i];
-                // NOTE: We reverse the order of the params here because func_a
-                // should be able to accept any params that func_b can accept,
-                // its params may be more lenient.
-                unify(arena, ctx, q.t, p.t)?;
-            }
-
-            if let Some(rest_a) = rest_a {
-                for q in params_b.iter().take(min_params_b).skip(min_params_a) {
-                    // NOTE: We reverse the order of the params here because func_a
-                    // should be able to accept any params that func_b can accept,
-                    // its params may be more lenient.
-                    unify(arena, ctx, q.t, rest_a.1)?;
-                }
-
-                if let Some(rest_b) = rest_b {
-                    // NOTE: We reverse the order of the params here because func_a
-                    // should be able to accept any params that func_b can accept,
-                    // its params may be more lenient.
-                    unify(arena, ctx, rest_b.1, rest_a.1)?;
-                }
-            }
-
-            unify(arena, ctx, func_a.ret, func_b.ret)?;
-
-            let never = new_keyword(arena, Keyword::Never);
-            let throws_a = func_a.throws.unwrap_or(never);
-            let throws_b = func_b.throws.unwrap_or(never);
-
-            unify(arena, ctx, throws_a, throws_b)?;
-
-            Ok(())
-        }
-        (TypeKind::Literal(lit1), TypeKind::Literal(lit2)) => {
-            let equal = match (&lit1, &lit2) {
-                (Lit::Boolean(value1), Lit::Boolean(value2)) => value1 == value2,
-                (Lit::Number(value1), Lit::Number(value2)) => value1 == value2,
-                (Lit::String(value1), Lit::String(value2)) => value1 == value2,
-                _ => false,
-            };
-            if !equal {
-                return Err(Errors::InferenceError(format!(
-                    "type mismatch: {} != {}",
-                    a_t.as_string(arena),
-                    b_t.as_string(arena),
-                )));
-            }
-            Ok(())
-        }
-        (TypeKind::Literal(Lit::Number(_)), TypeKind::Primitive(Primitive::Number)) => Ok(()),
-        (TypeKind::Literal(Lit::String(_)), TypeKind::Primitive(Primitive::String)) => Ok(()),
-        (TypeKind::Literal(Lit::Boolean(_)), TypeKind::Primitive(Primitive::Boolean)) => Ok(()),
-        (TypeKind::Primitive(prim1), TypeKind::Primitive(prim2)) => match (prim1, prim2) {
-            (Primitive::Number, Primitive::Number) => Ok(()),
-            (Primitive::String, Primitive::String) => Ok(()),
-            (Primitive::Boolean, Primitive::Boolean) => Ok(()),
-            (Primitive::Symbol, Primitive::Symbol) => Ok(()),
-            _ => Err(Errors::InferenceError(format!(
-                "type mismatch: {} != {}",
-                a_t.as_string(arena),
-                b_t.as_string(arena),
-            ))),
-        },
-        (TypeKind::Object(object1), TypeKind::Object(object2)) => {
-            // object1 must have atleast as the same properties as object2
-            // This is pretty inefficient... we should have some way of hashing
-            // each object element so that we can look them.  The problem comes
-            // in with functions where different signatures can expand to be the
-            // same.  Do these kinds of checks is going to be really slow.
-            // We could also try bucketing the different object element types
-            // to reduce the size of the n^2.
-
-            // NOTES:
-            // - we don't bother unifying setters because they aren't available
-            //   on immutable objects (setters need to be unified inside of
-            //   unify_mut() below)
-            // - we unify all of the other named elements all at once because
-            //   a property could be a function and we want that to unify with
-            //   a method of the same name
-            // - we should also unify indexers with other named values since
-            //   they can be accessed by name as well but are optional
-
-            let mut calls_1: Vec<&TCallable> = vec![];
-            let mut constructors_1: Vec<&TCallable> = vec![];
-            let mut mapped_1: Vec<&MappedType> = vec![];
-
-            let mut calls_2: Vec<&TCallable> = vec![];
-            let mut constructors_2: Vec<&TCallable> = vec![];
-            let mut mapped_2: Vec<&MappedType> = vec![];
-
-            let named_props_1: HashMap<_, _> = object1
-                .elems
-                .iter()
-                .filter_map(|elem| match elem {
-                    TObjElem::Call(_) => None,
-                    TObjElem::Constructor(_) => None,
-                    TObjElem::Mapped(_) => None,
-                    TObjElem::Prop(prop) => {
-                        // TODO: handle getters/setters properly
-                        Some((prop.name.to_string(), prop))
-                    }
-                })
-                .collect();
-
-            let named_props_2: HashMap<_, _> = object2
-                .elems
-                .iter()
-                .filter_map(|elem| match elem {
-                    TObjElem::Call(_) => None,
-                    TObjElem::Constructor(_) => None,
-                    TObjElem::Mapped(_) => None,
-                    TObjElem::Prop(prop) => {
-                        // TODO: handle getters/setters properly
-                        Some((prop.name.to_string(), prop))
-                    }
-                })
-                .collect();
-
-            // object1 must have at least as the same named elements as object2
-            // TODO: handle the case where object1 has an indexer that covers
-            // some of the named elements of object2
-            for (name, prop_2) in &named_props_2 {
-                match named_props_1.get(name) {
-                    Some(prop_1) => {
-                        let t1 = prop_1.get_type(arena);
-                        let t2 = prop_2.get_type(arena);
-                        unify(arena, ctx, t1, t2)?;
-                    }
-                    None => {
-                        return Err(Errors::InferenceError(format!(
-                            "'{}' is missing in {}",
-                            name,
-                            a_t.as_string(arena),
-                        )));
-                    }
-                }
-            }
-
-            for prop1 in &object1.elems {
-                match prop1 {
-                    TObjElem::Call(call) => calls_1.push(call),
-                    TObjElem::Constructor(constructor) => constructors_1.push(constructor),
-                    TObjElem::Mapped(mapped) => mapped_1.push(mapped),
-                    _ => (),
-                }
-            }
-
-            for prop2 in &object2.elems {
-                match prop2 {
-                    TObjElem::Call(call) => calls_2.push(call),
-                    TObjElem::Constructor(constructor) => constructors_2.push(constructor),
-                    TObjElem::Mapped(mapped) => mapped_2.push(mapped),
-                    _ => (),
-                }
-            }
-
-            match mapped_2.len() {
-                0 => (),
-                1 => {
-                    match mapped_1.len() {
-                        0 => {
-                            for (_, prop_1) in named_props_1 {
-                                let undefined = new_keyword(arena, Keyword::Undefined);
-                                let t1 = prop_1.get_type(arena);
-                                let t2 = new_union_type(arena, &[mapped_2[0].value, undefined]);
-                                unify(arena, ctx, t1, t2)?;
-                            }
-                        }
-                        1 => {
-                            unify(arena, ctx, mapped_1[0].value, mapped_2[0].value)?;
-                            // NOTE: the order is reverse here because object1
-                            // has to have at least the same keys as object2,
-                            // but it can have more.
-                            // TODO: lookup source instead of key... we only need
-                            // to look at key when it's not using the source or if
-                            // it's modifying the source.
-
-                            let mut mapping: HashMap<String, Index> = HashMap::new();
-                            mapping.insert(mapped_1[0].target.to_owned(), mapped_1[0].source);
-                            let mapped_1_key = instantiate_scheme(arena, mapped_1[0].key, &mapping);
-
-                            let mut mapping: HashMap<String, Index> = HashMap::new();
-                            mapping.insert(mapped_2[0].target.to_owned(), mapped_2[0].source);
-                            let mapped_2_key = instantiate_scheme(arena, mapped_2[0].key, &mapping);
-
-                            unify(arena, ctx, mapped_2_key, mapped_1_key)?;
-                        }
-                        _ => {
-                            return Err(Errors::InferenceError(format!(
-                                "{} has multiple indexers",
-                                a_t.as_string(arena)
-                            )))
-                        }
-                    }
-                }
-                _ => {
-                    return Err(Errors::InferenceError(format!(
-                        "{} has multiple indexers",
-                        b_t.as_string(arena)
+            (TypeKind::Keyword(kw1), TypeKind::Keyword(kw2)) => {
+                if kw1 == kw2 {
+                    Ok(())
+                } else {
+                    Err(Errors::InferenceError(format!(
+                        "type mismatch: {} != {}",
+                        a_t.as_string(&self.arena),
+                        b_t.as_string(&self.arena)
                     )))
                 }
             }
 
-            // TODO:
-            // - call (all calls in object1 must cover the calls in object2)
-            // - constructor (all constructors in object1 must cover the
-            //   constructors in object2)
+            (_, TypeKind::Keyword(Keyword::Unknown)) => {
+                // All types are assignable to `unknown`
+                Ok(())
+            }
+
+            (TypeKind::Union(union), _) => {
+                // All types in the union must be subtypes of t2
+                for t in union.types.iter() {
+                    self.unify(ctx, *t, b)?;
+                }
+                Ok(())
+            }
+            (_, TypeKind::Union(union)) => {
+                // If t1 is a subtype of any of the types in the union, then it is a
+                // subtype of the union.
+                for t2 in union.types.iter() {
+                    if self.unify(ctx, a, *t2).is_ok() {
+                        return Ok(());
+                    }
+                }
+
+                Err(Errors::InferenceError(format!(
+                    "type mismatch: unify({}, {}) failed",
+                    a_t.as_string(&self.arena),
+                    b_t.as_string(&self.arena)
+                )))
+            }
+            (TypeKind::Tuple(tuple1), TypeKind::Tuple(tuple2)) => {
+                'outer: {
+                    if tuple1.types.len() < tuple2.types.len() {
+                        // If there's a rest pattern in tuple1, then it can unify
+                        // with the reamining elements of tuple2.
+                        if let Some(last) = tuple1.types.last() {
+                            if let TypeKind::Rest(_) = self.arena[*last].kind {
+                                break 'outer;
+                            }
+                        }
+
+                        return Err(Errors::InferenceError(format!(
+                            "Expected tuple of length {}, got tuple of length {}",
+                            tuple2.types.len(),
+                            tuple1.types.len()
+                        )));
+                    }
+                }
+
+                for (i, (p, q)) in tuple1.types.iter().zip(tuple2.types.iter()).enumerate() {
+                    // let q_t = arena[*q];
+                    match (&self.arena[*p].kind, &self.arena[*q].kind) {
+                        (TypeKind::Rest(_), TypeKind::Rest(_)) => {
+                            return Err(Errors::InferenceError(
+                                "Can't unify two rest elements".to_string(),
+                            ))
+                        }
+                        (TypeKind::Rest(_), _) => {
+                            let rest_q = new_tuple_type(&mut self.arena, &tuple2.types[i..]);
+                            self.unify(ctx, *p, rest_q)?;
+                        }
+                        (_, TypeKind::Rest(_)) => {
+                            let rest_p = new_tuple_type(&mut self.arena, &tuple1.types[i..]);
+                            self.unify(ctx, rest_p, *q)?;
+                        }
+                        (_, _) => self.unify(ctx, *p, *q)?,
+                    }
+                }
+                Ok(())
+            }
+            (TypeKind::Tuple(tuple), TypeKind::Constructor(array)) if array.name == "Array" => {
+                let q = array.types[0];
+                for p in &tuple.types {
+                    match &self.arena[*p].kind {
+                        TypeKind::Constructor(Constructor { name, types }) if name == "Array" => {
+                            self.unify(ctx, types[0], q)?;
+                        }
+                        TypeKind::Rest(_) => self.unify(ctx, *p, b)?,
+                        _ => self.unify(ctx, *p, q)?,
+                    }
+                }
+                Ok(())
+            }
+            (TypeKind::Constructor(array), TypeKind::Tuple(tuple)) if array.name == "Array" => {
+                let p = array.types[0];
+                for q in &tuple.types {
+                    let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+                    let p_or_undefined = new_union_type(&mut self.arena, &[p, undefined]);
+
+                    match &self.arena[*q].kind {
+                        TypeKind::Rest(_) => self.unify(ctx, a, *q)?,
+                        _ => self.unify(ctx, p_or_undefined, *q)?,
+                    }
+                }
+                Ok(())
+            }
+            (TypeKind::Rest(rest), TypeKind::Constructor(array)) if (array.name == "Array") => {
+                self.unify(ctx, rest.arg, b)
+            }
+            (TypeKind::Rest(rest), TypeKind::Tuple(_)) => self.unify(ctx, rest.arg, b),
+            (TypeKind::Constructor(array), TypeKind::Rest(rest)) if (array.name == "Array") => {
+                self.unify(ctx, a, rest.arg)
+            }
+            (TypeKind::Tuple(_), TypeKind::Rest(rest)) => self.unify(ctx, a, rest.arg),
+            (TypeKind::Constructor(con_a), TypeKind::Constructor(con_b)) => {
+                // TODO: support type constructors with optional and default type params
+                if con_a.name != con_b.name || con_a.types.len() != con_b.types.len() {
+                    return Err(Errors::InferenceError(format!(
+                        "type mismatch: {} != {}",
+                        a_t.as_string(&self.arena),
+                        b_t.as_string(&self.arena),
+                    )));
+                }
+                for (p, q) in con_a.types.iter().zip(con_b.types.iter()) {
+                    self.unify(ctx, *p, *q)?;
+                }
+                Ok(())
+            }
+            (TypeKind::Function(func_a), TypeKind::Function(func_b)) => {
+                // Is this the right place to instantiate the function types?
+                let func_a = instantiate_func(&mut self.arena, func_a, None)?;
+                let func_b = instantiate_func(&mut self.arena, func_b, None)?;
+
+                let mut params_a = func_a.params;
+                let mut params_b = func_b.params;
+
+                if let Some(param) = params_a.get(0) {
+                    if param.is_self() {
+                        params_a.remove(0);
+                    }
+                }
+
+                if let Some(param) = params_b.get(0) {
+                    if param.is_self() {
+                        params_b.remove(0);
+                    }
+                }
+
+                let mut rest_a = None;
+                let mut rest_b = None;
+
+                for param in &params_a {
+                    if let TPat::Rest(rest) = &param.pattern {
+                        if rest_a.is_some() {
+                            return Err(Errors::InferenceError(
+                                "multiple rest params in function".to_string(),
+                            ));
+                        }
+                        rest_a = Some((rest, param.t));
+                    }
+                }
+
+                for param in &params_b {
+                    if let TPat::Rest(rest) = &param.pattern {
+                        if rest_b.is_some() {
+                            return Err(Errors::InferenceError(
+                                "multiple rest params in function".to_string(),
+                            ));
+                        }
+                        rest_b = Some((rest, param.t));
+                    }
+                }
+
+                // TODO: remove leading `self` or `mut self` param before proceding
+
+                let min_params_a = params_a.len() - rest_a.is_some() as usize;
+                let min_params_b = params_b.len() - rest_b.is_some() as usize;
+
+                if min_params_a > min_params_b {
+                    if let Some(rest_b) = rest_b {
+                        for i in 0..min_params_b {
+                            let p = &params_a[i];
+                            let q = &params_b[i];
+                            // NOTE: We reverse the order of the params here because func_a
+                            // should be able to accept any params that func_b can accept,
+                            // its params may be more lenient.
+                            self.unify(ctx, q.t, p.t)?;
+                        }
+
+                        let mut remaining_args_a = vec![];
+
+                        for p in &params_a[min_params_b..] {
+                            let arg = match &p.pattern {
+                                TPat::Rest(_) => match &self.arena[p.t].kind {
+                                    TypeKind::Tuple(tuple) => {
+                                        for t in &tuple.types {
+                                            remaining_args_a.push(*t);
+                                        }
+                                        continue;
+                                    }
+                                    TypeKind::Constructor(array) if array.name == "Array" => {
+                                        new_rest_type(&mut self.arena, p.t)
+                                    }
+                                    TypeKind::Constructor(_) => todo!(),
+                                    _ => {
+                                        return Err(Errors::InferenceError(format!(
+                                            "rest param must be an array or tuple, got {}",
+                                            self.print_type(&p.t)
+                                        )));
+                                    }
+                                },
+                                _ => p.t,
+                            };
+
+                            remaining_args_a.push(arg);
+                        }
+
+                        let remaining_args_a = new_tuple_type(&mut self.arena, &remaining_args_a);
+
+                        // NOTE: We reverse the order of the params here because func_a
+                        // should be able to accept any params that func_b can accept,
+                        // its params may be more lenient.
+                        self.unify(ctx, rest_b.1, remaining_args_a)?;
+
+                        self.unify(ctx, func_a.ret, func_b.ret)?;
+
+                        return Ok(());
+                    }
+
+                    return Err(Errors::InferenceError(format!(
+                        "{} is not a subtype of {} since it requires more params",
+                        a_t.as_string(&self.arena),
+                        b_t.as_string(&self.arena),
+                    )));
+                }
+
+                for i in 0..min_params_a {
+                    let p = &params_a[i];
+                    let q = &params_b[i];
+                    // NOTE: We reverse the order of the params here because func_a
+                    // should be able to accept any params that func_b can accept,
+                    // its params may be more lenient.
+                    self.unify(ctx, q.t, p.t)?;
+                }
+
+                if let Some(rest_a) = rest_a {
+                    for q in params_b.iter().take(min_params_b).skip(min_params_a) {
+                        // NOTE: We reverse the order of the params here because func_a
+                        // should be able to accept any params that func_b can accept,
+                        // its params may be more lenient.
+                        self.unify(ctx, q.t, rest_a.1)?;
+                    }
+
+                    if let Some(rest_b) = rest_b {
+                        // NOTE: We reverse the order of the params here because func_a
+                        // should be able to accept any params that func_b can accept,
+                        // its params may be more lenient.
+                        self.unify(ctx, rest_b.1, rest_a.1)?;
+                    }
+                }
+
+                self.unify(ctx, func_a.ret, func_b.ret)?;
+
+                let never = new_keyword(&mut self.arena, Keyword::Never);
+                let throws_a = func_a.throws.unwrap_or(never);
+                let throws_b = func_b.throws.unwrap_or(never);
+
+                self.unify(ctx, throws_a, throws_b)?;
+
+                Ok(())
+            }
+            (TypeKind::Literal(lit1), TypeKind::Literal(lit2)) => {
+                let equal = match (&lit1, &lit2) {
+                    (Lit::Boolean(value1), Lit::Boolean(value2)) => value1 == value2,
+                    (Lit::Number(value1), Lit::Number(value2)) => value1 == value2,
+                    (Lit::String(value1), Lit::String(value2)) => value1 == value2,
+                    _ => false,
+                };
+                if !equal {
+                    return Err(Errors::InferenceError(format!(
+                        "type mismatch: {} != {}",
+                        a_t.as_string(&self.arena),
+                        b_t.as_string(&self.arena),
+                    )));
+                }
+                Ok(())
+            }
+            (TypeKind::Literal(Lit::Number(_)), TypeKind::Primitive(Primitive::Number)) => Ok(()),
+            (TypeKind::Literal(Lit::String(_)), TypeKind::Primitive(Primitive::String)) => Ok(()),
+            (TypeKind::Literal(Lit::Boolean(_)), TypeKind::Primitive(Primitive::Boolean)) => Ok(()),
+            (TypeKind::Primitive(prim1), TypeKind::Primitive(prim2)) => match (prim1, prim2) {
+                (Primitive::Number, Primitive::Number) => Ok(()),
+                (Primitive::String, Primitive::String) => Ok(()),
+                (Primitive::Boolean, Primitive::Boolean) => Ok(()),
+                (Primitive::Symbol, Primitive::Symbol) => Ok(()),
+                _ => Err(Errors::InferenceError(format!(
+                    "type mismatch: {} != {}",
+                    a_t.as_string(&self.arena),
+                    b_t.as_string(&self.arena),
+                ))),
+            },
+            (TypeKind::Object(object1), TypeKind::Object(object2)) => {
+                // object1 must have atleast as the same properties as object2
+                // This is pretty inefficient... we should have some way of hashing
+                // each object element so that we can look them.  The problem comes
+                // in with functions where different signatures can expand to be the
+                // same.  Do these kinds of checks is going to be really slow.
+                // We could also try bucketing the different object element types
+                // to reduce the size of the n^2.
+
+                // NOTES:
+                // - we don't bother unifying setters because they aren't available
+                //   on immutable objects (setters need to be unified inside of
+                //   unify_mut() below)
+                // - we unify all of the other named elements all at once because
+                //   a property could be a function and we want that to unify with
+                //   a method of the same name
+                // - we should also unify indexers with other named values since
+                //   they can be accessed by name as well but are optional
+
+                let mut calls_1: Vec<&TCallable> = vec![];
+                let mut constructors_1: Vec<&TCallable> = vec![];
+                let mut mapped_1: Vec<&MappedType> = vec![];
+
+                let mut calls_2: Vec<&TCallable> = vec![];
+                let mut constructors_2: Vec<&TCallable> = vec![];
+                let mut mapped_2: Vec<&MappedType> = vec![];
+
+                let named_props_1: HashMap<_, _> = object1
+                    .elems
+                    .iter()
+                    .filter_map(|elem| match elem {
+                        TObjElem::Call(_) => None,
+                        TObjElem::Constructor(_) => None,
+                        TObjElem::Mapped(_) => None,
+                        TObjElem::Prop(prop) => {
+                            // TODO: handle getters/setters properly
+                            Some((prop.name.to_string(), prop))
+                        }
+                    })
+                    .collect();
+
+                let named_props_2: HashMap<_, _> = object2
+                    .elems
+                    .iter()
+                    .filter_map(|elem| match elem {
+                        TObjElem::Call(_) => None,
+                        TObjElem::Constructor(_) => None,
+                        TObjElem::Mapped(_) => None,
+                        TObjElem::Prop(prop) => {
+                            // TODO: handle getters/setters properly
+                            Some((prop.name.to_string(), prop))
+                        }
+                    })
+                    .collect();
+
+                // object1 must have at least as the same named elements as object2
+                // TODO: handle the case where object1 has an indexer that covers
+                // some of the named elements of object2
+                for (name, prop_2) in &named_props_2 {
+                    match named_props_1.get(name) {
+                        Some(prop_1) => {
+                            let t1 = prop_1.get_type(&mut self.arena);
+                            let t2 = prop_2.get_type(&mut self.arena);
+                            self.unify(ctx, t1, t2)?;
+                        }
+                        None => {
+                            return Err(Errors::InferenceError(format!(
+                                "'{}' is missing in {}",
+                                name,
+                                a_t.as_string(&self.arena),
+                            )));
+                        }
+                    }
+                }
+
+                for prop1 in &object1.elems {
+                    match prop1 {
+                        TObjElem::Call(call) => calls_1.push(call),
+                        TObjElem::Constructor(constructor) => constructors_1.push(constructor),
+                        TObjElem::Mapped(mapped) => mapped_1.push(mapped),
+                        _ => (),
+                    }
+                }
+
+                for prop2 in &object2.elems {
+                    match prop2 {
+                        TObjElem::Call(call) => calls_2.push(call),
+                        TObjElem::Constructor(constructor) => constructors_2.push(constructor),
+                        TObjElem::Mapped(mapped) => mapped_2.push(mapped),
+                        _ => (),
+                    }
+                }
+
+                match mapped_2.len() {
+                    0 => (),
+                    1 => {
+                        match mapped_1.len() {
+                            0 => {
+                                for (_, prop_1) in named_props_1 {
+                                    let undefined =
+                                        new_keyword(&mut self.arena, Keyword::Undefined);
+                                    let t1 = prop_1.get_type(&mut self.arena);
+                                    let t2 = new_union_type(
+                                        &mut self.arena,
+                                        &[mapped_2[0].value, undefined],
+                                    );
+                                    self.unify(ctx, t1, t2)?;
+                                }
+                            }
+                            1 => {
+                                self.unify(ctx, mapped_1[0].value, mapped_2[0].value)?;
+                                // NOTE: the order is reverse here because object1
+                                // has to have at least the same keys as object2,
+                                // but it can have more.
+                                // TODO: lookup source instead of key... we only need
+                                // to look at key when it's not using the source or if
+                                // it's modifying the source.
+
+                                let mut mapping: HashMap<String, Index> = HashMap::new();
+                                mapping.insert(mapped_1[0].target.to_owned(), mapped_1[0].source);
+                                let mapped_1_key =
+                                    instantiate_scheme(&mut self.arena, mapped_1[0].key, &mapping);
+
+                                let mut mapping: HashMap<String, Index> = HashMap::new();
+                                mapping.insert(mapped_2[0].target.to_owned(), mapped_2[0].source);
+                                let mapped_2_key =
+                                    instantiate_scheme(&mut self.arena, mapped_2[0].key, &mapping);
+
+                                self.unify(ctx, mapped_2_key, mapped_1_key)?;
+                            }
+                            _ => {
+                                return Err(Errors::InferenceError(format!(
+                                    "{} has multiple indexers",
+                                    a_t.as_string(&self.arena)
+                                )))
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(Errors::InferenceError(format!(
+                            "{} has multiple indexers",
+                            b_t.as_string(&self.arena)
+                        )))
+                    }
+                }
+
+                // TODO:
+                // - call (all calls in object1 must cover the calls in object2)
+                // - constructor (all constructors in object1 must cover the
+                //   constructors in object2)
+                Ok(())
+            }
+            (TypeKind::Object(object1), TypeKind::Intersection(intersection)) => {
+                let obj_types: Vec<_> = intersection
+                    .types
+                    .iter()
+                    .filter(|t| matches!(self.arena[**t].kind, TypeKind::Object(_)))
+                    .cloned()
+                    .collect();
+                let rest_types: Vec<_> = intersection
+                    .types
+                    .iter()
+                    .filter(|t| matches!(self.arena[**t].kind, TypeKind::Variable(_)))
+                    .cloned()
+                    .collect();
+                // TODO: check for other variants, if there are we should error
+
+                let obj_type = simplify_intersection(&mut self.arena, &obj_types);
+
+                match rest_types.len() {
+                    0 => self.unify(ctx, t1, obj_type),
+                    1 => {
+                        let all_obj_elems = match &self.arena[obj_type].kind {
+                            TypeKind::Object(obj) => obj.elems.to_owned(),
+                            _ => vec![],
+                        };
+
+                        let (obj_elems, rest_elems): (Vec<_>, Vec<_>) =
+                            object1.elems.iter().cloned().partition(|e| {
+                                all_obj_elems.iter().any(|oe| match (oe, e) {
+                                    // What to do about Call signatures?
+                                    // (TObjElem::Call(_), TObjElem::Call(_)) => todo!(),
+                                    (TObjElem::Prop(op), TObjElem::Prop(p)) => op.name == p.name,
+                                    _ => false,
+                                })
+                            });
+
+                        let new_obj_type = new_object_type(&mut self.arena, &obj_elems);
+                        self.unify(ctx, new_obj_type, obj_type)?;
+
+                        let new_rest_type = new_object_type(&mut self.arena, &rest_elems);
+                        self.unify(ctx, new_rest_type, rest_types[0])?;
+
+                        Ok(())
+                    }
+                    _ => Err(Errors::InferenceError(
+                        "Inference is undecidable".to_string(),
+                    )),
+                }
+            }
+            (TypeKind::Intersection(intersection), TypeKind::Object(object2)) => {
+                let obj_types: Vec<_> = intersection
+                    .types
+                    .iter()
+                    .filter(|t| matches!(self.arena[**t].kind, TypeKind::Object(_)))
+                    .cloned()
+                    .collect();
+                let rest_types: Vec<_> = intersection
+                    .types
+                    .iter()
+                    .filter(|t| matches!(self.arena[**t].kind, TypeKind::Variable(_)))
+                    .cloned()
+                    .collect();
+
+                let obj_type = simplify_intersection(&mut self.arena, &obj_types);
+
+                match rest_types.len() {
+                    0 => self.unify(ctx, t1, obj_type),
+                    1 => {
+                        let all_obj_elems = match &self.arena[obj_type].kind {
+                            TypeKind::Object(obj) => obj.elems.to_owned(),
+                            _ => vec![],
+                        };
+
+                        let (obj_elems, rest_elems): (Vec<_>, Vec<_>) =
+                            object2.elems.iter().cloned().partition(|e| {
+                                all_obj_elems.iter().any(|oe| match (oe, e) {
+                                    // What to do about Call signatures?
+                                    // (TObjElem::Call(_), TObjElem::Call(_)) => todo!(),
+                                    (TObjElem::Prop(op), TObjElem::Prop(p)) => op.name == p.name,
+                                    _ => false,
+                                })
+                            });
+
+                        let new_obj_type = new_object_type(&mut self.arena, &obj_elems);
+                        self.unify(ctx, obj_type, new_obj_type)?;
+
+                        let new_rest_type = new_object_type(&mut self.arena, &rest_elems);
+                        self.unify(ctx, rest_types[0], new_rest_type)?;
+
+                        Ok(())
+                    }
+                    _ => Err(Errors::InferenceError(
+                        "Inference is undecidable".to_string(),
+                    )),
+                }
+            }
+            _ => Err(Errors::InferenceError(format!(
+                "type mismatch: unify({}, {}) failed",
+                a_t.as_string(&self.arena),
+                b_t.as_string(&self.arena)
+            ))),
+        }
+    }
+
+    pub fn unify_mut(&mut self, ctx: &Context, t1: Index, t2: Index) -> Result<(), Errors> {
+        let t1 = self.prune(t1);
+        let t2 = self.prune(t2);
+
+        // TODO: only expand if unification fails since it's expensive
+        let t1 = self.expand(ctx, t1)?;
+        let t2 = self.expand(ctx, t2)?;
+
+        let t1_t = self.arena.get(t1).unwrap();
+        let t2_t = self.arena.get(t2).unwrap();
+
+        if t1_t.equals(t2_t, &self.arena) {
             Ok(())
+        } else {
+            Err(Errors::InferenceError(format!(
+                "unify_mut: {} != {}",
+                self.print_type(&t1),
+                self.print_type(&t2),
+            )))
         }
-        (TypeKind::Object(object1), TypeKind::Intersection(intersection)) => {
-            let obj_types: Vec<_> = intersection
-                .types
-                .iter()
-                .filter(|t| matches!(arena[**t].kind, TypeKind::Object(_)))
-                .cloned()
-                .collect();
-            let rest_types: Vec<_> = intersection
-                .types
-                .iter()
-                .filter(|t| matches!(arena[**t].kind, TypeKind::Variable(_)))
-                .cloned()
-                .collect();
-            // TODO: check for other variants, if there are we should error
-
-            let obj_type = simplify_intersection(arena, &obj_types);
-
-            match rest_types.len() {
-                0 => unify(arena, ctx, t1, obj_type),
-                1 => {
-                    let all_obj_elems = match &arena[obj_type].kind {
-                        TypeKind::Object(obj) => obj.elems.to_owned(),
-                        _ => vec![],
-                    };
-
-                    let (obj_elems, rest_elems): (Vec<_>, Vec<_>) =
-                        object1.elems.iter().cloned().partition(|e| {
-                            all_obj_elems.iter().any(|oe| match (oe, e) {
-                                // What to do about Call signatures?
-                                // (TObjElem::Call(_), TObjElem::Call(_)) => todo!(),
-                                (TObjElem::Prop(op), TObjElem::Prop(p)) => op.name == p.name,
-                                _ => false,
-                            })
-                        });
-
-                    let new_obj_type = new_object_type(arena, &obj_elems);
-                    unify(arena, ctx, new_obj_type, obj_type)?;
-
-                    let new_rest_type = new_object_type(arena, &rest_elems);
-                    unify(arena, ctx, new_rest_type, rest_types[0])?;
-
-                    Ok(())
-                }
-                _ => Err(Errors::InferenceError(
-                    "Inference is undecidable".to_string(),
-                )),
-            }
-        }
-        (TypeKind::Intersection(intersection), TypeKind::Object(object2)) => {
-            let obj_types: Vec<_> = intersection
-                .types
-                .iter()
-                .filter(|t| matches!(arena[**t].kind, TypeKind::Object(_)))
-                .cloned()
-                .collect();
-            let rest_types: Vec<_> = intersection
-                .types
-                .iter()
-                .filter(|t| matches!(arena[**t].kind, TypeKind::Variable(_)))
-                .cloned()
-                .collect();
-
-            let obj_type = simplify_intersection(arena, &obj_types);
-
-            match rest_types.len() {
-                0 => unify(arena, ctx, t1, obj_type),
-                1 => {
-                    let all_obj_elems = match &arena[obj_type].kind {
-                        TypeKind::Object(obj) => obj.elems.to_owned(),
-                        _ => vec![],
-                    };
-
-                    let (obj_elems, rest_elems): (Vec<_>, Vec<_>) =
-                        object2.elems.iter().cloned().partition(|e| {
-                            all_obj_elems.iter().any(|oe| match (oe, e) {
-                                // What to do about Call signatures?
-                                // (TObjElem::Call(_), TObjElem::Call(_)) => todo!(),
-                                (TObjElem::Prop(op), TObjElem::Prop(p)) => op.name == p.name,
-                                _ => false,
-                            })
-                        });
-
-                    let new_obj_type = new_object_type(arena, &obj_elems);
-                    unify(arena, ctx, obj_type, new_obj_type)?;
-
-                    let new_rest_type = new_object_type(arena, &rest_elems);
-                    unify(arena, ctx, rest_types[0], new_rest_type)?;
-
-                    Ok(())
-                }
-                _ => Err(Errors::InferenceError(
-                    "Inference is undecidable".to_string(),
-                )),
-            }
-        }
-        _ => Err(Errors::InferenceError(format!(
-            "type mismatch: unify({}, {}) failed",
-            a_t.as_string(arena),
-            b_t.as_string(arena)
-        ))),
     }
-}
 
-pub fn unify_mut(
-    arena: &mut Arena<Type>,
-    ctx: &Context,
-    t1: Index,
-    t2: Index,
-) -> Result<(), Errors> {
-    let t1 = prune(arena, t1);
-    let t2 = prune(arena, t2);
+    // This function unifies and infers the return type of a function call.
+    pub fn unify_call(
+        &mut self,
+        ctx: &mut Context,
+        args: &mut [Expr],
+        type_args: Option<&[Index]>,
+        t2: Index,
+    ) -> Result<(Index, Option<Index>), Errors> {
+        let ret_type = new_var_type(&mut self.arena, None);
+        let mut maybe_throws_type: Option<Index> = None;
+        // let throws_type = new_var_type(arena, None);
 
-    // TODO: only expand if unification fails since it's expensive
-    let t1 = expand(arena, ctx, t1)?;
-    let t2 = expand(arena, ctx, t2)?;
+        let b = self.prune(t2);
+        let b_t = self.arena.get(b).unwrap().clone();
 
-    let t1 = arena.get(t1).unwrap();
-    let t2 = arena.get(t2).unwrap();
-
-    if t1.equals(t2, arena) {
-        Ok(())
-    } else {
-        Err(Errors::InferenceError(format!(
-            "unify_mut: {} != {}",
-            t1.as_string(arena),
-            t2.as_string(arena)
-        )))
-    }
-}
-
-// This function unifies and infers the return type of a function call.
-pub fn unify_call(
-    arena: &mut Arena<Type>,
-    ctx: &mut Context,
-    args: &mut [Expr],
-    type_args: Option<&[Index]>,
-    t2: Index,
-) -> Result<(Index, Option<Index>), Errors> {
-    let ret_type = new_var_type(arena, None);
-    let mut maybe_throws_type: Option<Index> = None;
-    // let throws_type = new_var_type(arena, None);
-
-    let b = prune(arena, t2);
-    let b_t = arena.get(b).unwrap().clone();
-
-    match b_t.kind {
-        TypeKind::Variable(_) => {
-            let arg_types: Vec<FuncParam> = args
-                .iter_mut()
-                .enumerate()
-                .map(|(i, arg)| {
-                    let t = infer_expression(arena, arg, ctx)?;
-                    let param = FuncParam {
-                        pattern: TPat::Ident(BindingIdent {
-                            name: format!("arg{i}"),
-                            mutable: false,
-                            // loc: DUMMY_LOC,
-                            span: Span { start: 0, end: 0 },
-                        }),
-                        // name: format!("arg{i}"),
-                        t,
-                        optional: false,
-                    };
-                    Ok(param)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let call_type = new_func_type(arena, &arg_types, ret_type, &None, None);
-            bind(arena, ctx, b, call_type)?
-        }
-        TypeKind::Union(Union { types }) => {
-            let mut ret_types = vec![];
-            let mut throws_types = vec![];
-            for t in types.iter() {
-                let (ret_type, throws_type) = unify_call(arena, ctx, args, type_args, *t)?;
-                ret_types.push(ret_type);
-                if let Some(throws_type) = throws_type {
-                    throws_types.push(throws_type);
-                }
+        match b_t.kind {
+            TypeKind::Variable(_) => {
+                let arg_types: Vec<FuncParam> = args
+                    .iter_mut()
+                    .enumerate()
+                    .map(|(i, arg)| {
+                        let t = self.infer_expression(arg, ctx)?;
+                        let param = FuncParam {
+                            pattern: TPat::Ident(BindingIdent {
+                                name: format!("arg{i}"),
+                                mutable: false,
+                                // loc: DUMMY_LOC,
+                                span: Span { start: 0, end: 0 },
+                            }),
+                            // name: format!("arg{i}"),
+                            t,
+                            optional: false,
+                        };
+                        Ok(param)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let call_type = self.new_func_type(&arg_types, ret_type, &None, None);
+                self.bind(ctx, b, call_type)?
             }
-
-            let ret = new_union_type(arena, &ret_types.into_iter().unique().collect_vec());
-            let throws = new_union_type(arena, &throws_types.into_iter().unique().collect_vec());
-
-            let throws = match &arena[throws].kind {
-                TypeKind::Keyword(Keyword::Never) => None,
-                _ => Some(throws),
-            };
-
-            return Ok((ret, throws));
-        }
-        TypeKind::Intersection(Intersection { types }) => {
-            for t in types.iter() {
-                // TODO: if there are multiple overloads that unify, pick the
-                // best one.
-                let result = unify_call(arena, ctx, args, type_args, *t);
-                match result {
-                    Ok(ret_type) => return Ok(ret_type),
-                    Err(_) => continue,
-                }
-            }
-            return Err(Errors::InferenceError(
-                "no valid overload for args".to_string(),
-            ));
-        }
-        TypeKind::Tuple(_) => {
-            return Err(Errors::InferenceError("tuple is not callable".to_string()))
-        }
-        TypeKind::Constructor(Constructor {
-            name,
-            types: type_args,
-        }) => match ctx.schemes.get(&name) {
-            Some(scheme) => {
-                let mut mapping: HashMap<String, Index> = HashMap::new();
-                if let Some(type_params) = &scheme.type_params {
-                    for (param, arg) in type_params.iter().zip(type_args.iter()) {
-                        mapping.insert(param.name.clone(), arg.to_owned());
+            TypeKind::Union(Union { types }) => {
+                let mut ret_types = vec![];
+                let mut throws_types = vec![];
+                for t in types.iter() {
+                    let (ret_type, throws_type) = self.unify_call(ctx, args, type_args, *t)?;
+                    ret_types.push(ret_type);
+                    if let Some(throws_type) = throws_type {
+                        throws_types.push(throws_type);
                     }
                 }
 
-                let t = instantiate_scheme(arena, scheme.t, &mapping);
-                let type_args = if type_args.is_empty() {
-                    None
-                } else {
-                    Some(type_args.as_slice())
-                };
+                let ret = new_union_type(
+                    &mut self.arena,
+                    &ret_types.into_iter().unique().collect_vec(),
+                );
+                let throws = new_union_type(
+                    &mut self.arena,
+                    &throws_types.into_iter().unique().collect_vec(),
+                );
 
-                return unify_call(arena, ctx, args, type_args, t);
-            }
-            None => {
-                panic!("Couldn't find scheme for {name:#?}");
-            }
-        },
-        TypeKind::Literal(lit) => {
-            return Err(Errors::InferenceError(format!(
-                "literal {lit:#?} is not callable"
-            )));
-        }
-        TypeKind::Primitive(primitive) => {
-            return Err(Errors::InferenceError(format!(
-                "Primitive {primitive:#?} is not callable"
-            )));
-        }
-        TypeKind::Keyword(keyword) => {
-            return Err(Errors::InferenceError(format!("{keyword} is not callable")))
-        }
-        TypeKind::Object(_) => {
-            // TODO: check if the object has a callbale signature
-            return Err(Errors::InferenceError("object is not callable".to_string()));
-        }
-        TypeKind::Rest(_) => {
-            return Err(Errors::InferenceError("rest is not callable".to_string()));
-        }
-        TypeKind::Function(func) => {
-            let func = if func.type_params.is_some() {
-                instantiate_func(arena, &func, type_args)?
-            } else {
-                func
-            };
-
-            if args.len() < func.params.len() {
-                return Err(Errors::InferenceError(format!(
-                    "too few arguments to function: expected {}, got {}",
-                    func.params.len(),
-                    args.len()
-                )));
-            }
-
-            let arg_types = args
-                .iter_mut()
-                .map(|arg| {
-                    // TODO: handle spreads
-                    let t = infer_expression(arena, arg, ctx)?;
-                    Ok((arg, t))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            for ((arg, p), param) in arg_types.iter().zip(func.params.iter()) {
-                match check_mutability(ctx, &param.pattern, arg)? {
-                    true => unify_mut(arena, ctx, *p, param.t)?,
-                    false => unify(arena, ctx, *p, param.t)?,
-                };
-            }
-
-            unify(arena, ctx, ret_type, func.ret)?;
-
-            if let Some(throws) = func.throws {
-                let throws_type = new_var_type(arena, None);
-                unify(arena, ctx, throws_type, throws)?;
-
-                let throws_type = prune(arena, throws_type);
-                maybe_throws_type = match &arena[throws_type].kind {
+                let throws = match &self.arena[throws].kind {
                     TypeKind::Keyword(Keyword::Never) => None,
-                    _ => Some(throws_type),
+                    _ => Some(throws),
                 };
+
+                return Ok((ret, throws));
             }
-        }
-        TypeKind::KeyOf(KeyOf { t }) => {
-            return Err(Errors::InferenceError(format!(
-                "keyof {} is not callable",
-                arena[t].as_string(arena)
-            )));
-        }
-        TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
-            let t = get_prop(arena, ctx, obj, index)?;
-            unify_call(arena, ctx, args, type_args, t)?;
-        }
-        TypeKind::Conditional(Conditional {
-            check,
-            extends,
-            true_type,
-            false_type,
-        }) => {
-            match unify(arena, ctx, check, extends) {
-                Ok(_) => unify_call(arena, ctx, args, type_args, true_type)?,
-                Err(_) => unify_call(arena, ctx, args, type_args, false_type)?,
-            };
-        }
-        TypeKind::Infer(Infer { name }) => {
-            return Err(Errors::InferenceError(format!(
-                "infer {name} is not callable",
-            )));
-        }
-        TypeKind::Wildcard => {
-            return Err(Errors::InferenceError("_ is not callable".to_string()));
-        }
-        TypeKind::Binary(BinaryT {
-            op: _,
-            left: _,
-            right: _,
-        }) => todo!(),
-    }
-
-    // We need to prune the return type, because it might be a type variable.
-    let ret_type = prune(arena, ret_type);
-
-    Ok((ret_type, maybe_throws_type))
-}
-
-fn bind(arena: &mut Arena<Type>, ctx: &Context, a: Index, b: Index) -> Result<(), Errors> {
-    // eprint!("bind(");
-    // eprint!("{:#?}", arena[a].as_string(arena));
-    // if let Some(provenance) = &arena[a].provenance {
-    //     eprint!(" : {:#?}", provenance);
-    // }
-    // eprint!(", {:#?}", arena[b].as_string(arena));
-    // if let Some(provenance) = &arena[b].provenance {
-    //     eprint!(" : {:#?}", provenance);
-    // }
-    // eprintln!(")");
-
-    if a != b {
-        if occurs_in_type(arena, a, b) {
-            return Err(Errors::InferenceError("recursive unification".to_string()));
-        }
-
-        match arena.get_mut(a) {
-            Some(t) => match &mut t.kind {
-                TypeKind::Variable(avar) => {
-                    avar.instance = Some(b);
-                    if let Some(constraint) = avar.constraint {
-                        unify(arena, ctx, b, constraint)?;
+            TypeKind::Intersection(Intersection { types }) => {
+                for t in types.iter() {
+                    // TODO: if there are multiple overloads that unify, pick the
+                    // best one.
+                    let result = self.unify_call(ctx, args, type_args, *t);
+                    match result {
+                        Ok(ret_type) => return Ok(ret_type),
+                        Err(_) => continue,
                     }
                 }
-                _ => {
-                    unimplemented!("bind not implemented for {:#?}", t.kind);
+                return Err(Errors::InferenceError(
+                    "no valid overload for args".to_string(),
+                ));
+            }
+            TypeKind::Tuple(_) => {
+                return Err(Errors::InferenceError("tuple is not callable".to_string()))
+            }
+            TypeKind::Constructor(Constructor {
+                name,
+                types: type_args,
+            }) => match ctx.schemes.get(&name) {
+                Some(scheme) => {
+                    let mut mapping: HashMap<String, Index> = HashMap::new();
+                    if let Some(type_params) = &scheme.type_params {
+                        for (param, arg) in type_params.iter().zip(type_args.iter()) {
+                            mapping.insert(param.name.clone(), arg.to_owned());
+                        }
+                    }
+
+                    let t = instantiate_scheme(&mut self.arena, scheme.t, &mapping);
+                    let type_args = if type_args.is_empty() {
+                        None
+                    } else {
+                        Some(type_args.as_slice())
+                    };
+
+                    return self.unify_call(ctx, args, type_args, t);
+                }
+                None => {
+                    panic!("Couldn't find scheme for {name:#?}");
                 }
             },
-            None => todo!(),
+            TypeKind::Literal(lit) => {
+                return Err(Errors::InferenceError(format!(
+                    "literal {lit:#?} is not callable"
+                )));
+            }
+            TypeKind::Primitive(primitive) => {
+                return Err(Errors::InferenceError(format!(
+                    "Primitive {primitive:#?} is not callable"
+                )));
+            }
+            TypeKind::Keyword(keyword) => {
+                return Err(Errors::InferenceError(format!("{keyword} is not callable")))
+            }
+            TypeKind::Object(_) => {
+                // TODO: check if the object has a callbale signature
+                return Err(Errors::InferenceError("object is not callable".to_string()));
+            }
+            TypeKind::Rest(_) => {
+                return Err(Errors::InferenceError("rest is not callable".to_string()));
+            }
+            TypeKind::Function(func) => {
+                let func = if func.type_params.is_some() {
+                    instantiate_func(&mut self.arena, &func, type_args)?
+                } else {
+                    func
+                };
+
+                if args.len() < func.params.len() {
+                    return Err(Errors::InferenceError(format!(
+                        "too few arguments to function: expected {}, got {}",
+                        func.params.len(),
+                        args.len()
+                    )));
+                }
+
+                let arg_types = args
+                    .iter_mut()
+                    .map(|arg| {
+                        // TODO: handle spreads
+                        let t = self.infer_expression(arg, ctx)?;
+                        Ok((arg, t))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                for ((arg, p), param) in arg_types.iter().zip(func.params.iter()) {
+                    match check_mutability(ctx, &param.pattern, arg)? {
+                        true => self.unify_mut(ctx, *p, param.t)?,
+                        false => self.unify(ctx, *p, param.t)?,
+                    };
+                }
+
+                self.unify(ctx, ret_type, func.ret)?;
+
+                if let Some(throws) = func.throws {
+                    let throws_type = new_var_type(&mut self.arena, None);
+                    self.unify(ctx, throws_type, throws)?;
+
+                    let throws_type = self.prune(throws_type);
+                    maybe_throws_type = match &self.arena[throws_type].kind {
+                        TypeKind::Keyword(Keyword::Never) => None,
+                        _ => Some(throws_type),
+                    };
+                }
+            }
+            TypeKind::KeyOf(KeyOf { t }) => {
+                return Err(Errors::InferenceError(format!(
+                    "keyof {} is not callable",
+                    self.print_type(&t)
+                )));
+            }
+            TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
+                let t = self.get_prop(ctx, obj, index)?;
+                self.unify_call(ctx, args, type_args, t)?;
+            }
+            TypeKind::Conditional(Conditional {
+                check,
+                extends,
+                true_type,
+                false_type,
+            }) => {
+                match self.unify(ctx, check, extends) {
+                    Ok(_) => self.unify_call(ctx, args, type_args, true_type)?,
+                    Err(_) => self.unify_call(ctx, args, type_args, false_type)?,
+                };
+            }
+            TypeKind::Infer(Infer { name }) => {
+                return Err(Errors::InferenceError(format!(
+                    "infer {name} is not callable",
+                )));
+            }
+            TypeKind::Wildcard => {
+                return Err(Errors::InferenceError("_ is not callable".to_string()));
+            }
+            TypeKind::Binary(BinaryT {
+                op: _,
+                left: _,
+                right: _,
+            }) => todo!(),
+        }
+
+        // We need to prune the return type, because it might be a type variable.
+        let ret_type = self.prune(ret_type);
+
+        Ok((ret_type, maybe_throws_type))
+    }
+
+    fn bind(&mut self, ctx: &Context, a: Index, b: Index) -> Result<(), Errors> {
+        // eprint!("bind(");
+        // eprint!("{:#?}", arena[a].as_string(arena));
+        // if let Some(provenance) = &arena[a].provenance {
+        //     eprint!(" : {:#?}", provenance);
+        // }
+        // eprint!(", {:#?}", arena[b].as_string(arena));
+        // if let Some(provenance) = &arena[b].provenance {
+        //     eprint!(" : {:#?}", provenance);
+        // }
+        // eprintln!(")");
+
+        if a != b {
+            if self.occurs_in_type(a, b) {
+                return Err(Errors::InferenceError("recursive unification".to_string()));
+            }
+
+            match self.arena.get_mut(a) {
+                Some(t) => match &mut t.kind {
+                    TypeKind::Variable(avar) => {
+                        avar.instance = Some(b);
+                        if let Some(constraint) = avar.constraint {
+                            self.unify(ctx, b, constraint)?;
+                        }
+                    }
+                    _ => {
+                        unimplemented!("bind not implemented for {:#?}", t.kind);
+                    }
+                },
+                None => todo!(),
+            }
+        }
+        Ok(())
+    }
+
+    fn expand(&mut self, ctx: &Context, a: Index) -> Result<Index, Errors> {
+        let a_t = self.arena[a].clone();
+
+        match &a_t.kind {
+            TypeKind::Constructor(Constructor { name, .. }) if name == "Array" => Ok(a),
+            TypeKind::Constructor(Constructor { name, .. }) if name == "Promise" => Ok(a),
+            _ => self.expand_type(ctx, a),
         }
     }
-    Ok(())
 }
 
 // TODO: handle optional properties correctly
@@ -943,15 +962,5 @@ pub fn simplify_intersection(arena: &mut Arena<Type>, in_types: &[Index]) -> Ind
         out_types[0]
     } else {
         new_intersection_type(arena, &out_types)
-    }
-}
-
-fn expand(arena: &mut Arena<Type>, ctx: &Context, a: Index) -> Result<Index, Errors> {
-    let a_t = arena[a].clone();
-
-    match &a_t.kind {
-        TypeKind::Constructor(Constructor { name, .. }) if name == "Array" => Ok(a),
-        TypeKind::Constructor(Constructor { name, .. }) if name == "Promise" => Ok(a),
-        _ => expand_type(arena, ctx, a),
     }
 }

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -50,8 +50,8 @@ impl Checker {
                 } else {
                     Err(Errors::InferenceError(format!(
                         "type mismatch: {} != {}",
-                        a_t.as_string(&self.arena),
-                        b_t.as_string(&self.arena)
+                        self.print_type(&a),
+                        self.print_type(&b),
                     )))
                 }
             }
@@ -79,8 +79,8 @@ impl Checker {
 
                 Err(Errors::InferenceError(format!(
                     "type mismatch: unify({}, {}) failed",
-                    a_t.as_string(&self.arena),
-                    b_t.as_string(&self.arena)
+                    self.print_type(&a),
+                    self.print_type(&b),
                 )))
             }
             (TypeKind::Tuple(tuple1), TypeKind::Tuple(tuple2)) => {
@@ -162,8 +162,8 @@ impl Checker {
                 if con_a.name != con_b.name || con_a.types.len() != con_b.types.len() {
                     return Err(Errors::InferenceError(format!(
                         "type mismatch: {} != {}",
-                        a_t.as_string(&self.arena),
-                        b_t.as_string(&self.arena),
+                        self.print_type(&a),
+                        self.print_type(&b),
                     )));
                 }
                 for (p, q) in con_a.types.iter().zip(con_b.types.iter()) {
@@ -274,8 +274,8 @@ impl Checker {
 
                     return Err(Errors::InferenceError(format!(
                         "{} is not a subtype of {} since it requires more params",
-                        a_t.as_string(&self.arena),
-                        b_t.as_string(&self.arena),
+                        self.print_type(&a),
+                        self.print_type(&b),
                     )));
                 }
 
@@ -324,8 +324,8 @@ impl Checker {
                 if !equal {
                     return Err(Errors::InferenceError(format!(
                         "type mismatch: {} != {}",
-                        a_t.as_string(&self.arena),
-                        b_t.as_string(&self.arena),
+                        self.print_type(&a),
+                        self.print_type(&b),
                     )));
                 }
                 Ok(())
@@ -340,8 +340,8 @@ impl Checker {
                 (Primitive::Symbol, Primitive::Symbol) => Ok(()),
                 _ => Err(Errors::InferenceError(format!(
                     "type mismatch: {} != {}",
-                    a_t.as_string(&self.arena),
-                    b_t.as_string(&self.arena),
+                    self.print_type(&a),
+                    self.print_type(&b),
                 ))),
             },
             (TypeKind::Object(object1), TypeKind::Object(object2)) => {
@@ -413,7 +413,7 @@ impl Checker {
                             return Err(Errors::InferenceError(format!(
                                 "'{}' is missing in {}",
                                 name,
-                                a_t.as_string(&self.arena),
+                                self.print_type(&a),
                             )));
                         }
                     }
@@ -477,7 +477,7 @@ impl Checker {
                             _ => {
                                 return Err(Errors::InferenceError(format!(
                                     "{} has multiple indexers",
-                                    a_t.as_string(&self.arena)
+                                    self.print_type(&a),
                                 )))
                             }
                         }
@@ -485,7 +485,7 @@ impl Checker {
                     _ => {
                         return Err(Errors::InferenceError(format!(
                             "{} has multiple indexers",
-                            b_t.as_string(&self.arena)
+                            self.print_type(&b),
                         )))
                     }
                 }
@@ -593,8 +593,8 @@ impl Checker {
             }
             _ => Err(Errors::InferenceError(format!(
                 "type mismatch: unify({}, {}) failed",
-                a_t.as_string(&self.arena),
-                b_t.as_string(&self.arena)
+                self.print_type(&a),
+                self.print_type(&b),
             ))),
         }
     }
@@ -607,10 +607,7 @@ impl Checker {
         let t1 = self.expand(ctx, t1)?;
         let t2 = self.expand(ctx, t2)?;
 
-        let t1_t = self.arena.get(t1).unwrap();
-        let t2_t = self.arena.get(t2).unwrap();
-
-        if t1_t.equals(t2_t, &self.arena) {
+        if self.equals(&t1, &t2) {
             Ok(())
         } else {
             Err(Errors::InferenceError(format!(

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -4,627 +4,918 @@ use std::collections::{BTreeMap, HashMap};
 
 use escalier_ast::Literal;
 
+use crate::checker::Checker;
 use crate::context::*;
 use crate::errors::*;
 use crate::folder::walk_index;
 use crate::folder::Folder;
 use crate::key_value_store::KeyValueStore;
 use crate::types::*;
-use crate::unify::*;
 use crate::visitor::{self, Visitor};
 
-/// Checks whether a type variable occurs in a type expression.
-///
-/// Note: Must be called with v pre-pruned
-///
-/// Args:
-///     v:  The TypeVariable to be tested for
-///     type2: The type in which to search
-///
-/// Returns:
-///     True if v occurs in type2, otherwise False
-// TODO: reimplement as a fold operation
-pub fn occurs_in_type(arena: &mut Arena<Type>, v: Index, type2: Index) -> bool {
-    let pruned_type2 = prune(arena, type2);
-    if pruned_type2 == v {
-        return true;
+impl Checker {
+    /// Checks whether a type variable occurs in a type expression.
+    ///
+    /// Note: Must be called with v pre-pruned
+    ///
+    /// Args:
+    ///     v:  The TypeVariable to be tested for
+    ///     type2: The type in which to search
+    ///
+    /// Returns:
+    ///     True if v occurs in type2, otherwise False
+    // TODO: reimplement as a fold operation
+    pub fn occurs_in_type(&mut self, v: Index, type2: Index) -> bool {
+        let pruned_type2 = self.prune(type2);
+        if pruned_type2 == v {
+            return true;
+        }
+        // We clone here because we can't move out of a shared reference.
+        // TODO: Consider using Rc<RefCell<Type>> to avoid unnecessary cloning.
+        match self.arena.get(pruned_type2).unwrap().clone().kind {
+            TypeKind::Variable(_) => false,  // leaf node
+            TypeKind::Literal(_) => false,   // leaf node
+            TypeKind::Primitive(_) => false, // leaf node
+            TypeKind::Keyword(_) => false,   // leaf node
+            TypeKind::Infer(_) => false,     // leaf node
+            TypeKind::Wildcard => false,     // leaf node
+            TypeKind::Object(Object { elems }) => elems.iter().any(|elem| match elem {
+                TObjElem::Constructor(constructor) => {
+                    // TODO: check constraints and default on type_params
+                    let param_types: Vec<_> =
+                        constructor.params.iter().map(|param| param.t).collect();
+                    self.occurs_in(v, &param_types) || self.occurs_in_type(v, constructor.ret)
+                }
+                TObjElem::Call(call) => {
+                    // TODO: check constraints and default on type_params
+                    let param_types: Vec<_> = call.params.iter().map(|param| param.t).collect();
+                    self.occurs_in(v, &param_types) || self.occurs_in_type(v, call.ret)
+                }
+                TObjElem::Mapped(mapped) => {
+                    self.occurs_in_type(v, mapped.key)
+                        || self.occurs_in_type(v, mapped.value)
+                        || self.occurs_in_type(v, mapped.source)
+                    // TODO: handle .check and .extends
+                }
+                TObjElem::Prop(prop) => self.occurs_in_type(v, prop.t),
+            }),
+            TypeKind::Rest(Rest { arg }) => self.occurs_in_type(v, arg),
+            TypeKind::Function(Function {
+                params,
+                ret,
+                type_params: _, // TODO
+                throws: _,      // TODO
+            }) => {
+                // TODO: check constraints and default on type_params
+                let param_types: Vec<_> = params.iter().map(|param| param.t).collect();
+                self.occurs_in(v, &param_types) || self.occurs_in_type(v, ret)
+            }
+            TypeKind::Union(Union { types }) => self.occurs_in(v, &types),
+            TypeKind::Intersection(Intersection { types }) => self.occurs_in(v, &types),
+            TypeKind::Tuple(Tuple { types }) => self.occurs_in(v, &types),
+            TypeKind::Constructor(Constructor { types, .. }) => self.occurs_in(v, &types),
+            TypeKind::KeyOf(KeyOf { t }) => self.occurs_in_type(v, t),
+            TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
+                self.occurs_in_type(v, obj) || self.occurs_in_type(v, index)
+            }
+            TypeKind::Conditional(Conditional {
+                check,
+                extends,
+                true_type,
+                false_type,
+            }) => {
+                self.occurs_in_type(v, check)
+                    || self.occurs_in_type(v, extends)
+                    || self.occurs_in_type(v, true_type)
+                    || self.occurs_in_type(v, false_type)
+            }
+            TypeKind::Binary(BinaryT { op: _, left, right }) => {
+                self.occurs_in_type(v, left) || self.occurs_in_type(v, right)
+            }
+        }
     }
-    // We clone here because we can't move out of a shared reference.
-    // TODO: Consider using Rc<RefCell<Type>> to avoid unnecessary cloning.
-    match arena.get(pruned_type2).unwrap().clone().kind {
-        TypeKind::Variable(_) => false,  // leaf node
-        TypeKind::Literal(_) => false,   // leaf node
-        TypeKind::Primitive(_) => false, // leaf node
-        TypeKind::Keyword(_) => false,   // leaf node
-        TypeKind::Infer(_) => false,     // leaf node
-        TypeKind::Wildcard => false,     // leaf node
-        TypeKind::Object(Object { elems }) => elems.iter().any(|elem| match elem {
-            TObjElem::Constructor(constructor) => {
-                // TODO: check constraints and default on type_params
-                let param_types: Vec<_> = constructor.params.iter().map(|param| param.t).collect();
-                occurs_in(arena, v, &param_types) || occurs_in_type(arena, v, constructor.ret)
+
+    /// Checks whether a types variable occurs in any other types.
+    ///
+    /// Args:
+    ///     t:  The TypeVariable to be tested for
+    ///     types: The sequence of types in which to search
+    ///
+    /// Returns:
+    ///     True if t occurs in any of types, otherwise False
+    ///
+    pub fn occurs_in<'b, I>(&mut self, t: Index, types: I) -> bool
+    where
+        I: IntoIterator<Item = &'b Index>,
+    {
+        for t2 in types.into_iter() {
+            if self.occurs_in_type(t, *t2) {
+                return true;
             }
-            TObjElem::Call(call) => {
-                // TODO: check constraints and default on type_params
-                let param_types: Vec<_> = call.params.iter().map(|param| param.t).collect();
-                occurs_in(arena, v, &param_types) || occurs_in_type(arena, v, call.ret)
-            }
-            TObjElem::Mapped(mapped) => {
-                occurs_in_type(arena, v, mapped.key)
-                    || occurs_in_type(arena, v, mapped.value)
-                    || occurs_in_type(arena, v, mapped.source)
-                // TODO: handle .check and .extends
-            }
-            TObjElem::Prop(prop) => occurs_in_type(arena, v, prop.t),
-        }),
-        TypeKind::Rest(Rest { arg }) => occurs_in_type(arena, v, arg),
-        TypeKind::Function(Function {
-            params,
-            ret,
-            type_params: _, // TODO
-            throws: _,      // TODO
-        }) => {
-            // TODO: check constraints and default on type_params
-            let param_types: Vec<_> = params.iter().map(|param| param.t).collect();
-            occurs_in(arena, v, &param_types) || occurs_in_type(arena, v, ret)
         }
-        TypeKind::Union(Union { types }) => occurs_in(arena, v, &types),
-        TypeKind::Intersection(Intersection { types }) => occurs_in(arena, v, &types),
-        TypeKind::Tuple(Tuple { types }) => occurs_in(arena, v, &types),
-        TypeKind::Constructor(Constructor { types, .. }) => occurs_in(arena, v, &types),
-        TypeKind::KeyOf(KeyOf { t }) => occurs_in_type(arena, v, t),
-        TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
-            occurs_in_type(arena, v, obj) || occurs_in_type(arena, v, index)
+        false
+    }
+
+    /// Returns the currently defining instance of t.
+    ///
+    /// As a side effect, collapses the list of type instances. The function Prune
+    /// is used whenever a type expression has to be inspected: it will always
+    /// return a type expression which is either an uninstantiated type variable or
+    /// a type operator; i.e. it will skip instantiated variables, and will
+    /// actually prune them from expressions to remove long chains of instantiated
+    /// variables.
+    ///
+    /// Args:
+    ///     t: The type to be pruned
+    ///
+    /// Returns:
+    ///     An uninstantiated TypeVariable or a TypeOperator
+    pub fn prune(&mut self, t: Index) -> Index {
+        let v2 = match self.arena.get(t).unwrap().kind {
+            // TODO: handle .unwrap() panicing
+            TypeKind::Variable(Variable {
+                instance: Some(value),
+                ..
+            }) => value,
+            _ => {
+                return t;
+            }
+        };
+
+        let value = self.prune(v2);
+        match &mut self.arena.get_mut(t).unwrap().kind {
+            // TODO: handle .unwrap() panicing
+            TypeKind::Variable(Variable {
+                ref mut instance, ..
+            }) => {
+                *instance = Some(value);
+            }
+            _ => {
+                return t;
+            }
         }
-        TypeKind::Conditional(Conditional {
+        value
+    }
+
+    pub fn expand_alias_by_name(
+        &mut self,
+        ctx: &Context,
+        name: &str,
+        type_args: &[Index],
+    ) -> Result<Index, Errors> {
+        match ctx.schemes.get(name) {
+            Some(scheme) => self.expand_alias(ctx, name, scheme, type_args),
+            None => {
+                panic!("{} isn't defined", name);
+                // Err(Errors::InferenceError(format!("{} isn't defined", name)))
+            }
+        }
+    }
+
+    pub fn expand_alias(
+        &mut self,
+        ctx: &Context,
+        name: &str,
+        scheme: &Scheme,
+        type_args: &[Index],
+    ) -> Result<Index, Errors> {
+        match &scheme.type_params {
+            Some(type_params) => {
+                if type_params.len() != type_args.len() {
+                    return Err(Errors::InferenceError(format!(
+                        "{name} expects {} type args, but was passed {}",
+                        type_params.len(),
+                        type_args.len()
+                    )));
+                }
+
+                if let TypeKind::Conditional(Conditional { check, .. }) = self.arena[scheme.t].kind
+                {
+                    if let TypeKind::Constructor(tref) = &self.arena[check].kind.clone() {
+                        if let Some((index_of_check_type, _)) = type_params
+                            .iter()
+                            .find_position(|type_param| type_param.name == tref.name)
+                        {
+                            let type_arg = self.expand_type(ctx, type_args[index_of_check_type])?;
+
+                            if let TypeKind::Union(Union { types: union_types }) =
+                                &self.arena[type_arg].kind.clone()
+                            {
+                                let mut types = vec![];
+
+                                for t in union_types.iter() {
+                                    let mut mapping: HashMap<String, Index> = HashMap::new();
+
+                                    for (type_param, type_arg) in
+                                        type_params.iter().zip(type_args.iter())
+                                    {
+                                        if type_param.name == tref.name {
+                                            mapping.insert(type_param.name.to_owned(), *t);
+                                        } else {
+                                            mapping.insert(type_param.name.to_owned(), *type_arg);
+                                        }
+                                    }
+
+                                    let t = instantiate_scheme(&mut self.arena, scheme.t, &mapping);
+                                    types.push(self.expand_type(ctx, t)?);
+                                }
+
+                                let filtered_types = types
+                                    .into_iter()
+                                    .filter(|t| {
+                                        if let TypeKind::Keyword(kw) = &self.arena[*t].kind {
+                                            kw != &Keyword::Never
+                                        } else {
+                                            true
+                                        }
+                                    })
+                                    .collect::<Vec<_>>();
+
+                                let t = new_union_type(&mut self.arena, &filtered_types);
+                                return self.expand_type(ctx, t);
+                            }
+                        }
+                    }
+                }
+
+                let mut mapping: HashMap<String, Index> = HashMap::new();
+                for (param, arg) in type_params.iter().zip(type_args.iter()) {
+                    if let Some(constraint) = param.constraint {
+                        self.unify(ctx, *arg, constraint)?;
+                    }
+                    mapping.insert(param.name.clone(), arg.to_owned());
+                }
+
+                let t = instantiate_scheme(&mut self.arena, scheme.t, &mapping);
+                self.expand_type(ctx, t)
+            }
+            None => {
+                if type_args.is_empty() {
+                    let t = self.expand_type(ctx, scheme.t)?;
+                    Ok(t)
+                } else {
+                    Err(Errors::InferenceError(format!(
+                        "{name} doesn't require any type args"
+                    )))
+                }
+            }
+        }
+    }
+
+    pub fn expand_type(&mut self, ctx: &Context, t: Index) -> Result<Index, Errors> {
+        let t = self.prune(t);
+
+        // It's okay to clone here because we aren't mutating the type
+        let t = match &self.arena[t].clone().kind {
+            TypeKind::KeyOf(KeyOf { t }) => self.expand_keyof(ctx, *t)?,
+            TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
+                self.get_computed_member(ctx, *obj, *index)?
+            }
+            TypeKind::Conditional(conditional) => self.expand_conditional(ctx, conditional)?,
+            TypeKind::Constructor(Constructor { name, types, .. }) => {
+                self.expand_alias_by_name(ctx, name, types)?
+            }
+            TypeKind::Binary(binary) => self.expand_binary(ctx, binary)?,
+            TypeKind::Object(object) => return self.expand_object(ctx, object),
+            _ => return Ok(t), // Early return to avoid infinite loop
+        };
+
+        self.expand_type(ctx, t)
+    }
+
+    // Expands `keyof` types into one of the followwing:
+    // - string or number literals
+    // - string, number, or symbol type
+    // - never
+    // - union of any of those types
+    pub fn expand_keyof(&mut self, ctx: &Context, t: Index) -> Result<Index, Errors> {
+        let obj = match &self.arena[t].kind {
+            // Don't expand Array's since they have a special `keyof` behavior.  We
+            // don't want to expand them because we don't want to include array methods
+            // in the list of keys.  This is similar to how objects are treated.
+            TypeKind::Constructor(Constructor { name, .. }) if name == "Array" => t,
+            _ => self.expand_type(ctx, t)?,
+        };
+
+        match &self.arena[obj].kind.clone() {
+            TypeKind::Object(Object { elems }) => {
+                let mut string_keys: Vec<Index> = Vec::new();
+                let mut number_keys: Vec<Index> = Vec::new();
+                let mut maybe_string: Option<Index> = None;
+                let mut maybe_number: Option<Index> = None;
+                let mut maybe_symbol: Option<Index> = None;
+
+                for elem in elems {
+                    match elem {
+                        TObjElem::Call(_) => (),
+                        TObjElem::Constructor(_) => (),
+                        TObjElem::Mapped(mapped) => {
+                            let mapped_key = get_mapped_key(&mut self.arena, mapped);
+
+                            match &self.arena[mapped_key].kind {
+                                TypeKind::Primitive(Primitive::String) => {
+                                    maybe_string = Some(mapped_key);
+                                }
+                                TypeKind::Primitive(Primitive::Number) => {
+                                    maybe_number = Some(mapped_key);
+                                }
+                                TypeKind::Primitive(Primitive::Symbol) => {
+                                    maybe_symbol = Some(mapped_key);
+                                }
+                                _ => todo!(),
+                            }
+                        }
+                        TObjElem::Prop(TProp { name, .. }) => match name {
+                            TPropKey::StringKey(name) => {
+                                string_keys.push(new_lit_type(
+                                    &mut self.arena,
+                                    &Literal::String(name.to_owned()),
+                                ));
+                            }
+                            TPropKey::NumberKey(name) => {
+                                number_keys.push(new_lit_type(
+                                    &mut self.arena,
+                                    &Literal::Number(name.to_owned()),
+                                ));
+                            }
+                        },
+                    }
+                }
+
+                let mut all_keys: Vec<Index> = vec![];
+
+                match maybe_number {
+                    Some(number) => all_keys.push(number),
+                    None => all_keys.append(&mut number_keys),
+                }
+
+                match maybe_string {
+                    Some(string) => all_keys.push(string),
+                    None => all_keys.append(&mut string_keys),
+                }
+
+                if let Some(symbol) = maybe_symbol {
+                    all_keys.push(symbol);
+                }
+
+                Ok(new_union_type(&mut self.arena, &all_keys))
+            }
+            // NOTE: The behavior of `keyof` with arrays and tuples differs from
+            // TypeScript.  TypeScript includes the names of all the properties from
+            // Array.prototype as well.
+            // TODO(#637): Have interop layer translate between Escalier's and
+            // TypeScript's `keyof` utility type.
+            TypeKind::Constructor(array) if array.name == "Array" => {
+                Ok(new_primitive(&mut self.arena, Primitive::Number))
+            }
+            TypeKind::Tuple(tuple) => {
+                let keys: Vec<Index> = tuple
+                    .types
+                    .iter()
+                    .enumerate()
+                    .map(|(k, _)| new_lit_type(&mut self.arena, &Literal::Number(k.to_string())))
+                    .collect();
+                Ok(new_union_type(&mut self.arena, &keys))
+            }
+            TypeKind::Constructor(constructor) => {
+                let idx = self.expand_alias_by_name(ctx, &constructor.name, &constructor.types)?;
+                self.expand_keyof(ctx, idx)
+            }
+            TypeKind::Intersection(Intersection { types }) => {
+                let mut string_keys = BTreeMap::new();
+                let mut number_keys = BTreeMap::new();
+                let mut maybe_string = None;
+                let mut maybe_number = None;
+                let mut maybe_symbol = None;
+
+                for t in types {
+                    let keys = self.expand_keyof(ctx, *t)?;
+
+                    match &self.arena[keys].kind {
+                        TypeKind::Union(Union { types }) => {
+                            for t in types {
+                                match &self.arena[*t].kind {
+                                    TypeKind::Literal(Literal::Number(num)) => {
+                                        number_keys.insert(num.to_string(), *t);
+                                    }
+                                    TypeKind::Literal(Literal::String(str)) => {
+                                        string_keys.insert(str.to_string(), *t);
+                                    }
+                                    TypeKind::Primitive(Primitive::Number) => {
+                                        maybe_number = Some(*t);
+                                    }
+                                    TypeKind::Primitive(Primitive::String) => {
+                                        maybe_string = Some(*t);
+                                    }
+                                    TypeKind::Primitive(Primitive::Symbol) => {
+                                        maybe_symbol = Some(*t);
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        TypeKind::Literal(Literal::Number(num)) => {
+                            number_keys.insert(num.to_string(), keys);
+                        }
+                        TypeKind::Literal(Literal::String(str)) => {
+                            string_keys.insert(str.to_string(), keys);
+                        }
+                        TypeKind::Primitive(Primitive::Number) => {
+                            maybe_number = Some(keys);
+                        }
+                        TypeKind::Primitive(Primitive::String) => {
+                            maybe_string = Some(keys);
+                        }
+                        TypeKind::Primitive(Primitive::Symbol) => {
+                            maybe_symbol = Some(*t);
+                        }
+                        _ => (),
+                    }
+                }
+
+                let mut all_keys: Vec<Index> = vec![];
+
+                match maybe_number {
+                    Some(number) => all_keys.push(number),
+                    None => {
+                        all_keys.append(&mut number_keys.values().cloned().collect::<Vec<Index>>())
+                    }
+                }
+
+                match maybe_string {
+                    Some(string) => all_keys.push(string),
+                    None => {
+                        all_keys.append(&mut string_keys.values().cloned().collect::<Vec<Index>>())
+                    }
+                }
+
+                if let Some(symbol) = maybe_symbol {
+                    all_keys.push(symbol);
+                }
+
+                Ok(new_union_type(&mut self.arena, &all_keys))
+            }
+            TypeKind::Union(_) => Ok(new_keyword(&mut self.arena, Keyword::Never)),
+            TypeKind::Keyword(keyword) => match keyword {
+                // TODO: update get_property to handle these cases as well
+                Keyword::Null => Ok(new_keyword(&mut self.arena, Keyword::Never)),
+                Keyword::Undefined => Ok(new_keyword(&mut self.arena, Keyword::Never)),
+                Keyword::Unknown => Ok(new_keyword(&mut self.arena, Keyword::Never)),
+                Keyword::Never => {
+                    let string = new_primitive(&mut self.arena, Primitive::String);
+                    let number = new_primitive(&mut self.arena, Primitive::Number);
+                    let symbol = new_primitive(&mut self.arena, Primitive::Symbol);
+                    Ok(new_union_type(&mut self.arena, &[string, number, symbol]))
+                }
+            },
+            TypeKind::Primitive(primitive) => {
+                let scheme_name = primitive.get_scheme_name();
+                let idx = self.expand_alias_by_name(ctx, scheme_name, &[])?;
+                self.expand_keyof(ctx, idx)
+            }
+            TypeKind::Literal(literal) => match literal.get_scheme_name() {
+                Some(name) => {
+                    let idx = self.expand_alias_by_name(ctx, name, &[])?;
+                    self.expand_keyof(ctx, idx)
+                }
+                None => todo!(),
+            },
+            _ => {
+                let expanded_t = self.expand_type(ctx, t)?;
+                if expanded_t != t {
+                    self.expand_keyof(ctx, expanded_t)
+                } else {
+                    Ok(new_keyword(&mut self.arena, Keyword::Never))
+                }
+            }
+        }
+    }
+
+    // TODO: have a separate version of this for expanding conditional types that
+    // are the definition of a type alias.  In that situation, if the `check` is
+    // a type reference and the arg passed to the type alias is a union, then we
+    // have distribute the union.
+    pub fn expand_conditional(
+        &mut self,
+        ctx: &Context,
+        conditional: &Conditional,
+    ) -> Result<Index, Errors> {
+        let Conditional {
             check,
             extends,
             true_type,
             false_type,
-        }) => {
-            occurs_in_type(arena, v, check)
-                || occurs_in_type(arena, v, extends)
-                || occurs_in_type(arena, v, true_type)
-                || occurs_in_type(arena, v, false_type)
+        } = conditional;
+
+        let infer_types = find_infer_types(&mut self.arena, extends);
+
+        let mut type_param_map: HashMap<String, Index> = HashMap::new();
+        for infer_t in infer_types {
+            type_param_map.insert(infer_t.name.to_owned(), new_var_type(&mut self.arena, None));
         }
-        TypeKind::Binary(BinaryT { op: _, left, right }) => {
-            occurs_in_type(arena, v, left) || occurs_in_type(arena, v, right)
+
+        let extends = replace_infer_types(&mut self.arena, extends, &type_param_map);
+
+        match self.unify(ctx, *check, extends) {
+            Ok(_) => {
+                let true_type = instantiate_scheme(&mut self.arena, *true_type, &type_param_map);
+                Ok(true_type)
+            }
+            Err(_) => Ok(*false_type),
         }
     }
-}
 
-/// Checks whether a types variable occurs in any other types.
-///
-/// Args:
-///     t:  The TypeVariable to be tested for
-///     types: The sequence of types in which to search
-///
-/// Returns:
-///     True if t occurs in any of types, otherwise False
-///
-pub fn occurs_in<'a, I>(a: &mut Arena<Type>, t: Index, types: I) -> bool
-where
-    I: IntoIterator<Item = &'a Index>,
-{
-    for t2 in types.into_iter() {
-        if occurs_in_type(a, t, *t2) {
-            return true;
-        }
-    }
-    false
-}
+    pub fn expand_binary(&mut self, _ctx: &Context, binary: &BinaryT) -> Result<Index, Errors> {
+        let t = match (
+            &self.arena[binary.left].kind,
+            &self.arena[binary.right].kind,
+        ) {
+            (
+                TypeKind::Literal(Literal::Number(left)),
+                TypeKind::Literal(Literal::Number(right)),
+            ) => {
+                let left = left.parse::<f64>().unwrap();
+                let right = right.parse::<f64>().unwrap();
 
-/// Returns the currently defining instance of t.
-///
-/// As a side effect, collapses the list of type instances. The function Prune
-/// is used whenever a type expression has to be inspected: it will always
-/// return a type expression which is either an uninstantiated type variable or
-/// a type operator; i.e. it will skip instantiated variables, and will
-/// actually prune them from expressions to remove long chains of instantiated
-/// variables.
-///
-/// Args:
-///     t: The type to be pruned
-///
-/// Returns:
-///     An uninstantiated TypeVariable or a TypeOperator
-pub fn prune(arena: &mut Arena<Type>, t: Index) -> Index {
-    let v2 = match arena.get(t).unwrap().kind {
-        // TODO: handle .unwrap() panicing
-        TypeKind::Variable(Variable {
-            instance: Some(value),
-            ..
-        }) => value,
-        _ => {
-            return t;
-        }
-    };
+                let result = match binary.op {
+                    TBinaryOp::Add => left + right,
+                    TBinaryOp::Sub => left - right,
+                    TBinaryOp::Mul => left * right,
+                    TBinaryOp::Div => left / right,
+                    TBinaryOp::Mod => left % right,
+                };
 
-    let value = prune(arena, v2);
-    match &mut arena.get_mut(t).unwrap().kind {
-        // TODO: handle .unwrap() panicing
-        TypeKind::Variable(Variable {
-            ref mut instance, ..
-        }) => {
-            *instance = Some(value);
-        }
-        _ => {
-            return t;
-        }
-    }
-    value
-}
-
-pub fn expand_alias_by_name(
-    arena: &mut Arena<Type>,
-    ctx: &Context,
-    name: &str,
-    type_args: &[Index],
-) -> Result<Index, Errors> {
-    match ctx.schemes.get(name) {
-        Some(scheme) => expand_alias(arena, ctx, name, scheme, type_args),
-        None => {
-            panic!("{} isn't defined", name);
-            // Err(Errors::InferenceError(format!("{} isn't defined", name)))
-        }
-    }
-}
-
-pub fn expand_alias(
-    arena: &mut Arena<Type>,
-    ctx: &Context,
-    name: &str,
-    scheme: &Scheme,
-    type_args: &[Index],
-) -> Result<Index, Errors> {
-    match &scheme.type_params {
-        Some(type_params) => {
-            if type_params.len() != type_args.len() {
+                new_lit_type(&mut self.arena, &Literal::Number(result.to_string()))
+            }
+            (TypeKind::Literal(Literal::Number(_)), TypeKind::Primitive(Primitive::Number)) => {
+                new_primitive(&mut self.arena, Primitive::Number)
+            }
+            (TypeKind::Primitive(Primitive::Number), TypeKind::Literal(Literal::Number(_))) => {
+                new_primitive(&mut self.arena, Primitive::Number)
+            }
+            (TypeKind::Primitive(Primitive::Number), TypeKind::Primitive(Primitive::Number)) => {
+                new_primitive(&mut self.arena, Primitive::Number)
+            }
+            (_, _) => {
                 return Err(Errors::InferenceError(format!(
-                    "{name} expects {} type args, but was passed {}",
-                    type_params.len(),
-                    type_args.len()
+                    "Cannot perform binary operation on types: {:?} and {:?}",
+                    self.print_type(&binary.left),
+                    self.print_type(&binary.right),
                 )));
             }
+        };
 
-            if let TypeKind::Conditional(Conditional { check, .. }) = arena[scheme.t].kind {
-                if let TypeKind::Constructor(tref) = &arena[check].kind.clone() {
-                    if let Some((index_of_check_type, _)) = type_params
-                        .iter()
-                        .find_position(|type_param| type_param.name == tref.name)
-                    {
-                        let type_arg = expand_type(arena, ctx, type_args[index_of_check_type])?;
-
-                        if let TypeKind::Union(Union { types: union_types }) =
-                            &arena[type_arg].kind.clone()
-                        {
-                            let mut types = vec![];
-
-                            for t in union_types.iter() {
-                                let mut mapping: HashMap<String, Index> = HashMap::new();
-
-                                for (type_param, type_arg) in
-                                    type_params.iter().zip(type_args.iter())
-                                {
-                                    if type_param.name == tref.name {
-                                        mapping.insert(type_param.name.to_owned(), *t);
-                                    } else {
-                                        mapping.insert(type_param.name.to_owned(), *type_arg);
-                                    }
-                                }
-
-                                let t = instantiate_scheme(arena, scheme.t, &mapping);
-                                types.push(expand_type(arena, ctx, t)?);
-                            }
-
-                            let filtered_types = types
-                                .into_iter()
-                                .filter(|t| {
-                                    if let TypeKind::Keyword(kw) = &arena[*t].kind {
-                                        kw != &Keyword::Never
-                                    } else {
-                                        true
-                                    }
-                                })
-                                .collect::<Vec<_>>();
-
-                            let t = new_union_type(arena, &filtered_types);
-                            return expand_type(arena, ctx, t);
-                        }
-                    }
-                }
-            }
-
-            let mut mapping: HashMap<String, Index> = HashMap::new();
-            for (param, arg) in type_params.iter().zip(type_args.iter()) {
-                if let Some(constraint) = param.constraint {
-                    unify(arena, ctx, *arg, constraint)?;
-                }
-                mapping.insert(param.name.clone(), arg.to_owned());
-            }
-
-            let t = instantiate_scheme(arena, scheme.t, &mapping);
-            expand_type(arena, ctx, t)
-        }
-        None => {
-            if type_args.is_empty() {
-                let t = expand_type(arena, ctx, scheme.t)?;
-                Ok(t)
-            } else {
-                Err(Errors::InferenceError(format!(
-                    "{name} doesn't require any type args"
-                )))
-            }
-        }
+        Ok(t)
     }
-}
 
-pub fn expand_type(arena: &mut Arena<Type>, ctx: &Context, t: Index) -> Result<Index, Errors> {
-    let t = prune(arena, t);
+    pub fn expand_object(&mut self, ctx: &Context, object: &Object) -> Result<Index, Errors> {
+        let mut new_elems = vec![];
 
-    // It's okay to clone here because we aren't mutating the type
-    let t = match &arena[t].clone().kind {
-        TypeKind::KeyOf(KeyOf { t }) => expand_keyof(arena, ctx, *t)?,
-        TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
-            get_computed_member(arena, ctx, *obj, *index)?
-        }
-        TypeKind::Conditional(conditional) => expand_conditional(arena, ctx, conditional)?,
-        TypeKind::Constructor(Constructor { name, types, .. }) => {
-            expand_alias_by_name(arena, ctx, name, types)?
-        }
-        TypeKind::Binary(binary) => expand_binary(arena, ctx, binary)?,
-        TypeKind::Object(object) => return expand_object(arena, ctx, object),
-        _ => return Ok(t), // Early return to avoid infinite loop
-    };
+        for elem in &object.elems {
+            match elem {
+                // TODO: Handle `check` and `extends`
+                TObjElem::Mapped(mapped) => {
+                    let source = self.expand_type(ctx, mapped.source)?;
 
-    expand_type(arena, ctx, t)
-}
+                    match &self.arena[source].kind.clone() {
+                        TypeKind::Union(Union { types }) => {
+                            let mut non_literal_keys = vec![];
 
-// Expands `keyof` types into one of the followwing:
-// - string or number literals
-// - string, number, or symbol type
-// - never
-// - union of any of those types
-pub fn expand_keyof(arena: &mut Arena<Type>, ctx: &Context, t: Index) -> Result<Index, Errors> {
-    let obj = match &arena[t].kind {
-        // Don't expand Array's since they have a special `keyof` behavior.  We
-        // don't want to expand them because we don't want to include array methods
-        // in the list of keys.  This is similar to how objects are treated.
-        TypeKind::Constructor(Constructor { name, .. }) if name == "Array" => t,
-        _ => expand_type(arena, ctx, t)?,
-    };
+                            for t in types {
+                                let mut mapping: HashMap<String, Index> = HashMap::new();
+                                mapping.insert(mapped.target.to_owned(), *t);
+                                let key = instantiate_scheme(&mut self.arena, mapped.key, &mapping);
+                                let value =
+                                    instantiate_scheme(&mut self.arena, mapped.value, &mapping);
 
-    match &arena[obj].kind.clone() {
-        TypeKind::Object(Object { elems }) => {
-            let mut string_keys: Vec<Index> = Vec::new();
-            let mut number_keys: Vec<Index> = Vec::new();
-            let mut maybe_string: Option<Index> = None;
-            let mut maybe_number: Option<Index> = None;
-            let mut maybe_symbol: Option<Index> = None;
+                                let name = match &self.arena[key].kind {
+                                    TypeKind::Literal(Literal::String(name)) => {
+                                        TPropKey::StringKey(name.to_owned())
+                                    }
+                                    TypeKind::Literal(Literal::Number(name)) => {
+                                        TPropKey::NumberKey(name.to_owned())
+                                    }
+                                    _ => {
+                                        non_literal_keys.push(key);
+                                        continue;
+                                    }
+                                };
 
-            for elem in elems {
-                match elem {
-                    TObjElem::Call(_) => (),
-                    TObjElem::Constructor(_) => (),
-                    TObjElem::Mapped(mapped) => {
-                        let mapped_key = get_mapped_key(arena, mapped);
+                                new_elems.push(TObjElem::Prop(TProp {
+                                    name,
+                                    modifier: None,
+                                    optional: false, // TODO
+                                    mutable: false,  // TODO
+                                    t: self.expand_type(ctx, value)?,
+                                }));
 
-                        match &arena[mapped_key].kind {
-                            TypeKind::Primitive(Primitive::String) => {
-                                maybe_string = Some(mapped_key);
+                                if !non_literal_keys.is_empty() {
+                                    let union = new_union_type(&mut self.arena, &non_literal_keys);
+                                    new_elems.push(TObjElem::Mapped(MappedType {
+                                        target: mapped.target.to_owned(),
+                                        key: union,
+                                        value: mapped.value,
+                                        source: mapped.source,
+                                        check: mapped.check,
+                                        extends: mapped.extends,
+                                    }));
+                                }
                             }
-                            TypeKind::Primitive(Primitive::Number) => {
-                                maybe_number = Some(mapped_key);
-                            }
-                            TypeKind::Primitive(Primitive::Symbol) => {
-                                maybe_symbol = Some(mapped_key);
-                            }
-                            _ => todo!(),
+                        }
+                        _ => {
+                            new_elems.push(TObjElem::Mapped(mapped.to_owned()));
                         }
                     }
-                    TObjElem::Prop(TProp { name, .. }) => match name {
-                        TPropKey::StringKey(name) => {
-                            string_keys
-                                .push(new_lit_type(arena, &Literal::String(name.to_owned())));
-                        }
-                        TPropKey::NumberKey(name) => {
-                            number_keys
-                                .push(new_lit_type(arena, &Literal::Number(name.to_owned())));
-                        }
-                    },
                 }
+                _ => new_elems.push(elem.to_owned()),
             }
-
-            let mut all_keys: Vec<Index> = vec![];
-
-            match maybe_number {
-                Some(number) => all_keys.push(number),
-                None => all_keys.append(&mut number_keys),
-            }
-
-            match maybe_string {
-                Some(string) => all_keys.push(string),
-                None => all_keys.append(&mut string_keys),
-            }
-
-            if let Some(symbol) = maybe_symbol {
-                all_keys.push(symbol);
-            }
-
-            Ok(new_union_type(arena, &all_keys))
         }
-        // NOTE: The behavior of `keyof` with arrays and tuples differs from
-        // TypeScript.  TypeScript includes the names of all the properties from
-        // Array.prototype as well.
-        // TODO(#637): Have interop layer translate between Escalier's and
-        // TypeScript's `keyof` utility type.
-        TypeKind::Constructor(array) if array.name == "Array" => {
-            Ok(new_primitive(arena, Primitive::Number))
-        }
-        TypeKind::Tuple(tuple) => {
-            let keys: Vec<Index> = tuple
-                .types
-                .iter()
-                .enumerate()
-                .map(|(k, _)| new_lit_type(arena, &Literal::Number(k.to_string())))
-                .collect();
-            Ok(new_union_type(arena, &keys))
-        }
-        TypeKind::Constructor(constructor) => {
-            let idx = expand_alias_by_name(arena, ctx, &constructor.name, &constructor.types)?;
-            expand_keyof(arena, ctx, idx)
-        }
-        TypeKind::Intersection(Intersection { types }) => {
-            let mut string_keys = BTreeMap::new();
-            let mut number_keys = BTreeMap::new();
-            let mut maybe_string = None;
-            let mut maybe_number = None;
-            let mut maybe_symbol = None;
 
-            for t in types {
-                let keys = expand_keyof(arena, ctx, *t)?;
+        Ok(self.arena.insert(Type {
+            kind: TypeKind::Object(Object { elems: new_elems }),
+            provenance: None, // TODO
+        }))
+    }
 
-                match &arena[keys].kind {
-                    TypeKind::Union(Union { types }) => {
-                        for t in types {
-                            match &arena[*t].kind {
-                                TypeKind::Literal(Literal::Number(num)) => {
-                                    number_keys.insert(num.to_string(), *t);
-                                }
-                                TypeKind::Literal(Literal::String(str)) => {
-                                    string_keys.insert(str.to_string(), *t);
-                                }
-                                TypeKind::Primitive(Primitive::Number) => {
-                                    maybe_number = Some(*t);
-                                }
-                                TypeKind::Primitive(Primitive::String) => {
-                                    maybe_string = Some(*t);
-                                }
-                                TypeKind::Primitive(Primitive::Symbol) => {
-                                    maybe_symbol = Some(*t);
-                                }
-                                _ => (),
-                            }
+    pub fn get_computed_member(
+        &mut self,
+        ctx: &Context,
+        obj_idx: Index,
+        key_idx: Index,
+    ) -> Result<Index, Errors> {
+        // NOTE: cloning is fine here because we aren't mutating `obj_type` or
+        // `prop_type`.
+        let obj_type = self.arena[obj_idx].clone();
+        let key_type = self.arena[key_idx].clone();
+
+        match &obj_type.kind {
+            TypeKind::Object(_) => self.get_prop(ctx, obj_idx, key_idx),
+            // let tuple = [5, "hello", true]
+            // tuple[1]; // "hello"
+            TypeKind::Tuple(tuple) => {
+                match &key_type.kind {
+                    TypeKind::Literal(Literal::Number(value)) => {
+                        let index: usize = str::parse(value).map_err(|_| {
+                            Errors::InferenceError(format!("{} isn't a valid index", value))
+                        })?;
+                        if index < tuple.types.len() {
+                            // TODO: update AST with the inferred type
+                            return Ok(tuple.types[index]);
                         }
+                        Err(Errors::InferenceError(format!(
+                            "{index} was outside the bounds 0..{} of the tuple",
+                            tuple.types.len()
+                        )))
                     }
-                    TypeKind::Literal(Literal::Number(num)) => {
-                        number_keys.insert(num.to_string(), keys);
-                    }
-                    TypeKind::Literal(Literal::String(str)) => {
-                        string_keys.insert(str.to_string(), keys);
+                    TypeKind::Literal(Literal::String(_)) => {
+                        // TODO: look up methods on the `Array` interface
+                        // we need to instantiate the scheme such that `T` is equal
+                        // to the union of all types in the tuple
+                        self.get_prop(ctx, obj_idx, key_idx)
                     }
                     TypeKind::Primitive(Primitive::Number) => {
-                        maybe_number = Some(keys);
+                        let mut types = tuple.types.clone();
+                        types.push(new_keyword(&mut self.arena, Keyword::Undefined));
+                        Ok(new_union_type(&mut self.arena, &types))
                     }
-                    TypeKind::Primitive(Primitive::String) => {
-                        maybe_string = Some(keys);
-                    }
-                    TypeKind::Primitive(Primitive::Symbol) => {
-                        maybe_symbol = Some(*t);
-                    }
-                    _ => (),
+                    _ => Err(Errors::InferenceError(
+                        "Can only access tuple properties with a number".to_string(),
+                    )),
                 }
             }
-
-            let mut all_keys: Vec<Index> = vec![];
-
-            match maybe_number {
-                Some(number) => all_keys.push(number),
-                None => all_keys.append(&mut number_keys.values().cloned().collect::<Vec<Index>>()),
+            // declare let tuple: [number, number] | [string, string]
+            // tuple[1]; // number | string
+            TypeKind::Union(union) => {
+                let mut result_types = vec![];
+                let mut undefined_count = 0;
+                for idx in &union.types {
+                    match self.get_computed_member(ctx, *idx, key_idx) {
+                        Ok(t) => result_types.push(t),
+                        Err(_) => {
+                            // TODO: check what the error is, we may want to propagate
+                            // certain errors
+                            if undefined_count == 0 {
+                                let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+                                result_types.push(undefined);
+                            }
+                            undefined_count += 1;
+                        }
+                    }
+                }
+                if undefined_count == union.types.len() {
+                    // TODO: include name of property in error message
+                    Err(Errors::InferenceError(
+                        "Couldn't find property on object".to_string(),
+                    ))
+                } else {
+                    Ok(new_union_type(&mut self.arena, &result_types))
+                }
             }
-
-            match maybe_string {
-                Some(string) => all_keys.push(string),
-                None => all_keys.append(&mut string_keys.values().cloned().collect::<Vec<Index>>()),
+            TypeKind::Constructor(Constructor { name, types, .. }) => {
+                let idx = self.expand_alias_by_name(ctx, name, types)?;
+                self.get_computed_member(ctx, idx, key_idx)
             }
-
-            if let Some(symbol) = maybe_symbol {
-                all_keys.push(symbol);
-            }
-
-            Ok(new_union_type(arena, &all_keys))
-        }
-        TypeKind::Union(_) => Ok(new_keyword(arena, Keyword::Never)),
-        TypeKind::Keyword(keyword) => match keyword {
-            // TODO: update get_property to handle these cases as well
-            Keyword::Null => Ok(new_keyword(arena, Keyword::Never)),
-            Keyword::Undefined => Ok(new_keyword(arena, Keyword::Never)),
-            Keyword::Unknown => Ok(new_keyword(arena, Keyword::Never)),
-            Keyword::Never => {
-                let string = new_primitive(arena, Primitive::String);
-                let number = new_primitive(arena, Primitive::Number);
-                let symbol = new_primitive(arena, Primitive::Symbol);
-                Ok(new_union_type(arena, &[string, number, symbol]))
-            }
-        },
-        TypeKind::Primitive(primitive) => {
-            let scheme_name = primitive.get_scheme_name();
-            let idx = expand_alias_by_name(arena, ctx, scheme_name, &[])?;
-            expand_keyof(arena, ctx, idx)
-        }
-        TypeKind::Literal(literal) => match literal.get_scheme_name() {
-            Some(name) => {
-                let idx = expand_alias_by_name(arena, ctx, name, &[])?;
-                expand_keyof(arena, ctx, idx)
-            }
-            None => todo!(),
-        },
-        _ => {
-            let expanded_t = expand_type(arena, ctx, t)?;
-            if expanded_t != t {
-                expand_keyof(arena, ctx, expanded_t)
-            } else {
-                Ok(new_keyword(arena, Keyword::Never))
+            _ => {
+                // TODO: provide a more specific error message for type variables
+                Err(Errors::InferenceError(
+                    "Can only access properties on objects/tuples".to_string(),
+                ))
             }
         }
     }
-}
 
-// TODO: have a separate version of this for expanding conditional types that
-// are the definition of a type alias.  In that situation, if the `check` is
-// a type reference and the arg passed to the type alias is a union, then we
-// have distribute the union.
-pub fn expand_conditional(
-    arena: &mut Arena<Type>,
-    ctx: &Context,
-    conditional: &Conditional,
-) -> Result<Index, Errors> {
-    let Conditional {
-        check,
-        extends,
-        true_type,
-        false_type,
-    } = conditional;
+    // TODO(#624) - to behave differently when used to look up an lvalue vs a rvalue
+    pub fn get_prop(
+        &mut self,
+        ctx: &Context,
+        obj_idx: Index,
+        key_idx: Index,
+    ) -> Result<Index, Errors> {
+        let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+        // It's fine to clone here because we aren't mutating
+        let obj_type = self.arena[obj_idx].clone();
+        let key_type = self.arena[key_idx].clone();
 
-    let infer_types = find_infer_types(arena, extends);
+        if let TypeKind::Object(object) = &obj_type.kind {
+            match &key_type.kind {
+                TypeKind::Primitive(primitive)
+                    if primitive == &Primitive::Number
+                        || primitive == &Primitive::String
+                        || primitive == &Primitive::Symbol =>
+                {
+                    let mut maybe_mapped: Option<&MappedType> = None;
+                    let mut values: Vec<Index> = vec![];
 
-    let mut type_param_map: HashMap<String, Index> = HashMap::new();
-    for infer_t in infer_types {
-        type_param_map.insert(infer_t.name.to_owned(), new_var_type(arena, None));
-    }
-
-    let extends = replace_infer_types(arena, extends, &type_param_map);
-
-    match unify(arena, ctx, *check, extends) {
-        Ok(_) => {
-            let true_type = instantiate_scheme(arena, *true_type, &type_param_map);
-            Ok(true_type)
-        }
-        Err(_) => Ok(*false_type),
-    }
-}
-
-pub fn expand_binary(
-    arena: &mut Arena<Type>,
-    _ctx: &Context,
-    binary: &BinaryT,
-) -> Result<Index, Errors> {
-    let t = match (&arena[binary.left].kind, &arena[binary.right].kind) {
-        (TypeKind::Literal(Literal::Number(left)), TypeKind::Literal(Literal::Number(right))) => {
-            let left = left.parse::<f64>().unwrap();
-            let right = right.parse::<f64>().unwrap();
-
-            let result = match binary.op {
-                TBinaryOp::Add => left + right,
-                TBinaryOp::Sub => left - right,
-                TBinaryOp::Mul => left * right,
-                TBinaryOp::Div => left / right,
-                TBinaryOp::Mod => left % right,
-            };
-
-            new_lit_type(arena, &Literal::Number(result.to_string()))
-        }
-        (TypeKind::Literal(Literal::Number(_)), TypeKind::Primitive(Primitive::Number)) => {
-            new_primitive(arena, Primitive::Number)
-        }
-        (TypeKind::Primitive(Primitive::Number), TypeKind::Literal(Literal::Number(_))) => {
-            new_primitive(arena, Primitive::Number)
-        }
-        (TypeKind::Primitive(Primitive::Number), TypeKind::Primitive(Primitive::Number)) => {
-            new_primitive(arena, Primitive::Number)
-        }
-        (_, _) => {
-            return Err(Errors::InferenceError(format!(
-                "Cannot perform binary operation on types: {:?} and {:?}",
-                arena[binary.left].as_string(arena),
-                arena[binary.right].as_string(arena)
-            )))
-        }
-    };
-
-    Ok(t)
-}
-
-pub fn expand_object(
-    arena: &mut Arena<Type>,
-    ctx: &Context,
-    object: &Object,
-) -> Result<Index, Errors> {
-    let mut new_elems = vec![];
-
-    for elem in &object.elems {
-        match elem {
-            // TODO: Handle `check` and `extends`
-            TObjElem::Mapped(mapped) => {
-                let source = expand_type(arena, ctx, mapped.source)?;
-
-                match &arena[source].kind.clone() {
-                    TypeKind::Union(Union { types }) => {
-                        let mut non_literal_keys = vec![];
-
-                        for t in types {
-                            let mut mapping: HashMap<String, Index> = HashMap::new();
-                            mapping.insert(mapped.target.to_owned(), *t);
-                            let key = instantiate_scheme(arena, mapped.key, &mapping);
-                            let value = instantiate_scheme(arena, mapped.value, &mapping);
-
-                            let name = match &arena[key].kind {
-                                TypeKind::Literal(Literal::String(name)) => {
-                                    TPropKey::StringKey(name.to_owned())
+                    for elem in &object.elems {
+                        match elem {
+                            // Callable signatures have no name so we ignore them.
+                            TObjElem::Constructor(_) => continue,
+                            TObjElem::Call(_) => continue,
+                            TObjElem::Mapped(mapped) => {
+                                if maybe_mapped.is_some() {
+                                    return Err(Errors::InferenceError(
+                                        "Object types can only have a single mapped signature"
+                                            .to_string(),
+                                    ));
                                 }
-                                TypeKind::Literal(Literal::Number(name)) => {
-                                    TPropKey::NumberKey(name.to_owned())
-                                }
-                                _ => {
-                                    non_literal_keys.push(key);
-                                    continue;
-                                }
-                            };
+                                maybe_mapped = Some(mapped);
+                            }
+                            TObjElem::Prop(prop) => {
+                                match &prop.name {
+                                    TPropKey::StringKey(_) if primitive == &Primitive::String => (),
+                                    TPropKey::NumberKey(_) if primitive == &Primitive::Number => (),
+                                    _ => continue,
+                                };
 
-                            new_elems.push(TObjElem::Prop(TProp {
-                                name,
-                                modifier: None,
-                                optional: false, // TODO
-                                mutable: false,  // TODO
-                                t: expand_type(arena, ctx, value)?,
-                            }));
-
-                            if !non_literal_keys.is_empty() {
-                                let union = new_union_type(arena, &non_literal_keys);
-                                new_elems.push(TObjElem::Mapped(MappedType {
-                                    target: mapped.target.to_owned(),
-                                    key: union,
-                                    value: mapped.value,
-                                    source: mapped.source,
-                                    check: mapped.check,
-                                    extends: mapped.extends,
-                                }));
+                                let prop_t = match prop.optional {
+                                    true => new_union_type(&mut self.arena, &[prop.t, undefined]),
+                                    false => prop.t,
+                                };
+                                values.push(prop_t);
                             }
                         }
                     }
-                    _ => {
-                        new_elems.push(TObjElem::Mapped(mapped.to_owned()));
+
+                    // TODO: handle combinations of indexers and non-indexer elements
+                    if let Some(mapped) = maybe_mapped {
+                        let mapped_key = get_mapped_key(&mut self.arena, mapped);
+
+                        match self.unify(ctx, key_idx, mapped_key) {
+                            Ok(_) => {
+                                let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+                                Ok(new_union_type(&mut self.arena, &[mapped.value, undefined]))
+                            }
+                            Err(_) => Err(Errors::InferenceError(format!(
+                                "{} is not a valid indexer for {}",
+                                key_type.as_string(&self.arena),
+                                obj_type.as_string(&self.arena)
+                            ))),
+                        }
+                    } else if !values.is_empty() {
+                        values.push(undefined);
+                        Ok(new_union_type(&mut self.arena, &values))
+                    } else {
+                        Err(Errors::InferenceError(format!(
+                            "{} has no indexer",
+                            obj_type.as_string(&self.arena)
+                        )))
                     }
                 }
+                TypeKind::Literal(Literal::String(name)) => {
+                    let mut maybe_mapped: Option<&MappedType> = None;
+                    for elem in &object.elems {
+                        match elem {
+                            // Callable signatures have no name so we ignore them.
+                            TObjElem::Constructor(_) => continue,
+                            TObjElem::Call(_) => continue,
+                            TObjElem::Mapped(mapped) => {
+                                if maybe_mapped.is_some() {
+                                    return Err(Errors::InferenceError(
+                                        "Object types can only have a single mapped signature"
+                                            .to_string(),
+                                    ));
+                                }
+                                maybe_mapped = Some(mapped);
+                            }
+                            TObjElem::Prop(prop) => {
+                                let key = match &prop.name {
+                                    TPropKey::StringKey(key) => key,
+                                    TPropKey::NumberKey(key) => key,
+                                };
+                                if key == name {
+                                    let prop_t = match prop.optional {
+                                        true => {
+                                            new_union_type(&mut self.arena, &[prop.t, undefined])
+                                        }
+                                        false => prop.t,
+                                    };
+                                    return Ok(prop_t);
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(mapped) = maybe_mapped {
+                        let mapped_key = get_mapped_key(&mut self.arena, mapped);
+
+                        match self.unify(ctx, key_idx, mapped_key) {
+                            Ok(_) => {
+                                let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+                                Ok(new_union_type(&mut self.arena, &[mapped.value, undefined]))
+                            }
+                            Err(_) => Err(Errors::InferenceError(format!(
+                                "Couldn't find property {} in object",
+                                name,
+                            ))),
+                        }
+                    } else {
+                        Err(Errors::InferenceError(format!(
+                            "Couldn't find property '{name}' on object",
+                        )))
+                    }
+                }
+                TypeKind::Literal(Literal::Number(name)) => {
+                    let mut maybe_mapped: Option<&MappedType> = None;
+                    for elem in &object.elems {
+                        if let TObjElem::Mapped(mapped) = elem {
+                            if maybe_mapped.is_some() {
+                                return Err(Errors::InferenceError(
+                                    "Object types can only have a single mapped signature"
+                                        .to_string(),
+                                ));
+                            }
+                            maybe_mapped = Some(mapped);
+                        }
+                        // QUESTION: Do we care about allowing numbers as keys for
+                        // methods and props?
+                    }
+
+                    if let Some(mapped) = maybe_mapped {
+                        let mapped_key = get_mapped_key(&mut self.arena, mapped);
+                        match self.unify(ctx, key_idx, mapped_key) {
+                            Ok(_) => {
+                                let undefined = new_keyword(&mut self.arena, Keyword::Undefined);
+                                Ok(new_union_type(&mut self.arena, &[mapped.value, undefined]))
+                            }
+                            Err(_) => Err(Errors::InferenceError(format!(
+                                "Couldn't find property {} in object",
+                                name,
+                            ))),
+                        }
+                    } else {
+                        Err(Errors::InferenceError(format!(
+                            "Couldn't find property '{name}' on object",
+                        )))
+                    }
+                }
+                _ => Err(Errors::InferenceError(format!(
+                    "{} is not a valid key",
+                    self.print_type(&key_idx)
+                ))),
             }
-            _ => new_elems.push(elem.to_owned()),
+        } else {
+            Err(Errors::InferenceError(
+                "Can't access property on non-object type".to_string(),
+            ))
         }
     }
+}
 
-    Ok(arena.insert(Type {
-        kind: TypeKind::Object(Object { elems: new_elems }),
-        provenance: None, // TODO
-    }))
+pub fn filter_nullables(arena: &Arena<Type>, types: &[Index]) -> Vec<Index> {
+    types
+        .iter()
+        .filter(|t| {
+            !matches!(&arena[**t].kind, TypeKind::Keyword(Keyword::Undefined))
+                && !matches!(&arena[**t].kind, TypeKind::Keyword(Keyword::Null))
+        })
+        .cloned()
+        .collect()
+}
+
+fn get_mapped_key(arena: &mut Arena<Type>, mapped: &MappedType) -> Index {
+    let mut mapping: HashMap<String, Index> = HashMap::new();
+    mapping.insert(mapped.target.to_owned(), mapped.source);
+    instantiate_scheme(arena, mapped.key, &mapping)
 }
 
 pub struct FindInferVisitor<'a> {
@@ -706,281 +997,4 @@ pub fn replace_infer_types(
     let mut replace_visitor = ReplaceVisitor { arena, mapping };
 
     replace_visitor.fold_index(t)
-}
-
-pub fn get_computed_member(
-    arena: &mut Arena<Type>,
-    ctx: &Context,
-    obj_idx: Index,
-    key_idx: Index,
-) -> Result<Index, Errors> {
-    // NOTE: cloning is fine here because we aren't mutating `obj_type` or
-    // `prop_type`.
-    let obj_type = arena[obj_idx].clone();
-    let key_type = arena[key_idx].clone();
-
-    match &obj_type.kind {
-        TypeKind::Object(_) => get_prop(arena, ctx, obj_idx, key_idx),
-        // let tuple = [5, "hello", true]
-        // tuple[1]; // "hello"
-        TypeKind::Tuple(tuple) => {
-            match &key_type.kind {
-                TypeKind::Literal(Literal::Number(value)) => {
-                    let index: usize = str::parse(value).map_err(|_| {
-                        Errors::InferenceError(format!("{} isn't a valid index", value))
-                    })?;
-                    if index < tuple.types.len() {
-                        // TODO: update AST with the inferred type
-                        return Ok(tuple.types[index]);
-                    }
-                    Err(Errors::InferenceError(format!(
-                        "{index} was outside the bounds 0..{} of the tuple",
-                        tuple.types.len()
-                    )))
-                }
-                TypeKind::Literal(Literal::String(_)) => {
-                    // TODO: look up methods on the `Array` interface
-                    // we need to instantiate the scheme such that `T` is equal
-                    // to the union of all types in the tuple
-                    get_prop(arena, ctx, obj_idx, key_idx)
-                }
-                TypeKind::Primitive(Primitive::Number) => {
-                    let mut types = tuple.types.clone();
-                    types.push(new_keyword(arena, Keyword::Undefined));
-                    Ok(new_union_type(arena, &types))
-                }
-                _ => Err(Errors::InferenceError(
-                    "Can only access tuple properties with a number".to_string(),
-                )),
-            }
-        }
-        // declare let tuple: [number, number] | [string, string]
-        // tuple[1]; // number | string
-        TypeKind::Union(union) => {
-            let mut result_types = vec![];
-            let mut undefined_count = 0;
-            for idx in &union.types {
-                match get_computed_member(arena, ctx, *idx, key_idx) {
-                    Ok(t) => result_types.push(t),
-                    Err(_) => {
-                        // TODO: check what the error is, we may want to propagate
-                        // certain errors
-                        if undefined_count == 0 {
-                            let undefined = new_keyword(arena, Keyword::Undefined);
-                            result_types.push(undefined);
-                        }
-                        undefined_count += 1;
-                    }
-                }
-            }
-            if undefined_count == union.types.len() {
-                // TODO: include name of property in error message
-                Err(Errors::InferenceError(
-                    "Couldn't find property on object".to_string(),
-                ))
-            } else {
-                Ok(new_union_type(arena, &result_types))
-            }
-        }
-        TypeKind::Constructor(Constructor { name, types, .. }) => {
-            let idx = expand_alias_by_name(arena, ctx, name, types)?;
-            get_computed_member(arena, ctx, idx, key_idx)
-        }
-        _ => {
-            // TODO: provide a more specific error message for type variables
-            Err(Errors::InferenceError(
-                "Can only access properties on objects/tuples".to_string(),
-            ))
-        }
-    }
-}
-
-// TODO(#624) - to behave differently when used to look up an lvalue vs a rvalue
-pub fn get_prop(
-    arena: &mut Arena<Type>,
-    ctx: &Context,
-    obj_idx: Index,
-    key_idx: Index,
-) -> Result<Index, Errors> {
-    let undefined = new_keyword(arena, Keyword::Undefined);
-    // It's fine to clone here because we aren't mutating
-    let obj_type = arena[obj_idx].clone();
-    let key_type = arena[key_idx].clone();
-
-    if let TypeKind::Object(object) = &obj_type.kind {
-        match &key_type.kind {
-            TypeKind::Primitive(primitive)
-                if primitive == &Primitive::Number
-                    || primitive == &Primitive::String
-                    || primitive == &Primitive::Symbol =>
-            {
-                let mut maybe_mapped: Option<&MappedType> = None;
-                let mut values: Vec<Index> = vec![];
-
-                for elem in &object.elems {
-                    match elem {
-                        // Callable signatures have no name so we ignore them.
-                        TObjElem::Constructor(_) => continue,
-                        TObjElem::Call(_) => continue,
-                        TObjElem::Mapped(mapped) => {
-                            if maybe_mapped.is_some() {
-                                return Err(Errors::InferenceError(
-                                    "Object types can only have a single mapped signature"
-                                        .to_string(),
-                                ));
-                            }
-                            maybe_mapped = Some(mapped);
-                        }
-                        TObjElem::Prop(prop) => {
-                            match &prop.name {
-                                TPropKey::StringKey(_) if primitive == &Primitive::String => (),
-                                TPropKey::NumberKey(_) if primitive == &Primitive::Number => (),
-                                _ => continue,
-                            };
-
-                            let prop_t = match prop.optional {
-                                true => new_union_type(arena, &[prop.t, undefined]),
-                                false => prop.t,
-                            };
-                            values.push(prop_t);
-                        }
-                    }
-                }
-
-                // TODO: handle combinations of indexers and non-indexer elements
-                if let Some(mapped) = maybe_mapped {
-                    let mapped_key = get_mapped_key(arena, mapped);
-
-                    match unify(arena, ctx, key_idx, mapped_key) {
-                        Ok(_) => {
-                            let undefined = new_keyword(arena, Keyword::Undefined);
-                            Ok(new_union_type(arena, &[mapped.value, undefined]))
-                        }
-                        Err(_) => Err(Errors::InferenceError(format!(
-                            "{} is not a valid indexer for {}",
-                            key_type.as_string(arena),
-                            obj_type.as_string(arena)
-                        ))),
-                    }
-                } else if !values.is_empty() {
-                    values.push(undefined);
-                    Ok(new_union_type(arena, &values))
-                } else {
-                    Err(Errors::InferenceError(format!(
-                        "{} has no indexer",
-                        obj_type.as_string(arena)
-                    )))
-                }
-            }
-            TypeKind::Literal(Literal::String(name)) => {
-                let mut maybe_mapped: Option<&MappedType> = None;
-                for elem in &object.elems {
-                    match elem {
-                        // Callable signatures have no name so we ignore them.
-                        TObjElem::Constructor(_) => continue,
-                        TObjElem::Call(_) => continue,
-                        TObjElem::Mapped(mapped) => {
-                            if maybe_mapped.is_some() {
-                                return Err(Errors::InferenceError(
-                                    "Object types can only have a single mapped signature"
-                                        .to_string(),
-                                ));
-                            }
-                            maybe_mapped = Some(mapped);
-                        }
-                        TObjElem::Prop(prop) => {
-                            let key = match &prop.name {
-                                TPropKey::StringKey(key) => key,
-                                TPropKey::NumberKey(key) => key,
-                            };
-                            if key == name {
-                                let prop_t = match prop.optional {
-                                    true => new_union_type(arena, &[prop.t, undefined]),
-                                    false => prop.t,
-                                };
-                                return Ok(prop_t);
-                            }
-                        }
-                    }
-                }
-
-                if let Some(mapped) = maybe_mapped {
-                    let mapped_key = get_mapped_key(arena, mapped);
-
-                    match unify(arena, ctx, key_idx, mapped_key) {
-                        Ok(_) => {
-                            let undefined = new_keyword(arena, Keyword::Undefined);
-                            Ok(new_union_type(arena, &[mapped.value, undefined]))
-                        }
-                        Err(_) => Err(Errors::InferenceError(format!(
-                            "Couldn't find property {} in object",
-                            name,
-                        ))),
-                    }
-                } else {
-                    Err(Errors::InferenceError(format!(
-                        "Couldn't find property '{name}' on object",
-                    )))
-                }
-            }
-            TypeKind::Literal(Literal::Number(name)) => {
-                let mut maybe_mapped: Option<&MappedType> = None;
-                for elem in &object.elems {
-                    if let TObjElem::Mapped(mapped) = elem {
-                        if maybe_mapped.is_some() {
-                            return Err(Errors::InferenceError(
-                                "Object types can only have a single mapped signature".to_string(),
-                            ));
-                        }
-                        maybe_mapped = Some(mapped);
-                    }
-                    // QUESTION: Do we care about allowing numbers as keys for
-                    // methods and props?
-                }
-
-                if let Some(mapped) = maybe_mapped {
-                    let mapped_key = get_mapped_key(arena, mapped);
-                    match unify(arena, ctx, key_idx, mapped_key) {
-                        Ok(_) => {
-                            let undefined = new_keyword(arena, Keyword::Undefined);
-                            Ok(new_union_type(arena, &[mapped.value, undefined]))
-                        }
-                        Err(_) => Err(Errors::InferenceError(format!(
-                            "Couldn't find property {} in object",
-                            name,
-                        ))),
-                    }
-                } else {
-                    Err(Errors::InferenceError(format!(
-                        "Couldn't find property '{name}' on object",
-                    )))
-                }
-            }
-            _ => Err(Errors::InferenceError(format!(
-                "{} is not a valid key",
-                arena[key_idx].as_string(arena)
-            ))),
-        }
-    } else {
-        Err(Errors::InferenceError(
-            "Can't access property on non-object type".to_string(),
-        ))
-    }
-}
-
-pub fn filter_nullables(arena: &Arena<Type>, types: &[Index]) -> Vec<Index> {
-    types
-        .iter()
-        .filter(|t| {
-            !matches!(&arena[**t].kind, TypeKind::Keyword(Keyword::Undefined))
-                && !matches!(&arena[**t].kind, TypeKind::Keyword(Keyword::Null))
-        })
-        .cloned()
-        .collect()
-}
-
-fn get_mapped_key(arena: &mut Arena<Type>, mapped: &MappedType) -> Index {
-    let mut mapping: HashMap<String, Index> = HashMap::new();
-    mapping.insert(mapped.target.to_owned(), mapped.source);
-    instantiate_scheme(arena, mapped.key, &mapping)
 }

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -787,8 +787,8 @@ impl Checker {
                             }
                             Err(_) => Err(Errors::InferenceError(format!(
                                 "{} is not a valid indexer for {}",
-                                key_type.as_string(&self.arena),
-                                obj_type.as_string(&self.arena)
+                                self.print_type(&key_idx),
+                                self.print_type(&obj_idx),
                             ))),
                         }
                     } else if !values.is_empty() {
@@ -797,7 +797,7 @@ impl Checker {
                     } else {
                         Err(Errors::InferenceError(format!(
                             "{} has no indexer",
-                            obj_type.as_string(&self.arena)
+                            self.print_type(&obj_idx),
                         )))
                     }
                 }

--- a/crates/escalier_hm/tests/exceptions_test.rs
+++ b/crates/escalier_hm/tests/exceptions_test.rs
@@ -14,8 +14,8 @@ fn test_env() -> (Checker, Context) {
     };
     let mut context = Context::default();
 
-    let number = new_primitive(&mut checker.arena, Primitive::Number);
-    let type_param_t = new_constructor(&mut checker.arena, "T", &[]);
+    let number = checker.new_primitive(Primitive::Number);
+    let type_param_t = checker.new_constructor("T", &[]);
 
     let push_t = checker.new_func_type(
         &[types::FuncParam {
@@ -34,36 +34,33 @@ fn test_env() -> (Checker, Context) {
 
     // [P]: T for P in number;
     let mapped = types::TObjElem::Mapped(types::MappedType {
-        key: new_constructor(&mut checker.arena, "P", &[]),
-        value: new_constructor(&mut checker.arena, "T", &[]),
+        key: checker.new_constructor("P", &[]),
+        value: checker.new_constructor("T", &[]),
         target: "P".to_string(),
-        source: new_primitive(&mut checker.arena, Primitive::Number),
+        source: checker.new_primitive(Primitive::Number),
         check: None,
         extends: None,
     });
 
-    let array_interface = new_object_type(
-        &mut checker.arena,
-        &[
-            // .push(item: T) -> number;
-            types::TObjElem::Prop(types::TProp {
-                name: types::TPropKey::StringKey("push".to_string()),
-                modifier: None,
-                t: push_t,
-                optional: false,
-                mutable: false,
-            }),
-            // .length: number;
-            types::TObjElem::Prop(types::TProp {
-                name: types::TPropKey::StringKey("length".to_string()),
-                modifier: None,
-                optional: false,
-                mutable: false,
-                t: number,
-            }),
-            mapped,
-        ],
-    );
+    let array_interface = checker.new_object_type(&[
+        // .push(item: T) -> number;
+        types::TObjElem::Prop(types::TProp {
+            name: types::TPropKey::StringKey("push".to_string()),
+            modifier: None,
+            t: push_t,
+            optional: false,
+            mutable: false,
+        }),
+        // .length: number;
+        types::TObjElem::Prop(types::TProp {
+            name: types::TPropKey::StringKey("length".to_string()),
+            modifier: None,
+            optional: false,
+            mutable: false,
+            t: number,
+        }),
+        mapped,
+    ]);
     let array_scheme = Scheme {
         type_params: Some(vec![types::TypeParam {
             name: "T".to_string(),

--- a/crates/escalier_hm/tests/exceptions_test.rs
+++ b/crates/escalier_hm/tests/exceptions_test.rs
@@ -3,20 +3,21 @@ use generational_arena::Arena;
 use escalier_ast::*;
 use escalier_parser::parse;
 
+use escalier_hm::checker::Checker;
 use escalier_hm::context::*;
 use escalier_hm::errors::*;
-use escalier_hm::infer::*;
 use escalier_hm::types::{self, *};
 
-fn test_env() -> (Arena<Type>, Context) {
-    let mut arena = Arena::new();
+fn test_env() -> (Checker, Context) {
+    let mut checker = Checker {
+        arena: Arena::new(),
+    };
     let mut context = Context::default();
 
-    let number = new_primitive(&mut arena, Primitive::Number);
-    let type_param_t = new_constructor(&mut arena, "T", &[]);
+    let number = new_primitive(&mut checker.arena, Primitive::Number);
+    let type_param_t = new_constructor(&mut checker.arena, "T", &[]);
 
-    let push_t = new_func_type(
-        &mut arena,
+    let push_t = checker.new_func_type(
         &[types::FuncParam {
             pattern: TPat::Ident(BindingIdent {
                 name: "item".to_string(),
@@ -33,16 +34,16 @@ fn test_env() -> (Arena<Type>, Context) {
 
     // [P]: T for P in number;
     let mapped = types::TObjElem::Mapped(types::MappedType {
-        key: new_constructor(&mut arena, "P", &[]),
-        value: new_constructor(&mut arena, "T", &[]),
+        key: new_constructor(&mut checker.arena, "P", &[]),
+        value: new_constructor(&mut checker.arena, "T", &[]),
         target: "P".to_string(),
-        source: new_primitive(&mut arena, Primitive::Number),
+        source: new_primitive(&mut checker.arena, Primitive::Number),
         check: None,
         extends: None,
     });
 
     let array_interface = new_object_type(
-        &mut arena,
+        &mut checker.arena,
         &[
             // .push(item: T) -> number;
             types::TObjElem::Prop(types::TProp {
@@ -74,12 +75,12 @@ fn test_env() -> (Arena<Type>, Context) {
 
     context.schemes.insert("Array".to_string(), array_scheme);
 
-    (arena, context)
+    (checker, context)
 }
 
 #[test]
 fn basic_throws_test() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let add: fn (a: number, b: number) -> number
@@ -93,23 +94,23 @@ fn basic_throws_test() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("div").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number throws "DIV_BY_ZERO""#
     );
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number throws "DIV_BY_ZERO""#
     );
 
     let binding = my_ctx.values.get("bar").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number"#
     );
 
@@ -118,7 +119,7 @@ fn basic_throws_test() -> Result<(), Errors> {
 
 #[test]
 fn constrained_throws() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let div: fn (a: number, b: number) -> number throws "DIV_BY_ZERO"
@@ -128,11 +129,11 @@ fn constrained_throws() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number throws string"#
     );
 
@@ -141,7 +142,7 @@ fn constrained_throws() -> Result<(), Errors> {
 
 #[test]
 fn constrained_throws_type_mismatch() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let div: fn (a: number, b: number) -> number throws "DIV_BY_ZERO"
@@ -151,7 +152,7 @@ fn constrained_throws_type_mismatch() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -165,7 +166,7 @@ fn constrained_throws_type_mismatch() -> Result<(), Errors> {
 
 #[test]
 fn throws_multiple_exceptions() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let sqrt: fn (a: number) -> number throws "NEGATIVE_NUMBER"
@@ -176,11 +177,11 @@ fn throws_multiple_exceptions() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number throws "NEGATIVE_NUMBER" | "DIV_BY_ZERO""#
     );
 
@@ -189,7 +190,7 @@ fn throws_multiple_exceptions() -> Result<(), Errors> {
 
 #[test]
 fn unify_call_throws_with_func_sig_throws() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let sqrt: fn (a: number) -> number throws "NEGATIVE_NUMBER"
@@ -200,11 +201,11 @@ fn unify_call_throws_with_func_sig_throws() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number throws string"#
     );
 
@@ -213,7 +214,7 @@ fn unify_call_throws_with_func_sig_throws() -> Result<(), Errors> {
 
 #[test]
 fn unify_call_throws_with_func_sig_throws_failure() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let sqrt: fn (a: number) -> number throws "NEGATIVE_NUMBER"
@@ -224,7 +225,7 @@ fn unify_call_throws_with_func_sig_throws_failure() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -238,7 +239,7 @@ fn unify_call_throws_with_func_sig_throws_failure() -> Result<(), Errors> {
 
 #[test]
 fn scoped_throws() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let div: fn (a: number, b: number) -> number throws "DIV_BY_ZERO"
@@ -249,11 +250,11 @@ fn scoped_throws() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number"#
     );
 
@@ -262,7 +263,7 @@ fn scoped_throws() -> Result<(), Errors> {
 
 #[test]
 fn throws_coalesces_duplicate_exceptions() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let div: fn (a: number, b: number) -> number throws "DIV_BY_ZERO"
@@ -272,11 +273,11 @@ fn throws_coalesces_duplicate_exceptions() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         // TODO: dedupe this
         r#"(a: number, b: number) -> number throws "DIV_BY_ZERO""#
     );
@@ -286,7 +287,7 @@ fn throws_coalesces_duplicate_exceptions() -> Result<(), Errors> {
 
 #[test]
 fn callback_with_throws() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let div: fn (a: number, b: number) -> number throws "DIV_BY_ZERO"
@@ -307,26 +308,23 @@ fn callback_with_throws() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"() -> Array<number> throws "DIV_BY_ZERO""#
     );
 
     let binding = my_ctx.values.get("bar").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"() -> Array<number>"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"() -> Array<number>"#);
 
     Ok(())
 }
 
 #[test]
 fn infer_throws_from_throw() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let div = fn (a, b) {
@@ -338,11 +336,11 @@ fn infer_throws_from_throw() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("div").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number throws "DIV_BY_ZERO""#
     );
 
@@ -351,7 +349,7 @@ fn infer_throws_from_throw() -> Result<(), Errors> {
 
 #[test]
 fn try_catches_throw() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let log: fn (msg: string) -> undefined
@@ -367,11 +365,11 @@ fn try_catches_throw() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("div").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number | 0"#
     );
 
@@ -380,7 +378,7 @@ fn try_catches_throw() -> Result<(), Errors> {
 
 #[test]
 fn try_catches_throw_and_rethrows() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let log: fn (msg: string) -> undefined
@@ -396,11 +394,11 @@ fn try_catches_throw_and_rethrows() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("div").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b: number) -> number throws "RETHROWN_ERROR""#
     );
 
@@ -409,7 +407,7 @@ fn try_catches_throw_and_rethrows() -> Result<(), Errors> {
 
 #[test]
 fn try_catches_throw_return_inside_try_catch() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let log: fn (msg: string) -> undefined
@@ -427,11 +425,11 @@ fn try_catches_throw_return_inside_try_catch() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("div").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         // TODO: the return type should be `number` because all `return` statements
         // return numbers and code appearing after the `try-catch` is
         // unreachable.

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -4030,11 +4030,9 @@ fn test_tuple_type_equality() -> Result<(), Errors> {
     checker.infer_program(&mut program, &mut my_ctx)?;
 
     let a = my_ctx.values.get("a").unwrap();
-    let a_t = checker.arena[a.index].clone();
     let b = my_ctx.values.get("b").unwrap();
-    let b_t = checker.arena[b.index].clone();
 
-    assert!(a_t.equals(&b_t, &checker.arena));
+    assert!(checker.equals(&a.index, &b.index));
 
     Ok(())
 }
@@ -4052,11 +4050,9 @@ fn test_function_type_equality() -> Result<(), Errors> {
     checker.infer_program(&mut program, &mut my_ctx)?;
 
     let add = my_ctx.values.get("add").unwrap();
-    let add_t = checker.arena[add.index].clone();
     let sub = my_ctx.values.get("sub").unwrap();
-    let sub_t = checker.arena[sub.index].clone();
 
-    assert!(add_t.equals(&sub_t, &checker.arena));
+    assert!(checker.equals(&add.index, &sub.index));
 
     Ok(())
 }
@@ -4074,11 +4070,9 @@ fn test_literal_type_equality() -> Result<(), Errors> {
     checker.infer_program(&mut program, &mut my_ctx)?;
 
     let a = my_ctx.values.get("a").unwrap();
-    let a_t = checker.arena[a.index].clone();
     let b = my_ctx.values.get("b").unwrap();
-    let b_t = checker.arena[b.index].clone();
 
-    assert!(a_t.equals(&b_t, &checker.arena));
+    assert!(checker.equals(&a.index, &b.index));
 
     Ok(())
 }
@@ -4097,11 +4091,9 @@ fn test_mutable_object_type_equality() -> Result<(), Errors> {
     checker.infer_program(&mut program, &mut my_ctx)?;
 
     let p = my_ctx.values.get("p").unwrap();
-    let p_t = checker.arena[p.index].clone();
     let q = my_ctx.values.get("q").unwrap();
-    let q_t = checker.arena[q.index].clone();
 
-    assert!(p_t.equals(&q_t, &checker.arena));
+    assert!(checker.equals(&p.index, &q.index));
 
     Ok(())
 }
@@ -4747,10 +4739,7 @@ fn type_level_arithmetic_incorrect_operands() -> Result<(), Errors> {
     checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Sum").unwrap();
-    assert_eq!(
-        checker.arena[result.t].as_string(&checker.arena),
-        r#""hello" + true"#
-    );
+    assert_eq!(checker.print_type(&result.t), r#""hello" + true"#);
     let result = checker.expand_type(&my_ctx, result.t);
 
     assert_eq!(

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -3,11 +3,10 @@ use generational_arena::{Arena, Index};
 use escalier_ast::{self as syntax, Literal as Lit, *};
 use escalier_parser::parse;
 
+use escalier_hm::checker::Checker;
 use escalier_hm::context::*;
 use escalier_hm::errors::*;
-use escalier_hm::infer::*;
 use escalier_hm::types::{self, *};
-use escalier_hm::util::expand_type;
 
 fn new_num_lit_type(arena: &mut Arena<Type>, value: &str) -> Index {
     arena.insert(Type::from(TypeKind::Literal(Lit::Number(value.to_owned()))))
@@ -17,15 +16,16 @@ fn new_str_lit_type(arena: &mut Arena<Type>, value: &str) -> Index {
     arena.insert(Type::from(TypeKind::Literal(Lit::String(value.to_owned()))))
 }
 
-fn test_env() -> (Arena<Type>, Context) {
-    let mut arena = Arena::new();
+fn test_env() -> (Checker, Context) {
+    let mut checker = Checker {
+        arena: Arena::new(),
+    };
     let mut context = Context::default();
 
-    let number = new_primitive(&mut arena, Primitive::Number);
-    let type_param_t = new_constructor(&mut arena, "T", &[]);
+    let number = new_primitive(&mut checker.arena, Primitive::Number);
+    let type_param_t = new_constructor(&mut checker.arena, "T", &[]);
 
-    let push_t = new_func_type(
-        &mut arena,
+    let push_t = checker.new_func_type(
         &[types::FuncParam {
             pattern: TPat::Ident(BindingIdent {
                 name: "item".to_string(),
@@ -42,16 +42,16 @@ fn test_env() -> (Arena<Type>, Context) {
 
     // [P]: T for P in number;
     let mapped = types::TObjElem::Mapped(types::MappedType {
-        key: new_constructor(&mut arena, "P", &[]),
-        value: new_constructor(&mut arena, "T", &[]),
+        key: new_constructor(&mut checker.arena, "P", &[]),
+        value: new_constructor(&mut checker.arena, "T", &[]),
         target: "P".to_string(),
-        source: new_primitive(&mut arena, Primitive::Number),
+        source: new_primitive(&mut checker.arena, Primitive::Number),
         check: None,
         extends: None,
     });
 
     let array_interface = new_object_type(
-        &mut arena,
+        &mut checker.arena,
         &[
             // .push(item: T) -> number;
             types::TObjElem::Prop(types::TProp {
@@ -83,7 +83,7 @@ fn test_env() -> (Arena<Type>, Context) {
 
     context.schemes.insert("Array".to_string(), array_scheme);
 
-    (arena, context)
+    (checker, context)
 }
 
 /// Sets up some predefined types using the type constructors TypeVariable,
@@ -93,7 +93,7 @@ fn test_env() -> (Arena<Type>, Context) {
 
 #[test]
 fn test_complex_logic() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let a: number
@@ -103,17 +103,17 @@ fn test_complex_logic() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
 
     Ok(())
 }
 
 #[test]
 fn test_string_equality() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let a: string
@@ -123,19 +123,19 @@ fn test_string_equality() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("eq").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
     let binding = my_ctx.values.get("neq").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
 
     Ok(())
 }
 
 #[test]
 fn test_if_else() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let cond: boolean
@@ -144,16 +144,16 @@ fn test_if_else() -> Result<(), Errors> {
 
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
 
-    assert_eq!(arena[binding.index].as_string(&arena), r#"5 | 10"#);
+    assert_eq!(checker.print_type(&binding.index), r#"5 | 10"#);
     Ok(())
 }
 
 #[test]
 fn test_chained_if_else() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let cond1: boolean
@@ -163,16 +163,16 @@ fn test_chained_if_else() -> Result<(), Errors> {
 
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
 
-    assert_eq!(arena[binding.index].as_string(&arena), r#"5 | 10 | 15"#);
+    assert_eq!(checker.print_type(&binding.index), r#"5 | 10 | 15"#);
     Ok(())
 }
 
 #[test]
 fn test_factorial() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // factorial
     let src = r#"
@@ -186,11 +186,11 @@ fn test_factorial() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("fact").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(n: number) -> 1 | number"#
     );
     Ok(())
@@ -198,7 +198,7 @@ fn test_factorial() -> Result<(), Errors> {
 
 #[test]
 fn test_mutual_recursion() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let even = fn (x) => if (x == 0) {
@@ -214,16 +214,16 @@ fn test_mutual_recursion() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("even").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> true | boolean"#
     );
     let binding = my_ctx.values.get("odd").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> true | boolean"#
     );
 
@@ -232,7 +232,7 @@ fn test_mutual_recursion() -> Result<(), Errors> {
 
 #[test]
 fn test_mutual_recursion_using_destructuring() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let {even, odd} = {
@@ -249,16 +249,16 @@ fn test_mutual_recursion_using_destructuring() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("even").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> true | boolean"#
     );
     let binding = my_ctx.values.get("odd").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> true | boolean"#
     );
 
@@ -267,14 +267,14 @@ fn test_mutual_recursion_using_destructuring() -> Result<(), Errors> {
 
 #[test]
 fn test_no_top_level_redeclaration() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let id = fn (x) => x
     let id = fn (y) => y
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -289,28 +289,28 @@ fn test_no_top_level_redeclaration() -> Result<(), Errors> {
 #[should_panic]
 #[test]
 fn test_mismatch() {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"fn (x) => [x(3), x(true)]"#;
 
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx).unwrap();
+    checker.infer_program(&mut program, &mut my_ctx).unwrap();
 }
 
 #[should_panic = "called `Result::unwrap()` on an `Err` value: InferenceError(\"Undefined symbol \\\"f\\\"\")"]
 #[test]
 fn test_pair() {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"[f(3), f(true)]"#;
 
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx).unwrap();
+    checker.infer_program(&mut program, &mut my_ctx).unwrap();
 }
 
 #[test]
 fn test_mul() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
         let f = fn (x) => x
@@ -318,27 +318,27 @@ fn test_mul() -> Result<(), Errors> {
     "#;
 
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"[4, true]"#);
+    assert_eq!(checker.print_type(&binding.index), r#"[4, true]"#);
     Ok(())
 }
 
 #[should_panic = "recursive unification"]
 #[test]
 fn test_recursive() {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"fn (f) => f(f)"#;
 
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx).unwrap();
+    checker.infer_program(&mut program, &mut my_ctx).unwrap();
 }
 
 #[test]
 fn test_number_literal() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let g = fn (f) => 5
@@ -346,16 +346,16 @@ fn test_number_literal() -> Result<(), Errors> {
     "#;
 
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"5"#);
+    assert_eq!(checker.print_type(&binding.index), r#"5"#);
     Ok(())
 }
 
 #[test]
 fn test_generic_nongeneric() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let result = fn (g) {
@@ -365,44 +365,41 @@ fn test_generic_nongeneric() -> Result<(), Errors> {
 
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"<A>(g: A) -> [A, A]"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"<A>(g: A) -> [A, A]"#);
     Ok(())
 }
 
 #[test]
 fn test_basic_generics() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // example that demonstrates generic and non-generic variables:
     let src = r#"let result = fn (x) => x"#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"<A>(x: A) -> A"#);
+    assert_eq!(checker.print_type(&binding.index), r#"<A>(x: A) -> A"#);
 
     Ok(())
 }
 
 #[test]
 fn test_composition() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // Function composition
     // fn f (fn g (fn arg (f g arg)))
     let src = r#"let result = fn (f) => fn (g) => fn (arg) => g(f(arg))"#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<A, C, B>(f: (arg0: A) -> B) -> (g: (arg0: B) -> C) -> (arg: A) -> C"#
     );
     Ok(())
@@ -410,7 +407,7 @@ fn test_composition() -> Result<(), Errors> {
 
 #[test]
 fn test_skk() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let S = fn (f) => fn (g) => fn (x) => f(x)(g(x))
@@ -419,27 +416,27 @@ fn test_skk() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("S").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<A, C, B>(f: (arg0: A) -> (arg0: B) -> C) -> (g: (arg0: A) -> B) -> (x: A) -> C"#
     );
     let binding = my_ctx.values.get("K").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<A, B>(x: A) -> (y: B) -> A"#
     );
     let binding = my_ctx.values.get("I").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"<A>(x: A) -> A"#);
+    assert_eq!(checker.print_type(&binding.index), r#"<A>(x: A) -> A"#);
 
     Ok(())
 }
 
 #[test]
 fn test_composition_with_statements() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // Function composition
     let src = r#"
@@ -453,10 +450,10 @@ fn test_composition_with_statements() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<A, B, C>(f: (arg0: A) -> B) -> (g: (arg0: B) -> C) -> (arg: A) -> C"#
     );
     Ok(())
@@ -464,7 +461,7 @@ fn test_composition_with_statements() -> Result<(), Errors> {
 
 #[test]
 fn test_subtype() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let times = fn (x, y) => x * y
@@ -472,15 +469,15 @@ fn test_subtype() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
     Ok(())
 }
 
 #[test]
 fn test_callback_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // It's okay for the callback arg to take fewer params since extra params
     // are ignored.  It's also okay for its params to be supertypes of the
@@ -494,15 +491,15 @@ fn test_callback_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
     Ok(())
 }
 
 #[test]
 fn test_callback_error_too_many_params() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: fn (cb: fn (x: number) -> boolean) -> boolean
@@ -511,7 +508,7 @@ fn test_callback_error_too_many_params() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
     assert_eq!(
         result,
         Err(Errors::InferenceError("(a: number, b: string) -> boolean is not a subtype of (x: number) -> boolean since it requires more params".to_string())),
@@ -521,14 +518,14 @@ fn test_callback_error_too_many_params() -> Result<(), Errors> {
 
 #[test]
 fn test_union_subtype() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
-    let lit1 = new_num_lit_type(&mut arena, "5");
-    let lit2 = new_num_lit_type(&mut arena, "10");
+    let lit1 = new_num_lit_type(&mut checker.arena, "5");
+    let lit2 = new_num_lit_type(&mut checker.arena, "10");
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {
-            index: new_union_type(&mut arena, &[lit1, lit2]),
+            index: new_union_type(&mut checker.arena, &[lit1, lit2]),
             is_mut: false,
         },
     );
@@ -539,24 +536,24 @@ fn test_union_subtype() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
     Ok(())
 }
 
 #[test]
 fn test_calling_a_union() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
-    let bool = new_primitive(&mut arena, Primitive::Boolean);
-    let str = new_primitive(&mut arena, Primitive::String);
-    let fn1 = new_func_type(&mut arena, &[], bool, &None, None);
-    let fn2 = new_func_type(&mut arena, &[], str, &None, None);
+    let bool = new_primitive(&mut checker.arena, Primitive::Boolean);
+    let str = new_primitive(&mut checker.arena, Primitive::String);
+    let fn1 = checker.new_func_type(&[], bool, &None, None);
+    let fn2 = checker.new_func_type(&[], str, &None, None);
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {
-            index: new_union_type(&mut arena, &[fn1, fn2]),
+            index: new_union_type(&mut checker.arena, &[fn1, fn2]),
             is_mut: false,
         },
     );
@@ -564,18 +561,15 @@ fn test_calling_a_union() -> Result<(), Errors> {
     let src = r#"let result = foo()"#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"boolean | string"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"boolean | string"#);
     Ok(())
 }
 
 #[test]
 fn call_with_too_few_args() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let times = fn (x, y) => x * y
@@ -583,7 +577,7 @@ fn call_with_too_few_args() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -597,9 +591,9 @@ fn call_with_too_few_args() -> Result<(), Errors> {
 
 #[test]
 fn literal_isnt_callable() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
-    let lit = new_num_lit_type(&mut arena, "5");
+    let lit = new_num_lit_type(&mut checker.arena, "5");
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {
@@ -611,7 +605,7 @@ fn literal_isnt_callable() -> Result<(), Errors> {
     let src = r#"let result = foo()"#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -625,15 +619,15 @@ fn literal_isnt_callable() -> Result<(), Errors> {
 
 #[test]
 fn infer_basic_tuple() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"let result = [5, "hello"]"#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         "[5, \"hello\"]".to_string(),
     );
 
@@ -642,7 +636,7 @@ fn infer_basic_tuple() -> Result<(), Errors> {
 
 #[test]
 fn tuple_member() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let tuple = [5, "hello"]
@@ -652,16 +646,13 @@ fn tuple_member() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("second").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#""hello""#.to_string(),
-    );
+    assert_eq!(checker.print_type(&binding.index), r#""hello""#.to_string(),);
     let binding = my_ctx.values.get("any").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"5 | "hello" | undefined"#.to_string(),
     );
 
@@ -670,7 +661,7 @@ fn tuple_member() -> Result<(), Errors> {
 
 #[test]
 fn tuple_member_invalid_index() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let tuple = [5, "hello"]
@@ -678,7 +669,7 @@ fn tuple_member_invalid_index() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -692,7 +683,7 @@ fn tuple_member_invalid_index() -> Result<(), Errors> {
 
 #[test]
 fn array_member() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let array: Array<number>
@@ -702,16 +693,16 @@ fn array_member() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("first").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         "number | undefined".to_string(),
     );
     let binding = my_ctx.values.get("any").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         "number | undefined".to_string(),
     );
 
@@ -720,7 +711,7 @@ fn array_member() -> Result<(), Errors> {
 
 #[test]
 fn tuple_member_error_out_of_bounds() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let tuple = [5, "hello"]
@@ -728,7 +719,7 @@ fn tuple_member_error_out_of_bounds() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -742,7 +733,7 @@ fn tuple_member_error_out_of_bounds() -> Result<(), Errors> {
 
 #[test]
 fn tuple_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: fn (x: [number, string]) -> boolean
@@ -750,12 +741,9 @@ fn tuple_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        "boolean".to_string(),
-    );
+    assert_eq!(checker.print_type(&binding.index), "boolean".to_string(),);
 
     Ok(())
 }
@@ -764,7 +752,7 @@ fn tuple_subtyping() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn more_tuple_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let tuple1: [number, ...string[]] = [5]
@@ -773,14 +761,14 @@ fn more_tuple_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn tuple_subtyping_not_enough_elements() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: fn (x: [number, string]) -> boolean
@@ -788,7 +776,7 @@ fn tuple_subtyping_not_enough_elements() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -802,16 +790,16 @@ fn tuple_subtyping_not_enough_elements() -> Result<(), Errors> {
 
 #[test]
 fn infer_basic_object() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"let result = {a: 5, b: "hello"}"#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         "{a: 5, b: \"hello\"}".to_string(),
     );
 
@@ -820,7 +808,7 @@ fn infer_basic_object() -> Result<(), Errors> {
 
 #[test]
 fn object_member() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let obj = {a: 5, b: "hello"}
@@ -828,17 +816,17 @@ fn object_member() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
 
-    assert_eq!(arena[binding.index].as_string(&arena), "5".to_string(),);
+    assert_eq!(checker.print_type(&binding.index), "5".to_string(),);
 
     Ok(())
 }
 
 #[test]
 fn object_member_string_key() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let obj = {a: 5, b: "hello"}
@@ -847,11 +835,11 @@ fn object_member_string_key() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         "5 | \"hello\" | undefined".to_string(),
     );
 
@@ -860,7 +848,7 @@ fn object_member_string_key() -> Result<(), Errors> {
 
 #[test]
 fn object_member_missing_prop() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let obj = {a: 5, b: "hello"}
@@ -868,7 +856,7 @@ fn object_member_missing_prop() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -882,7 +870,7 @@ fn object_member_missing_prop() -> Result<(), Errors> {
 
 #[test]
 fn object_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // Each prop must be a subtype of the expected element type
     // It's okay to pass an object with extra props
@@ -892,20 +880,17 @@ fn object_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("result").unwrap();
 
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        "boolean".to_string(),
-    );
+    assert_eq!(checker.print_type(&binding.index), "boolean".to_string(),);
 
     Ok(())
 }
 
 #[test]
 fn object_signatures() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // Each prop must be a subtype of the expected element type
     // It's okay to pass an object with extra props
@@ -922,11 +907,11 @@ fn object_signatures() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("obj").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         "{fn(a: number) -> string, foo: (a: number) -> string, bar: (self: t14, a: number) -> string, get baz: (self: t18) -> string, set baz: (self: t21, value: string) -> undefined, [P]: number for P in string, qux: string}".to_string(),
     );
 
@@ -935,7 +920,7 @@ fn object_signatures() -> Result<(), Errors> {
 
 #[test]
 fn object_callable_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -947,7 +932,7 @@ fn object_callable_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
@@ -957,7 +942,7 @@ fn object_callable_subtyping() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn object_callable_subtyping_failure_case() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -969,7 +954,7 @@ fn object_callable_subtyping_failure_case() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -983,7 +968,7 @@ fn object_callable_subtyping_failure_case() -> Result<(), Errors> {
 
 #[test]
 fn object_method_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -995,14 +980,14 @@ fn object_method_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn object_property_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -1017,14 +1002,14 @@ fn object_property_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn object_mapped_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -1036,14 +1021,14 @@ fn object_mapped_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn object_methods_and_properties_should_unify() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -1055,14 +1040,14 @@ fn object_methods_and_properties_should_unify() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn object_mappeds_should_unify_with_all_named_obj_elems() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -1078,14 +1063,14 @@ fn object_mappeds_should_unify_with_all_named_obj_elems() -> Result<(), Errors> 
 
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn object_mappeds_and_properties_unify_failure() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -1098,7 +1083,7 @@ fn object_mappeds_and_properties_unify_failure() -> Result<(), Errors> {
 
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1112,7 +1097,7 @@ fn object_mappeds_and_properties_unify_failure() -> Result<(), Errors> {
 
 #[test]
 fn object_properties_and_getter_should_unify() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: {
@@ -1124,7 +1109,7 @@ fn object_properties_and_getter_should_unify() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
@@ -1133,7 +1118,7 @@ fn object_properties_and_getter_should_unify() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn mutable_object_properties_unify_with_getters_setters() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let mut foo: {
@@ -1146,14 +1131,14 @@ fn mutable_object_properties_unify_with_getters_setters() -> Result<(), Errors> 
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn object_subtyping_missing_prop() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: fn (x: {a: number, b: string}) -> boolean
@@ -1161,7 +1146,7 @@ fn object_subtyping_missing_prop() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1175,7 +1160,7 @@ fn object_subtyping_missing_prop() -> Result<(), Errors> {
 
 #[test]
 fn test_subtype_error() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let times = fn (x, y) => x * y
@@ -1183,7 +1168,7 @@ fn test_subtype_error() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1197,14 +1182,14 @@ fn test_subtype_error() -> Result<(), Errors> {
 
 #[test]
 fn test_union_subtype_error() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
-    let lit1 = new_num_lit_type(&mut arena, "5");
-    let lit2 = new_str_lit_type(&mut arena, "hello");
+    let lit1 = new_num_lit_type(&mut checker.arena, "5");
+    let lit2 = new_str_lit_type(&mut checker.arena, "hello");
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {
-            index: new_union_type(&mut arena, &[lit1, lit2]),
+            index: new_union_type(&mut checker.arena, &[lit1, lit2]),
             is_mut: false,
         },
     );
@@ -1215,7 +1200,7 @@ fn test_union_subtype_error() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1229,14 +1214,14 @@ fn test_union_subtype_error() -> Result<(), Errors> {
 
 #[test]
 fn test_union_subtype_error_with_type_ann() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let x: number | string = true
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1250,7 +1235,7 @@ fn test_union_subtype_error_with_type_ann() -> Result<(), Errors> {
 
 #[test]
 fn test_program() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let num = 5
@@ -1259,13 +1244,13 @@ fn test_program() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("num").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"5"#);
+    assert_eq!(checker.print_type(&binding.index), r#"5"#);
 
     let binding = my_ctx.values.get("str").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#""hello""#);
+    assert_eq!(checker.print_type(&binding.index), r#""hello""#);
 
     // TODO: implement std::fmt for Program et al
     // eprintln!("program = {program}");
@@ -1281,7 +1266,7 @@ fn test_program() -> Result<(), Errors> {
 
 #[test]
 fn test_program_with_generic_func() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let id = fn (x) => x
@@ -1290,23 +1275,23 @@ fn test_program_with_generic_func() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("id").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"<A>(x: A) -> A"#);
+    assert_eq!(checker.print_type(&binding.index), r#"<A>(x: A) -> A"#);
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"5"#);
+    assert_eq!(checker.print_type(&binding.index), r#"5"#);
 
     let binding = my_ctx.values.get("b").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#""hello""#);
+    assert_eq!(checker.print_type(&binding.index), r#""hello""#);
 
     Ok(())
 }
 
 #[test]
 fn test_program_with_generic_func_multiple_type_params() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let fst = fn (x, y) => x
@@ -1314,17 +1299,17 @@ fn test_program_with_generic_func_multiple_type_params() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("fst").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<A, B>(x: A, y: B) -> A"#
     );
 
     let binding = my_ctx.values.get("snd").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<A, B>(x: A, y: B) -> B"#
     );
 
@@ -1333,7 +1318,7 @@ fn test_program_with_generic_func_multiple_type_params() -> Result<(), Errors> {
 
 #[test]
 fn test_function_with_multiple_statements() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let result = fn () {
@@ -1344,10 +1329,10 @@ fn test_function_with_multiple_statements() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"() -> 50"#);
+    assert_eq!(checker.print_type(&binding.index), r#"() -> 50"#);
 
     if let StmtKind::Let {
         expr: Some(init), ..
@@ -1384,12 +1369,12 @@ fn test_function_with_multiple_statements() -> Result<(), Errors> {
 
 #[test]
 fn test_inferred_type_on_ast_nodes() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"let result = fn (x, y) => x * y"#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     if let StmtKind::Let {
         expr: Some(init), ..
@@ -1399,8 +1384,8 @@ fn test_inferred_type_on_ast_nodes() -> Result<(), Errors> {
             let x_t = params[0].pattern.inferred_type.unwrap();
             let y_t = params[1].pattern.inferred_type.unwrap();
 
-            assert_eq!(arena[x_t].as_string(&arena), "number");
-            assert_eq!(arena[y_t].as_string(&arena), "number");
+            assert_eq!(checker.print_type(&x_t), "number");
+            assert_eq!(checker.print_type(&y_t), "number");
         } else {
             panic!("expected a lambda");
         }
@@ -1413,16 +1398,16 @@ fn test_inferred_type_on_ast_nodes() -> Result<(), Errors> {
 
 #[test]
 fn test_unary_op() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"let neg = fn (x) => -x"#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("neg").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> number"#
     );
     Ok(())
@@ -1430,18 +1415,18 @@ fn test_unary_op() -> Result<(), Errors> {
 
 #[test]
 fn test_async_return_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn () => 5
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("foo").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"() -> Promise<5, never>"#
     );
     Ok(())
@@ -1449,18 +1434,18 @@ fn test_async_return_type() -> Result<(), Errors> {
 
 #[test]
 fn throws_in_async() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn (cond) => if (cond) { throw "error" } else { 5 }
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("foo").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(cond: boolean) -> Promise<5, "error">"#
     );
     Ok(())
@@ -1468,7 +1453,7 @@ fn throws_in_async() -> Result<(), Errors> {
 
 #[test]
 fn await_async_func_with_throw() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn (cond) => if (cond) { throw "error" } else { 5 }
@@ -1476,17 +1461,17 @@ fn await_async_func_with_throw() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(cond: boolean) -> Promise<5, "error">"#
     );
 
     let binding = my_ctx.values.get("bar").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"() -> Promise<5, "error">"#
     );
 
@@ -1495,7 +1480,7 @@ fn await_async_func_with_throw() -> Result<(), Errors> {
 
 #[test]
 fn catch_await_async_func_that_throws() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn (cond) => if (cond) { throw "error" } else { 5 }
@@ -1509,17 +1494,17 @@ fn catch_await_async_func_that_throws() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(cond: boolean) -> Promise<5, "error">"#
     );
 
     let binding = my_ctx.values.get("bar").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"() -> Promise<5 | 10, never>"#
     );
 
@@ -1528,7 +1513,7 @@ fn catch_await_async_func_that_throws() -> Result<(), Errors> {
 
 #[test]
 fn test_async_without_return() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn () {
@@ -1537,11 +1522,11 @@ fn test_async_without_return() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("foo").unwrap();
 
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"() -> Promise<undefined, never>"#
     );
     Ok(())
@@ -1549,7 +1534,7 @@ fn test_async_without_return() -> Result<(), Errors> {
 
 #[test]
 fn test_await_in_async() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn () => 5
@@ -1561,17 +1546,17 @@ fn test_await_in_async() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("bar").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"() -> Promise<5, never>"#
     );
 
     let binding = my_ctx.values.get("baz").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"() -> Promise<5, never>"#
     );
 
@@ -1580,7 +1565,7 @@ fn test_await_in_async() -> Result<(), Errors> {
 
 #[test]
 fn test_await_outside_of_async() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn () => 5
@@ -1591,7 +1576,7 @@ fn test_await_outside_of_async() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
     assert_eq!(
         result,
         Err(Errors::InferenceError(
@@ -1604,14 +1589,14 @@ fn test_await_outside_of_async() -> Result<(), Errors> {
 
 #[test]
 fn test_await_non_promise() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = async fn () => await 5
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
     assert_eq!(
         result,
         Err(Errors::InferenceError(
@@ -1627,7 +1612,7 @@ fn test_await_non_promise() -> Result<(), Errors> {
 
 #[test]
 fn test_do_expr() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let sum = do {
@@ -1646,31 +1631,31 @@ fn test_do_expr() -> Result<(), Errors> {
     // TODO: If there's a newline before a postfix operator, we should
     // ignore the postfix operator.
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("sum").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"["hello", 15]"#);
+    assert_eq!(checker.print_type(&binding.index), r#"["hello", 15]"#);
 
     Ok(())
 }
 
 #[test]
 fn test_empty_do_expr() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"let sum = do {}"#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("sum").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"undefined"#);
+    assert_eq!(checker.print_type(&binding.index), r#"undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn test_let_with_type_ann() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let x: number = 5
@@ -1688,17 +1673,17 @@ fn test_let_with_type_ann() -> Result<(), Errors> {
     // This should be valid, but we don't support it yet
     // let baz: (number) => number = <A>(a: A) => a;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("x").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     Ok(())
 }
 
 #[test]
 fn test_function_overloads() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let add: (fn (a: number, b: number) -> number) & (fn (a: string, b: string) -> string)
@@ -1706,27 +1691,27 @@ fn test_function_overloads() -> Result<(), Errors> {
     let msg = add("hello, ", "world")
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("sum").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     let binding = my_ctx.values.get("msg").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn test_function_no_valid_overload() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let add: (fn (a: number, b: number) -> number) & (fn (a: string, b: string) -> string)
     add(5, "world")
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1740,13 +1725,13 @@ fn test_function_no_valid_overload() -> Result<(), Errors> {
 
 #[test]
 fn test_declare_cant_have_initializer() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let add: fn (a: number, b: number) -> number = fn (a, b) => a + b
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1760,13 +1745,13 @@ fn test_declare_cant_have_initializer() -> Result<(), Errors> {
 
 #[test]
 fn test_declare_must_have_type_annotations() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let add
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1780,13 +1765,13 @@ fn test_declare_must_have_type_annotations() -> Result<(), Errors> {
 
 #[test]
 fn test_normal_decl_must_have_initializer() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let add: fn (a: number, b: number) -> number
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1800,7 +1785,7 @@ fn test_normal_decl_must_have_initializer() -> Result<(), Errors> {
 
 #[test]
 fn test_pattern_matching_is_patterns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: allow trailing `,` when doing pattern matching
     let src = r#"
@@ -1811,17 +1796,17 @@ fn test_pattern_matching_is_patterns() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("name").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number | "bar""#);
+    assert_eq!(checker.print_type(&binding.index), r#"number | "bar""#);
 
     Ok(())
 }
 
 #[test]
 fn test_pattern_matching_does_not_refine_expr() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: allow trailing `,` when doing pattern matching
     let src = r#"
@@ -1832,7 +1817,7 @@ fn test_pattern_matching_does_not_refine_expr() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1846,7 +1831,7 @@ fn test_pattern_matching_does_not_refine_expr() -> Result<(), Errors> {
 
 #[test]
 fn test_pattern_not_a_subtype_of_expr() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: allow trailing `,` when doing pattern matching
     let src = r#"
@@ -1858,7 +1843,7 @@ fn test_pattern_not_a_subtype_of_expr() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1872,7 +1857,7 @@ fn test_pattern_not_a_subtype_of_expr() -> Result<(), Errors> {
 
 #[test]
 fn test_pattern_matching_array() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: allow trailing `,` when doing pattern matching
     let src = r#"
@@ -1885,11 +1870,11 @@ fn test_pattern_matching_array() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         // TODO: update unions to merge elements whenever possible
         r#"0 | number | number | Array<number>"#
     );
@@ -1899,7 +1884,7 @@ fn test_pattern_matching_array() -> Result<(), Errors> {
 
 #[test]
 fn test_pattern_matching_object() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: allow trailing `,` when doing pattern matching
     // TODO: add support for omitting fields in object patterns
@@ -1911,17 +1896,17 @@ fn test_pattern_matching_object() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("key").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string | string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string | string"#);
 
     Ok(())
 }
 
 #[test]
 fn member_access_on_union() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: allow trailing `,` when doing pattern matching
     // TODO: add support for omitting fields in object patterns
@@ -1930,20 +1915,17 @@ fn member_access_on_union() -> Result<(), Errors> {
     let b = obj.b
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("b").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"string | boolean"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"string | boolean"#);
 
     Ok(())
 }
 
 #[test]
 fn member_access_optional_property() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let obj: {a?: number, b: string}
@@ -1951,22 +1933,19 @@ fn member_access_optional_property() -> Result<(), Errors> {
     let b = obj.b
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
     let binding = my_ctx.values.get("b").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn member_access_on_unknown_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let obj: unknown
@@ -1974,7 +1953,7 @@ fn member_access_on_unknown_type() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -1988,14 +1967,14 @@ fn member_access_on_unknown_type() -> Result<(), Errors> {
 
 #[test]
 fn member_access_on_type_variable() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let get_a = fn (x) => x.a
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2009,7 +1988,7 @@ fn member_access_on_type_variable() -> Result<(), Errors> {
 
 #[test]
 fn test_object_destructuring_assignment() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: add support for omitting fields in object patterns
     let src = r#"
@@ -2017,42 +1996,36 @@ fn test_object_destructuring_assignment() -> Result<(), Errors> {
     let {a, b, c} = obj
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
 
     let binding = my_ctx.values.get("b").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     let binding = my_ctx.values.get("c").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
 
     Ok(())
 }
 
 #[test]
 fn test_object_destructuring_assignment_with_rest() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let obj: {a?: number, b: string, c: boolean}
     let {a, ...rest} = obj
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
     let binding = my_ctx.values.get("rest").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"{b: string, c: boolean}"#
     );
 
@@ -2061,17 +2034,17 @@ fn test_object_destructuring_assignment_with_rest() -> Result<(), Errors> {
 
 #[test]
 fn test_object_nested_destructuring_assignment() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let obj: {a: {b: {c: string}}}
     let {a: {b: {c}}} = obj
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("c").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     assert_eq!(my_ctx.values.get("a"), None);
     assert_eq!(my_ctx.values.get("b"), None);
@@ -2081,88 +2054,82 @@ fn test_object_nested_destructuring_assignment() -> Result<(), Errors> {
 
 #[test]
 fn test_tuple_destrcuturing_assignment() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple: [number, string, boolean]
     let [a, b, c] = tuple
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     let binding = my_ctx.values.get("b").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn test_tuple_destructuring_assignment_with_rest() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple: [number, string, boolean]
     let [a, ...tuple_rest] = tuple
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
     let binding = my_ctx.values.get("tuple_rest").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"[string, boolean]"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"[string, boolean]"#);
 
     Ok(())
 }
 
 #[test]
 fn test_array_destructuring_assignment_with_rest() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let array: Array<string>
     let [a, ...array_rest] = array
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"string | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"string | undefined"#);
     let binding = my_ctx.values.get("array_rest").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"Array<string>"#);
+    assert_eq!(checker.print_type(&binding.index), r#"Array<string>"#);
 
     Ok(())
 }
 
 #[test]
 fn test_tuple_nested_destrcuturing_assignment() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple: [number, [string, [boolean]]]
     let [_, [_, [c]]] = tuple
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("c").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
 
     Ok(())
 }
 
 #[test]
 fn test_explicit_type_params() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let identity = fn (x) => x
@@ -2170,26 +2137,26 @@ fn test_explicit_type_params() -> Result<(), Errors> {
     let y = identity<string>("hello")
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("x").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
     let binding = my_ctx.values.get("y").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn test_explicit_type_params_type_error() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let identity = fn (x) => x
     identity<number>("hello")
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2203,14 +2170,14 @@ fn test_explicit_type_params_type_error() -> Result<(), Errors> {
 
 #[test]
 fn test_explicit_type_params_too_many_type_args() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let identity = fn (x) => x
     identity<number, string>(5)
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2224,7 +2191,7 @@ fn test_explicit_type_params_too_many_type_args() -> Result<(), Errors> {
 
 #[test]
 fn test_type_param_with_constraint() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let identity = fn <T: number | string>(x: T) -> T => x
@@ -2232,40 +2199,40 @@ fn test_type_param_with_constraint() -> Result<(), Errors> {
     let y = identity("hello")
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("identity").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<T:number | string>(x: T) -> T"#
     );
     let binding = my_ctx.values.get("x").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"5"#);
+    assert_eq!(checker.print_type(&binding.index), r#"5"#);
     let binding = my_ctx.values.get("y").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#""hello""#);
+    assert_eq!(checker.print_type(&binding.index), r#""hello""#);
 
     Ok(())
 }
 
 #[test]
 fn test_mix_explicit_implicit_type_params() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let fst = fn <B>(a, b: B) => a
     let snd = fn <B>(a, b: B) -> B => b
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("fst").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<B, A>(a: A, b: B) -> A"#
     );
     let binding = my_ctx.values.get("snd").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<B, A>(a: A, b: B) -> B"#
     );
 
@@ -2274,13 +2241,13 @@ fn test_mix_explicit_implicit_type_params() -> Result<(), Errors> {
 
 #[test]
 fn test_duplicate_type_param_names_error() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let fst = fn <T, T>(a: T, b: T) -> T => a
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2294,14 +2261,14 @@ fn test_duplicate_type_param_names_error() -> Result<(), Errors> {
 
 #[test]
 fn test_type_param_with_violated_constraint() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let identity = fn <T: number | string>(x: T) -> T => x
     identity(true)
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2315,36 +2282,36 @@ fn test_type_param_with_violated_constraint() -> Result<(), Errors> {
 
 #[test]
 fn test_type_ann_func_with_type_constraint() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let identity: fn <T: number | string>(x: T) -> T = fn (x) => x
     let x = identity<number>(5)
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("identity").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"<T:number | string>(x: T) -> T"#
     );
     let binding = my_ctx.values.get("x").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     Ok(())
 }
 
 #[test]
 fn test_type_ann_func_with_type_constraint_error() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let id1 = fn <T: number | string>(x: T) -> T => x
     let id2: fn <T: boolean>(x: T) -> T = id1
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2358,7 +2325,7 @@ fn test_type_ann_func_with_type_constraint_error() -> Result<(), Errors> {
 
 #[test]
 fn test_callback_with_type_param_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: fn (callback: fn <T: number>(x: T) -> T) -> boolean
@@ -2366,17 +2333,17 @@ fn test_callback_with_type_param_subtyping() -> Result<(), Errors> {
     let result = foo(identity)
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
 
     Ok(())
 }
 
 #[test]
 fn test_callback_with_type_param_subtyping_error() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let foo: fn (callback: fn <T: number | string>(x: T) -> T) -> boolean
@@ -2384,7 +2351,7 @@ fn test_callback_with_type_param_subtyping_error() -> Result<(), Errors> {
     let result = foo(identity)
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2398,32 +2365,32 @@ fn test_callback_with_type_param_subtyping_error() -> Result<(), Errors> {
 
 #[test]
 fn test_return_type_checking() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn () -> string => "hello"
     let result = foo()
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"() -> string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"() -> string"#);
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn test_return_value_is_not_subtype_of_return_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn () -> number => "hello"
     "#;
     let mut program = parse(src).unwrap();
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2437,7 +2404,7 @@ fn test_return_value_is_not_subtype_of_return_type() -> Result<(), Errors> {
 
 #[test]
 fn test_multiple_returns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn (x) {
@@ -2448,11 +2415,11 @@ fn test_multiple_returns() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> true | "hello""#
     );
 
@@ -2461,7 +2428,7 @@ fn test_multiple_returns() -> Result<(), Errors> {
 
 #[test]
 fn test_no_returns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn (x) {
@@ -2469,11 +2436,11 @@ fn test_no_returns() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> undefined"#
     );
 
@@ -2482,7 +2449,7 @@ fn test_no_returns() -> Result<(), Errors> {
 
 #[test]
 fn test_multiple_returns_with_nested_functions() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn (x) {
@@ -2495,11 +2462,11 @@ fn test_multiple_returns_with_nested_functions() -> Result<(), Errors> {
     }
     "#;
     let mut program = parse(src).unwrap();
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(x: number) -> () -> true | "hello""#
     );
 
@@ -2508,7 +2475,7 @@ fn test_multiple_returns_with_nested_functions() -> Result<(), Errors> {
 
 #[test]
 fn type_alias() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -2516,10 +2483,10 @@ fn type_alias() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("p").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"{x: number, y: number}"#
     );
 
@@ -2528,7 +2495,7 @@ fn type_alias() -> Result<(), Errors> {
 
 #[test]
 fn type_alias_with_params_with_destructuring() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Node<T> = {value: T}
@@ -2537,19 +2504,19 @@ fn type_alias_with_params_with_destructuring() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("node").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"{value: string}"#);
+    assert_eq!(checker.print_type(&binding.index), r#"{value: string}"#);
     let binding = my_ctx.values.get("value").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn type_alias_with_params_with_member_access() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Node<T> = {value: T}
@@ -2558,19 +2525,19 @@ fn type_alias_with_params_with_member_access() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("node").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"{value: string}"#);
+    assert_eq!(checker.print_type(&binding.index), r#"{value: string}"#);
     let binding = my_ctx.values.get("value").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn type_alias_with_params_with_computed_member_access() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Node<T> = {value: T}
@@ -2580,19 +2547,19 @@ fn type_alias_with_params_with_computed_member_access() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("node").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"{value: string}"#);
+    assert_eq!(checker.print_type(&binding.index), r#"{value: string}"#);
     let binding = my_ctx.values.get("value").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn instantiate_type_alias_with_too_many_type_args() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Node<T> = {value: T}
@@ -2600,7 +2567,7 @@ fn instantiate_type_alias_with_too_many_type_args() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2614,7 +2581,7 @@ fn instantiate_type_alias_with_too_many_type_args() -> Result<(), Errors> {
 
 #[test]
 fn instantiate_type_alias_with_args_when_it_has_no_type_params() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -2622,7 +2589,7 @@ fn instantiate_type_alias_with_args_when_it_has_no_type_params() -> Result<(), E
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2636,7 +2603,7 @@ fn instantiate_type_alias_with_args_when_it_has_no_type_params() -> Result<(), E
 
 #[test]
 fn property_accesses_on_unions() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple_union: [number, number] | [string]
@@ -2648,21 +2615,21 @@ fn property_accesses_on_unions() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("elem").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number | string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number | string"#);
     let binding = my_ctx.values.get("x1").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number | string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number | string"#);
     let binding = my_ctx.values.get("x2").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number | string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number | string"#);
 
     Ok(())
 }
 
 #[test]
 fn maybe_property_accesses_on_unions() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple_union: [number, number] | [string]
@@ -2672,25 +2639,19 @@ fn maybe_property_accesses_on_unions() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("maybe_elem").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
     let binding = my_ctx.values.get("maybe_y").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn optional_chaining() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: string}
@@ -2701,26 +2662,20 @@ fn optional_chaining() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("x").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
 
     let binding = my_ctx.values.get("y").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"string | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"string | undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn optional_chaining_with_alias() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type OptPoint = {x: number, y: string} | undefined
@@ -2730,26 +2685,20 @@ fn optional_chaining_with_alias() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("x").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
 
     let binding = my_ctx.values.get("y").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"string | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"string | undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn optional_chaining_unnecessary_chaining() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Obj = {msg: string}
@@ -2758,17 +2707,17 @@ fn optional_chaining_unnecessary_chaining() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("msg").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn optional_chaining_multiple_levels() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Obj = {a?: {b?: {c?: number}}}
@@ -2777,20 +2726,17 @@ fn optional_chaining_multiple_levels() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("c").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn calling_variable_whose_type_is_aliased_function_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Fn = fn () -> number
@@ -2799,17 +2745,17 @@ fn calling_variable_whose_type_is_aliased_function_type() -> Result<(), Errors> 
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     Ok(())
 }
 
 #[test]
 fn optional_chaining_call() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Fn = fn () -> number
@@ -2818,13 +2764,10 @@ fn optional_chaining_call() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("result").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"number | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"number | undefined"#);
 
     Ok(())
 }
@@ -2832,7 +2775,7 @@ fn optional_chaining_call() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn destructuring_unions() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple_union: [number, number] | [string]
@@ -2842,7 +2785,7 @@ fn destructuring_unions() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     // TODO: write assertions for this test once the desired
     // behavior has been implemented.
@@ -2852,7 +2795,7 @@ fn destructuring_unions() -> Result<(), Errors> {
 
 #[test]
 fn missing_property_accesses_on_union_of_tuples() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple_union: [number, number] | [string]
@@ -2860,7 +2803,7 @@ fn missing_property_accesses_on_union_of_tuples() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2874,7 +2817,7 @@ fn missing_property_accesses_on_union_of_tuples() -> Result<(), Errors> {
 
 #[test]
 fn missing_property_accesses_on_union_of_objects() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let object_union: {x: number, y: number} | {x: string}
@@ -2882,7 +2825,7 @@ fn missing_property_accesses_on_union_of_objects() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2896,7 +2839,7 @@ fn missing_property_accesses_on_union_of_objects() -> Result<(), Errors> {
 
 #[test]
 fn methods_on_arrays() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let num_array: Array<number> = []
@@ -2908,16 +2851,16 @@ fn methods_on_arrays() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
     let binding = my_ctx.values.get("len").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     Ok(())
 }
 
 #[test]
 fn properties_on_tuple() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let tuple: [number, string] = [5, "hello"]
@@ -2925,10 +2868,10 @@ fn properties_on_tuple() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("len").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     Ok(())
 }
@@ -2936,7 +2879,7 @@ fn properties_on_tuple() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn set_array_element() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let array: Array<number>
@@ -2945,7 +2888,7 @@ fn set_array_element() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
@@ -2953,7 +2896,7 @@ fn set_array_element() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn set_tuple_element() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let tuple: [number, number]
@@ -2962,17 +2905,17 @@ fn set_tuple_element() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("len").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"number"#);
+    assert_eq!(checker.print_type(&binding.index), r#"number"#);
 
     Ok(())
 }
 
 #[test]
 fn methods_on_arrays_incorrect_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let num_array: Array<number> = []
@@ -2980,7 +2923,7 @@ fn methods_on_arrays_incorrect_type() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -2994,7 +2937,7 @@ fn methods_on_arrays_incorrect_type() -> Result<(), Errors> {
 
 #[test]
 fn test_unknown() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let a: unknown = 5
@@ -3003,21 +2946,21 @@ fn test_unknown() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"unknown"#);
+    assert_eq!(checker.print_type(&binding.index), r#"unknown"#);
     let binding = my_ctx.values.get("b").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"unknown"#);
+    assert_eq!(checker.print_type(&binding.index), r#"unknown"#);
     let binding = my_ctx.values.get("c").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"unknown"#);
+    assert_eq!(checker.print_type(&binding.index), r#"unknown"#);
 
     Ok(())
 }
 
 #[test]
 fn test_unknown_assignment_error() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let a: unknown = 5
@@ -3025,7 +2968,7 @@ fn test_unknown_assignment_error() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3039,7 +2982,7 @@ fn test_unknown_assignment_error() -> Result<(), Errors> {
 
 #[test]
 fn test_type_param_explicit_unknown_constraint() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let add = fn <T: unknown>(a: T, b: T) -> T {
@@ -3048,7 +2991,7 @@ fn test_type_param_explicit_unknown_constraint() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3062,7 +3005,7 @@ fn test_type_param_explicit_unknown_constraint() -> Result<(), Errors> {
 
 #[test]
 fn test_type_param_implicit_unknown_constraint() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let add = fn <T>(a: T, b: T) -> T {
@@ -3071,7 +3014,7 @@ fn test_type_param_implicit_unknown_constraint() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3085,7 +3028,7 @@ fn test_type_param_implicit_unknown_constraint() -> Result<(), Errors> {
 
 #[test]
 fn test_optional_function_params() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn (a: number, b?: number) -> number {
@@ -3094,11 +3037,11 @@ fn test_optional_function_params() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"(a: number, b?: number) -> number"#
     );
 
@@ -3107,7 +3050,7 @@ fn test_optional_function_params() -> Result<(), Errors> {
 
 #[test]
 fn test_func_param_patterns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn ({ a: x, b }: { a: number, b: string }) {
@@ -3119,16 +3062,16 @@ fn test_func_param_patterns() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"({a, b}: {a: number, b: string}) -> number"#
     );
     let binding = my_ctx.values.get("bar").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"([a, b]: [number, string]) -> string"#
     );
 
@@ -3137,7 +3080,7 @@ fn test_func_param_patterns() -> Result<(), Errors> {
 
 #[test]
 fn test_func_param_object_rest_patterns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn ({ a, ...rest }: { a: number, b: string }) {
@@ -3146,11 +3089,11 @@ fn test_func_param_object_rest_patterns() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("foo").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"({a, ...rest}: {a: number, b: string}) -> string"#
     );
 
@@ -3159,7 +3102,7 @@ fn test_func_param_object_rest_patterns() -> Result<(), Errors> {
 
 #[test]
 fn test_func_param_object_multiple_rest_patterns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn ({ a, ...rest1, ...rest2 }: { a: number, b: string }) {
@@ -3168,7 +3111,7 @@ fn test_func_param_object_multiple_rest_patterns() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3182,7 +3125,7 @@ fn test_func_param_object_multiple_rest_patterns() -> Result<(), Errors> {
 
 #[test]
 fn test_func_param_tuple_rest_patterns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let bar = fn ([a, ...rest]: [number, string, boolean]) {
@@ -3191,11 +3134,11 @@ fn test_func_param_tuple_rest_patterns() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("bar").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"([a, ...rest]: [number, string, boolean]) -> boolean"#
     );
 
@@ -3204,7 +3147,7 @@ fn test_func_param_tuple_rest_patterns() -> Result<(), Errors> {
 
 #[test]
 fn test_index_access_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = {a: string, b?: number, [P]: boolean for P in string}
@@ -3214,27 +3157,27 @@ fn test_index_access_type() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("A").unwrap();
-    assert_eq!(arena[scheme.t].as_string(&arena), r#"Foo["a"]"#);
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&scheme.t), r#"Foo["a"]"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"string"#);
 
     let scheme = my_ctx.schemes.get("B").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number | undefined"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"number | undefined"#);
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"boolean | undefined"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"boolean | undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn test_index_access_type_using_string_as_mapped() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = {a: string, b: number, c: boolean}
@@ -3242,12 +3185,12 @@ fn test_index_access_type_using_string_as_mapped() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("T").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
     assert_eq!(
-        arena[t].as_string(&arena),
+        checker.print_type(&t),
         r#"string | number | boolean | undefined"#
     );
 
@@ -3256,7 +3199,7 @@ fn test_index_access_type_using_string_as_mapped() -> Result<(), Errors> {
 
 #[test]
 fn test_index_access_type_using_number_as_mapped() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = {a: string, b: number, [P]: boolean for P in number}
@@ -3264,18 +3207,18 @@ fn test_index_access_type_using_number_as_mapped() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("T").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"boolean | undefined"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"boolean | undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn test_index_access_type_missing_property() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = {a: string, b?: number}
@@ -3283,10 +3226,10 @@ fn test_index_access_type_missing_property() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let result = expand_type(&mut arena, &my_ctx, scheme.t);
+    let result = checker.expand_type(&my_ctx, scheme.t);
 
     // TODO: check that the index access is valid where it's inferred
     assert_eq!(
@@ -3301,7 +3244,7 @@ fn test_index_access_type_missing_property() -> Result<(), Errors> {
 
 #[test]
 fn test_index_access_type_missing_mapped() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = {[P]: string for P in number}
@@ -3309,10 +3252,10 @@ fn test_index_access_type_missing_mapped() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let result = expand_type(&mut arena, &my_ctx, scheme.t);
+    let result = checker.expand_type(&my_ctx, scheme.t);
 
     // TODO: check that the index access is valid where it's inferred
     assert_eq!(
@@ -3327,7 +3270,7 @@ fn test_index_access_type_missing_mapped() -> Result<(), Errors> {
 
 #[test]
 fn test_index_access_type_number_mapped() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = {[P]: string for P in number}
@@ -3336,24 +3279,21 @@ fn test_index_access_type_number_mapped() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("T").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"string | undefined"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"string | undefined"#);
 
     let binding = my_ctx.values.get("t").unwrap();
-    assert_eq!(
-        arena[binding.index].as_string(&arena),
-        r#"string | undefined"#
-    );
+    assert_eq!(checker.print_type(&binding.index), r#"string | undefined"#);
 
     Ok(())
 }
 
 #[test]
 fn test_mapped_type_pick() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Pick<T, K> = {[P]: T[P] for P in K}
@@ -3362,18 +3302,18 @@ fn test_mapped_type_pick() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"{a: string, b: number}"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"{a: string, b: number}"#);
 
     Ok(())
 }
 
 #[test]
 fn test_pick_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Pick<T, K> = {[P]: T[P] for P in K}
@@ -3382,18 +3322,18 @@ fn test_pick_type() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"{a: string, b: number}"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"{a: string, b: number}"#);
 
     Ok(())
 }
 
 #[test]
 fn test_exclude_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Exclude<T, U> = if (T : U) { never } else { T }
@@ -3402,18 +3342,18 @@ fn test_exclude_type() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""a" | "b""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""a" | "b""#);
 
     Ok(())
 }
 
 #[test]
 fn test_omit_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Pick<T, K> = {[P]: T[P] for P in K}
@@ -3424,18 +3364,18 @@ fn test_omit_type() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"{a: string, b: number}"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"{a: string, b: number}"#);
 
     Ok(())
 }
 
 #[test]
 fn test_index_access_type_on_tuple() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = [number, string, boolean]
@@ -3444,17 +3384,17 @@ fn test_index_access_type_on_tuple() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("t").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"string"#);
+    assert_eq!(checker.print_type(&binding.index), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn test_index_access_type_on_tuple_with_number_key() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = [number, string, boolean]
@@ -3463,11 +3403,11 @@ fn test_index_access_type_on_tuple_with_number_key() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("t").unwrap();
     assert_eq!(
-        arena[binding.index].as_string(&arena),
+        checker.print_type(&binding.index),
         r#"number | string | boolean | undefined"#
     );
 
@@ -3476,7 +3416,7 @@ fn test_index_access_type_on_tuple_with_number_key() -> Result<(), Errors> {
 
 #[test]
 fn test_index_access_out_of_bounds_on_tuple() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = [number, string, boolean]
@@ -3485,7 +3425,7 @@ fn test_index_access_out_of_bounds_on_tuple() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3499,7 +3439,7 @@ fn test_index_access_out_of_bounds_on_tuple() -> Result<(), Errors> {
 
 #[test]
 fn test_index_access_not_usize() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = [number, string, boolean]
@@ -3508,7 +3448,7 @@ fn test_index_access_not_usize() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3522,7 +3462,7 @@ fn test_index_access_not_usize() -> Result<(), Errors> {
 
 #[test]
 fn test_typeof() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     let foo = {a: "hello", b: 5, c: true}
@@ -3530,18 +3470,18 @@ fn test_typeof() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("Foo").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"{a: "hello", b: 5, c: true}"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"{a: "hello", b: 5, c: true}"#);
 
     Ok(())
 }
 
 #[test]
 fn test_keyof_obj() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     let a = {x: "hello", y: 5, z: true}
@@ -3555,34 +3495,34 @@ fn test_keyof_obj() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("A").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""x" | "y" | "z""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""x" | "y" | "z""#);
 
     let scheme = my_ctx.schemes.get("B").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""x""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""x""#);
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"never"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"never"#);
 
     let scheme = my_ctx.schemes.get("D").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"string"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"string"#);
 
     let scheme = my_ctx.schemes.get("E").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number | "x""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"number | "x""#);
 
     Ok(())
 }
 
 #[test]
 fn test_keyof_array_tuple() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"   
     type Foo = keyof Array<number>
@@ -3592,30 +3532,30 @@ fn test_keyof_array_tuple() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("Foo").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"number"#);
 
     let scheme = my_ctx.schemes.get("Bar").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"0 | 1 | 2"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"0 | 1 | 2"#);
 
     let scheme = my_ctx.schemes.get("Baz").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"0"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"0"#);
 
     let scheme = my_ctx.schemes.get("Qux").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"never"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"never"#);
 
     Ok(())
 }
 
 #[test]
 fn test_keyof_alias() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -3623,18 +3563,18 @@ fn test_keyof_alias() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("Foo").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""x" | "y""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""x" | "y""#);
 
     Ok(())
 }
 
 #[test]
 fn test_keyof_literal() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type String = {
@@ -3654,26 +3594,26 @@ fn test_keyof_literal() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("A").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""length" | "slice""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""length" | "slice""#);
 
     let scheme = my_ctx.schemes.get("B").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""toFixed" | "toString""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""toFixed" | "toString""#);
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""valueOf""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""valueOf""#);
 
     Ok(())
 }
 
 #[test]
 fn test_keyof_primitive() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type String = {
@@ -3693,26 +3633,26 @@ fn test_keyof_primitive() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("A").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""length" | "slice""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""length" | "slice""#);
 
     let scheme = my_ctx.schemes.get("B").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""toFixed" | "toString""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""toFixed" | "toString""#);
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""valueOf""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""valueOf""#);
 
     Ok(())
 }
 
 #[test]
 fn test_keyof_unknown_undefined_null() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type A = keyof unknown
@@ -3722,30 +3662,30 @@ fn test_keyof_unknown_undefined_null() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("A").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"never"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"never"#);
 
     let scheme = my_ctx.schemes.get("B").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"never"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"never"#);
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"never"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"never"#);
 
     let scheme = my_ctx.schemes.get("D").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"string | number | symbol"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"string | number | symbol"#);
 
     Ok(())
 }
 
 #[test]
 fn test_keyof_intersection() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type A = keyof ({a: number} & {b: string})
@@ -3755,30 +3695,30 @@ fn test_keyof_intersection() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let scheme = my_ctx.schemes.get("A").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""a" | "b""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""a" | "b""#);
 
     let scheme = my_ctx.schemes.get("B").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""a" | "b" | "c""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""a" | "b" | "c""#);
 
     let scheme = my_ctx.schemes.get("C").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""a""#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#""a""#);
 
     let scheme = my_ctx.schemes.get("D").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, scheme.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"string"#);
+    let t = checker.expand_type(&my_ctx, scheme.t)?;
+    assert_eq!(checker.print_type(&t), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn test_mutually_recursive_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
     let src = r#"
     type A = {
         a: number,
@@ -3793,14 +3733,14 @@ fn test_mutually_recursive_type() -> Result<(), Errors> {
 
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn test_mutually_recursive_type_with_index_access_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
     let src = r#"
     type Foo = {
         a: number,
@@ -3817,21 +3757,21 @@ fn test_mutually_recursive_type_with_index_access_type() -> Result<(), Errors> {
 
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn test_type_alias_with_undefined_def() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
     let src = r#"
     type A = B
     "#;
 
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3843,7 +3783,7 @@ fn test_type_alias_with_undefined_def() -> Result<(), Errors> {
 
 #[test]
 fn test_mutable_error_arg_passing() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: handle `declare let scale: fn(mut p: Point, ...);
     let src = r#"
@@ -3856,7 +3796,7 @@ fn test_mutable_error_arg_passing() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3870,7 +3810,7 @@ fn test_mutable_error_arg_passing() -> Result<(), Errors> {
 
 #[test]
 fn test_mutable_error_arg_passing_with_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: handle `declare let scale: fn(mut p: Point, ...);
     let src = r#"
@@ -3880,7 +3820,7 @@ fn test_mutable_error_arg_passing_with_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3894,7 +3834,7 @@ fn test_mutable_error_arg_passing_with_subtyping() -> Result<(), Errors> {
 
 #[test]
 fn test_mutable_ok_arg_passing() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: handle `declare let scale: fn(mut p: Point, ...);
     let src = r#"
@@ -3922,14 +3862,14 @@ fn test_mutable_ok_arg_passing() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn test_mutable_error_arg_passing_declared_fn() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -3939,7 +3879,7 @@ fn test_mutable_error_arg_passing_declared_fn() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -3953,7 +3893,7 @@ fn test_mutable_error_arg_passing_declared_fn() -> Result<(), Errors> {
 
 #[test]
 fn test_mutable_ok_arg_passing_declared_fns() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: handle `declare let scale: fn(mut p: Point, ...);
     let src = r#"
@@ -3977,14 +3917,14 @@ fn test_mutable_ok_arg_passing_declared_fns() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn test_mutable_error_assignment() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -3993,7 +3933,7 @@ fn test_mutable_error_assignment() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -4007,7 +3947,7 @@ fn test_mutable_error_assignment() -> Result<(), Errors> {
 
 #[test]
 fn test_mutable_ok_assignments() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -4025,14 +3965,14 @@ fn test_mutable_ok_assignments() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn test_mutable_invalid_assignments() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"    
     let mut arr1: Array<number> = [1, 2, 3]
@@ -4040,7 +3980,7 @@ fn test_mutable_invalid_assignments() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -4054,7 +3994,7 @@ fn test_mutable_invalid_assignments() -> Result<(), Errors> {
 
 #[test]
 fn test_sub_objects_are_mutable() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Obj = {a: {b: {c: string}}}
@@ -4065,21 +4005,21 @@ fn test_sub_objects_are_mutable() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("b1").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"{c: string}"#);
+    assert_eq!(checker.print_type(&binding.index), r#"{c: string}"#);
 
     let binding = my_ctx.values.get("b2").unwrap();
     // TODO: create helper function to print bindings, not just types
-    assert_eq!(arena[binding.index].as_string(&arena), r#"{c: string}"#);
+    assert_eq!(checker.print_type(&binding.index), r#"{c: string}"#);
 
     Ok(())
 }
 
 #[test]
 fn test_tuple_type_equality() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let a: [number, string]
@@ -4087,21 +4027,21 @@ fn test_tuple_type_equality() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let a = my_ctx.values.get("a").unwrap();
-    let a_t = arena[a.index].clone();
+    let a_t = checker.arena[a.index].clone();
     let b = my_ctx.values.get("b").unwrap();
-    let b_t = arena[b.index].clone();
+    let b_t = checker.arena[b.index].clone();
 
-    assert!(a_t.equals(&b_t, &arena));
+    assert!(a_t.equals(&b_t, &checker.arena));
 
     Ok(())
 }
 
 #[test]
 fn test_function_type_equality() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     declare let add: fn(a: number, b: number) -> number
@@ -4109,21 +4049,21 @@ fn test_function_type_equality() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let add = my_ctx.values.get("add").unwrap();
-    let add_t = arena[add.index].clone();
+    let add_t = checker.arena[add.index].clone();
     let sub = my_ctx.values.get("sub").unwrap();
-    let sub_t = arena[sub.index].clone();
+    let sub_t = checker.arena[sub.index].clone();
 
-    assert!(add_t.equals(&sub_t, &arena));
+    assert!(add_t.equals(&sub_t, &checker.arena));
 
     Ok(())
 }
 
 #[test]
 fn test_literal_type_equality() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let a = 5
@@ -4131,21 +4071,21 @@ fn test_literal_type_equality() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let a = my_ctx.values.get("a").unwrap();
-    let a_t = arena[a.index].clone();
+    let a_t = checker.arena[a.index].clone();
     let b = my_ctx.values.get("b").unwrap();
-    let b_t = arena[b.index].clone();
+    let b_t = checker.arena[b.index].clone();
 
-    assert!(a_t.equals(&b_t, &arena));
+    assert!(a_t.equals(&b_t, &checker.arena));
 
     Ok(())
 }
 
 #[test]
 fn test_mutable_object_type_equality() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -4154,21 +4094,21 @@ fn test_mutable_object_type_equality() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let p = my_ctx.values.get("p").unwrap();
-    let p_t = arena[p.index].clone();
+    let p_t = checker.arena[p.index].clone();
     let q = my_ctx.values.get("q").unwrap();
-    let q_t = arena[q.index].clone();
+    let q_t = checker.arena[q.index].clone();
 
-    assert!(p_t.equals(&q_t, &arena));
+    assert!(p_t.equals(&q_t, &checker.arena));
 
     Ok(())
 }
 
 #[test]
 fn test_mutating_mutable_object() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -4178,14 +4118,14 @@ fn test_mutating_mutable_object() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn test_mutating_immutable_object_errors() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Point = {x: number, y: number}
@@ -4194,7 +4134,7 @@ fn test_mutating_immutable_object_errors() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -4208,7 +4148,7 @@ fn test_mutating_immutable_object_errors() -> Result<(), Errors> {
 
 #[test]
 fn conditional_type_exclude() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Exclude<T, U> = if (T: U) { never } else { T }
@@ -4216,18 +4156,18 @@ fn conditional_type_exclude() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""b" | "c" | "d""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""b" | "c" | "d""#);
 
     Ok(())
 }
 
 #[test]
 fn chained_conditional_types() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Foo<T> = if (T: string) { 
@@ -4241,18 +4181,18 @@ fn chained_conditional_types() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""num" | "str""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""num" | "str""#);
 
     Ok(())
 }
 
 #[test]
 fn match_type_with_catchall() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Foo<T> = match (T) {
@@ -4264,18 +4204,18 @@ fn match_type_with_catchall() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""num" | "str""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""num" | "str""#);
 
     Ok(())
 }
 
 #[test]
 fn match_type_without_catchall() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Foo<T> = match (T) {
@@ -4287,22 +4227,22 @@ fn match_type_without_catchall() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("True").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""num""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""num""#);
 
     let result = my_ctx.schemes.get("Never").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"never"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"never"#);
 
     Ok(())
 }
 
 #[test]
 fn match_type_with_tuples() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // NOTE: The arrays need to be matched in reverse order
     // because they're open.  This means that the first match
@@ -4324,38 +4264,38 @@ fn match_type_with_tuples() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Tuple0").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""unit""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""unit""#);
 
     let result = my_ctx.schemes.get("Tuple1").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""1-tuple""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""1-tuple""#);
 
     let result = my_ctx.schemes.get("Tuple2").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""pair""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""pair""#);
 
     let result = my_ctx.schemes.get("Tuple3").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""triplet""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""triplet""#);
 
     let result = my_ctx.schemes.get("Tuple4").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""n-tuple""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""n-tuple""#);
 
     let result = my_ctx.schemes.get("Tuple5").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#""n-tuple""#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#""n-tuple""#);
 
     Ok(())
 }
 
 #[test]
 fn conditional_type_with_placeholders() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
         type IsArray<T> = if (T: Array<_>) { true } else { false }
@@ -4364,22 +4304,22 @@ fn conditional_type_with_placeholders() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("T").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"true"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"true"#);
 
     let result = my_ctx.schemes.get("F").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"false"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"false"#);
 
     Ok(())
 }
 
 #[test]
 fn conditional_type_with_constraint() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
         type IsArrayOfNumbers<T> = if (T: Array<number>) { true } else { false }
@@ -4388,22 +4328,22 @@ fn conditional_type_with_constraint() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("T").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"true"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"true"#);
 
     let result = my_ctx.schemes.get("F").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"false"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"false"#);
 
     Ok(())
 }
 
 #[test]
 fn unify_tuple_and_array() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
         let tuple = [1, 2, 3]
@@ -4411,7 +4351,7 @@ fn unify_tuple_and_array() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
@@ -4419,7 +4359,7 @@ fn unify_tuple_and_array() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn conditional_type_with_function_subtyping() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
         type IsFunction<T> = if (T: fn (...args: _) -> _) { true } else { false }
@@ -4428,22 +4368,22 @@ fn conditional_type_with_function_subtyping() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("T").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"true"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"true"#);
 
     let result = my_ctx.schemes.get("F").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"false"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"false"#);
 
     Ok(())
 }
 
 #[test]
 fn return_type_rest_placeholder() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: introduce a placeholder type that will unify with anything
     // we need to make sure we aren't adding `_` to non_generic
@@ -4461,26 +4401,26 @@ fn return_type_rest_placeholder() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("RT1").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"boolean"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"boolean"#);
 
     let result = my_ctx.schemes.get("RT2").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"number"#);
 
     let result = my_ctx.schemes.get("RT3").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"string"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"string"#);
 
     Ok(())
 }
 
 #[test]
 fn return_type_of_union() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
         type ReturnType<
@@ -4494,18 +4434,18 @@ fn return_type_of_union() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Result").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number | string"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"number | string"#);
 
     Ok(())
 }
 
 #[test]
 fn parameters_utility_type() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Parameters<T : fn (...args: _) -> _> = if (
@@ -4523,24 +4463,24 @@ fn parameters_utility_type() -> Result<(), Errors> {
 
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("P1").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"[string, number]"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"[string, number]"#);
 
     let result = my_ctx.schemes.get("P2").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"[string, ...Array<number>]"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"[string, ...Array<number>]"#);
 
     let result = my_ctx.schemes.get("P3").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"[string, number, boolean]"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"[string, number, boolean]"#);
 
     let result = my_ctx.schemes.get("P4").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
+    let t = checker.expand_type(&my_ctx, result.t)?;
     assert_eq!(
-        arena[t].as_string(&arena),
+        checker.print_type(&t),
         r#"[string, number, boolean, ...Array<string>]"#
     );
 
@@ -4549,7 +4489,7 @@ fn parameters_utility_type() -> Result<(), Errors> {
 
 #[test]
 fn function_subtyping_with_rest_placeholder() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let none: fn (...args: _) -> boolean = fn () => true
@@ -4563,21 +4503,21 @@ fn function_subtyping_with_rest_placeholder() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn function_subtyping_with_rest_array_fails() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let result: fn (...args: Array<_>) -> boolean = fn (a: string, b: number) => true
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -4591,14 +4531,14 @@ fn function_subtyping_with_rest_array_fails() -> Result<(), Errors> {
 
 #[test]
 fn function_multiple_rest_params_in_type_fails() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let result: fn (...args: _, ...moar_args: _) -> boolean = fn (a: string, b: number) => true
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -4612,14 +4552,14 @@ fn function_multiple_rest_params_in_type_fails() -> Result<(), Errors> {
 
 #[test]
 fn function_multiple_rest_params_function_fails() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let result: fn (...args: _) -> boolean = fn (...args: _, ...moar_args: _) => true
     "#;
     let mut program = parse(src).unwrap();
 
-    let result = infer_program(&mut arena, &mut program, &mut my_ctx);
+    let result = checker.infer_program(&mut program, &mut my_ctx);
 
     assert_eq!(
         result,
@@ -4635,7 +4575,7 @@ fn function_multiple_rest_params_function_fails() -> Result<(), Errors> {
 #[test]
 #[ignore]
 fn function_call_with_spread_args() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let foo = fn (a: number, b: string) => true
@@ -4644,14 +4584,14 @@ fn function_call_with_spread_args() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     Ok(())
 }
 
 #[test]
 fn arithmetic_op_const_folding() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let a = 3
@@ -4664,29 +4604,29 @@ fn arithmetic_op_const_folding() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("sum").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"5"#);
+    assert_eq!(checker.print_type(&binding.index), r#"5"#);
 
     let binding = my_ctx.values.get("diff").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"1"#);
+    assert_eq!(checker.print_type(&binding.index), r#"1"#);
 
     let binding = my_ctx.values.get("prod").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"6"#);
+    assert_eq!(checker.print_type(&binding.index), r#"6"#);
 
     let binding = my_ctx.values.get("quot").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"1.5"#);
+    assert_eq!(checker.print_type(&binding.index), r#"1.5"#);
 
     let binding = my_ctx.values.get("rem").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"1"#);
+    assert_eq!(checker.print_type(&binding.index), r#"1"#);
 
     Ok(())
 }
 
 #[test]
 fn comparison_op_const_folding() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let a = 3
@@ -4700,32 +4640,32 @@ fn comparison_op_const_folding() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("gt").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"true"#);
+    assert_eq!(checker.print_type(&binding.index), r#"true"#);
 
     let binding = my_ctx.values.get("gte").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"true"#);
+    assert_eq!(checker.print_type(&binding.index), r#"true"#);
 
     let binding = my_ctx.values.get("lt").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"false"#);
+    assert_eq!(checker.print_type(&binding.index), r#"false"#);
 
     let binding = my_ctx.values.get("lte").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"false"#);
+    assert_eq!(checker.print_type(&binding.index), r#"false"#);
 
     let binding = my_ctx.values.get("eq").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"false"#);
+    assert_eq!(checker.print_type(&binding.index), r#"false"#);
 
     let binding = my_ctx.values.get("neq").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"true"#);
+    assert_eq!(checker.print_type(&binding.index), r#"true"#);
 
     Ok(())
 }
 
 #[test]
 fn other_equality_checks() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     let a = "foo" == "bar"
@@ -4735,26 +4675,26 @@ fn other_equality_checks() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let binding = my_ctx.values.get("a").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"false"#);
+    assert_eq!(checker.print_type(&binding.index), r#"false"#);
 
     let binding = my_ctx.values.get("b").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"true"#);
+    assert_eq!(checker.print_type(&binding.index), r#"true"#);
 
     let binding = my_ctx.values.get("c").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
 
     let binding = my_ctx.values.get("d").unwrap();
-    assert_eq!(arena[binding.index].as_string(&arena), r#"boolean"#);
+    assert_eq!(checker.print_type(&binding.index), r#"boolean"#);
 
     Ok(())
 }
 
 #[test]
 fn type_level_arithmetic() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type A = 10 + 5
@@ -4765,50 +4705,53 @@ fn type_level_arithmetic() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("A").unwrap();
-    assert_eq!(arena[result.t].as_string(&arena), r#"10 + 5"#);
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"15"#);
+    assert_eq!(checker.print_type(&result.t), r#"10 + 5"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"15"#);
 
     let result = my_ctx.schemes.get("B").unwrap();
-    assert_eq!(arena[result.t].as_string(&arena), r#"10 - 5"#);
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"5"#);
+    assert_eq!(checker.print_type(&result.t), r#"10 - 5"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"5"#);
 
     let result = my_ctx.schemes.get("C").unwrap();
-    assert_eq!(arena[result.t].as_string(&arena), r#"10 * 5"#);
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"50"#);
+    assert_eq!(checker.print_type(&result.t), r#"10 * 5"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"50"#);
 
     let result = my_ctx.schemes.get("D").unwrap();
-    assert_eq!(arena[result.t].as_string(&arena), r#"10 / 5"#);
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"2"#);
+    assert_eq!(checker.print_type(&result.t), r#"10 / 5"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"2"#);
 
     let result = my_ctx.schemes.get("E").unwrap();
-    assert_eq!(arena[result.t].as_string(&arena), r#"10 % 5"#);
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"0"#);
+    assert_eq!(checker.print_type(&result.t), r#"10 % 5"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"0"#);
 
     Ok(())
 }
 
 #[test]
 fn type_level_arithmetic_incorrect_operands() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Sum = "hello" + true
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Sum").unwrap();
-    assert_eq!(arena[result.t].as_string(&arena), r#""hello" + true"#);
-    let result = expand_type(&mut arena, &my_ctx, result.t);
+    assert_eq!(
+        checker.arena[result.t].as_string(&checker.arena),
+        r#""hello" + true"#
+    );
+    let result = checker.expand_type(&my_ctx, result.t);
 
     assert_eq!(
         result,
@@ -4822,7 +4765,7 @@ fn type_level_arithmetic_incorrect_operands() -> Result<(), Errors> {
 
 #[test]
 fn check_type_constraints() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Add<A: string, B: string> = A + B
@@ -4830,10 +4773,10 @@ fn check_type_constraints() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("A").unwrap();
-    let result = expand_type(&mut arena, &my_ctx, result.t);
+    let result = checker.expand_type(&my_ctx, result.t);
 
     assert_eq!(
         result,
@@ -4847,7 +4790,7 @@ fn check_type_constraints() -> Result<(), Errors> {
 
 #[test]
 fn type_level_arithmetic_with_alias() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     let src = r#"
     type Add<A: number, B: number> = A + B
@@ -4858,30 +4801,30 @@ fn type_level_arithmetic_with_alias() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("A").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"15"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"15"#);
 
     let result = my_ctx.schemes.get("B").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"number"#);
 
     let result = my_ctx.schemes.get("C").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"number"#);
 
     let result = my_ctx.schemes.get("D").unwrap();
-    let t = expand_type(&mut arena, &my_ctx, result.t)?;
-    assert_eq!(arena[t].as_string(&arena), r#"number"#);
+    let t = checker.expand_type(&my_ctx, result.t)?;
+    assert_eq!(checker.print_type(&t), r#"number"#);
 
     Ok(())
 }
 
 #[test]
 fn type_level_arithmetic_with_incorrect_types() -> Result<(), Errors> {
-    let (mut arena, mut my_ctx) = test_env();
+    let (mut checker, mut my_ctx) = test_env();
 
     // TODO: Check type aliases without type parameters eagerly (this likely
     // requires a separate pass) or something similar to how we handle mutual
@@ -4892,10 +4835,10 @@ fn type_level_arithmetic_with_incorrect_types() -> Result<(), Errors> {
     "#;
     let mut program = parse(src).unwrap();
 
-    infer_program(&mut arena, &mut program, &mut my_ctx)?;
+    checker.infer_program(&mut program, &mut my_ctx)?;
 
     let result = my_ctx.schemes.get("Sum").unwrap();
-    let result = expand_type(&mut arena, &my_ctx, result.t);
+    let result = checker.expand_type(&my_ctx, result.t);
 
     assert_eq!(
         result,

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -22,8 +22,8 @@ fn test_env() -> (Checker, Context) {
     };
     let mut context = Context::default();
 
-    let number = new_primitive(&mut checker.arena, Primitive::Number);
-    let type_param_t = new_constructor(&mut checker.arena, "T", &[]);
+    let number = checker.new_primitive(Primitive::Number);
+    let type_param_t = checker.new_constructor("T", &[]);
 
     let push_t = checker.new_func_type(
         &[types::FuncParam {
@@ -42,36 +42,33 @@ fn test_env() -> (Checker, Context) {
 
     // [P]: T for P in number;
     let mapped = types::TObjElem::Mapped(types::MappedType {
-        key: new_constructor(&mut checker.arena, "P", &[]),
-        value: new_constructor(&mut checker.arena, "T", &[]),
+        key: checker.new_constructor("P", &[]),
+        value: checker.new_constructor("T", &[]),
         target: "P".to_string(),
-        source: new_primitive(&mut checker.arena, Primitive::Number),
+        source: checker.new_primitive(Primitive::Number),
         check: None,
         extends: None,
     });
 
-    let array_interface = new_object_type(
-        &mut checker.arena,
-        &[
-            // .push(item: T) -> number;
-            types::TObjElem::Prop(types::TProp {
-                name: types::TPropKey::StringKey("push".to_string()),
-                modifier: None,
-                t: push_t,
-                optional: false,
-                mutable: false,
-            }),
-            // .length: number;
-            types::TObjElem::Prop(types::TProp {
-                name: types::TPropKey::StringKey("length".to_string()),
-                modifier: None,
-                optional: false,
-                mutable: false,
-                t: number,
-            }),
-            mapped,
-        ],
-    );
+    let array_interface = checker.new_object_type(&[
+        // .push(item: T) -> number;
+        types::TObjElem::Prop(types::TProp {
+            name: types::TPropKey::StringKey("push".to_string()),
+            modifier: None,
+            t: push_t,
+            optional: false,
+            mutable: false,
+        }),
+        // .length: number;
+        types::TObjElem::Prop(types::TProp {
+            name: types::TPropKey::StringKey("length".to_string()),
+            modifier: None,
+            optional: false,
+            mutable: false,
+            t: number,
+        }),
+        mapped,
+    ]);
     let array_scheme = Scheme {
         type_params: Some(vec![types::TypeParam {
             name: "T".to_string(),
@@ -525,7 +522,7 @@ fn test_union_subtype() -> Result<(), Errors> {
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {
-            index: new_union_type(&mut checker.arena, &[lit1, lit2]),
+            index: checker.new_union_type(&[lit1, lit2]),
             is_mut: false,
         },
     );
@@ -546,14 +543,14 @@ fn test_union_subtype() -> Result<(), Errors> {
 fn test_calling_a_union() -> Result<(), Errors> {
     let (mut checker, mut my_ctx) = test_env();
 
-    let bool = new_primitive(&mut checker.arena, Primitive::Boolean);
-    let str = new_primitive(&mut checker.arena, Primitive::String);
+    let bool = checker.new_primitive(Primitive::Boolean);
+    let str = checker.new_primitive(Primitive::String);
     let fn1 = checker.new_func_type(&[], bool, &None, None);
     let fn2 = checker.new_func_type(&[], str, &None, None);
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {
-            index: new_union_type(&mut checker.arena, &[fn1, fn2]),
+            index: checker.new_union_type(&[fn1, fn2]),
             is_mut: false,
         },
     );
@@ -1189,7 +1186,7 @@ fn test_union_subtype_error() -> Result<(), Errors> {
     my_ctx.values.insert(
         "foo".to_string(),
         Binding {
-            index: new_union_type(&mut checker.arena, &[lit1, lit2]),
+            index: checker.new_union_type(&[lit1, lit2]),
             is_mut: false,
         },
     );


### PR DESCRIPTION
This PR introduces a `Checker` struct and makes a bunch of functions that were taking `arena` as a param to be methods on `Checker`.  This simplifies calls to those methods.  It also will make recoverable error handling easier in the future because we can store the diagnostics on `Checker` instead of having to pass them around as params to everything.