### PR TITLE
Port escalier_old_codegen to work with new AST and type checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "escalier_ast",
  "escalier_hm",
  "escalier_parser",
+ "generational-arena",
  "insta",
  "itertools 0.10.5",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,9 @@ name = "escalier_ast"
 version = "0.1.0"
 dependencies = [
  "generational-arena",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
 ]
 
 [[package]]
@@ -384,6 +387,26 @@ dependencies = [
  "pretty_assertions",
  "tree-sitter",
  "tree_sitter_escalier",
+]
+
+[[package]]
+name = "escalier_codegen"
+version = "0.1.0"
+dependencies = [
+ "escalier_ast",
+ "escalier_hm",
+ "escalier_parser",
+ "insta",
+ "itertools 0.10.5",
+ "pretty_assertions",
+ "sourcemap",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_transforms_react",
+ "swc_ecma_visit",
+ "testing_macros",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/escalier",
     "crates/escalier_ast",
     "crates/escalier_cli",
+    "crates/escalier_codegen",
     "crates/escalier_hm",
     "crates/escalier_lsp",
     "crates/escalier_old_infer",

--- a/crates/escalier_ast/Cargo.toml
+++ b/crates/escalier_ast/Cargo.toml
@@ -6,4 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+swc_atoms = "0.5.6"
+swc_ecma_ast = "0.107.0"
+swc_common = { version = "0.31.16", features = ["sourcemap"] }
 generational-arena = "0.2.8"

--- a/crates/escalier_ast/src/class.rs
+++ b/crates/escalier_ast/src/class.rs
@@ -73,6 +73,7 @@ pub struct Field {
     pub is_public: bool,
     pub type_ann: Option<TypeAnn>,
     pub init: Option<Box<Expr>>,
+    // TODO: add `is_static` and `is_optional` fields
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/escalier_ast/src/expr.rs
+++ b/crates/escalier_ast/src/expr.rs
@@ -22,7 +22,7 @@ pub enum ObjectKey {
 // TODO: track source location
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Prop {
-    Shorthand(String), // TODO: use Identifier
+    Shorthand(Ident),
     Property { key: ObjectKey, value: Expr },
 }
 

--- a/crates/escalier_ast/src/identifier.rs
+++ b/crates/escalier_ast/src/identifier.rs
@@ -1,3 +1,7 @@
+use swc_atoms::JsWord;
+use swc_common::{self, BytePos, SyntaxContext};
+use swc_ecma_ast;
+
 use crate::span::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -11,4 +15,37 @@ pub struct BindingIdent {
     pub name: String,
     pub span: Span,
     pub mutable: bool,
+}
+
+// TODO: add implementations of From for more nodes
+impl From<&Ident> for swc_ecma_ast::Ident {
+    fn from(ident: &Ident) -> Self {
+        let span = swc_common::Span {
+            lo: BytePos(ident.span.start as u32 + 1),
+            hi: BytePos(ident.span.end as u32 + 1),
+            ctxt: SyntaxContext::empty(),
+        };
+
+        swc_ecma_ast::Ident {
+            span,
+            sym: JsWord::from(ident.name.to_owned()),
+            optional: false,
+        }
+    }
+}
+
+impl From<&BindingIdent> for swc_ecma_ast::Ident {
+    fn from(binding: &BindingIdent) -> Self {
+        let span = swc_common::Span {
+            lo: BytePos(binding.span.start as u32 + 1),
+            hi: BytePos(binding.span.end as u32 + 1),
+            ctxt: SyntaxContext::empty(),
+        };
+
+        swc_ecma_ast::Ident {
+            span,
+            sym: JsWord::from(binding.name.to_owned()),
+            optional: false,
+        }
+    }
 }

--- a/crates/escalier_ast/src/literal.rs
+++ b/crates/escalier_ast/src/literal.rs
@@ -1,4 +1,7 @@
 use std::fmt;
+use swc_atoms::JsWord;
+use swc_common;
+use swc_ecma_ast::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Literal {
@@ -30,5 +33,33 @@ impl fmt::Display for Literal {
             Literal::Null => write!(f, "null"),
             Literal::Undefined => write!(f, "undefined"),
         }
+    }
+}
+
+impl From<&Literal> for swc_ecma_ast::Expr {
+    fn from(literal: &Literal) -> Self {
+        // TODO: use the span from the literal
+        let span = swc_common::DUMMY_SP;
+
+        let lit = match literal {
+            Literal::Number(value) => Lit::Num(Number {
+                span,
+                value: value.parse().unwrap(),
+                raw: None,
+            }),
+            Literal::String(value) => Lit::Str(Str {
+                span,
+                value: swc_atoms::JsWord::from(value.as_str()),
+                raw: None,
+            }),
+            Literal::Boolean(value) => Lit::Bool(Bool {
+                span,
+                value: *value,
+            }),
+            Literal::Null => todo!(),
+            Literal::Undefined => todo!(),
+        };
+
+        Expr::Lit(lit)
     }
 }

--- a/crates/escalier_ast/src/literal.rs
+++ b/crates/escalier_ast/src/literal.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use swc_atoms::JsWord;
 use swc_common;
 use swc_ecma_ast::*;
 

--- a/crates/escalier_codegen/Cargo.toml
+++ b/crates/escalier_codegen/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "escalier_codegen"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+escalier_ast = { version = "0.1.0", path = "../escalier_ast" }
+escalier_hm = { version = "0.1.0", path = "../escalier_hm" }
+itertools = "0.10.3"
+sourcemap = "6"
+swc_atoms = "0.5.6"
+swc_ecma_ast = "0.107.0"
+swc_common = { version = "0.31.16", features = ["sourcemap"] }
+swc_ecma_codegen = "0.142.1"
+swc_ecma_transforms_react = "0.176.1"
+swc_ecma_visit = "0.93.0"
+
+[dev-dependencies]
+escalier_parser = { version = "0.1.0", path = "../escalier_parser" }
+insta = "1.13.0"
+pretty_assertions = "1.2.1"
+testing_macros = "0.2.5"

--- a/crates/escalier_codegen/Cargo.toml
+++ b/crates/escalier_codegen/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+generational-arena = "0.2.8"
 escalier_ast = { version = "0.1.0", path = "../escalier_ast" }
 escalier_hm = { version = "0.1.0", path = "../escalier_hm" }
 itertools = "0.10.3"

--- a/crates/escalier_codegen/src/d_ts.rs
+++ b/crates/escalier_codegen/src/d_ts.rs
@@ -1,0 +1,913 @@
+use generational_arena::Index;
+use std::collections::BTreeSet;
+use std::rc::Rc;
+use swc_atoms::*;
+use swc_common::{SourceMap, DUMMY_SP};
+use swc_ecma_ast::*;
+use swc_ecma_codegen::*;
+
+use escalier_ast::visitor::*;
+use escalier_ast::{self as values};
+use escalier_hm::checker::Checker;
+use escalier_hm::context::Context;
+use escalier_hm::type_error::TypeError;
+use escalier_hm::types;
+
+pub fn codegen_d_ts(
+    program: &values::Program,
+    ctx: &Context,
+    checker: &Checker,
+) -> core::result::Result<String, TypeError> {
+    Ok(print_d_ts(&build_d_ts(program, ctx, checker)?))
+}
+
+fn print_d_ts(program: &Program) -> String {
+    let mut buf = vec![];
+    let cm = Rc::new(SourceMap::default());
+
+    let mut emitter = Emitter {
+        cfg: swc_ecma_codegen::Config {
+            ..Default::default()
+        },
+        cm: cm.clone(),
+        comments: None,
+        wr: text_writer::JsWriter::new(cm, "\n", &mut buf, None),
+    };
+
+    emitter.emit_program(program).unwrap();
+
+    String::from_utf8_lossy(&buf).to_string()
+}
+
+fn build_type_params_from_type_params(
+    type_params: Option<&Vec<types::TypeParam>>,
+    ctx: &Context,
+    checker: &Checker,
+) -> Option<Box<TsTypeParamDecl>> {
+    type_params.as_ref().map(|type_params| {
+        Box::from(TsTypeParamDecl {
+            span: DUMMY_SP,
+            params: type_params
+                .iter()
+                .map(|type_param| {
+                    let constraint = type_param
+                        .constraint
+                        .as_ref()
+                        .map(|constraint| Box::from(build_type(constraint, ctx, checker)));
+                    TsTypeParam {
+                        span: DUMMY_SP,
+                        name: build_ident(&type_param.name),
+                        is_in: false,
+                        is_out: false,
+                        is_const: false, // TODO: find ways to leverage this
+                        constraint,
+                        default: None, // TODO
+                    }
+                })
+                .collect(),
+        })
+    })
+}
+
+fn build_d_ts(
+    program: &values::Program,
+    ctx: &Context,
+    checker: &Checker,
+) -> core::result::Result<Program, TypeError> {
+    // TODO: Create a common `Export` type
+    let mut type_exports: BTreeSet<String> = BTreeSet::new();
+    let mut value_exports: BTreeSet<String> = BTreeSet::new();
+
+    for stmt in &program.stmts {
+        match &stmt.kind {
+            // values::StmtKind::ClassDecl(class_decl) => {
+            //     let name = class_decl.ident.name.to_owned();
+            //     value_exports.insert(name.to_owned());
+            //     type_exports.insert(name.to_owned());
+            //     type_exports.insert(format!("{name}Constructor"));
+
+            //     // NOTE: The Readonly version of the interface type is generated
+            //     // when we process `type_exports`.
+            // }
+            values::StmtKind::Let { pattern, .. } => {
+                let bindings = get_bindings(pattern);
+                for name in bindings {
+                    value_exports.insert(name);
+                }
+            }
+            values::StmtKind::TypeDecl { name, .. } => {
+                type_exports.insert(name.to_owned());
+            }
+            values::StmtKind::Expr { .. } => (), // nothing is exported
+            // values::StmtKind::ForStmt(_) => (), // nothing is exported
+            values::StmtKind::Return { .. } => (), // nothing is exported
+        }
+    }
+
+    let mut body: Vec<ModuleItem> = vec![];
+
+    for name in type_exports {
+        let scheme = ctx.get_scheme(&name)?;
+
+        let type_params =
+            build_type_params_from_type_params(scheme.type_params.as_ref(), ctx, checker);
+
+        if let types::TypeKind::Object(obj) = &checker.arena[scheme.t].kind {
+            let mutable_decl =
+                ModuleItem::Stmt(Stmt::Decl(Decl::TsTypeAlias(Box::from(TsTypeAliasDecl {
+                    span: DUMMY_SP,
+                    declare: true,
+                    id: build_ident(&name),
+                    type_params: type_params.clone(),
+                    type_ann: Box::from(build_obj_type(obj, ctx, checker)),
+                }))));
+            body.push(mutable_decl);
+
+            if !name.ends_with("Constructor") {
+                if let Some(obj) = immutable_obj_type(obj) {
+                    let immutable_decl = ModuleItem::Stmt(Stmt::Decl(Decl::TsTypeAlias(
+                        Box::from(TsTypeAliasDecl {
+                            span: DUMMY_SP,
+                            declare: true,
+                            id: build_ident(format!("Readonly{name}").as_str()),
+                            type_params,
+                            type_ann: Box::from(build_obj_type(&obj, ctx, checker)),
+                        }),
+                    )));
+
+                    body.push(immutable_decl);
+                }
+            }
+        } else {
+            let decl =
+                ModuleItem::Stmt(Stmt::Decl(Decl::TsTypeAlias(Box::from(TsTypeAliasDecl {
+                    span: DUMMY_SP,
+                    declare: true,
+                    id: build_ident(&name),
+                    type_params,
+                    type_ann: Box::from(build_type(&scheme.t, ctx, checker)),
+                }))));
+
+            body.push(decl);
+        }
+    }
+
+    for name in value_exports {
+        let binding = ctx.get_binding(&name)?;
+
+        let pat = Pat::Ident(BindingIdent {
+            id: build_ident(&name),
+            type_ann: Some(Box::from(TsTypeAnn {
+                span: DUMMY_SP,
+                type_ann: Box::from(build_type(&binding.index, ctx, checker)),
+            })),
+        });
+
+        let decl = ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+            span: DUMMY_SP,
+            decl: Decl::Var(Box::from(VarDecl {
+                span: DUMMY_SP,
+                kind: VarDeclKind::Const,
+                declare: true,
+                decls: vec![VarDeclarator {
+                    span: DUMMY_SP,
+                    name: pat,
+                    init: None,
+                    definite: false,
+                }],
+            })),
+        }));
+
+        body.push(decl);
+    }
+
+    Ok(Program::Module(Module {
+        span: DUMMY_SP,
+        body,
+        shebang: None,
+    }))
+}
+
+// TODO: create a trait for this and then provide multiple implementations
+pub fn build_ident(name: &str) -> Ident {
+    Ident {
+        span: DUMMY_SP,
+        sym: JsWord::from(name.to_owned()),
+        optional: false,
+    }
+}
+
+pub fn build_ts_pattern(pat: &types::TPat) -> Pat {
+    match pat {
+        types::TPat::Ident(bi) => Pat::Ident(BindingIdent {
+            id: build_ident(&bi.name),
+            type_ann: None,
+        }),
+        _ => todo!(),
+    }
+}
+
+fn tpat_to_pat(pat: &types::TPat, type_ann: Option<Box<TsTypeAnn>>) -> Pat {
+    match pat {
+        types::TPat::Ident(bi) => Pat::Ident(BindingIdent {
+            id: build_ident(&bi.name),
+            type_ann,
+        }),
+        types::TPat::Rest(rest) => Pat::Rest(RestPat {
+            span: DUMMY_SP,
+            dot3_token: DUMMY_SP,
+            arg: Box::from(tpat_to_pat(rest.arg.as_ref(), None)),
+            type_ann,
+        }),
+        types::TPat::Tuple(tuple) => Pat::Array(ArrayPat {
+            span: DUMMY_SP,
+            elems: tuple
+                .elems
+                .iter()
+                .map(|elem| elem.as_ref().map(|elem| tpat_to_pat(elem, None)))
+                .collect(),
+            optional: false,
+            type_ann,
+        }),
+        types::TPat::Object(obj) => {
+            let props: Vec<ObjectPatProp> = obj
+                .props
+                .iter()
+                .map(|prop| {
+                    match prop {
+                        types::TObjectPatProp::KeyValue(kv) => {
+                            ObjectPatProp::KeyValue(KeyValuePatProp {
+                                key: PropName::Ident(build_ident(&kv.key)),
+                                value: Box::from(tpat_to_pat(&kv.value, None)),
+                            })
+                        }
+                        types::TObjectPatProp::Assign(assign) => {
+                            ObjectPatProp::Assign(AssignPatProp {
+                                span: DUMMY_SP,
+                                key: build_ident(&assign.key),
+                                // TODO: handle default values
+                                value: None,
+                            })
+                        }
+                        types::TObjectPatProp::Rest(rest) => ObjectPatProp::Rest(RestPat {
+                            span: DUMMY_SP,
+                            dot3_token: DUMMY_SP,
+                            arg: Box::from(tpat_to_pat(rest.arg.as_ref(), None)),
+                            type_ann: None,
+                        }),
+                    }
+                })
+                .collect();
+            Pat::Object(ObjectPat {
+                span: DUMMY_SP,
+                props,
+                optional: false,
+                type_ann,
+            })
+        }
+        types::TPat::Lit(_) => todo!(),
+        types::TPat::Is(_) => todo!(),
+        types::TPat::Wildcard => todo!(),
+    }
+}
+
+pub fn pat_to_fn_param(param: &types::FuncParam, pat: Pat) -> TsFnParam {
+    match pat {
+        Pat::Ident(bi) => {
+            let id = Ident {
+                optional: param.optional,
+                ..bi.id
+            };
+            TsFnParam::Ident(BindingIdent { id, ..bi })
+        }
+        Pat::Array(array) => TsFnParam::Array(array),
+        Pat::Rest(rest) => TsFnParam::Rest(rest),
+        Pat::Object(obj) => TsFnParam::Object(obj),
+        Pat::Assign(_) => todo!(),
+        Pat::Invalid(_) => todo!(),
+        Pat::Expr(_) => todo!(),
+    }
+}
+
+pub fn build_ts_fn_type_with_params(
+    params: &[types::FuncParam],
+    ret: &Index,
+    type_params: Option<Box<TsTypeParamDecl>>,
+    ctx: &Context,
+    checker: &Checker,
+) -> TsType {
+    let params: Vec<TsFnParam> = params
+        .iter()
+        .map(|param| {
+            let type_ann = Some(Box::from(build_type_ann(&param.t, ctx, checker)));
+            let pat = tpat_to_pat(&param.pattern, type_ann);
+            pat_to_fn_param(param, pat)
+        })
+        .collect();
+
+    TsType::TsFnOrConstructorType(TsFnOrConstructorType::TsFnType(TsFnType {
+        span: DUMMY_SP,
+        params,
+        type_params,
+        type_ann: Box::from(build_type_ann(ret, ctx, checker)),
+    }))
+}
+
+/// Converts an internal Type to a TsType for eventual export to .d.ts.
+///
+/// `expr` should be the original expression that `t` was inferred
+/// from if it exists.
+pub fn build_type(
+    t: &Index,
+    // type_params: Option<&TsTypeParamDecl>,
+    ctx: &Context,
+    checker: &Checker,
+) -> TsType {
+    let t = &checker.arena[*t];
+    let mutable = false;
+    // let mutable = t.mutable;
+    match &t.kind {
+        types::TypeKind::Variable(types::Variable {
+            id,
+            constraint: _,
+            instance,
+        }) => {
+            if let Some(instance) = instance {
+                return build_type(instance, ctx, checker);
+            }
+
+            // TODO: handle constraints on type variables
+            // This will likely be easier if we stop using type variables for
+            // type parameters.
+            let chars: Vec<_> = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+                .chars()
+                .collect();
+            let id = chars.get(id.to_owned() as usize).unwrap();
+
+            TsType::TsTypeRef(TsTypeRef {
+                span: DUMMY_SP,
+                type_name: TsEntityName::from(Ident {
+                    span: DUMMY_SP,
+                    sym: JsWord::from(format!("{id}")),
+                    optional: false,
+                }),
+                type_params: None,
+            })
+        }
+        types::TypeKind::Keyword(keyword) => {
+            let kind = match keyword {
+                types::Keyword::Null => TsKeywordTypeKind::TsNullKeyword,
+                types::Keyword::Undefined => TsKeywordTypeKind::TsUndefinedKeyword,
+                types::Keyword::Never => TsKeywordTypeKind::TsNeverKeyword,
+                types::Keyword::Unknown => TsKeywordTypeKind::TsUnknownKeyword,
+                // TODO:
+                // types::Keyword::Object => TsKeywordTypeKind::TsObjectKeyword,
+                // types::Keyword::Self_ => return TsType::TsThisType(TsThisType { span: DUMMY_SP }),
+            };
+
+            TsType::TsKeywordType(TsKeywordType {
+                span: DUMMY_SP,
+                kind,
+            })
+        }
+        types::TypeKind::Primitive(primitive) => {
+            let kind = match primitive {
+                types::Primitive::Number => TsKeywordTypeKind::TsNumberKeyword,
+                types::Primitive::Boolean => TsKeywordTypeKind::TsBooleanKeyword,
+                types::Primitive::String => TsKeywordTypeKind::TsNumberKeyword,
+                types::Primitive::Symbol => TsKeywordTypeKind::TsNumberKeyword,
+            };
+
+            TsType::TsKeywordType(TsKeywordType {
+                span: DUMMY_SP,
+                kind,
+            })
+        }
+        types::TypeKind::Literal(lit) => {
+            let lit = match lit {
+                values::Literal::Number(n) => TsLit::Number(Number {
+                    span: DUMMY_SP,
+                    value: n.parse().unwrap(),
+                    raw: Some(Atom::new(n.clone())),
+                }),
+                values::Literal::Boolean(b) => TsLit::Bool(Bool {
+                    span: DUMMY_SP,
+                    value: b.to_owned(),
+                }),
+                values::Literal::String(s) => TsLit::Str(Str {
+                    span: DUMMY_SP,
+                    value: JsWord::from(s.clone()),
+                    raw: None,
+                }),
+                values::Literal::Null => {
+                    return TsType::TsKeywordType(TsKeywordType {
+                        span: DUMMY_SP,
+                        kind: TsKeywordTypeKind::TsNullKeyword,
+                    })
+                }
+                values::Literal::Undefined => {
+                    return TsType::TsKeywordType(TsKeywordType {
+                        span: DUMMY_SP,
+                        kind: TsKeywordTypeKind::TsUndefinedKeyword,
+                    })
+                }
+            };
+
+            TsType::TsLitType(TsLitType {
+                span: DUMMY_SP,
+                lit,
+            })
+        }
+        types::TypeKind::Function(types::Function {
+            params,
+            ret,
+            type_params,
+            throws: _,
+        }) => {
+            let type_params =
+                build_type_params_from_type_params(type_params.as_ref(), ctx, checker);
+            build_ts_fn_type_with_params(params, ret, type_params, ctx, checker)
+        }
+        types::TypeKind::Union(types::Union { types }) => {
+            TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(TsUnionType {
+                span: DUMMY_SP,
+                types: sort_types(types)
+                    .iter()
+                    .map(|t| Box::from(build_type(t, ctx, checker)))
+                    .collect(),
+            }))
+        }
+        types::TypeKind::Intersection(types::Intersection { types }) => {
+            TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsIntersectionType(
+                TsIntersectionType {
+                    span: DUMMY_SP,
+                    types: sort_types(types)
+                        .iter()
+                        .map(|t| Box::from(build_type(t, ctx, checker)))
+                        .collect(),
+                },
+            ))
+        }
+        types::TypeKind::Object(obj) => build_obj_type(obj, ctx, checker),
+        types::TypeKind::Constructor(types::Constructor {
+            name,
+            types: type_args,
+            ..
+        }) => {
+            let mut sym = JsWord::from(name.to_owned());
+            let use_readonly_utility = false;
+
+            if !mutable && !name.ends_with("Constructor") {
+                if let Ok(scheme) = ctx.get_scheme(name) {
+                    if let types::TypeKind::Object(obj) = &checker.arena[scheme.t].kind {
+                        if immutable_obj_type(obj).is_some() {
+                            if name == "RegExp"
+                                || name == "RegExpExecArray"
+                                || name == "RegExpMatchArray"
+                            {
+                                // Don't pre-pend "Readonly" on to these types
+                            } else {
+                                // TODO: keep track of which types are derived from
+                                // .d.ts files and whether or not they have Readonly
+                                // variants like ReadonlyArray, ReadonlySet, etc.
+                                sym = JsWord::from(format!("Readonly{name}"));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Reverse overrides when exporting types
+            let type_args =
+                if type_args.is_empty() || name == "RegExpMatchArray" || name == "RegExp" {
+                    None
+                } else {
+                    // swc's AST calls these type params when really they're type args
+                    Some(Box::from(TsTypeParamInstantiation {
+                        span: DUMMY_SP,
+                        params: type_args
+                            .iter()
+                            .map(|t| Box::from(build_type(t, ctx, checker)))
+                            .collect(),
+                    }))
+                };
+
+            let t = TsType::TsTypeRef(TsTypeRef {
+                span: DUMMY_SP,
+                type_name: TsEntityName::from(Ident {
+                    span: DUMMY_SP,
+                    sym,
+                    optional: false,
+                }),
+                type_params: type_args,
+            });
+
+            // TODO: Write a test that uses this code
+            if use_readonly_utility {
+                TsType::TsTypeRef(TsTypeRef {
+                    span: DUMMY_SP,
+                    type_name: TsEntityName::from(Ident {
+                        span: DUMMY_SP,
+                        sym: JsWord::from("Readonly".to_string()),
+                        optional: false,
+                    }),
+                    type_params: Some(Box::from(TsTypeParamInstantiation {
+                        span: DUMMY_SP,
+                        params: vec![Box::from(t)],
+                    })),
+                })
+            } else {
+                t
+            }
+        }
+        types::TypeKind::Tuple(types::Tuple { types }) => {
+            let type_ann = TsType::TsTupleType(TsTupleType {
+                span: DUMMY_SP,
+                elem_types: types
+                    .iter()
+                    .map(|t| TsTupleElement {
+                        span: DUMMY_SP,
+                        label: None,
+                        ty: Box::from(build_type(t, ctx, checker)),
+                    })
+                    .collect(),
+            });
+
+            if mutable {
+                type_ann
+            } else {
+                TsType::TsTypeOperator(TsTypeOperator {
+                    span: DUMMY_SP,
+                    op: TsTypeOperatorOp::ReadOnly,
+                    type_ann: Box::from(type_ann),
+                })
+            }
+        }
+        types::TypeKind::Array(types::Array { t }) => {
+            let type_ann = TsType::TsArrayType(TsArrayType {
+                span: DUMMY_SP,
+                elem_type: Box::from(build_type(t, ctx, checker)),
+            });
+
+            if mutable {
+                type_ann
+            } else {
+                TsType::TsTypeOperator(TsTypeOperator {
+                    span: DUMMY_SP,
+                    op: TsTypeOperatorOp::ReadOnly,
+                    type_ann: Box::from(type_ann),
+                })
+            }
+        }
+        types::TypeKind::Rest(_) => todo!(),
+        // types::TypeKind::This => TsType::TsThisType(TsThisType { span: DUMMY_SP }),
+        types::TypeKind::KeyOf(types::KeyOf { t }) => TsType::TsTypeOperator(TsTypeOperator {
+            span: DUMMY_SP,
+            op: TsTypeOperatorOp::KeyOf,
+            type_ann: Box::from(build_type(t, ctx, checker)),
+        }),
+        types::TypeKind::IndexedAccess(types::IndexedAccess { obj: object, index }) => {
+            TsType::TsIndexedAccessType(TsIndexedAccessType {
+                span: DUMMY_SP,
+                readonly: false,
+                obj_type: Box::from(build_type(object, ctx, checker)),
+                index_type: Box::from(build_type(index, ctx, checker)),
+            })
+        }
+        types::TypeKind::Conditional(types::Conditional {
+            check: check_type,
+            extends: extends_type,
+            true_type,
+            false_type,
+        }) => TsType::TsConditionalType(TsConditionalType {
+            span: DUMMY_SP,
+            check_type: Box::from(build_type(check_type, ctx, checker)),
+            extends_type: Box::from(build_type(extends_type, ctx, checker)),
+            true_type: Box::from(build_type(true_type, ctx, checker)),
+            false_type: Box::from(build_type(false_type, ctx, checker)),
+        }),
+        types::TypeKind::Infer(types::Infer { name }) => TsType::TsInferType(TsInferType {
+            span: DUMMY_SP,
+            type_param: TsTypeParam {
+                span: DUMMY_SP,
+                name: Ident {
+                    span: DUMMY_SP,
+                    sym: JsWord::from(name.to_string()),
+                    optional: false,
+                },
+                is_in: false,
+                is_out: false,
+                is_const: false, // TODO: find ways to leverage this
+                constraint: None,
+                default: None,
+            },
+        }),
+        types::TypeKind::Wildcard => todo!(),
+        types::TypeKind::Binary(_) => {
+            // Depending on the operator, we'll need to convert this to either
+            // a `number` or `boolean` type.
+            todo!()
+        }
+    }
+}
+
+// TODO: generate separate types for immutable and mutable object types
+fn build_obj_type(obj: &types::Object, ctx: &Context, checker: &Checker) -> TsType {
+    let mut members: Vec<TsTypeElement> = vec![];
+    let mut mapped_types: Vec<TsType> = vec![];
+
+    for elem in &obj.elems {
+        match elem {
+            types::TObjElem::Call(_) => todo!(),
+            types::TObjElem::Constructor(types::TCallable {
+                params,
+                ret,
+                type_params,
+            }) => {
+                let type_params =
+                    build_type_params_from_type_params(type_params.as_ref(), ctx, checker);
+                let params: Vec<TsFnParam> = params
+                    .iter()
+                    .map(|param| {
+                        let type_ann = Some(Box::from(build_type_ann(&param.t, ctx, checker)));
+                        let pat = tpat_to_pat(&param.pattern, type_ann);
+                        pat_to_fn_param(param, pat)
+                    })
+                    .collect();
+
+                let type_elem = TsTypeElement::TsConstructSignatureDecl(TsConstructSignatureDecl {
+                    span: DUMMY_SP,
+                    params,
+                    type_ann: Some(Box::from(build_type_ann(ret, ctx, checker))),
+                    type_params,
+                });
+
+                members.push(type_elem);
+            }
+            types::TObjElem::Prop(prop) => {
+                let key = match &prop.name {
+                    types::TPropKey::StringKey(key) => key.to_owned(),
+                    types::TPropKey::NumberKey(key) => key.to_owned(),
+                };
+
+                match prop.modifier {
+                    // TODO: have separate node types so that we don't have to
+                    // check whether props with modifiers are functions or not
+                    Some(_) => todo!(),
+                    None => {
+                        let type_elem = TsTypeElement::TsPropertySignature(TsPropertySignature {
+                            span: DUMMY_SP,
+                            readonly: false,
+                            key: Box::from(Expr::from(build_ident(&key))),
+                            computed: false,
+                            optional: prop.optional,
+                            init: None,
+                            params: vec![],
+                            type_ann: Some(Box::from(build_type_ann(&prop.t, ctx, checker))),
+                            type_params: None,
+                        });
+                        members.push(type_elem);
+                    }
+                };
+            }
+            types::TObjElem::Mapped(types::MappedType {
+                key,
+                value,
+                target, // TODO: make this an Ident
+                source,
+                // TODO:
+                check: _,
+                extends: _,
+            }) => {
+                let mapped = TsType::TsMappedType(TsMappedType {
+                    span: DUMMY_SP,
+                    readonly: None, // TODO
+                    optional: None, // TODO
+                    name_type: Some(Box::new(build_type(key, ctx, checker))),
+                    type_ann: Some(Box::new(build_type(value, ctx, checker))),
+                    type_param: TsTypeParam {
+                        span: DUMMY_SP,
+                        name: Ident {
+                            span: DUMMY_SP,
+                            sym: JsWord::from(target.to_owned()),
+                            optional: false,
+                        },
+                        is_in: true,
+                        is_out: false,
+                        is_const: false,
+                        constraint: Some(Box::new(build_type(source, ctx, checker))),
+                        default: None, // TODO
+                    },
+                });
+
+                mapped_types.push(mapped);
+            }
+        }
+    }
+
+    // types::TObjElem::Method(types::TMethod {
+    //     name,
+    //     params,
+    //     ret,
+    //     type_params,
+    //     is_mutating: _, // TODO
+    // }) => {
+    //     let key = match name {
+    //         TPropKey::StringKey(key) => key.to_owned(),
+    //         TPropKey::NumberKey(key) => key.to_owned(),
+    //     };
+    //     // TODO: dedupe with build_ts_fn_type_with_params
+    //     let type_params =
+    //         build_type_params_from_type_params(type_params.as_ref(), ctx, checker);
+    //     let params: Vec<TsFnParam> = params
+    //         .iter()
+    //         .map(|param| {
+    //             let type_ann = Some(Box::from(build_type_ann(&param.t, ctx, checker)));
+    //             let pat = tpat_to_pat(&param.pattern, type_ann);
+    //             pat_to_fn_param(param, pat)
+    //         })
+    //         .collect();
+
+    //     Some(TsTypeElement::TsMethodSignature(TsMethodSignature {
+    //         span: DUMMY_SP,
+    //         readonly: false, // `readonly` modifier can't appear on methods
+    //         key: Box::from(Ident {
+    //             span: DUMMY_SP,
+    //             sym: JsWord::from(key),
+    //             optional: false,
+    //         }),
+    //         computed: false,
+    //         optional: false,
+    //         params,
+    //         type_ann: Some(Box::from(build_type_ann(ret, ctx, checker))),
+    //         type_params,
+    //     }))
+    // }
+    // types::TObjElem::Getter(TGetter { name, ret }) => {
+    //     let key = match name {
+    //         TPropKey::StringKey(key) => key.to_owned(),
+    //         TPropKey::NumberKey(key) => key.to_owned(),
+    //     };
+    //     Some(TsTypeElement::TsGetterSignature(TsGetterSignature {
+    //         span: DUMMY_SP,
+    //         readonly: false,
+    //         key: Box::from(Ident {
+    //             span: DUMMY_SP,
+    //             sym: JsWord::from(key),
+    //             optional: false,
+    //         }),
+    //         computed: false,
+    //         optional: false,
+    //         type_ann: Some(Box::from(build_type_ann(ret, ctx, checker))),
+    //     }))
+    // }
+    // types::TObjElem::Setter(TSetter { name, param }) => {
+    //     let key = match name {
+    //         TPropKey::StringKey(key) => key.to_owned(),
+    //         TPropKey::NumberKey(key) => key.to_owned(),
+    //     };
+
+    //     let type_ann = Some(Box::from(build_type_ann(&param.t, ctx, checker)));
+    //     let pat = tpat_to_pat(&param.pattern, type_ann);
+    //     let param = pat_to_fn_param(param, pat);
+
+    //     Some(TsTypeElement::TsSetterSignature(TsSetterSignature {
+    //         span: DUMMY_SP,
+    //         readonly: false,
+    //         key: Box::from(Ident {
+    //             span: DUMMY_SP,
+    //             sym: JsWord::from(key),
+    //             optional: false,
+    //         }),
+    //         param,
+    //         computed: false,
+    //         optional: false,
+    //     }))
+    // }
+    // types::TObjElem::Index(index) => {
+    //     Some(TsTypeElement::TsIndexSignature(TsIndexSignature {
+    //         span: DUMMY_SP,
+    //         readonly: !index.mutable,
+    //         params: vec![TsFnParam::Ident(BindingIdent {
+    //             id: build_ident(&index.key.name),
+    //             type_ann: Some(Box::from(build_type_ann(&index.key.t, ctx, checker))),
+    //         })],
+    //         type_ann: Some(Box::from(build_type_ann(&index.t, ctx, checker))),
+    //         is_static: false,
+    //     }))
+    // }
+
+    if mapped_types.is_empty() {
+        TsType::TsTypeLit(TsTypeLit {
+            span: DUMMY_SP,
+            members,
+        })
+    } else {
+        let mut types = vec![Box::new(TsType::TsTypeLit(TsTypeLit {
+            span: DUMMY_SP,
+            members,
+        }))];
+
+        for mapped_type in mapped_types {
+            types.push(Box::new(mapped_type));
+        }
+
+        TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsIntersectionType(
+            TsIntersectionType {
+                span: DUMMY_SP,
+                types,
+            },
+        ))
+    }
+}
+
+fn build_type_ann(t: &Index, ctx: &Context, checker: &Checker) -> TsTypeAnn {
+    TsTypeAnn {
+        span: DUMMY_SP,
+        type_ann: Box::from(build_type(t, ctx, checker)),
+    }
+}
+
+// TODO: implement this for real
+fn sort_types(types: &[Index]) -> Vec<Index> {
+    types.to_owned()
+    // let mut sorted_types = types.to_owned();
+    // sorted_types.sort_by_key(|a| a.to_string());
+    // sorted_types
+}
+
+pub fn immutable_obj_type(obj: &types::Object) -> Option<types::Object> {
+    let mut changed = false;
+    let elems: Vec<types::TObjElem> = obj
+        .elems
+        .iter()
+        .filter_map(|elem| match elem {
+            types::TObjElem::Call(_) => Some(elem.to_owned()),
+            types::TObjElem::Constructor(_) => Some(elem.to_owned()),
+            // types::TObjElem::Method(method) => {
+            //     if method.is_mutating {
+            //         changed = true;
+            //         None
+            //     } else {
+            //         Some(elem.to_owned())
+            //     }
+            //     // TODO: Convert any `mut Self` to `Self`.  This is going to be
+            //     // a little tricky b/c we need to know the name of the type and
+            //     // in the case of arrays, that it's an array and what its type
+            //     // argument is.
+            // }
+            // types::TObjElem::Getter(_) => Some(elem.to_owned()),
+            // types::TObjElem::Setter(_) => {
+            //     changed = true;
+            //     None
+            // }
+            // types::TObjElem::Index(index) => {
+            //     if index.mutable {
+            //         changed = true;
+            //     }
+            //     Some(types::TObjElem::Index(TIndex {
+            //         mutable: false,
+            //         ..index.to_owned()
+            //     }))
+            // }
+            types::TObjElem::Prop(prop) => {
+                if prop.mutable {
+                    changed = true;
+                }
+                Some(types::TObjElem::Prop(types::TProp {
+                    mutable: false,
+                    ..prop.to_owned()
+                }))
+            }
+            types::TObjElem::Mapped(_) => todo!(),
+        })
+        .collect();
+
+    if changed {
+        Some(types::Object {
+            elems,
+            // is_interface: obj.is_interface,
+        })
+    } else {
+        None
+    }
+}
+
+struct BindingsVisitor {
+    pub bindings: Vec<String>,
+}
+
+impl Visitor for BindingsVisitor {
+    fn visit_pattern(&mut self, pattern: &values::Pattern) {
+        if let values::PatternKind::Ident(ident) = &pattern.kind {
+            self.bindings.push(ident.name.to_owned())
+        }
+        values::walk_pattern(self, pattern)
+    }
+}
+
+fn get_bindings(pattern: &values::Pattern) -> Vec<String> {
+    let mut visitor = BindingsVisitor { bindings: vec![] };
+    visitor.visit_pattern(pattern);
+    visitor.bindings
+}

--- a/crates/escalier_codegen/src/js.rs
+++ b/crates/escalier_codegen/src/js.rs
@@ -1,0 +1,1472 @@
+use std::rc::Rc;
+
+use swc_atoms::*;
+use swc_common::comments::SingleThreadedComments;
+use swc_common::hygiene::Mark;
+use swc_common::source_map::{
+    self, DefaultSourceMapGenConfig, FilePathMapping, Globals, DUMMY_SP, GLOBALS,
+};
+use swc_common::{self, BytePos, FileName, SyntaxContext};
+use swc_ecma_ast::*;
+use swc_ecma_codegen::*;
+use swc_ecma_transforms_react::{react, Options, Runtime};
+use swc_ecma_visit::*;
+
+use escalier_ast::{self as values};
+
+pub struct Context {
+    pub temp_id: u32,
+}
+
+impl Context {
+    pub fn new_ident(&mut self) -> Ident {
+        let ident = Ident {
+            span: DUMMY_SP,
+            sym: JsWord::from(format!("$temp_{}", self.temp_id)),
+            optional: false,
+        };
+        self.temp_id += 1;
+        ident
+    }
+}
+
+pub fn codegen_js(src: &str, program: &values::Program) -> (String, String) {
+    let mut ctx = Context { temp_id: 0 };
+    let program = build_js(program, &mut ctx);
+
+    let cm = Rc::new(source_map::SourceMap::default());
+    let comments: Option<SingleThreadedComments> = None;
+    let options = Options {
+        runtime: Some(Runtime::Automatic),
+        ..Default::default()
+    };
+
+    let globals = Globals::default();
+    // The call to Mark::new() must be wrapped in a GLOBALS.set() closure
+    GLOBALS.set(&globals, || {
+        let top_level_mark = Mark::new();
+        let unresolved_mark = Mark::new();
+        let mut v = react(cm, comments, options, top_level_mark, unresolved_mark);
+        let program = program.fold_with(&mut v);
+        print_js(src, &program)
+    })
+}
+
+fn print_js(src: &str, program: &Program) -> (String, String) {
+    let mut buf = vec![];
+    let mut src_map = vec![];
+    let cm = Rc::new(source_map::SourceMap::new(FilePathMapping::empty()));
+
+    cm.new_source_file(FileName::Anon, String::from(src));
+
+    {
+        let wr = text_writer::JsWriter::new(cm.clone(), "\n", &mut buf, Some(&mut src_map));
+        let mut emitter = Emitter {
+            cfg: swc_ecma_codegen::Config {
+                ..Default::default()
+            },
+            cm: cm.clone(),
+            comments: None,
+            wr,
+        };
+        emitter.emit_program(program).unwrap();
+    }
+
+    let output_code = String::from_utf8_lossy(&buf).to_string();
+    let source_map = cm.build_source_map_with_config(&src_map, None, DefaultSourceMapGenConfig);
+
+    let mut source_map_buf: Vec<u8> = vec![];
+    source_map.to_writer(&mut source_map_buf).unwrap();
+
+    (output_code, String::from_utf8(source_map_buf).unwrap())
+}
+
+fn build_js(program: &values::Program, ctx: &mut Context) -> Program {
+    let body: Vec<ModuleItem> = program
+        .stmts
+        .iter()
+        .flat_map(|child| {
+            let mut stmts: Vec<Stmt> = vec![];
+            let result = match &child.kind {
+                values::StmtKind::Let {
+                    pattern,
+                    expr: init,
+                    is_declare: declare,
+                    ..
+                } => match declare {
+                    true => ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP })),
+                    false => {
+                        // It should be okay to unwrap this here since any decl that isn't
+                        // using `declare` should have an initial value.
+                        let init = init.as_ref().unwrap();
+
+                        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                            span: DUMMY_SP,
+                            decl: Decl::Var(Box::from(build_var_decl(
+                                pattern,
+                                Some(init),
+                                &mut stmts,
+                                ctx,
+                            ))),
+                        }))
+                    }
+                },
+                values::StmtKind::TypeDecl { .. } => {
+                    ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP }))
+                }
+                values::StmtKind::Expr { expr } => ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                    span: DUMMY_SP,
+                    expr: Box::from(build_expr(expr, &mut stmts, ctx)),
+                })),
+                // values::StmtKind::ClassDecl(values::ClassDecl { class, ident, .. }) => {
+                //     let ident = Ident::from(ident);
+                //     let class = build_class(class, &mut stmts, ctx);
+
+                //     ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl {
+                //         ident,
+                //         class: Box::from(class),
+                //         declare: false,
+                //     })))
+                // }
+
+                // values::StmtKind::ForStmt(for_stmt) => ModuleItem::Stmt(Stmt::ForOf(ForOfStmt {
+                //     span: DUMMY_SP,
+                //     is_await: false,
+                //     left: ForHead::VarDecl(Box::from(build_var_decl(
+                //         &for_stmt.pattern,
+                //         None,
+                //         &mut stmts,
+                //         ctx,
+                //     ))),
+                //     right: Box::from(build_expr(&for_stmt.expr, &mut stmts, ctx)),
+                //     body: Box::from(Stmt::Block(build_body_block_stmt(
+                //         &for_stmt.body,
+                //         &BlockFinalizer::ExprStmt,
+                //         ctx,
+                //     ))),
+                // })),
+                values::StmtKind::Return { .. } => {
+                    panic!("return statements aren't allowed at the top level")
+                }
+            };
+
+            let mut items: Vec<ModuleItem> = stmts
+                .iter()
+                .map(|stmt| ModuleItem::Stmt(stmt.to_owned()))
+                .collect();
+            items.push(result);
+
+            items
+        })
+        .collect();
+
+    Program::Module(Module {
+        span: DUMMY_SP,
+        body,
+        shebang: None,
+    })
+}
+
+fn build_var_decl(
+    pattern: &values::Pattern,
+    init: Option<&values::Expr>,
+    stmts: &mut Vec<Stmt>,
+    ctx: &mut Context,
+) -> VarDecl {
+    VarDecl {
+        span: DUMMY_SP,
+        kind: VarDeclKind::Const,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name: build_pattern(pattern, stmts, ctx).unwrap(),
+            init: init.map(|init| Box::from(build_expr(init, stmts, ctx))),
+            definite: false,
+        }],
+    }
+}
+
+// TODO: See if we can avoid returning an Option<> here so that we don't have
+// to unwrap() in when calling it from build_expr().
+fn build_pattern(
+    pattern: &values::Pattern,
+    stmts: &mut Vec<Stmt>,
+    ctx: &mut Context,
+) -> Option<Pat> {
+    let span = swc_common::Span {
+        lo: BytePos(pattern.span.start as u32 + 1),
+        hi: BytePos(pattern.span.end as u32 + 1),
+        ctxt: SyntaxContext::empty(),
+    };
+
+    match &pattern.kind {
+        // unassignable patterns
+        values::PatternKind::Lit(_) => None,
+
+        // TODO: we need to have something we can assign `_` to when it appears
+        // in object destructuring otherwise if there's a `...rest` that's also
+        // in the pattern we'll end up with the wrong items assigned to `rest`.
+        values::PatternKind::Wildcard => Some(Pat::Ident(BindingIdent {
+            id: ctx.new_ident(),
+            type_ann: None,
+        })),
+
+        // assignable patterns
+        values::PatternKind::Ident(binding_ident) => Some(Pat::Ident(BindingIdent {
+            id: Ident::from(binding_ident),
+            type_ann: None,
+        })),
+        values::PatternKind::Rest(values::RestPat { arg }) => {
+            let dot3_token = swc_common::Span {
+                lo: BytePos(pattern.span.start as u32 + 1),
+                hi: BytePos(pattern.span.start as u32 + 4),
+                ctxt: SyntaxContext::empty(),
+            };
+            let arg = build_pattern(arg, stmts, ctx).unwrap();
+            Some(Pat::Rest(RestPat {
+                span,
+                dot3_token,
+                type_ann: None,
+                arg: Box::from(arg),
+            }))
+        }
+        values::PatternKind::Object(values::ObjectPat { props, optional }) => {
+            let props: Vec<ObjectPatProp> = props
+                .iter()
+                .filter_map(|p| match p {
+                    values::ObjectPatProp::KeyValue(kvp) => {
+                        build_pattern(kvp.value.as_ref(), stmts, ctx).map(|value| {
+                            ObjectPatProp::KeyValue(KeyValuePatProp {
+                                key: PropName::Ident(Ident::from(&kvp.key)),
+                                value: Box::from(value),
+                            })
+                        })
+                    }
+                    values::ObjectPatProp::Shorthand(values::ShorthandPatProp {
+                        ident,
+                        init,
+                        ..
+                    }) => Some(ObjectPatProp::Assign(AssignPatProp {
+                        span: DUMMY_SP,
+                        key: Ident::from(ident),
+                        value: init
+                            .clone()
+                            .map(|value| Box::from(build_expr(&value, stmts, ctx))),
+                    })),
+                    values::ObjectPatProp::Rest(values::RestPat { arg }) => {
+                        let dot3_token = swc_common::Span {
+                            lo: BytePos(pattern.span.start as u32 + 1),
+                            hi: BytePos(pattern.span.start as u32 + 4),
+                            ctxt: SyntaxContext::empty(),
+                        };
+                        let span = swc_common::Span {
+                            lo: BytePos(pattern.span.start as u32 + 1),
+                            hi: BytePos(pattern.span.end as u32 + 1),
+                            ctxt: SyntaxContext::empty(),
+                        };
+                        Some(ObjectPatProp::Rest(RestPat {
+                            span,
+                            dot3_token,
+                            arg: Box::from(build_pattern(arg, stmts, ctx)?),
+                            type_ann: None,
+                        }))
+                    }
+                })
+                .collect();
+
+            Some(Pat::Object(ObjectPat {
+                span,
+                optional: optional.to_owned(),
+                type_ann: None, // because we're generating .js
+                props,
+            }))
+        }
+        values::PatternKind::Tuple(values::TuplePat { elems, optional }) => {
+            let elems: Vec<Option<Pat>> = elems
+                .iter()
+                .map(|elem| match elem {
+                    Some(elem) => build_pattern(&elem.pattern, stmts, ctx),
+                    None => None,
+                })
+                .collect();
+
+            // TODO: If all elems are None, we can drop the array pattern.
+            Some(Pat::Array(ArrayPat {
+                span,
+                elems,
+                optional: optional.to_owned(),
+                type_ann: None, // because we're generating .js.
+            }))
+        }
+        values::PatternKind::Is(values::IsPat { ident, .. }) => Some(Pat::Ident(BindingIdent {
+            id: Ident::from(ident),
+            type_ann: None,
+        })),
+    }
+}
+
+fn build_expr(expr: &values::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Expr {
+    let span = swc_common::Span {
+        lo: BytePos(expr.span.start as u32 + 1),
+        hi: BytePos(expr.span.end as u32 + 1),
+        ctxt: SyntaxContext::empty(),
+    };
+
+    match &expr.kind {
+        values::ExprKind::Call(values::Call {
+            callee: lam, args, ..
+        }) => {
+            let callee = Callee::Expr(Box::from(build_expr(lam.as_ref(), stmts, ctx)));
+
+            let args: Vec<ExprOrSpread> = args
+                .iter()
+                // TODO: Support spreading args when calling functions
+                .map(|arg| ExprOrSpread {
+                    // spread: if arg.spread.is_some() {
+                    //     Some(DUMMY_SP)
+                    // } else {
+                    //     None
+                    // },
+                    spread: None,
+                    expr: Box::from(build_expr(arg, stmts, ctx)),
+                })
+                .collect();
+
+            Expr::Call(CallExpr {
+                span,
+                callee,
+                args,
+                type_args: None,
+            })
+        }
+        // TODO: Support `Point::new(5, 10)` -> `new Point(5, 10)`.
+        // values::ExprKind::New(values::New { expr, args, .. }) => {
+        //     let callee = Box::from(build_expr(expr.as_ref(), stmts, ctx));
+
+        //     let args: Vec<ExprOrSpread> = args
+        //         .iter()
+        //         .map(|arg| ExprOrSpread {
+        //             spread: if arg.spread.is_some() {
+        //                 Some(DUMMY_SP)
+        //             } else {
+        //                 None
+        //             },
+        //             expr: Box::from(build_expr(arg.expr.as_ref(), stmts, ctx)),
+        //         })
+        //         .collect();
+
+        //     Expr::New(NewExpr {
+        //         span,
+        //         callee,
+        //         args: Some(args), // JavaScript allows `new Array`, but we don't
+        //         type_args: None,
+        //     })
+        // }
+        values::ExprKind::Ident(ident) => Expr::from(Ident::from(ident)),
+        values::ExprKind::Function(values::Function {
+            params: args,
+            body,
+            is_async,
+            ..
+        }) => {
+            let params: Vec<Pat> = args
+                .iter()
+                .map(|arg| build_pattern(&arg.pattern, stmts, ctx).unwrap())
+                .collect();
+
+            let body = match body {
+                values::BlockOrExpr::Block(body) => BlockStmtOrExpr::BlockStmt(
+                    build_body_block_stmt(body, &BlockFinalizer::ExprStmt, ctx),
+                ),
+                values::BlockOrExpr::Expr(expr) => {
+                    BlockStmtOrExpr::Expr(Box::from(build_expr(expr, stmts, ctx)))
+                }
+            };
+
+            Expr::Arrow(ArrowExpr {
+                span,
+                params,
+                body: Box::new(body),
+                is_async: is_async.to_owned(),
+                is_generator: false,
+                type_params: None,
+                return_type: None,
+            })
+        }
+        values::ExprKind::Assign(values::Assign { left, right, op: _ }) => {
+            // TODO: handle other operators
+            Expr::Assign(AssignExpr {
+                span,
+                left: PatOrExpr::Expr(Box::from(build_expr(left, stmts, ctx))),
+                right: Box::from(build_expr(right, stmts, ctx)),
+                op: AssignOp::Assign,
+            })
+        }
+        // values::ExprKind::Literal(lit) => Expr::from(lit),
+        values::ExprKind::Str(values::Str { value, .. }) => Expr::Lit(Lit::Str(Str {
+            span,
+            value: swc_atoms::JsWord::from(value.as_str()),
+            raw: None,
+        })),
+        values::ExprKind::Num(values::Num { value, .. }) => Expr::Lit(Lit::Num(Number {
+            span,
+            value: value.parse().unwrap(),
+            raw: None,
+        })),
+        values::ExprKind::Bool(values::Bool { value, .. }) => Expr::Lit(Lit::Bool(Bool {
+            span,
+            value: *value,
+        })),
+        // values::ExprKind::Keyword(keyword) => match keyword {
+        //     values::Keyword::Null => {
+        //         swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Null(swc_ecma_ast::Null { span }))
+        //     }
+        //     values::Keyword::Undefined => {
+        //         // NOTE: `undefined` is actually an identifier in JavaScript.
+        //         swc_ecma_ast::Expr::Ident(swc_ecma_ast::Ident {
+        //             span,
+        //             sym: swc_atoms::JsWord::from(String::from("undefined")),
+        //             optional: false,
+        //         })
+        //     }
+        //     _ => panic!("{keyword} should only be used as a type"),
+        // },
+        values::ExprKind::Null(_) => {
+            swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Null(swc_ecma_ast::Null { span }))
+        }
+        values::ExprKind::Undefined(_) => {
+            // NOTE: `undefined` is actually an identifier in JavaScript.
+            swc_ecma_ast::Expr::Ident(swc_ecma_ast::Ident {
+                span,
+                sym: swc_atoms::JsWord::from(String::from("undefined")),
+                optional: false,
+            })
+        }
+        values::ExprKind::Binary(values::Binary {
+            op, left, right, ..
+        }) => {
+            let op = match op {
+                values::BinaryOp::Plus => BinaryOp::Add,
+                values::BinaryOp::Minus => BinaryOp::Sub,
+                values::BinaryOp::Times => BinaryOp::Mul,
+                values::BinaryOp::Divide => BinaryOp::Div,
+                values::BinaryOp::Equals => BinaryOp::EqEqEq,
+                values::BinaryOp::NotEquals => BinaryOp::NotEqEq,
+                values::BinaryOp::LessThan => BinaryOp::Lt,
+                values::BinaryOp::LessThanOrEqual => BinaryOp::LtEq,
+                values::BinaryOp::GreaterThan => BinaryOp::Gt,
+                values::BinaryOp::GreaterThanOrEqual => BinaryOp::GtEq,
+                _ => todo!(),
+            };
+
+            let left = Box::from(build_expr(left, stmts, ctx));
+
+            let wrap_left = match left.as_ref() {
+                Expr::Bin(left) => left.op.precedence() < op.precedence(),
+                _ => false,
+            };
+
+            let right = Box::from(build_expr(right, stmts, ctx));
+
+            let wrap_right = match right.as_ref() {
+                Expr::Bin(right) => match (op, right.op) {
+                    (BinaryOp::Div, BinaryOp::Div) => true,
+                    (BinaryOp::Sub, BinaryOp::Sub) => true,
+                    _ => right.op.precedence() < op.precedence(),
+                },
+                _ => false,
+            };
+
+            Expr::Bin(BinExpr {
+                span,
+                op,
+                left: if wrap_left {
+                    Box::from(Expr::Paren(ParenExpr {
+                        span: DUMMY_SP,
+                        expr: left,
+                    }))
+                } else {
+                    left
+                },
+                right: if wrap_right {
+                    Box::from(Expr::Paren(ParenExpr {
+                        span: DUMMY_SP,
+                        expr: right,
+                    }))
+                } else {
+                    right
+                },
+            })
+        }
+        values::ExprKind::Unary(values::Unary { right: arg, op, .. }) => {
+            let op = match op {
+                values::UnaryOp::Minus => UnaryOp::Minus,
+                values::UnaryOp::Not => todo!(),
+                values::UnaryOp::Plus => todo!(),
+            };
+
+            Expr::Unary(UnaryExpr {
+                span,
+                op,
+                arg: Box::from(build_expr(arg, stmts, ctx)),
+            })
+        }
+        // values::ExprKind::Fix(values::Fix { expr, .. }) => match &expr.kind {
+        //     values::ExprKind::Lambda(values::Lambda { body, .. }) => match body {
+        //         values::BlockOrExpr::Expr(expr) => build_expr(expr, stmts, ctx),
+        //         values::BlockOrExpr::Block(_) => panic!("Invalid recursive function"),
+        //     },
+        //     _ => panic!("Fix should only wrap a lambda"),
+        // },
+        values::ExprKind::IfElse(values::IfElse {
+            cond,
+            consequent,
+            alternate,
+            ..
+        }) => {
+            // let $temp_n;
+            let temp_id = ctx.new_ident();
+            let temp_decl = build_let_decl_stmt(&temp_id);
+            stmts.push(temp_decl);
+
+            let finalizer = BlockFinalizer::Assign(temp_id.clone());
+
+            // if (cond) { ...; $temp_n = <cons_res> } else { ...; $temp_n = <alt_res> }
+            let test = Box::from(build_expr(cond.as_ref(), stmts, ctx));
+            let cons = Box::from(Stmt::Block(build_body_block_stmt(
+                consequent, &finalizer, ctx,
+            )));
+            let alt = alternate.as_ref().map(|alt| {
+                let block = match alt {
+                    values::BlockOrExpr::Block(alt) => {
+                        Stmt::Block(build_body_block_stmt(alt, &finalizer, ctx))
+                    }
+                    values::BlockOrExpr::Expr(_) => todo!(),
+                };
+                Box::from(block)
+            });
+            stmts.push(Stmt::If(IfStmt {
+                span,
+                test,
+                cons,
+                alt,
+            }));
+
+            // $temp_n
+            Expr::Ident(temp_id)
+        }
+        values::ExprKind::Object(values::Object { properties: props }) => {
+            let props: Vec<PropOrSpread> = props
+                .iter()
+                .map(|prop| match prop {
+                    values::PropOrSpread::Prop(prop) => match prop {
+                        values::expr::Prop::Shorthand(ident) => {
+                            PropOrSpread::Prop(Box::from(Prop::Shorthand(Ident::from(ident))))
+                        }
+                        values::expr::Prop::Property { key, value } => {
+                            PropOrSpread::Prop(Box::from(Prop::KeyValue(KeyValueProp {
+                                key: prop_name_from_object_key(key, ctx),
+                                value: Box::from(build_expr(value, stmts, ctx)),
+                            })))
+                        }
+                    },
+                    values::PropOrSpread::Spread(_) => todo!(),
+                })
+                .collect();
+
+            Expr::Object(ObjectLit { span, props })
+        }
+        values::ExprKind::Await(values::Await { arg: expr, .. }) => Expr::Await(AwaitExpr {
+            span,
+            arg: Box::from(build_expr(expr.as_ref(), stmts, ctx)),
+        }),
+        values::ExprKind::JSXElement(elem) => {
+            Expr::JSXElement(Box::from(build_jsx_element(elem, stmts, ctx)))
+        }
+        values::ExprKind::JSXFragment(_) => todo!(),
+        values::ExprKind::Tuple(values::Tuple { elements: elems }) => Expr::Array(ArrayLit {
+            span,
+            elems: elems
+                .iter()
+                .map(|elem| match elem {
+                    values::ExprOrSpread::Expr(expr) => Some(ExprOrSpread {
+                        spread: None,
+                        expr: Box::from(build_expr(expr, stmts, ctx)),
+                    }),
+                    values::ExprOrSpread::Spread(spread) => Some(ExprOrSpread {
+                        spread: Some(DUMMY_SP),
+                        expr: Box::from(build_expr(spread, stmts, ctx)),
+                    }),
+                })
+                .collect(),
+        }),
+        values::ExprKind::Member(values::Member {
+            object: obj,
+            property: prop,
+            ..
+        }) => {
+            let prop = match prop {
+                values::MemberProp::Ident(ident) => MemberProp::Ident(Ident::from(ident)),
+                values::MemberProp::Computed(values::ComputedPropName { expr, .. }) => {
+                    MemberProp::Computed(ComputedPropName {
+                        span: DUMMY_SP,
+                        expr: Box::from(build_expr(expr, stmts, ctx)),
+                    })
+                }
+            };
+            Expr::Member(MemberExpr {
+                span,
+                obj: Box::from(build_expr(obj, stmts, ctx)),
+                prop,
+            })
+        }
+        // values::ExprKind::Empty => Expr::from(Ident {
+        //     span,
+        //     sym: JsWord::from("undefined"),
+        //     optional: false,
+        // }),
+        // values::ExprKind::LetExpr(_) => {
+        //     panic!("LetExpr should always be handled by the IfElse branch")
+        // }
+        values::ExprKind::TemplateLiteral(template) => {
+            Expr::Tpl(build_template_literal(template, stmts, ctx))
+        }
+        // TODO: support tagged templates
+        // values::ExprKind::TaggedTemplateLiteral(values::TaggedTemplateLiteral {
+        //     tag,
+        //     template,
+        // }) => {
+        //     Expr::TaggedTpl(TaggedTpl {
+        //         span,
+        //         tag: Box::from(Expr::Ident(Ident::from(tag))),
+        //         type_params: None, // TODO: support type params on tagged templates
+
+        //         tpl: Box::new(build_template_literal(template, stmts, ctx)),
+        //     })
+        // }
+        values::ExprKind::Match(values::Match { expr, arms, .. }) => {
+            // let $temp_n;
+            let ret_temp_id = ctx.new_ident();
+            let ret_decl = build_let_decl_stmt(&ret_temp_id);
+            stmts.push(ret_decl);
+
+            // let $temp_m = <expr>
+            let temp_id = ctx.new_ident();
+            let temp_decl = build_const_decl_stmt(&temp_id, build_expr(expr, stmts, ctx));
+            stmts.push(temp_decl);
+
+            // TODO: we want to stop when we encounter the first
+            // irrefutable pattern since all subsequent patterns
+            // shouldn't be matched.
+            let mut has_catchall: bool = false;
+            let mut built_arms: Vec<(_, _)> = vec![];
+            for arm in arms {
+                if has_catchall {
+                    panic!("Catchall must appear last in match");
+                }
+
+                let (cond, block) = build_arm(arm, &temp_id, &ret_temp_id, stmts, ctx);
+
+                if cond.is_none() {
+                    has_catchall = true
+                }
+
+                built_arms.push((cond, block));
+            }
+
+            // We reverse the order of the arms because when building
+            // an if/else-if/else chain we need to start with the `else`
+            // and work our way back to the initial `if`.
+            built_arms.reverse();
+            let mut iter = built_arms.iter();
+            let first = match iter.next() {
+                Some((cond, block)) => match cond {
+                    Some(cond) => Stmt::If(IfStmt {
+                        span: DUMMY_SP,
+                        test: Box::from(cond.to_owned()),
+                        cons: Box::from(Stmt::Block(block.to_owned())),
+                        alt: None,
+                    }),
+                    None => Stmt::Block(block.to_owned()),
+                },
+                None => panic!("No arms in match"),
+            };
+
+            let if_else = iter.fold(first, |prev, (cond, block)| {
+                Stmt::If(IfStmt {
+                    span,
+                    test: Box::from(cond.to_owned().unwrap()),
+                    cons: Box::from(Stmt::Block(block.to_owned())),
+                    alt: Some(Box::from(prev)),
+                })
+            });
+
+            stmts.push(if_else);
+
+            // $temp_n
+            Expr::Ident(ret_temp_id)
+        }
+        values::ExprKind::Class(class) => {
+            let ident = Some(Ident::from(&values::Ident {
+                name: "TODO".to_string(),
+                span: values::Span { start: 0, end: 0 },
+            }));
+            let class = build_class(class, stmts, ctx);
+
+            Expr::Class(ClassExpr {
+                ident,
+                class: Box::from(class),
+            })
+        }
+        // values::ExprKind::Regex(regex) => Expr::Lit(Lit::Regex(Regex {
+        //     span,
+        //     exp: Atom::new(regex.pattern.as_ref()),
+        //     flags: match &regex.flags {
+        //         Some(flags) => Atom::new(flags.as_ref()),
+        //         None => Atom::new(""),
+        //     },
+        // })),
+        values::ExprKind::Do(do_expr) => {
+            let temp_id = ctx.new_ident();
+            let temp_decl = build_let_decl_stmt(&temp_id);
+            stmts.push(temp_decl);
+
+            let finalizer = BlockFinalizer::Assign(temp_id.clone());
+
+            let block_stmt = build_body_block_stmt(&do_expr.body, &finalizer, ctx);
+            stmts.push(Stmt::Block(block_stmt));
+
+            Expr::Ident(temp_id)
+        }
+        values::ExprKind::Try(_) => todo!(),
+        values::ExprKind::Yield(_) => todo!(),
+        values::ExprKind::Throw(_) => todo!(),
+    }
+}
+
+fn prop_name_from_object_key(key: &values::ObjectKey, ctx: &mut Context) -> PropName {
+    match key {
+        values::ObjectKey::Ident(ident) => PropName::Ident(Ident::from(ident)),
+        values::ObjectKey::String(string) => PropName::Str(Str {
+            span: DUMMY_SP,
+            value: JsWord::from(string.to_owned()),
+            raw: None,
+        }),
+        values::ObjectKey::Number(number) => PropName::Num(Number {
+            span: DUMMY_SP,
+            value: number.parse().unwrap(),
+            raw: None,
+        }),
+        values::ObjectKey::Computed(expr) => PropName::Computed(ComputedPropName {
+            span: DUMMY_SP,
+            expr: Box::from(build_expr(expr, &mut vec![], ctx)),
+        }),
+    }
+}
+
+enum BlockFinalizer {
+    ExprStmt,
+    Assign(Ident),
+}
+
+fn build_finalizer(expr: &Expr, finalizer: &BlockFinalizer) -> Stmt {
+    match &finalizer {
+        BlockFinalizer::Assign(id) => Stmt::Expr(ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::from(Expr::Assign(AssignExpr {
+                span: DUMMY_SP,
+                op: AssignOp::Assign,
+                left: PatOrExpr::Pat(Box::from(Pat::Ident(BindingIdent {
+                    id: id.to_owned(),
+                    type_ann: None,
+                }))),
+                right: Box::from(expr.to_owned()),
+            })),
+        }),
+        BlockFinalizer::ExprStmt => Stmt::Expr(ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::from(expr.to_owned()),
+        }),
+    }
+}
+
+// NOTE: If an identifier has been specified in `assign_id` the last statement
+// in the block will assign the final expression to that identifier.  If it's
+// `None`, the last statement will be an actual return statement returning the
+// final expression.
+fn build_body_block_stmt(
+    body: &values::Block,
+    finalizer: &BlockFinalizer,
+    ctx: &mut Context,
+) -> BlockStmt {
+    let mut new_stmts: Vec<Stmt> = vec![];
+    let len = body.stmts.len();
+
+    for (i, stmt) in body.stmts.iter().enumerate() {
+        match &stmt.kind {
+            values::StmtKind::Let {
+                pattern,
+                type_ann: _,
+                expr: Some(init),
+                is_declare: _,
+                ..
+            } => {
+                let stmt = match build_pattern(pattern, &mut new_stmts, ctx) {
+                    Some(name) => {
+                        build_const_decl_stmt_with_pat(name, build_expr(init, &mut new_stmts, ctx))
+                    }
+                    None => todo!(),
+                };
+                new_stmts.push(stmt);
+            }
+            values::StmtKind::Expr { expr } => {
+                let expr = build_expr(expr, &mut new_stmts, ctx);
+                let stmt = if i == len - 1 {
+                    build_finalizer(&expr, finalizer)
+                } else {
+                    Stmt::Expr(ExprStmt {
+                        span: DUMMY_SP,
+                        expr: Box::from(expr),
+                    })
+                };
+                new_stmts.push(stmt);
+            }
+            // values::StmtKind::Class { class, ident, .. } => {
+            //     let ident = Ident::from(ident);
+            //     let class = build_class(class, &mut new_stmts, ctx);
+            //     let stmt = Stmt::Decl(Decl::Class(ClassDecl {
+            //         ident,
+            //         class: Box::from(class),
+            //         declare: false,
+            //     }));
+            //     new_stmts.push(stmt);
+            // }
+            // values::StmtKind::ForStmt(for_stmt) => {
+            //     let stmt = Stmt::ForOf(ForOfStmt {
+            //         span: DUMMY_SP,
+            //         is_await: false,
+            //         left: ForHead::VarDecl(Box::from(build_var_decl(
+            //             &for_stmt.pattern,
+            //             None,
+            //             &mut new_stmts,
+            //             ctx,
+            //         ))),
+            //         right: Box::from(build_expr(&for_stmt.expr, &mut new_stmts, ctx)),
+            //         body: Box::from(Stmt::Block(build_body_block_stmt(
+            //             &for_stmt.body,
+            //             &BlockFinalizer::ExprStmt,
+            //             ctx,
+            //         ))),
+            //     });
+            //     new_stmts.push(stmt);
+            // }
+            values::StmtKind::Return { arg } => {
+                let stmt = Stmt::Return(ReturnStmt {
+                    span: DUMMY_SP,
+                    arg: arg
+                        .as_ref()
+                        .map(|arg| Box::from(build_expr(arg, &mut new_stmts, ctx))),
+                });
+                new_stmts.push(stmt);
+            }
+
+            // Types are ignored when generating .js code.
+            values::StmtKind::TypeDecl { .. } => (),
+            // Variable declarations that use `declare` are ignored as well.
+            values::StmtKind::Let { .. } => (),
+        }
+    }
+
+    if body.stmts.is_empty() {
+        let undefined = swc_ecma_ast::Expr::Ident(swc_ecma_ast::Ident {
+            span: DUMMY_SP,
+            sym: swc_atoms::JsWord::from(String::from("undefined")),
+            optional: false,
+        });
+        match finalizer {
+            BlockFinalizer::ExprStmt => (),
+            _ => new_stmts.push(build_finalizer(&undefined, finalizer)),
+        }
+    }
+
+    BlockStmt {
+        span: DUMMY_SP,
+        stmts: new_stmts,
+    }
+}
+
+// fn build_let_expr(
+//     let_expr: &values::LetExpr,
+//     consequent: &values::Block,
+//     alternate: Option<&values::Block>,
+//     stmts: &mut Vec<Stmt>,
+//     ctx: &mut Context,
+// ) -> Expr {
+//     let LetExpr { pat, expr, .. } = let_expr;
+
+//     let ret_id = ctx.new_ident();
+//     let ret_decl = build_let_decl_stmt(&ret_id);
+//     stmts.push(ret_decl);
+
+//     let temp_id = ctx.new_ident();
+//     let temp_decl = build_const_decl_stmt(&temp_id, build_expr(expr, stmts, ctx));
+//     stmts.push(temp_decl);
+
+//     let cond = build_cond_for_pat(pat, &temp_id);
+
+//     let finalizer = BlockFinalizer::Assign(ret_id.clone());
+//     let mut block = build_body_block_stmt(consequent, &finalizer, ctx);
+
+//     if let Some(name) = build_pattern(pat, stmts, ctx) {
+//         // TODO: ignore the refutuable patterns when destructuring
+//         let destructure = build_const_decl_stmt_with_pat(name, Expr::from(temp_id));
+//         block.stmts.insert(0, destructure);
+//     }
+
+//     match cond {
+//         Some(cond) => {
+//             let alt = alternate
+//                 .as_ref()
+//                 .map(|alt| Box::from(Stmt::Block(build_body_block_stmt(alt, &finalizer, ctx))));
+//             let if_else = Stmt::If(IfStmt {
+//                 span: DUMMY_SP,
+//                 test: Box::from(cond),
+//                 cons: Box::from(Stmt::Block(block)),
+//                 alt,
+//             });
+//             stmts.push(if_else);
+//         }
+//         None => {
+//             stmts.push(Stmt::Block(block));
+//         }
+//     };
+
+//     Expr::Ident(ret_id)
+// }
+
+fn build_arm(
+    arm: &values::MatchArm,
+    id: &Ident,
+    ret_id: &Ident,
+    stmts: &mut Vec<Stmt>,
+    ctx: &mut Context,
+) -> (Option<Expr>, BlockStmt) {
+    let values::MatchArm {
+        pattern: pat,
+        body,
+        guard,
+        ..
+    } = arm;
+
+    let cond = build_cond_for_pat(pat, id);
+
+    let mut block = match body {
+        values::BlockOrExpr::Block(body) => {
+            build_body_block_stmt(body, &BlockFinalizer::Assign(ret_id.to_owned()), ctx)
+        }
+        values::BlockOrExpr::Expr(_) => todo!(),
+    };
+
+    // If pattern has assignables, assign them
+    if let Some(name) = build_pattern(pat, stmts, ctx) {
+        let destructure = build_const_decl_stmt_with_pat(name, Expr::from(id.to_owned()));
+        block.stmts.insert(0, destructure);
+    }
+
+    let cond = match (cond, guard) {
+        (Some(cond), Some(guard)) => {
+            // If the pattern was refutable and there's a guard then
+            // we return them logically AND-ed together.
+            Some(Expr::Bin(BinExpr {
+                span: DUMMY_SP,
+                op: BinaryOp::LogicalAnd,
+                left: Box::from(cond),
+                right: Box::from(build_expr(guard, stmts, ctx)),
+            }))
+        }
+        (Some(cond), None) => Some(cond),
+        (None, Some(guard)) => Some(build_expr(guard, stmts, ctx)),
+        (None, None) => None,
+    };
+
+    (cond, block)
+}
+
+fn build_jsx_element(
+    elem: &values::JSXElement,
+    stmts: &mut Vec<Stmt>,
+    ctx: &mut Context,
+) -> JSXElement {
+    let name = match &elem.opening.name {
+        values::JSXElementName::Ident(name) => JSXElementName::Ident(Ident {
+            span: DUMMY_SP,
+            sym: JsWord::from(name.name.to_owned()),
+            optional: false,
+        }),
+        values::JSXElementName::JSXMemberExpr(_) => todo!(),
+    };
+
+    let elem = JSXElement {
+        span: DUMMY_SP,
+        opening: JSXOpeningElement {
+            span: DUMMY_SP,
+            name: name.to_owned(),
+            attrs: elem
+                .opening
+                .attrs
+                .iter()
+                .map(|values::JSXAttr { value, name, .. }| {
+                    let value = value.as_ref().map(|val| match val {
+                        values::JSXAttrValue::Str(value) => JSXAttrValue::Lit(Lit::Str(Str {
+                            span: DUMMY_SP,
+                            value: JsWord::from(value.to_owned()),
+                            raw: None,
+                            // Some would include the quotes around the string
+                            // Some(JsWord::from(s.value.to_owned())),
+                        })),
+                        values::JSXAttrValue::ExprContainer(values::JSXExprContainer {
+                            expr,
+                            ..
+                        }) => JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                            span: DUMMY_SP,
+                            expr: JSXExpr::Expr(Box::from(build_expr(expr.as_ref(), stmts, ctx))),
+                        }),
+                    });
+
+                    JSXAttrOrSpread::JSXAttr(JSXAttr {
+                        span: DUMMY_SP,
+                        name: JSXAttrName::Ident(Ident {
+                            span: DUMMY_SP,
+                            sym: JsWord::from(name.to_owned()),
+                            optional: false,
+                        }),
+                        value,
+                    })
+                })
+                .collect(),
+            self_closing: false,
+            type_args: None,
+        },
+        children: elem
+            .children
+            .iter()
+            .map(|child| {
+                let result: JSXElementChild = match child {
+                    values::JSXElementChild::Text(values::JSXText { value, .. }) => {
+                        JSXElementChild::JSXText(JSXText {
+                            span: DUMMY_SP,
+                            value: Atom::new(value.clone()),
+                            raw: Atom::new(value.clone()),
+                        })
+                    }
+                    values::JSXElementChild::ExprContainer(values::JSXExprContainer {
+                        expr,
+                        ..
+                    }) => JSXElementChild::JSXExprContainer(JSXExprContainer {
+                        span: DUMMY_SP,
+                        expr: JSXExpr::Expr(Box::from(build_expr(expr, stmts, ctx))),
+                    }),
+                    values::JSXElementChild::Element(elem) => {
+                        JSXElementChild::JSXElement(Box::from(build_jsx_element(elem, stmts, ctx)))
+                    }
+                    values::JSXElementChild::SpreadChild(_) => todo!(),
+                    values::JSXElementChild::Fragment(_) => todo!(),
+                };
+                result
+            })
+            .collect(),
+        closing: Some(JSXClosingElement {
+            span: DUMMY_SP,
+            name,
+        }),
+    };
+
+    elem
+}
+
+// fn build_lit(lit: &values::Lit) -> Lit {
+//     match lit {
+//         values::Lit::Num(n) => Lit::Num(Number {
+//             span: DUMMY_SP,
+//             value: n.value.parse().unwrap(),
+//             raw: None,
+//         }),
+//         values::Lit::Bool(b) => Lit::Bool(Bool {
+//             span: DUMMY_SP,
+//             value: b.value,
+//         }),
+//         values::Lit::Str(s) => Lit::Str(Str {
+//             span: DUMMY_SP,
+//             value: JsWord::from(s.value.to_owned()),
+//             raw: None,
+//             // Some would include the quotes around the string
+//             // Some(JsWord::from(s.value.to_owned())),
+//         }),
+//     }
+// }
+
+fn build_class(class: &values::Class, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Class {
+    let body: Vec<ClassMember> = class
+        .body
+        .iter()
+        .filter_map(|member| match member {
+            values::ClassMember::Constructor(constructor) => {
+                let body = build_body_block_stmt(&constructor.body, &BlockFinalizer::ExprStmt, ctx);
+                // In Crochet, `self` is always the first param in methods, but
+                // it represents `this` in JavaScript which is implicit so we
+                // ignore it here.
+                let mut iter = constructor.params.iter();
+                iter.next();
+                let params: Vec<ParamOrTsParamProp> = iter
+                    .map(|param| {
+                        let pat = build_pattern(&param.pattern, stmts, ctx).unwrap();
+                        ParamOrTsParamProp::Param(Param {
+                            span: DUMMY_SP,
+                            decorators: vec![],
+                            pat,
+                        })
+                    })
+                    .collect();
+
+                Some(ClassMember::Constructor(Constructor {
+                    span: DUMMY_SP, // TODO
+                    key: PropName::Ident(Ident {
+                        span: DUMMY_SP, // TODO
+                        sym: swc_atoms::JsWord::from(String::from("constructor")),
+                        optional: false,
+                    }),
+                    params,
+                    body: Some(body),
+                    accessibility: None,
+                    is_optional: false,
+                }))
+            }
+            values::ClassMember::Method(method) => {
+                let body = build_body_block_stmt(&method.body, &BlockFinalizer::ExprStmt, ctx);
+
+                // In Escalier, `self` is always the first param in non-static
+                // methods, but it represents `this` in JavaScript which is
+                // implicit so we ignore it here.
+                let mut iter = method.params.iter();
+                // TODO: Check if the first param is `self` and skip over it if it is
+                // if !method.is_static {
+                //     iter.next();
+                // }
+                let params: Vec<Param> = iter
+                    .map(|param| {
+                        let pat = build_pattern(&param.pattern, stmts, ctx).unwrap();
+                        Param {
+                            span: DUMMY_SP,
+                            decorators: vec![],
+                            pat,
+                        }
+                    })
+                    .collect();
+
+                Some(ClassMember::Method(ClassMethod {
+                    span: DUMMY_SP, // TODO
+                    key: prop_name_from_prop_name(&method.name, ctx),
+                    function: Box::from(Function {
+                        params,
+                        decorators: vec![],
+                        span: DUMMY_SP, // TODO
+                        body: Some(body),
+                        is_generator: false,
+                        is_async: false,   // TODO
+                        type_params: None, // TODO
+                        return_type: None,
+                    }),
+                    kind: MethodKind::Method,
+                    is_static: false,
+                    accessibility: None,
+                    is_abstract: false,
+                    is_optional: false,
+                    is_override: false,
+                }))
+            }
+            values::ClassMember::Field(prop) => {
+                if prop.init.is_some() {
+                    Some(ClassMember::ClassProp(ClassProp {
+                        span: DUMMY_SP, // TODO
+                        value: prop
+                            .init
+                            .as_ref()
+                            .map(|value| Box::from(build_expr(value, stmts, ctx))),
+                        key: PropName::Ident(Ident::from(&prop.name)),
+                        type_ann: None,
+                        is_static: false, // TODO,
+                        decorators: vec![],
+                        accessibility: None,
+                        is_abstract: false,
+                        is_optional: false, // TODO,
+                        is_override: false,
+                        readonly: false, // TODO
+                        declare: false,
+                        definite: false,
+                    }))
+                } else {
+                    None
+                }
+            }
+            values::ClassMember::Getter(_) => todo!(),
+            values::ClassMember::Setter(_) => todo!(),
+        })
+        .collect();
+
+    Class {
+        span: DUMMY_SP, // TODO
+        decorators: vec![],
+        super_class: None,
+        is_abstract: false,
+        super_type_params: None,
+        type_params: None,
+        implements: vec![],
+        body,
+    }
+}
+
+fn prop_name_from_prop_name(prop_name: &values::PropName, ctx: &mut Context) -> PropName {
+    match prop_name {
+        values::PropName::Ident(ident) => PropName::Ident(Ident::from(ident)),
+        values::PropName::Computed(expr) => PropName::Computed(ComputedPropName {
+            span: DUMMY_SP,
+            expr: Box::from(build_expr(expr, &mut vec![], ctx)),
+        }),
+    }
+}
+
+fn build_cond_for_pat(_pat: &values::Pattern, _id: &Ident) -> Option<Expr> {
+    // TODO: implmenent `is_refutable`
+    // if values::is_refutable(pat) {
+    //     // Right now the only refutable pattern we support is LitPat.
+    //     // In the future there will be other refutable patterns such as
+    //     // array length, typeof, and instanceof checks.
+
+    //     let mut conds: Vec<Condition> = vec![];
+
+    //     get_conds_for_pat(pat, &mut conds, &mut vec![]);
+
+    //     let mut iter = conds.iter();
+
+    //     let first = match iter.next() {
+    //         Some(cond) => cond_to_expr(cond, id),
+    //         None => return None,
+    //     };
+
+    //     Some(iter.fold(first, |prev, next| {
+    //         Expr::Bin(BinExpr {
+    //             span: DUMMY_SP,
+    //             op: BinaryOp::LogicalOr,
+    //             left: Box::from(prev),
+    //             right: Box::from(cond_to_expr(next, id)),
+    //         })
+    //     }))
+    // } else {
+    //     None
+    // }
+    None
+}
+
+fn build_template_literal(
+    template: &values::TemplateLiteral,
+    stmt: &mut Vec<Stmt>,
+    ctx: &mut Context,
+) -> Tpl {
+    Tpl {
+        span: DUMMY_SP,
+        exprs: template
+            .exprs
+            .iter()
+            .map(|expr| Box::from(build_expr(expr, stmt, ctx)))
+            .collect(),
+        quasis: template
+            .parts
+            .iter()
+            .map(|quasi| {
+                // let cooked = match &quasi.cooked {
+                //     values::Lit::Str(values::Str { value, .. }) => value,
+                //     _ => panic!("quasi.cooked must be a string"),
+                // };
+                // let raw = match &quasi.raw {
+                //     values::Lit::Str(values::Str { value, .. }) => value,
+                //     _ => panic!("quasi.raw must be a string"),
+                // };
+                TplElement {
+                    span: DUMMY_SP,
+                    cooked: Some(Atom::new(quasi.value.clone())),
+                    raw: Atom::new(quasi.value.clone()),
+                    tail: false, // TODO: set this to `true` if it's the last quasi
+                }
+            })
+            .collect(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathElem {
+    ObjProp(String),
+    ArrayIndex(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Check {
+    EqualLit(values::Literal),
+    Typeof(String), // limit this to primitives: "number", "string", "boolean"
+    Instanceof(values::Ident),
+    // TODO: array length
+}
+
+type Path = Vec<PathElem>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Condition {
+    path: Path,
+    check: Check,
+}
+
+fn get_conds_for_pat(pat: &values::Pattern, conds: &mut Vec<Condition>, path: &mut Path) {
+    match &pat.kind {
+        // irrefutable
+        values::PatternKind::Ident(_) => (),
+        values::PatternKind::Rest(_) => (),
+        values::PatternKind::Wildcard => (),
+
+        // refutable and possibly refutable
+        values::PatternKind::Object(values::ObjectPat { props, .. }) => {
+            for prop in props {
+                match prop {
+                    values::ObjectPatProp::KeyValue(values::KeyValuePatProp {
+                        value, key, ..
+                    }) => {
+                        path.push(PathElem::ObjProp(key.name.clone()));
+                        get_conds_for_pat(value, conds, path);
+                        path.pop();
+                    }
+                    values::ObjectPatProp::Shorthand(_) => (),
+                    values::ObjectPatProp::Rest(_) => (),
+                }
+            }
+        }
+        values::PatternKind::Tuple(values::TuplePat { elems, .. }) => {
+            for (index, elem) in elems.iter().enumerate() {
+                path.push(PathElem::ArrayIndex(index as u32));
+                if let Some(elem) = elem {
+                    get_conds_for_pat(&elem.pattern, conds, path);
+                }
+                path.pop();
+            }
+        }
+        values::PatternKind::Lit(values::LitPat { lit, .. }) => {
+            conds.push(Condition {
+                path: path.to_owned(),
+                check: Check::EqualLit(lit.to_owned()),
+            });
+        }
+        values::PatternKind::Is(values::IsPat { is_id, .. }) => match is_id.name.as_ref() {
+            "string" | "number" | "boolean" => {
+                conds.push(Condition {
+                    path: path.to_owned(),
+                    check: Check::Typeof(is_id.name.to_owned()),
+                });
+            }
+            _ => {
+                eprintln!("adding Check::Instanceof condition");
+                conds.push(Condition {
+                    path: path.to_owned(),
+                    check: Check::Instanceof(is_id.to_owned()),
+                });
+            }
+        },
+    }
+}
+
+fn cond_to_expr(cond: &Condition, id: &Ident) -> Expr {
+    let Condition { check, path } = cond;
+
+    let left = path
+        .iter()
+        .fold(Expr::Ident(id.to_owned()), |prev, path_elem| {
+            let prop: MemberProp = match path_elem {
+                PathElem::ObjProp(name) => MemberProp::Ident(Ident {
+                    span: DUMMY_SP,
+                    sym: JsWord::from(name.to_owned()),
+                    optional: false,
+                }),
+                PathElem::ArrayIndex(index) => MemberProp::Computed(ComputedPropName {
+                    span: DUMMY_SP,
+                    expr: Box::from(Expr::Lit(Lit::Num(Number {
+                        span: DUMMY_SP,
+                        value: index.to_owned() as f64,
+                        raw: None,
+                    }))),
+                }),
+            };
+
+            Expr::Member(MemberExpr {
+                span: DUMMY_SP,
+                obj: Box::from(prev),
+                prop,
+            })
+        });
+
+    match check {
+        Check::EqualLit(lit) => Expr::Bin(BinExpr {
+            span: DUMMY_SP,
+            op: BinaryOp::EqEqEq,
+            left: Box::from(left),
+            right: Box::from(Expr::from(lit)),
+        }),
+        Check::Typeof(str) => Expr::Bin(BinExpr {
+            span: DUMMY_SP,
+            op: BinaryOp::EqEqEq,
+            left: Box::from(Expr::Unary(UnaryExpr {
+                span: DUMMY_SP,
+                op: UnaryOp::TypeOf,
+                arg: Box::from(left),
+            })),
+            right: Box::from(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                value: JsWord::from(str.to_owned()),
+                raw: None,
+            }))),
+        }),
+        Check::Instanceof(id) => Expr::Bin(BinExpr {
+            span: DUMMY_SP,
+            op: BinaryOp::InstanceOf,
+            left: Box::from(left),
+            right: Box::from(Expr::Ident(Ident::from(id))),
+        }),
+    }
+}
+
+fn build_const_decl_stmt(id: &Ident, expr: Expr) -> Stmt {
+    build_const_decl_stmt_with_pat(Pat::Ident(BindingIdent::from(id.to_owned())), expr)
+}
+
+fn build_const_decl_stmt_with_pat(name: Pat, expr: Expr) -> Stmt {
+    Stmt::Decl(Decl::Var(Box::from(VarDecl {
+        span: DUMMY_SP,
+        kind: VarDeclKind::Const,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name,
+            init: Some(Box::from(expr)),
+            definite: false,
+        }],
+    })))
+}
+
+fn build_let_decl_stmt(id: &Ident) -> Stmt {
+    Stmt::Decl(Decl::Var(Box::from(VarDecl {
+        span: DUMMY_SP,
+        kind: VarDeclKind::Let,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name: Pat::Ident(BindingIdent::from(id.to_owned())),
+            init: None,
+            definite: false,
+        }],
+    })))
+}

