### PR TITLE
Parse line comments before statements

### DIFF
--- a/crates/escalier_parser/src/expr_parser.rs
+++ b/crates/escalier_parser/src/expr_parser.rs
@@ -77,6 +77,12 @@ impl<'a> Parser<'a> {
         assert_eq!(open.kind, TokenKind::LeftBrace);
         let mut stmts = Vec::new();
         while self.peek().unwrap_or(&EOF).kind != TokenKind::RightBrace {
+            // TODO: attach comments to AST nodes
+            if let TokenKind::Comment(_) = &self.peek().unwrap_or(&EOF).kind {
+                self.next(); // consumes the comment
+                continue;
+            }
+
             stmts.push(self.parse_stmt()?);
 
             // The last statement in a block is allowed to omit the trailing

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_comments-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_comments-2.snap
@@ -1,0 +1,130 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(r#\"\n            let make_point = fn (x: number, y: number) {\n                // returns a point\n                return {x, y}\n            }\n            \"#)"
+---
+[
+    Stmt {
+        kind: VarDecl(
+            VarDecl {
+                is_declare: false,
+                is_var: false,
+                pattern: Pattern {
+                    kind: Ident(
+                        BindingIdent {
+                            name: "make_point",
+                            span: 17..27,
+                            mutable: false,
+                        },
+                    ),
+                    span: 17..27,
+                    inferred_type: None,
+                },
+                expr: Some(
+                    Expr {
+                        kind: Function(
+                            Function {
+                                type_params: None,
+                                params: [
+                                    FuncParam {
+                                        pattern: Pattern {
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "x",
+                                                    span: 34..35,
+                                                    mutable: false,
+                                                },
+                                            ),
+                                            span: 34..35,
+                                            inferred_type: None,
+                                        },
+                                        type_ann: Some(
+                                            TypeAnn {
+                                                kind: Number,
+                                                span: 37..43,
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        optional: false,
+                                    },
+                                    FuncParam {
+                                        pattern: Pattern {
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "y",
+                                                    span: 45..46,
+                                                    mutable: false,
+                                                },
+                                            ),
+                                            span: 45..46,
+                                            inferred_type: None,
+                                        },
+                                        type_ann: Some(
+                                            TypeAnn {
+                                                kind: Number,
+                                                span: 48..54,
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        optional: false,
+                                    },
+                                ],
+                                body: Block(
+                                    Block {
+                                        span: 55..136,
+                                        stmts: [
+                                            Stmt {
+                                                kind: Return(
+                                                    ReturnStmt {
+                                                        arg: Some(
+                                                            Expr {
+                                                                kind: Object(
+                                                                    Object {
+                                                                        properties: [
+                                                                            Prop(
+                                                                                Shorthand(
+                                                                                    Ident {
+                                                                                        name: "x",
+                                                                                        span: 117..118,
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                            Prop(
+                                                                                Shorthand(
+                                                                                    Ident {
+                                                                                        name: "y",
+                                                                                        span: 120..121,
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        ],
+                                                                    },
+                                                                ),
+                                                                span: 115..122,
+                                                                inferred_type: None,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                span: 115..122,
+                                                inferred_type: None,
+                                            },
+                                        ],
+                                    },
+                                ),
+                                type_ann: None,
+                                throws: None,
+                                is_async: false,
+                                is_gen: false,
+                            },
+                        ),
+                        span: 30..136,
+                        inferred_type: None,
+                    },
+                ),
+                type_ann: None,
+            },
+        ),
+        span: 13..136,
+        inferred_type: None,
+    },
+]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_comments.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_comments.snap
@@ -1,0 +1,72 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(r#\"\n            let x = 5  // x-coord\n            let y = 10 // y-coord\n            \"#)"
+---
+[
+    Stmt {
+        kind: VarDecl(
+            VarDecl {
+                is_declare: false,
+                is_var: false,
+                pattern: Pattern {
+                    kind: Ident(
+                        BindingIdent {
+                            name: "x",
+                            span: 17..18,
+                            mutable: false,
+                        },
+                    ),
+                    span: 17..18,
+                    inferred_type: None,
+                },
+                expr: Some(
+                    Expr {
+                        kind: Num(
+                            Num {
+                                value: "5",
+                            },
+                        ),
+                        span: 21..22,
+                        inferred_type: None,
+                    },
+                ),
+                type_ann: None,
+            },
+        ),
+        span: 13..22,
+        inferred_type: None,
+    },
+    Stmt {
+        kind: VarDecl(
+            VarDecl {
+                is_declare: false,
+                is_var: false,
+                pattern: Pattern {
+                    kind: Ident(
+                        BindingIdent {
+                            name: "y",
+                            span: 51..52,
+                            mutable: false,
+                        },
+                    ),
+                    span: 51..52,
+                    inferred_type: None,
+                },
+                expr: Some(
+                    Expr {
+                        kind: Num(
+                            Num {
+                                value: "10",
+                            },
+                        ),
+                        span: 55..57,
+                        inferred_type: None,
+                    },
+                ),
+                type_ann: None,
+            },
+        ),
+        span: 47..57,
+        inferred_type: None,
+    },
+]

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -162,6 +162,11 @@ impl<'a> Parser<'a> {
     pub fn parse_program(&mut self) -> Result<Program, ParseError> {
         let mut stmts = Vec::new();
         while self.peek().unwrap_or(&EOF).kind != TokenKind::Eof {
+            // TODO: attach comments to AST nodes
+            if let TokenKind::Comment(_) = &self.peek().unwrap_or(&EOF).kind {
+                self.next(); // consumes the comment
+                continue;
+            }
             stmts.push(self.parse_stmt()?);
         }
         Ok(Program { stmts })
@@ -320,6 +325,25 @@ mod tests {
             for ({x, y} in points) {
                 console.log(`(${x}, ${y})`)
             }"#
+        ));
+    }
+
+    #[test]
+    fn parse_comments() {
+        insta::assert_debug_snapshot!(parse(
+            r#"
+            let x = 5  // x-coord
+            let y = 10 // y-coord
+            "#
+        ));
+
+        insta::assert_debug_snapshot!(parse(
+            r#"
+            let make_point = fn (x: number, y: number) {
+                // returns a point
+                return {x, y}
+            }
+            "#
         ));
     }
 }

--- a/crates/escalier_parser/src/token.rs
+++ b/crates/escalier_parser/src/token.rs
@@ -3,6 +3,7 @@ use escalier_ast::*;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TokenKind {
     Identifier(String), // [a-zA-Z_][a-zA-Z0-9_]*
+    Comment(String),
 
     // Literals
     BoolLit(bool),


### PR DESCRIPTION
We need to support parsing comments (even if we just ignore them for now) so that we can support the examples on the demo page.