### PR TITLE
Fix Pick<T, K>

### DIFF
--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -230,9 +230,17 @@ impl Checker {
                     }
                 }
 
+                // Contraints can reference other type params so we need to
+                // replace references in them with the type args themselves.
+                let mut type_param_mapping: HashMap<String, Index> = HashMap::new();
+                for (param, arg) in type_params.iter().zip(type_args.iter()) {
+                    type_param_mapping.insert(param.name.clone(), *arg);
+                }
+
                 let mut mapping: HashMap<String, Index> = HashMap::new();
                 for (param, arg) in type_params.iter().zip(type_args.iter()) {
                     if let Some(constraint) = param.constraint {
+                        let constraint = self.instantiate_type(&constraint, &type_param_mapping);
                         self.unify(ctx, *arg, constraint)?;
                     }
                     mapping.insert(param.name.clone(), arg.to_owned());

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -230,24 +230,30 @@ impl Checker {
                     }
                 }
 
-                // Contraints can reference other type params so we need to
-                // replace references in them with the type args themselves.
-                let mut type_param_mapping: HashMap<String, Index> = HashMap::new();
+                // Contraints can reference other type params so we need make
+                // sure that definitions for each type param are in scope where
+                // each type param is defined to be the corresponding type arg.
+                let mut sig_ctx = ctx.clone();
                 for (param, arg) in type_params.iter().zip(type_args.iter()) {
-                    type_param_mapping.insert(param.name.clone(), *arg);
+                    sig_ctx.schemes.insert(
+                        param.name.clone(),
+                        Scheme {
+                            type_params: None,
+                            t: *arg,
+                        },
+                    );
                 }
 
                 let mut mapping: HashMap<String, Index> = HashMap::new();
                 for (param, arg) in type_params.iter().zip(type_args.iter()) {
                     if let Some(constraint) = param.constraint {
-                        let constraint = self.instantiate_type(&constraint, &type_param_mapping);
-                        self.unify(ctx, *arg, constraint)?;
+                        self.unify(&sig_ctx, *arg, constraint)?;
                     }
                     mapping.insert(param.name.clone(), arg.to_owned());
                 }
 
                 let t = self.instantiate_type(&scheme.t, &mapping);
-                self.expand_type(ctx, t)
+                self.expand_type(&sig_ctx, t)
             }
             None => {
                 if type_args.is_empty() {

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -3332,8 +3332,9 @@ fn test_index_access_type_number_mapped() -> Result<(), TypeError> {
 fn test_mapped_type_pick() -> Result<(), TypeError> {
     let (mut checker, mut my_ctx) = test_env();
 
+    // TODO: replace `T` in type variable constraints as well
     let src = r#"   
-    type Pick<T, K> = {[P]: T[P] for P in K}
+    type Pick<T, K : keyof T> = {[P]: T[P] for P in K}
     type Obj = {a: string, b: number, c: boolean}
     type Result = Pick<Obj, "a" | "b">
     "#;

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_keyof.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_keyof.snap
@@ -1,0 +1,99 @@
+---
+source: crates/escalier_parser/src/stmt_parser.rs
+expression: "parse(\"type Pick<T, K : keyof T> = {[P]: T[P] for P in K}\")"
+---
+[
+    Stmt {
+        kind: TypeDecl(
+            TypeDecl {
+                name: "Pick",
+                type_ann: TypeAnn {
+                    kind: Object(
+                        [
+                            Mapped(
+                                Mapped {
+                                    key: TypeAnn {
+                                        kind: TypeRef(
+                                            "P",
+                                            None,
+                                        ),
+                                        span: 30..31,
+                                        inferred_type: None,
+                                    },
+                                    value: TypeAnn {
+                                        kind: IndexedAccess(
+                                            TypeAnn {
+                                                kind: TypeRef(
+                                                    "T",
+                                                    None,
+                                                ),
+                                                span: 34..35,
+                                                inferred_type: None,
+                                            },
+                                            TypeAnn {
+                                                kind: TypeRef(
+                                                    "P",
+                                                    None,
+                                                ),
+                                                span: 36..37,
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        span: 34..37,
+                                        inferred_type: None,
+                                    },
+                                    target: "P",
+                                    source: TypeAnn {
+                                        kind: TypeRef(
+                                            "K",
+                                            None,
+                                        ),
+                                        span: 48..49,
+                                        inferred_type: None,
+                                    },
+                                    check: None,
+                                    extends: None,
+                                },
+                            ),
+                        ],
+                    ),
+                    span: 27..50,
+                    inferred_type: None,
+                },
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 11..12,
+                            name: "T",
+                            bound: None,
+                            default: None,
+                        },
+                        TypeParam {
+                            span: 14..25,
+                            name: "K",
+                            bound: Some(
+                                TypeAnn {
+                                    kind: KeyOf(
+                                        TypeAnn {
+                                            kind: TypeRef(
+                                                "T",
+                                                None,
+                                            ),
+                                            span: 23..24,
+                                            inferred_type: None,
+                                        },
+                                    ),
+                                    span: 17..22,
+                                    inferred_type: None,
+                                },
+                            ),
+                            default: None,
+                        },
+                    ],
+                ),
+            },
+        ),
+        span: 0..50,
+        inferred_type: None,
+    },
+]

--- a/crates/escalier_parser/src/stmt_parser.rs
+++ b/crates/escalier_parser/src/stmt_parser.rs
@@ -351,4 +351,9 @@ mod tests {
     fn parse_typeof() {
         insta::assert_debug_snapshot!(parse("type RetType = GetReturnType<typeof foo>"));
     }
+
+    #[test]
+    fn parse_keyof() {
+        insta::assert_debug_snapshot!(parse("type Pick<T, K : keyof T> = {[P]: T[P] for P in K}"));
+    }
 }


### PR DESCRIPTION
Constraints on type params can reference other type params.  This PR creates a new `sig_ctx` Context when inferring and expanding type aliases.  We add entries to `sig_ctx.schemes` for each type param where the value is the corresponding type argument.