### PR TITLE
Refactor precedence handling in parser

### DIFF
--- a/crates/escalier_parser/src/expr_parser.rs
+++ b/crates/escalier_parser/src/expr_parser.rs
@@ -3,7 +3,7 @@ use escalier_ast::*;
 
 use crate::parse_error::ParseError;
 use crate::parser::*;
-use crate::precedence::{Associativity, OpInfo, Operator, Precedence, PRECEDENCE_TABLE};
+use crate::precedence::{OpInfo, Operator, Precedence, PRECEDENCE_TABLE};
 use crate::token::*;
 
 fn get_prefix_op_info(op: &Token) -> Option<OpInfo> {

--- a/crates/escalier_parser/src/precedence.rs
+++ b/crates/escalier_parser/src/precedence.rs
@@ -118,7 +118,10 @@ lazy_static! {
             (17, Associativity::NotApplicable),
         );
         table.insert(Operator::FunctionCall, (17, Associativity::NotApplicable));
-        table.insert(Operator::TemplateLiteral, (17, Associativity::NotApplicable));
+        table.insert(
+            Operator::TemplateLiteral,
+            (17, Associativity::NotApplicable),
+        );
 
         table.insert(Operator::LogicalNot, (14, Associativity::NotApplicable));
         table.insert(Operator::UnaryPlus, (14, Associativity::NotApplicable));
@@ -153,7 +156,6 @@ lazy_static! {
         table.insert(Operator::LogicalOr, (3, Associativity::Left));
         table.insert(Operator::NullishCoalescing, (3, Associativity::Left));
 
-        // QUESTION: How do we prevent chaining of assignment operators?
         table.insert(Operator::Assignment, (2, Associativity::NotApplicable));
         table.insert(Operator::Conditional, (2, Associativity::Left));
         table.insert(Operator::Arrow, (2, Associativity::Right));

--- a/crates/escalier_parser/src/precedence.rs
+++ b/crates/escalier_parser/src/precedence.rs
@@ -13,7 +13,7 @@ pub enum Associativity {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Operator {
     // 18
-    Grouping,
+    // Grouping, - parsed as an atom
 
     // 17
     MemberAccess,
@@ -93,7 +93,7 @@ pub enum Operator {
     // 2
     Assignment,
     Conditional,
-    Arrow,
+    // Arrow, - superseded by `fn`
     Yield,
     YieldStar,
     Spread,
@@ -144,11 +144,14 @@ lazy_static! {
     pub static ref PRECEDENCE_TABLE: HashMap<Operator, OpInfo> = {
         let mut table: HashMap<Operator, OpInfo> = HashMap::new();
 
-        // Grouping is parsed as an atom
-        // table.insert(Operator::Grouping, (18, Associativity::Neither));
-
-        table.insert(Operator::MemberAccess, OpInfo::new_infix(17, Associativity::Left));
-        table.insert(Operator::OptionalChaining, OpInfo::new_infix(17, Associativity::Left));
+        table.insert(
+            Operator::MemberAccess,
+            OpInfo::new_infix(17, Associativity::Left),
+        );
+        table.insert(
+            Operator::OptionalChaining,
+            OpInfo::new_infix(17, Associativity::Left),
+        );
         table.insert(Operator::ComputedMemberAccess, OpInfo::new_postfix(17));
         table.insert(Operator::NewWithArgumentList, OpInfo::new_postfix(17));
         table.insert(Operator::FunctionCall, OpInfo::new_postfix(17));
@@ -163,35 +166,88 @@ lazy_static! {
         table.insert(Operator::Await, OpInfo::new_prefix(14));
         table.insert(Operator::Throw, OpInfo::new_prefix(14));
 
-        table.insert(Operator::Exponentiation, OpInfo::new_infix(13, Associativity::Right));
+        table.insert(
+            Operator::Exponentiation,
+            OpInfo::new_infix(13, Associativity::Right),
+        );
 
-        table.insert(Operator::Multiplication, OpInfo::new_infix(12, Associativity::Left));
-        table.insert(Operator::Division, OpInfo::new_infix(12, Associativity::Left));
-        table.insert(Operator::Remainder, OpInfo::new_infix(12, Associativity::Left));
+        table.insert(
+            Operator::Multiplication,
+            OpInfo::new_infix(12, Associativity::Left),
+        );
+        table.insert(
+            Operator::Division,
+            OpInfo::new_infix(12, Associativity::Left),
+        );
+        table.insert(
+            Operator::Remainder,
+            OpInfo::new_infix(12, Associativity::Left),
+        );
 
-        table.insert(Operator::Addition, OpInfo::new_infix(11, Associativity::Left));
-        table.insert(Operator::Subtraction, OpInfo::new_infix(11, Associativity::Left));
+        table.insert(
+            Operator::Addition,
+            OpInfo::new_infix(11, Associativity::Left),
+        );
+        table.insert(
+            Operator::Subtraction,
+            OpInfo::new_infix(11, Associativity::Left),
+        );
 
-        table.insert(Operator::LessThan, OpInfo::new_infix(9, Associativity::Left));
-        table.insert(Operator::LessThanOrEqual, OpInfo::new_infix(9, Associativity::Left));
-        table.insert(Operator::GreaterThan, OpInfo::new_infix(9, Associativity::Left));
-        table.insert(Operator::GreaterThanOrEqual, OpInfo::new_infix(9, Associativity::Left));
+        table.insert(
+            Operator::LessThan,
+            OpInfo::new_infix(9, Associativity::Left),
+        );
+        table.insert(
+            Operator::LessThanOrEqual,
+            OpInfo::new_infix(9, Associativity::Left),
+        );
+        table.insert(
+            Operator::GreaterThan,
+            OpInfo::new_infix(9, Associativity::Left),
+        );
+        table.insert(
+            Operator::GreaterThanOrEqual,
+            OpInfo::new_infix(9, Associativity::Left),
+        );
         table.insert(Operator::In, OpInfo::new_infix(9, Associativity::Left));
-        table.insert(Operator::Instanceof, OpInfo::new_infix(9, Associativity::Left));
+        table.insert(
+            Operator::Instanceof,
+            OpInfo::new_infix(9, Associativity::Left),
+        );
 
         table.insert(Operator::Equals, OpInfo::new_infix(8, Associativity::Left));
-        table.insert(Operator::NotEquals, OpInfo::new_infix(8, Associativity::Left));
+        table.insert(
+            Operator::NotEquals,
+            OpInfo::new_infix(8, Associativity::Left),
+        );
 
-        table.insert(Operator::LogicalAnd, OpInfo::new_infix(4, Associativity::Left));
+        table.insert(
+            Operator::LogicalAnd,
+            OpInfo::new_infix(4, Associativity::Left),
+        );
 
-        table.insert(Operator::LogicalOr, OpInfo::new_infix(3, Associativity::Left));
-        table.insert(Operator::NullishCoalescing, OpInfo::new_infix(3, Associativity::Left));
+        table.insert(
+            Operator::LogicalOr,
+            OpInfo::new_infix(3, Associativity::Left),
+        );
+        table.insert(
+            Operator::NullishCoalescing,
+            OpInfo::new_infix(3, Associativity::Left),
+        );
 
-        table.insert(Operator::Assignment, OpInfo::new_infix(2, Associativity::Neither));
-        table.insert(Operator::Conditional, OpInfo::new_infix(2, Associativity::Left));
-        table.insert(Operator::Arrow, OpInfo::new_infix(2, Associativity::Right));
+        table.insert(
+            Operator::Assignment,
+            OpInfo::new_infix(2, Associativity::Neither),
+        );
+        table.insert(
+            Operator::Conditional,
+            OpInfo::new_infix(2, Associativity::Left),
+        );
         table.insert(Operator::Yield, OpInfo::new_infix(2, Associativity::Right));
-        table.insert(Operator::YieldStar, OpInfo::new_infix(2, Associativity::Right));
+        table.insert(
+            Operator::YieldStar,
+            OpInfo::new_infix(2, Associativity::Right),
+        );
         table.insert(Operator::Spread, OpInfo::new_infix(2, Associativity::Right));
 
         table

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-2.snap
@@ -1,48 +1,59 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"x = y = z\")"
+expression: "parse(\"x.a = y.b\")"
 ---
 Expr {
     kind: Assign(
         Assign {
             left: Expr {
-                kind: Ident(
-                    Ident {
-                        name: "x",
-                        span: 0..1,
+                kind: Member(
+                    Member {
+                        object: Expr {
+                            kind: Ident(
+                                Ident {
+                                    name: "x",
+                                    span: 0..1,
+                                },
+                            ),
+                            span: 0..1,
+                            inferred_type: None,
+                        },
+                        property: Ident(
+                            Ident {
+                                name: "a",
+                                span: 2..3,
+                            },
+                        ),
+                        opt_chain: false,
                     },
                 ),
-                span: 0..1,
+                span: 0..3,
                 inferred_type: None,
             },
             op: Assign,
             right: Expr {
-                kind: Assign(
-                    Assign {
-                        left: Expr {
+                kind: Member(
+                    Member {
+                        object: Expr {
                             kind: Ident(
                                 Ident {
                                     name: "y",
-                                    span: 4..5,
+                                    span: 6..7,
                                 },
                             ),
-                            span: 4..5,
+                            span: 6..7,
                             inferred_type: None,
                         },
-                        op: Assign,
-                        right: Expr {
-                            kind: Ident(
-                                Ident {
-                                    name: "z",
-                                    span: 8..9,
-                                },
-                            ),
-                            span: 8..9,
-                            inferred_type: None,
-                        },
+                        property: Ident(
+                            Ident {
+                                name: "b",
+                                span: 8..9,
+                            },
+                        ),
+                        opt_chain: false,
                     },
                 ),
-                span: 4..9,
+                span: 6..9,
                 inferred_type: None,
             },
         },

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-3.snap
@@ -1,63 +1,32 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"x.a = y.b\")"
+expression: "parse(\"x += 1\")"
 ---
 Expr {
     kind: Assign(
         Assign {
             left: Expr {
-                kind: Member(
-                    Member {
-                        object: Expr {
-                            kind: Ident(
-                                Ident {
-                                    name: "x",
-                                    span: 0..1,
-                                },
-                            ),
-                            span: 0..1,
-                            inferred_type: None,
-                        },
-                        property: Ident(
-                            Ident {
-                                name: "a",
-                                span: 2..3,
-                            },
-                        ),
-                        opt_chain: false,
+                kind: Ident(
+                    Ident {
+                        name: "x",
+                        span: 0..1,
                     },
                 ),
-                span: 0..3,
+                span: 0..1,
                 inferred_type: None,
             },
-            op: Assign,
+            op: AddAssign,
             right: Expr {
-                kind: Member(
-                    Member {
-                        object: Expr {
-                            kind: Ident(
-                                Ident {
-                                    name: "y",
-                                    span: 6..7,
-                                },
-                            ),
-                            span: 6..7,
-                            inferred_type: None,
-                        },
-                        property: Ident(
-                            Ident {
-                                name: "b",
-                                span: 8..9,
-                            },
-                        ),
-                        opt_chain: false,
+                kind: Num(
+                    Num {
+                        value: "1",
                     },
                 ),
-                span: 6..9,
+                span: 5..6,
                 inferred_type: None,
             },
         },
     ),
-    span: 0..9,
+    span: 0..6,
     inferred_type: None,
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-4.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"x += 1\")"
+expression: "parse(\"x -= 1\")"
 ---
 Expr {
     kind: Assign(
@@ -15,7 +15,7 @@ Expr {
                 span: 0..1,
                 inferred_type: None,
             },
-            op: AddAssign,
+            op: SubAssign,
             right: Expr {
                 kind: Num(
                     Num {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-5.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-5.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"x -= 1\")"
+expression: "parse(\"x *= 2\")"
 ---
 Expr {
     kind: Assign(
@@ -15,11 +15,11 @@ Expr {
                 span: 0..1,
                 inferred_type: None,
             },
-            op: SubAssign,
+            op: MulAssign,
             right: Expr {
                 kind: Num(
                     Num {
-                        value: "1",
+                        value: "2",
                     },
                 ),
                 span: 5..6,

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-6.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-6.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"x *= 2\")"
+expression: "parse(\"x /= 2\")"
 ---
 Expr {
     kind: Assign(
@@ -15,7 +15,7 @@ Expr {
                 span: 0..1,
                 inferred_type: None,
             },
-            op: MulAssign,
+            op: DivAssign,
             right: Expr {
                 kind: Num(
                     Num {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-7.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_assignment-7.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/escalier_parser/src/expr_parser.rs
-expression: "parse(\"x /= 2\")"
+expression: "parse(\"x %= 2\")"
 ---
 Expr {
     kind: Assign(
@@ -15,7 +15,7 @@ Expr {
                 span: 0..1,
                 inferred_type: None,
             },
-            op: DivAssign,
+            op: ModAssign,
             right: Expr {
                 kind: Num(
                     Num {

--- a/crates/escalier_parser/src/type_ann_parser.rs
+++ b/crates/escalier_parser/src/type_ann_parser.rs
@@ -2,10 +2,10 @@ use escalier_ast::*;
 
 use crate::parse_error::ParseError;
 use crate::parser::*;
-use crate::precedence::{Associativity, Operator, PRECEDENCE_TABLE};
+use crate::precedence::{Associativity, OpInfo, Operator, Precedence, PRECEDENCE_TABLE};
 use crate::token::*;
 
-fn get_infix_precedence(op: &Token) -> Option<(u8, Associativity)> {
+fn get_infix_op_info(op: &Token) -> Option<OpInfo> {
     match &op.kind {
         // multiplicative
         TokenKind::Times => PRECEDENCE_TABLE.get(&Operator::Multiplication).cloned(),
@@ -16,16 +16,16 @@ fn get_infix_precedence(op: &Token) -> Option<(u8, Associativity)> {
         TokenKind::Plus => PRECEDENCE_TABLE.get(&Operator::Addition).cloned(),
         TokenKind::Minus => PRECEDENCE_TABLE.get(&Operator::Subtraction).cloned(),
 
-        TokenKind::Ampersand => Some((4, Associativity::Left)), // same as LogicalAnd
-        TokenKind::Pipe => Some((3, Associativity::Left)),      // same as LogicalOr
+        TokenKind::Ampersand => Some(OpInfo::new_infix(4, Associativity::Left)), // same as LogicalAnd
+        TokenKind::Pipe => Some(OpInfo::new_infix(3, Associativity::Left)), // same as LogicalOr
 
         _ => None,
     }
 }
 
-fn get_postfix_precedence(op: &Token) -> Option<(u8, Associativity)> {
+fn get_postfix_op_info(op: &Token) -> Option<OpInfo> {
     match &op.kind {
-        TokenKind::LeftBracket => Some((12, Associativity::NotApplicable)),
+        TokenKind::LeftBracket => Some(OpInfo::new_postfix(12)),
         _ => None,
     }
 }
@@ -507,13 +507,9 @@ impl<'a> Parser<'a> {
     fn parse_type_ann_postfix(
         &mut self,
         lhs: TypeAnn,
-        next_precedence: (u8, Associativity),
+        next_op_info: OpInfo,
     ) -> Result<TypeAnn, ParseError> {
-        let _precedence = match next_precedence.1 {
-            Associativity::Left => next_precedence.0 * 10,
-            Associativity::Right => next_precedence.0 * 10 - 1,
-            Associativity::NotApplicable => next_precedence.0 * 10 + 1,
-        };
+        let _precedence = next_op_info.infix_postfix_prec();
 
         let token = self.peek().unwrap_or(&EOF).clone();
 
@@ -552,7 +548,10 @@ impl<'a> Parser<'a> {
         Ok(type_ann)
     }
 
-    fn parse_type_ann_with_precedence(&mut self, precedence: u8) -> Result<TypeAnn, ParseError> {
+    fn parse_type_ann_with_precedence(
+        &mut self,
+        precedence: Precedence,
+    ) -> Result<TypeAnn, ParseError> {
         let mut lhs = self.parse_type_ann_atom()?;
 
         loop {
@@ -565,18 +564,18 @@ impl<'a> Parser<'a> {
                 return Ok(lhs);
             }
 
-            if let Some(next_precedence) = get_postfix_precedence(&next) {
-                if precedence < next_precedence.0 * 10 {
-                    lhs = self.parse_type_ann_postfix(lhs.clone(), next_precedence)?;
+            if let Some(next_op_info) = get_postfix_op_info(&next) {
+                if precedence < next_op_info.normalized_prec() {
+                    lhs = self.parse_type_ann_postfix(lhs.clone(), next_op_info)?;
                     continue;
                 } else {
                     return Ok(lhs);
                 }
             }
 
-            if let Some(next_precedence) = get_infix_precedence(&next) {
-                if precedence < next_precedence.0 * 10 {
-                    lhs = self.parse_type_ann_infix(lhs.clone(), next_precedence)?;
+            if let Some(next_op_info) = get_infix_op_info(&next) {
+                if precedence < next_op_info.normalized_prec() {
+                    lhs = self.parse_type_ann_infix(lhs.clone(), next_op_info)?;
                     continue;
                 } else {
                     return Ok(lhs);
@@ -590,17 +589,13 @@ impl<'a> Parser<'a> {
     fn parse_type_ann_infix(
         &mut self,
         lhs: TypeAnn,
-        next_precedence: (u8, Associativity),
+        next_op_info: OpInfo,
     ) -> Result<TypeAnn, ParseError> {
         let token = self.peek().unwrap_or(&EOF).clone();
 
         self.next();
 
-        let precedence = match next_precedence.1 {
-            Associativity::Left => next_precedence.0 * 10,
-            Associativity::Right => next_precedence.0 * 10 - 1,
-            Associativity::NotApplicable => next_precedence.0 * 10 + 1,
-        };
+        let precedence = next_op_info.infix_postfix_prec();
 
         let result = match &token.kind {
             TokenKind::Ampersand => {

--- a/crates/escalier_parser/src/type_ann_parser.rs
+++ b/crates/escalier_parser/src/type_ann_parser.rs
@@ -545,17 +545,6 @@ impl<'a> Parser<'a> {
                         }
                     }
                 }
-                // let next = self.peek().unwrap_or(&EOF);
-                // let merged_span = merge_spans(&lhs.span, &next.span);
-                // assert_eq!(
-                //     self.next().unwrap_or(EOF.clone()).kind,
-                //     TokenKind::RightBracket
-                // );
-                // TypeAnn {
-                //     kind: TypeAnnKind::Array(Box::new(lhs)),
-                //     span: merged_span,
-                //     inferred_type: None,
-                // }
             }
             _ => panic!("unexpected token: {:?}", token),
         };


### PR DESCRIPTION
- add parse_infix() and parse_prefix() methods to expr_parser.rs
- normalize precedence, handle Right associativity, prevent assignment chaining
- update type_ann_parser to mimic changes to expr_parser