--- a/crates/escalier_codegen/src/lib.rs
+++ b/crates/escalier_codegen/src/lib.rs
@@ -1,5 +1,5 @@
-// pub mod d_ts;
+pub mod d_ts;
 pub mod js;
 
-// pub use d_ts::codegen_d_ts;
+pub use d_ts::codegen_d_ts;
 pub use js::codegen_js;

--- a/crates/escalier_codegen/src/lib.rs
+++ b/crates/escalier_codegen/src/lib.rs
@@ -1,0 +1,5 @@
+// pub mod d_ts;
+pub mod js;
+
+// pub use d_ts::codegen_d_ts;
+pub use js::codegen_js;

--- a/crates/escalier_codegen/tests/codegen_test.rs
+++ b/crates/escalier_codegen/tests/codegen_test.rs
@@ -105,20 +105,18 @@ fn tagged_template_literals() {
     "###);
 }
 
-// TODO: fix parsing of pattern matching, including `if` guards
 #[test]
-#[ignore]
 fn pattern_matching() {
     let src = r#"
     let result = match (count + 1) {
-        0 -> "none",
-        1 -> "one",
-        2 -> "a couple",
-        n if (n < 5) -> {
+        0 => "none",
+        1 => "one",
+        2 => "a couple",
+        n if (n < 5) => {
             console.log(`n = ${n}`)
             "a few"
         },
-        _ -> {
+        _ => {
             console.log("fallthrough")
             "many"
         }
@@ -148,16 +146,14 @@ fn pattern_matching() {
     "###);
 }
 
-// TODO: fix parsing of pattern matching, including `if` guards
 #[test]
-#[ignore]
 fn pattern_matching_with_disjoint_union() {
     let src = r#"
     type Event = {type: "mousedown", x: number, y: number} | {type: "keydown", key: string}
     declare let event: Event
     let result = match (event) {
-        {type: "mousedown", x, y} -> `mousedown: (${x}, ${y})`,
-        {type: "keydown", key} if (key != "Escape") -> key
+        {type: "mousedown", x, y} => `mousedown: (${x}, ${y})`,
+        {type: "keydown", key} if (key != "Escape") => key
     }
     "#;
     let (js, _) = compile(src);
@@ -178,16 +174,14 @@ fn pattern_matching_with_disjoint_union() {
     "###);
 }
 
-// TODO: finish porting codgen_d_ts()
 #[test]
 // TODO: Have a better error message when there's multiple catch-alls
 #[should_panic = "Catchall must appear last in match"]
-#[ignore]
 fn pattern_matching_multiple_catchall_panics() {
     let src = r#"
     let result = match (value) {
-        n -> "foo",
-        _ -> "bar"
+        n => "foo",
+        _ => "bar"
     }
     "#;
 

--- a/crates/escalier_codegen/tests/codegen_test.rs
+++ b/crates/escalier_codegen/tests/codegen_test.rs
@@ -572,7 +572,7 @@ fn function_with_optional_param_and_rest_param() -> Result<(), TypeError> {
     checker.infer_program(&mut program, &mut ctx)?;
     let result = codegen_d_ts(&program, &ctx, &checker)?;
 
-    insta::assert_snapshot!(result, @"export declare const foo: (x?: number, ...y: readonly number[]) => number | undefined;
+    insta::assert_snapshot!(result, @"export declare const foo: (x?: number, ...y: Array<number>) => number;
 ");
 
     Ok(())

--- a/crates/escalier_codegen/tests/codegen_test.rs
+++ b/crates/escalier_codegen/tests/codegen_test.rs
@@ -1,0 +1,1087 @@
+// use escalier_codegen::d_ts::codegen_d_ts;
+use escalier_ast::Program;
+use escalier_codegen::js::codegen_js;
+use escalier_hm::checker::Checker;
+use escalier_hm::context::Context;
+use escalier_hm::type_error::TypeError;
+use escalier_parser::parse;
+
+fn compile(input: &str) -> (String, String) {
+    let program = parse(input).unwrap();
+    codegen_js(input, &program)
+}
+
+fn codegen_d_ts(_program: &Program, _ctx: &Context) -> Result<String, TypeError> {
+    Ok("TODO".to_string())
+}
+
+#[test]
+fn js_print_multiple_decls() {
+    let (js, _) = compile("let foo = \"hello\"\nlet bar = \"world\"");
+
+    insta::assert_snapshot!(js, @r###"
+    export const foo = "hello";
+    export const bar = "world";
+    "###);
+}
+
+#[test]
+fn unary_minus() {
+    let src = r#"
+    let negate = fn (x) => -x
+    "#;
+
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const negate = (x)=>-x;
+");
+}
+
+#[test]
+fn fn_with_block_without_return() {
+    let src = r#"
+    let foo = fn (x, y) {
+        let z = x + y
+        z
+    }
+    "#;
+
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const foo = (x, y)=>{
+        const z = x + y;
+        z;
+    };
+    "###);
+}
+
+#[test]
+fn fn_with_block_with_return() {
+    let src = r#"
+    let foo = fn (x, y) {
+        let z = x + y
+        return z
+    }
+    "#;
+
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const foo = (x, y)=>{
+        const z = x + y;
+        return z;
+    };
+    "###);
+}
+
+#[test]
+fn template_literals() {
+    let src = r#"
+    let a = `hello, world`
+    let p = {x: 5, y: 10}
+    console.log(`p = (${p.x}, ${p.y})`)
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const a = `hello, world`;
+    export const p = {
+        x: 5,
+        y: 10
+    };
+    console.log(`p = (${p.x}, ${p.y})`);
+    "###);
+}
+
+// TODO: add support for tagged template strings
+#[test]
+#[ignore]
+fn tagged_template_literals() {
+    let src = r#"
+    let id = "12345"
+    let query = sql`SELECT * FROM users WHERE id = "${id}"`
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const id = "12345";
+    export const query = sql`SELECT * FROM users WHERE id = "${id}"`;
+    "###);
+}
+
+// TODO: fix parsing of pattern matching, including `if` guards
+#[test]
+#[ignore]
+fn pattern_matching() {
+    let src = r#"
+    let result = match (count + 1) {
+        0 -> "none",
+        1 -> "one",
+        2 -> "a couple",
+        n if (n < 5) -> {
+            console.log(`n = ${n}`)
+            "a few"
+        },
+        _ -> {
+            console.log("fallthrough")
+            "many"
+        }
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    const $temp_1 = count + 1;
+    if ($temp_1 === 0) {
+        $temp_0 = "none";
+    } else if ($temp_1 === 1) {
+        $temp_0 = "one";
+    } else if ($temp_1 === 2) {
+        $temp_0 = "a couple";
+    } else if (n < 5) {
+        const n = $temp_1;
+        console.log(`n = ${n}`);
+        $temp_0 = "a few";
+    } else {
+        const $temp_2 = $temp_1;
+        console.log("fallthrough");
+        $temp_0 = "many";
+    }
+    export const result = $temp_0;
+    "###);
+}
+
+// TODO: fix parsing of pattern matching, including `if` guards
+#[test]
+#[ignore]
+fn pattern_matching_with_disjoint_union() {
+    let src = r#"
+    type Event = {type: "mousedown", x: number, y: number} | {type: "keydown", key: string}
+    declare let event: Event
+    let result = match (event) {
+        {type: "mousedown", x, y} -> `mousedown: (${x}, ${y})`,
+        {type: "keydown", key} if (key != "Escape") -> key
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    ;
+    ;
+    let $temp_0;
+    const $temp_1 = event;
+    if ($temp_1.type === "mousedown") {
+        const { x, y } = $temp_1;
+        $temp_0 = `mousedown: (${x}, ${y})`;
+    } else if ($temp_1.type === "keydown" && key !== "Escape") {
+        const { key } = $temp_1;
+        $temp_0 = key;
+    }
+    export const result = $temp_0;
+    "###);
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+// TODO: Have a better error message when there's multiple catch-alls
+#[should_panic = "Catchall must appear last in match"]
+#[ignore]
+fn pattern_matching_multiple_catchall_panics() {
+    let src = r#"
+    let result = match (value) {
+        n -> "foo",
+        _ -> "bar"
+    }
+    "#;
+
+    compile(src);
+}
+
+#[test]
+#[should_panic = "No arms in match"]
+fn pattern_matching_no_arms_panics() {
+    let src = r#"
+    let result = match (value) {
+    }
+    "#;
+
+    compile(src);
+}
+
+#[test]
+fn simple_if_else() {
+    let src = r#"
+    let result = if (cond) {
+        console.log("true")
+        5
+    } else {
+        console.log("false")
+        10
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    if (cond) {
+        console.log("true");
+        $temp_0 = 5;
+    } else {
+        console.log("false");
+        $temp_0 = 10;
+    }
+    export const result = $temp_0;
+    "###);
+}
+
+#[test]
+fn simple_if_else_inside_fn() {
+    let src = r#"
+    let foo = fn () {
+        let result = if (cond) {
+            console.log("true")
+            5
+        } else {
+            console.log("false")
+            10
+        }
+        return result
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const foo = ()=>{
+        let $temp_0;
+        if (cond) {
+            console.log("true");
+            $temp_0 = 5;
+        } else {
+            console.log("false");
+            $temp_0 = 10;
+        }
+        const result = $temp_0;
+        return result;
+    };
+    "###);
+}
+
+#[test]
+fn simple_if_else_inside_fn_as_expr() {
+    let src = r#"
+    let foo = fn () => if (cond) {
+        console.log("true")
+        5
+    } else {
+        console.log("false")
+        10
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    // TODO: all of this code should be inside the body of
+    // the function, not outside it
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    if (cond) {
+        console.log("true");
+        $temp_0 = 5;
+    } else {
+        console.log("false");
+        $temp_0 = 10;
+    }
+    export const foo = ()=>$temp_0;
+    "###);
+}
+
+#[test]
+fn nested_if_else() {
+    let src = r#"
+    let result = if (c1) {
+        if (c2) {
+            5
+        } else {
+            10
+        }
+    } else {
+        if (c3) {
+            "hello"
+        } else {
+            "world"
+        }
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    if (c1) {
+        let $temp_1;
+        if (c2) {
+            $temp_1 = 5;
+        } else {
+            $temp_1 = 10;
+        }
+        $temp_0 = $temp_1;
+    } else {
+        let $temp_2;
+        if (c3) {
+            $temp_2 = "hello";
+        } else {
+            $temp_2 = "world";
+        }
+        $temp_0 = $temp_2;
+    }
+    export const result = $temp_0;
+    "###);
+}
+
+#[test]
+fn multiple_lets_inside_a_function() {
+    let src = r#"
+    let do_math = fn () {
+        let x = 5
+        let y = 10
+        let result = x + y
+        return result
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const do_math = ()=>{
+        const x = 5;
+        const y = 10;
+        const result = x + y;
+        return result;
+    };
+    "###);
+}
+
+// TODO: do we want to support `if-let`?
+#[test]
+#[ignore]
+fn codegen_if_let_with_rename() {
+    // TODO: don't allow irrefutable patterns to be used with if-let
+    let src = r#"
+    let result = if (let {x: a, y: b} = {x: 5, y: 10}) {
+        a + b
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    const $temp_1 = {
+        x: 5,
+        y: 10
+    };
+    {
+        const { x: a, y: b } = $temp_1;
+        $temp_0 = a + b;
+    }export const result = $temp_0;
+    "###);
+}
+
+// TODO: do we want to support `if-let`?
+#[test]
+#[ignore]
+fn codegen_if_let_refutable_pattern_nested_obj() {
+    let src = r#"
+    let action = {type: "moveto", point: {x: 5, y: 10}}
+    if (let {type: "moveto", point: {x, y}} = action) {
+        x + y
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const action = {
+        type: "moveto",
+        point: {
+            x: 5,
+            y: 10
+        }
+    };
+    let $temp_0;
+    const $temp_1 = action;
+    if ($temp_1.type === "moveto") {
+        const { point: { x, y } } = $temp_1;
+        $temp_0 = x + y;
+    }
+    $temp_0;
+    "###);
+}
+
+// TODO: do we want to support `if-let`?
+#[test]
+#[ignore]
+fn codegen_if_let_with_else() {
+    let src = r#"
+    declare let a: string | number
+    let result = if (let x is number = a) {
+        x + 5
+    } else if (let y is string = a) {
+        y
+    } else {
+        true
+    }
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    ;
+    let $temp_0;
+    const $temp_1 = a;
+    if (typeof $temp_1 === "number") {
+        const x = $temp_1;
+        $temp_0 = x + 5;
+    } else {
+        let $temp_2;
+        const $temp_3 = a;
+        if (typeof $temp_3 === "string") {
+            const y = $temp_3;
+            $temp_2 = y;
+        } else {
+            $temp_2 = true;
+        }
+        $temp_0 = $temp_2;
+    }
+    export const result = $temp_0;
+    "###);
+}
+
+#[test]
+fn codegen_block_with_multiple_non_let_lines() {
+    let src = r#"let result = do {
+        let x = 5
+        x + 0
+        x
+    }"#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    {
+        const x = 5;
+        x + 0;
+        $temp_0 = x;
+    }export const result = $temp_0;
+    "###);
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn destructuring_function_object_params() -> Result<(), TypeError> {
+    let src = r#"
+    let foo = fn ({x, y: b}) => x + b
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const foo = ({ x, y: b })=>x + b;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx).unwrap();
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @r###"
+    export declare const foo: ({ x, y: b }: {
+        readonly x: number;
+        readonly y: number;
+    }) => number;
+    "###);
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn destructuring_function_array_params() -> Result<(), TypeError> {
+    let src = r#"
+    let foo = fn ([a, b]) => a + b
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const foo = ([a, b])=>a + b;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const foo: ([a, b]: readonly [number, number]) => number;
+");
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn function_with_rest_param() -> Result<(), TypeError> {
+    let src = r#"
+    let foo = fn (x: number, ...y: number[]) => x
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const foo = (x, ...y)=>x;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const foo: (x: number, ...y: readonly number[]) => number;
+");
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn function_with_optional_param() -> Result<(), TypeError> {
+    let src = r#"
+    let foo = fn (x: number, y?: number) => x
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const foo = (x, y)=>x;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const foo: (x: number, y?: number) => number;
+");
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn function_with_optional_param_and_rest_param() -> Result<(), TypeError> {
+    let src = r#"
+    let foo = fn (x?: number, ...y: number[]) => x
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const foo = (x, ...y)=>x;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const foo: (x?: number, ...y: readonly number[]) => number | undefined;
+");
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn generic_function() -> Result<(), TypeError> {
+    let src = r#"
+    let fst = fn <T>(a: T, b: T) => a
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const fst = (a, b)=>a;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const fst: <A>(a: A, b: A) => A;
+");
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn constrained_generic_function() -> Result<(), TypeError> {
+    let src = r#"
+    let fst = fn <T extends number | string>(a: T, b: T) => a
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @"export const fst = (a, b)=>a;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const fst: <A extends number | string>(a: A, b: A) => A;
+");
+
+    Ok(())
+}
+
+#[test]
+fn variable_declaration_with_destructuring() -> Result<(), TypeError> {
+    let src = r#"
+    let [x, y] = [5, 10]
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const [x, y] = [
+        5,
+        10
+    ];
+    "###);
+
+    // TODO: Support destructuring in top-level decls
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"TODO");
+
+    Ok(())
+}
+
+#[test]
+fn computed_property() {
+    let src = r#"
+    let p = {x: 5, y: 10}
+    let x = p["x"]
+    let q = [5, 10]
+    let y = q[1]
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const p = {
+        x: 5,
+        y: 10
+    };
+    export const x = p["x"];
+    export const q = [
+        5,
+        10
+    ];
+    export const y = q[1];
+    "###);
+}
+
+// TODO: handle spreading args
+#[test]
+#[ignore]
+fn spread_args() {
+    let src = r#"
+    let add = fn (a, b) => a + b
+    let sum = add(...[5, 10])
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const add = (a, b)=>a + b;
+    export const sum = add(...[
+        5,
+        10
+    ]);
+    "###);
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn mutable_array() -> Result<(), TypeError> {
+    let src = r#"
+    let mut arr: number[] = [1, 2, 3]
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const arr = [
+        1,
+        2,
+        3
+    ];
+    "###);
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const arr: number[];
+");
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+// NOTE: types themselves cannot be mutable, only references to them
+#[test]
+#[ignore]
+fn mutable_obj() -> Result<(), TypeError> {
+    let src = r#"
+    type Point = {x: number, y: number}
+    "#;
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    // This should be:
+    // declare type MutablePoint = {x: number; y: number};
+    // declare type Point = Readonly<{x: number; y: number}>;
+    insta::assert_snapshot!(result, @r###"
+    declare type Point = {
+        x: number;
+        y: number;
+    };
+    declare type ReadonlyPoint = {
+        readonly x: number;
+        readonly y: number;
+    };
+    "###);
+
+    Ok(())
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn mutable_indexer() -> Result<(), TypeError> {
+    let src = r#"
+    type Dict = {mut [key: string]: string}
+    "#;
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @r###"
+    declare type Dict = {
+        [key: string]: string;
+    };
+    declare type ReadonlyDict = {
+        readonly [key: string]: string;
+    };
+    "###);
+
+    Ok(())
+}
+
+// TODO: finish porting class handling code
+#[test]
+#[ignore]
+fn class_with_methods() {
+    let src = r#"
+    class Foo {
+        x: number
+        constructor: fn (self, x) {
+            self.x = x
+        }
+        foo: fn (self, y) {
+            return self.x + y
+        }
+        bar: fn (self, y) {
+            self.x + y
+        }
+    }
+    "#;
+
+    let (js, _srcmap) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    class Foo {
+        constructor(x){
+            self.x = x;
+        }
+        foo(y) {
+            return self.x + y;
+        }
+        bar(y) {
+            self.x + y;
+        }
+    }
+    "###);
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn for_loop() -> Result<(), TypeError> {
+    let src = r#"
+    let mut sum: number = 0
+    for (const num in [1, 2, 3]) {
+        sum = sum + num
+    }
+    "#;
+
+    let (js, _) = compile(src);
+    insta::assert_snapshot!(js, @r###"
+    export const sum = 0;
+    for (const num of [
+        1,
+        2,
+        3
+    ]){
+        sum = sum + num;
+    }
+    "###);
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @r###"export declare const sum: number;
+    "###);
+
+    Ok(())
+}
+
+// TODO: handle for-loops
+#[test]
+#[ignore]
+fn for_loop_inside_fn() -> Result<(), TypeError> {
+    let src = r#"
+    let sum = fn (arr: number[]) {
+        let mut result: number = 0
+        for (const num in arr) {
+            result = result + num
+        }
+        return result
+    };
+    "#;
+
+    let (js, _) = compile(src);
+    insta::assert_snapshot!(js, @r###"
+    export const sum = (arr)=>{
+        const result = 0;
+        for (const num of arr){
+            result = result + num;
+        }
+        return result;
+    };
+    "###);
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    //     let result = codegen_d_ts(&program, &ctx)?;
+
+    //     insta::assert_snapshot!(result, @"export declare const sum: (arr: readonly number[]) => number;
+    // ");
+
+    Ok(())
+}
+
+#[test]
+fn type_decl_inside_block() -> Result<(), TypeError> {
+    let src = r#"
+    let result = do {
+        type Point = {x: number, y: number}
+        let p: Point = {x: 5, y: 10}
+        p.x + p.y
+    }
+    "#;
+
+    let (js, _) = compile(src);
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    {
+        const p = {
+            x: 5,
+            y: 10
+        };
+        $temp_0 = p.x + p.y;
+    }export const result = $temp_0;
+    "###);
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"TODO");
+
+    Ok(())
+}
+
+#[test]
+fn type_decl_inside_block_with_escape() -> Result<(), TypeError> {
+    let src = r#"
+    let result = do {
+        type Point = {x: number, y: number}
+        let p: Point = {x: 5, y: 10}
+        p
+    }
+    "#;
+
+    let (js, _) = compile(src);
+    insta::assert_snapshot!(js, @r###"
+    let $temp_0;
+    {
+        const p = {
+            x: 5,
+            y: 10
+        };
+        $temp_0 = p;
+    }export const result = $temp_0;
+    "###);
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    // TODO: How do we ensure that types defined within a block can't escape?
+    insta::assert_snapshot!(result, @"TODO");
+
+    Ok(())
+}
+
+// TODO: handle class decls
+#[test]
+#[ignore]
+fn class_inside_function() -> Result<(), TypeError> {
+    let src = r#"
+    let foo = fn () {
+        class Point {
+            x: number
+            y: number
+            constructor: fn (self, x, y) {
+                self.x = x
+                self.y = y
+            }
+        }
+        const p = new Point(5, 10)
+        return p
+    }
+    "#;
+
+    let (js, _) = compile(src);
+    insta::assert_snapshot!(js, @r###"
+    export const foo = ()=>{
+        class Point {
+            constructor(x, y){
+                self.x = x;
+                self.y = y;
+            }
+        }
+        const p = new Point(5, 10);
+        return p;
+    };
+    "###);
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const foo: () => Point;
+");
+
+    Ok(())
+}
+
+#[test]
+#[should_panic = "return statements aren't allowed at the top level"]
+fn top_level_return() {
+    let src = r#"
+    return 5
+    "#;
+    let (js, _) = compile(src);
+
+    insta::assert_snapshot!(js, @r###"
+    export const add = (a, b)=>a + b;
+    export const sum = add(...[
+        5,
+        10
+    ]);
+    "###);
+}
+
+// TODO: finish porting codgen_d_ts()
+#[test]
+#[ignore]
+fn multiple_returns_stress_test() -> Result<(), TypeError> {
+    let src = r#"
+    let foo = fn (cond: boolean) {
+        let bar = fn () {
+            if (cond) {
+                return 5
+            }
+        }
+        if (cond) {
+            return bar()
+        }
+        return 10
+    }
+    "#;
+
+    let (js, _) = compile(src);
+    insta::assert_snapshot!(js, @r###"
+    export const foo = (cond)=>{
+        const bar = ()=>{
+            let $temp_0;
+            if (cond) {
+                return 5;
+            }
+            $temp_0;
+        };
+        let $temp_1;
+        if (cond) {
+            return bar();
+        }
+        $temp_1;
+        return 10;
+    };
+    "###);
+
+    let mut program = parse(src).unwrap();
+    let mut checker = Checker::default();
+    let mut ctx = Context::default();
+    checker.infer_program(&mut program, &mut ctx)?;
+    let result = codegen_d_ts(&program, &ctx)?;
+
+    insta::assert_snapshot!(result, @"export declare const foo: (cond: boolean) => 10 | 5;
+");
+
+    Ok(())
+}

--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -39,6 +39,15 @@ impl Context {
             }),
         }
     }
+
+    pub fn get_binding(&self, name: &str) -> Result<Binding, TypeError> {
+        match self.values.get(name) {
+            Some(binding) => Ok(binding.to_owned()),
+            None => Err(TypeError {
+                message: format!("{} is not in scope", name),
+            }),
+        }
+    }
 }
 
 impl Checker {

--- a/crates/escalier_hm/src/folder.rs
+++ b/crates/escalier_hm/src/folder.rs
@@ -72,6 +72,15 @@ pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
 
             TypeKind::Tuple(Tuple { types: new_types })
         }
+        TypeKind::Array(Array { t }) => {
+            let new_t = folder.fold_index(t);
+
+            if new_t == *t {
+                return *index;
+            }
+
+            TypeKind::Array(Array { t: new_t })
+        }
         TypeKind::Keyword(_) => return *index,
         TypeKind::Primitive(_) => return *index,
         TypeKind::Literal(_) => return *index,

--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -91,11 +91,11 @@ impl Checker {
                         match prop_or_spread {
                             PropOrSpread::Spread(_) => todo!(),
                             PropOrSpread::Prop(prop) => match prop {
-                                expr::Prop::Shorthand(ident) => {
+                                expr::Prop::Shorthand(Ident {name, span: _}) => {
                                     prop_types.push(types::TObjElem::Prop(types::TProp {
-                                        name: TPropKey::StringKey(ident.to_owned()),
+                                        name: TPropKey::StringKey(name.to_owned()),
                                         modifier: None,
-                                        t: checker.get_type(ident, ctx)?,
+                                        t: checker.get_type(name, ctx)?,
                                         mutable: false,
                                         optional: false,
                                     }));

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -318,6 +318,11 @@ pub struct Tuple {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Array {
+    pub t: Index,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeyOf {
     pub t: Index,
 }
@@ -369,6 +374,7 @@ pub enum TypeKind {
     Constructor(Constructor), // TODO: rename to TypeRef
     Union(Union),
     Intersection(Intersection),
+    Array(Array),
     Tuple(Tuple),
     Keyword(Keyword),
     Primitive(Primitive),
@@ -426,6 +432,7 @@ impl Checker {
             TypeKind::Tuple(Tuple { types }) => {
                 format!("[{}]", self.print_types(types).join(", "))
             }
+            TypeKind::Array(Array { t }) => format!("{}[]", self.print_type(t)),
             TypeKind::Constructor(Constructor { name, types }) => {
                 if types.is_empty() {
                     name.to_string()

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -723,6 +723,11 @@ impl Checker {
                     message: "tuple is not callable".to_string(),
                 })
             }
+            TypeKind::Array(_) => {
+                return Err(TypeError {
+                    message: "array is not callable".to_string(),
+                })
+            }
             TypeKind::Constructor(Constructor {
                 name,
                 types: type_args,

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -73,6 +73,7 @@ impl Checker {
             TypeKind::Union(Union { types }) => self.occurs_in(v, &types),
             TypeKind::Intersection(Intersection { types }) => self.occurs_in(v, &types),
             TypeKind::Tuple(Tuple { types }) => self.occurs_in(v, &types),
+            TypeKind::Array(Array { t }) => self.occurs_in_type(v, t),
             TypeKind::Constructor(Constructor { types, .. }) => self.occurs_in(v, &types),
             TypeKind::KeyOf(KeyOf { t }) => self.occurs_in_type(v, t),
             TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -33,6 +33,9 @@ pub fn walk_index<V: Visitor>(visitor: &mut V, index: &Index) {
         TypeKind::Tuple(Tuple { types }) => {
             walk_indexes(visitor, types);
         }
+        TypeKind::Array(Array { t }) => {
+            visitor.visit_index(t);
+        }
         TypeKind::Keyword(_) => (),
         TypeKind::Primitive(_) => (),
         TypeKind::Literal(_) => (),

--- a/crates/escalier_parser/src/expr_parser.rs
+++ b/crates/escalier_parser/src/expr_parser.rs
@@ -220,7 +220,10 @@ impl<'a> Parser<'a> {
                                 if p.peek().unwrap_or(&EOF).kind == TokenKind::Comma
                                     || p.peek().unwrap_or(&EOF).kind == TokenKind::RightBrace =>
                             {
-                                Ok(PropOrSpread::Prop(expr::Prop::Shorthand(id.to_owned())))
+                                Ok(PropOrSpread::Prop(expr::Prop::Shorthand(Ident {
+                                    span: next.span,
+                                    name: id.to_owned(),
+                                })))
                             }
                             _ => {
                                 let key = match &next.kind {

--- a/crates/escalier_parser/src/jsx_parser.rs
+++ b/crates/escalier_parser/src/jsx_parser.rs
@@ -9,7 +9,7 @@ impl<'a> Parser<'a> {
         let start = self.scanner.cursor();
 
         assert_eq!(self.next().unwrap_or(EOF.clone()).kind, TokenKind::LessThan);
-        let name_token = self.lex_ident_or_keyword();
+        let name_token = self.lex_ident_or_keyword(IdentMode::Default);
         let name = match name_token.kind {
             TokenKind::Identifier(name) => JSXElementName::Ident(Ident {
                 name,
@@ -59,7 +59,7 @@ impl<'a> Parser<'a> {
 
             assert_eq!(self.scanner.pop(), Some('<'));
             assert_eq!(self.scanner.pop(), Some('/'));
-            let end_name = self.lex_ident_or_keyword();
+            let end_name = self.lex_ident_or_keyword(IdentMode::Default);
             assert_eq!(self.scanner.pop(), Some('>'));
 
             let end = self.scanner.cursor();
@@ -114,7 +114,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_jsx_attribute(&mut self) -> Result<JSXAttr, ParseError> {
-        let name = self.lex_ident_or_keyword();
+        let name = self.lex_ident_or_keyword(IdentMode::Default);
 
         let name = match name.kind {
             TokenKind::Identifier(name) => name,

--- a/crates/escalier_parser/src/pattern_parser.rs
+++ b/crates/escalier_parser/src/pattern_parser.rs
@@ -1,7 +1,7 @@
 use escalier_ast::*;
 
 use crate::parse_error::ParseError;
-use crate::parser::Parser;
+use crate::parser::{IdentMode, Parser};
 use crate::token::*;
 
 impl<'a> Parser<'a> {
@@ -118,8 +118,13 @@ impl<'a> Parser<'a> {
             TokenKind::LeftBrace => {
                 let mut props: Vec<ObjectPatProp> = vec![];
 
-                while self.peek().unwrap_or(&EOF).kind != TokenKind::RightBrace {
-                    let first = self.peek().unwrap_or(&EOF);
+                while self
+                    .peek_with_mode(IdentMode::PropName)
+                    .unwrap_or(&EOF)
+                    .kind
+                    != TokenKind::RightBrace
+                {
+                    let first = self.peek_with_mode(IdentMode::PropName).unwrap_or(&EOF);
                     let first_span = first.span;
                     match &self.next().unwrap_or(EOF.clone()).kind {
                         TokenKind::Identifier(name) => {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_class_with_private_constructor_public_methods.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_class_with_private_constructor_public_methods.snap
@@ -94,12 +94,18 @@ Expr {
                                                         properties: [
                                                             Prop(
                                                                 Shorthand(
-                                                                    "x",
+                                                                    Ident {
+                                                                        name: "x",
+                                                                        span: 136..137,
+                                                                    },
                                                                 ),
                                                             ),
                                                             Prop(
                                                                 Shorthand(
-                                                                    "y",
+                                                                    Ident {
+                                                                        name: "y",
+                                                                        span: 139..140,
+                                                                    },
                                                                 ),
                                                             ),
                                                         ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-8.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_object_literals-8.snap
@@ -8,12 +8,18 @@ Expr {
             properties: [
                 Prop(
                     Shorthand(
-                        "a",
+                        Ident {
+                            name: "a",
+                            span: 2..3,
+                        },
                     ),
                 ),
                 Prop(
                     Shorthand(
-                        "b",
+                        Ident {
+                            name: "b",
+                            span: 5..6,
+                        },
                     ),
                 ),
             ],

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_type_alias-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_type_alias-4.snap
@@ -1,0 +1,112 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(r#\"type Event = {type: \"mousedown\", x: number, y: number} | {type: \"keydown\", key: string}\"#)"
+---
+[
+    Stmt {
+        kind: TypeDecl {
+            name: "Event",
+            type_ann: TypeAnn {
+                kind: Union(
+                    [
+                        TypeAnn {
+                            kind: Object(
+                                [
+                                    Prop(
+                                        Prop {
+                                            span: 0..0,
+                                            name: "type",
+                                            modifier: None,
+                                            optional: false,
+                                            mutable: false,
+                                            type_ann: TypeAnn {
+                                                kind: StrLit(
+                                                    "mousedown",
+                                                ),
+                                                span: 20..31,
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    Prop(
+                                        Prop {
+                                            span: 0..0,
+                                            name: "x",
+                                            modifier: None,
+                                            optional: false,
+                                            mutable: false,
+                                            type_ann: TypeAnn {
+                                                kind: Number,
+                                                span: 36..42,
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    Prop(
+                                        Prop {
+                                            span: 0..0,
+                                            name: "y",
+                                            modifier: None,
+                                            optional: false,
+                                            mutable: false,
+                                            type_ann: TypeAnn {
+                                                kind: Number,
+                                                span: 47..53,
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                ],
+                            ),
+                            span: 12..54,
+                            inferred_type: None,
+                        },
+                        TypeAnn {
+                            kind: Object(
+                                [
+                                    Prop(
+                                        Prop {
+                                            span: 0..0,
+                                            name: "type",
+                                            modifier: None,
+                                            optional: false,
+                                            mutable: false,
+                                            type_ann: TypeAnn {
+                                                kind: StrLit(
+                                                    "keydown",
+                                                ),
+                                                span: 64..73,
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    Prop(
+                                        Prop {
+                                            span: 0..0,
+                                            name: "key",
+                                            modifier: None,
+                                            optional: false,
+                                            mutable: false,
+                                            type_ann: TypeAnn {
+                                                kind: String,
+                                                span: 80..86,
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                ],
+                            ),
+                            span: 56..87,
+                            inferred_type: None,
+                        },
+                    ],
+                ),
+                span: 12..87,
+                inferred_type: None,
+            },
+            type_params: None,
+        },
+        span: 0..87,
+        inferred_type: None,
+    },
+]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_types-4.snap
@@ -1,0 +1,102 @@
+---
+source: crates/escalier_parser/src/type_ann_parser.rs
+expression: "parse(r#\"{type: \"mousedown\", x: number, y: number} | {type: \"keydown\", key: string}\"#)"
+---
+TypeAnn {
+    kind: Union(
+        [
+            TypeAnn {
+                kind: Object(
+                    [
+                        Prop(
+                            Prop {
+                                span: 0..0,
+                                name: "type",
+                                modifier: None,
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeAnn {
+                                    kind: StrLit(
+                                        "mousedown",
+                                    ),
+                                    span: 7..18,
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        Prop(
+                            Prop {
+                                span: 0..0,
+                                name: "x",
+                                modifier: None,
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeAnn {
+                                    kind: Number,
+                                    span: 23..29,
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        Prop(
+                            Prop {
+                                span: 0..0,
+                                name: "y",
+                                modifier: None,
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeAnn {
+                                    kind: Number,
+                                    span: 34..40,
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                    ],
+                ),
+                span: 0..41,
+                inferred_type: None,
+            },
+            TypeAnn {
+                kind: Object(
+                    [
+                        Prop(
+                            Prop {
+                                span: 0..0,
+                                name: "type",
+                                modifier: None,
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeAnn {
+                                    kind: StrLit(
+                                        "keydown",
+                                    ),
+                                    span: 51..60,
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        Prop(
+                            Prop {
+                                span: 0..0,
+                                name: "key",
+                                modifier: None,
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeAnn {
+                                    kind: String,
+                                    span: 67..73,
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                    ],
+                ),
+                span: 43..74,
+                inferred_type: None,
+            },
+        ],
+    ),
+    span: 0..74,
+    inferred_type: None,
+}

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -268,7 +268,10 @@ mod tests {
             } else {
                 never 
             }"#
-        ))
+        ));
+        insta::assert_debug_snapshot!(parse(
+            r#"type Event = {type: "mousedown", x: number, y: number} | {type: "keydown", key: string}"#
+        ));
     }
 
     #[test]

--- a/crates/escalier_parser/src/type_ann_parser.rs
+++ b/crates/escalier_parser/src/type_ann_parser.rs
@@ -86,8 +86,17 @@ impl<'a> Parser<'a> {
                 self.next(); // consumes '{'
                 let mut props: Vec<ObjectProp> = vec![];
 
-                while self.peek().unwrap_or(&EOF).kind != TokenKind::RightBrace {
-                    match self.next().unwrap_or(EOF.clone()).kind {
+                while self
+                    .peek_with_mode(IdentMode::PropName)
+                    .unwrap_or(&EOF)
+                    .kind
+                    != TokenKind::RightBrace
+                {
+                    match self
+                        .next_with_mode(IdentMode::PropName)
+                        .unwrap_or(EOF.clone())
+                        .kind
+                    {
                         TokenKind::Identifier(name) => {
                             let optional =
                                 if self.peek().unwrap_or(&EOF).kind == TokenKind::Question {
@@ -251,10 +260,11 @@ impl<'a> Parser<'a> {
                                 }
                             }
                         }
-                        _ => {
+                        token => {
+                            eprintln!("token: {:?}", token);
                             return Err(ParseError {
                                 message: "expected identifier or indexer".to_string(),
-                            })
+                            });
                         }
                     }
 
@@ -739,6 +749,9 @@ mod tests {
         insta::assert_debug_snapshot!(parse("{a: number, b?: string, c: boolean}"));
         insta::assert_debug_snapshot!(parse("{a: {b: {c: boolean}}}"));
         insta::assert_debug_snapshot!(parse("{\n  a: number,\n  b?: string,\n  c: boolean,\n}"));
+        insta::assert_debug_snapshot!(parse(
+            r#"{type: "mousedown", x: number, y: number} | {type: "keydown", key: string}"#
+        ))
     }
 
     #[test]


### PR DESCRIPTION
TODO:
- [x] port `codegen_d_ts()`
- [ ] ~fix all the codegen tests~ I'm going to file separate tickets for all the issues