### PR TITLE
Maintain property optionality across mapped types

### DIFF
--- a/crates/escalier_hm/src/infer.rs
+++ b/crates/escalier_hm/src/infer.rs
@@ -1354,14 +1354,14 @@ impl Checker {
         // We're not mutating `kind` so this should be safe.
         let kind: &TypeKind = unsafe { transmute(&self.arena[obj_idx].kind) };
         match kind {
-            TypeKind::Object(_) => self.get_prop(ctx, obj_idx, key_idx, is_mut),
+            TypeKind::Object(_) => self.get_prop_value(ctx, obj_idx, key_idx, is_mut),
             // declare let obj: {x: number} | {x: string}
             // obj.x; // number | string
             TypeKind::Union(union) => {
                 let mut result_types = vec![];
                 let mut undefined_count = 0;
                 for idx in &union.types {
-                    match self.get_prop(ctx, *idx, key_idx, is_mut) {
+                    match self.get_prop_value(ctx, *idx, key_idx, is_mut) {
                         Ok(t) => result_types.push(t),
                         Err(_) => {
                             // TODO: check what the error is, we may want to propagate

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -916,7 +916,7 @@ impl Checker {
             }
             TypeKind::IndexedAccess(IndexedAccess { obj, index }) => {
                 let is_mut = true;
-                let t = self.get_prop(ctx, obj, index, is_mut)?;
+                let t = self.get_prop_value(ctx, obj, index, is_mut)?;
                 self.unify_call(ctx, args, type_args, t)?;
             }
             TypeKind::Conditional(Conditional {

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -3335,7 +3335,7 @@ fn test_mapped_type_pick() -> Result<(), TypeError> {
     // TODO: replace `T` in type variable constraints as well
     let src = r#"   
     type Pick<T, K : keyof T> = {[P]: T[P] for P in K}
-    type Obj = {a: string, b: number, c: boolean}
+    type Obj = {a?: string, b: number, c: boolean}
     type Result = Pick<Obj, "a" | "b">
     "#;
     let mut program = parse(src).unwrap();
@@ -3344,7 +3344,10 @@ fn test_mapped_type_pick() -> Result<(), TypeError> {
 
     let scheme = my_ctx.schemes.get("Result").unwrap();
     let t = checker.expand_type(&my_ctx, scheme.t)?;
-    assert_eq!(checker.print_type(&t), r#"{a: string, b: number}"#);
+    assert_eq!(
+        checker.print_type(&t),
+        r#"{a?: string | undefined, b: number}"#
+    );
 
     assert_no_errors(&checker)
 }

--- a/crates/escalier_interop/tests/integration_test.rs
+++ b/crates/escalier_interop/tests/integration_test.rs
@@ -483,7 +483,7 @@ fn infer_pick() {
 
     let result = checker.print_type(&t);
     // TODO: maintain the optionality of properties across mapped types
-    assert_eq!(result, "{a: number, b: string | undefined}");
+    assert_eq!(result, "{a: number, b?: string | undefined}");
 }
 
 // #[test]
@@ -602,7 +602,7 @@ fn infer_omit() {
     let result = checker.print_type(&t);
 
     // TODO: maintain the optionality of props across mapped types
-    assert_eq!(result, "{a: number, d: number | undefined}");
+    assert_eq!(result, "{a: number, d?: number | undefined}");
 }
 
 #[test]


### PR DESCRIPTION
`Pick<{a?: string, b: number, c: boolean}, "a" | "b">` now returns `{a?: string | undefined, c: number}`.  This behaviour matches TS' behaviour.