### PR TITLE
Generalize callable (and newable) signatures

### DIFF
--- a/crates/escalier_ast/src/type_ann.rs
+++ b/crates/escalier_ast/src/type_ann.rs
@@ -8,19 +8,10 @@ use crate::type_param::TypeParam;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ObjectProp {
-    Call(ObjCallable),
-    Constructor(ObjCallable),
+    Call(FunctionType),
+    Constructor(FunctionType),
     Prop(Prop),
     Mapped(Mapped),
-}
-
-// TODO: dedupe with `FunctionType` below
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ObjCallable {
-    pub span: Span,
-    pub type_params: Option<Vec<TypeParam>>,
-    pub params: Vec<FuncParam>,
-    pub ret: Box<TypeAnn>,
 }
 
 // TODO: dedupe with TPropModifier
@@ -62,8 +53,7 @@ pub struct Mapped {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FunctionType {
-    // TODO
-    // pub span: Span,
+    pub span: Span,
     pub type_params: Option<Vec<TypeParam>>,
     pub params: Vec<FuncParam>,
     pub ret: Box<TypeAnn>,

--- a/crates/escalier_codegen/src/d_ts.rs
+++ b/crates/escalier_codegen/src/d_ts.rs
@@ -623,10 +623,11 @@ fn build_obj_type(obj: &types::Object, ctx: &Context, checker: &Checker) -> TsTy
     for elem in &obj.elems {
         match elem {
             types::TObjElem::Call(_) => todo!(),
-            types::TObjElem::Constructor(types::TCallable {
+            types::TObjElem::Constructor(types::Function {
                 params,
                 ret,
                 type_params,
+                throws: _, // TODO
             }) => {
                 let type_params =
                     build_type_params_from_type_params(type_params.as_ref(), ctx, checker);

--- a/crates/escalier_hm/src/folder.rs
+++ b/crates/escalier_hm/src/folder.rs
@@ -84,58 +84,15 @@ pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
         TypeKind::Keyword(_) => return *index,
         TypeKind::Primitive(_) => return *index,
         TypeKind::Literal(_) => return *index,
-        TypeKind::Function(Function {
-            params,
-            ret,
-            type_params,
-            throws,
-        }) => {
-            let new_params = walk_func_params(folder, params);
-            let new_ret = folder.fold_index(ret);
-            let new_type_params = walk_type_params(folder, type_params);
-            let new_throws = throws.map(|throws| folder.fold_index(&throws));
-
-            if new_params == *params
-                && new_ret == *ret
-                && new_type_params == *type_params
-                && new_throws == *throws
-            {
-                return *index;
-            }
-
-            TypeKind::Function(Function {
-                params: new_params,
-                ret: new_ret,
-                type_params: new_type_params,
-                throws: new_throws,
-            })
-        }
+        TypeKind::Function(function) => TypeKind::Function(walk_function(folder, function)),
         TypeKind::Object(Object { elems }) => {
             let elems: Vec<_> = elems
                 .iter()
                 .map(|elem| match elem {
-                    TObjElem::Constructor(Function {
-                        params,
-                        ret,
-                        type_params,
-                        throws,
-                    }) => TObjElem::Constructor(Function {
-                        params: walk_func_params(folder, params),
-                        ret: folder.fold_index(ret),
-                        type_params: walk_type_params(folder, type_params),
-                        throws: throws.map(|throws| folder.fold_index(&throws)),
-                    }),
-                    TObjElem::Call(Function {
-                        params,
-                        ret,
-                        type_params,
-                        throws,
-                    }) => TObjElem::Call(Function {
-                        params: walk_func_params(folder, params),
-                        ret: folder.fold_index(ret),
-                        type_params: walk_type_params(folder, type_params),
-                        throws: throws.map(|throws| folder.fold_index(&throws)),
-                    }),
+                    TObjElem::Call(function) => TObjElem::Call(walk_function(folder, function)),
+                    TObjElem::Constructor(function) => {
+                        TObjElem::Constructor(walk_function(folder, function))
+                    }
                     TObjElem::Mapped(MappedType {
                         key,
                         value,
@@ -162,10 +119,6 @@ pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
                             extends: new_extends,
                         })
                     }
-                    // TObjElem::Index(index) => TObjElem::Index(TIndex {
-                    //     t: folder.fold_index(&index.t),
-                    //     ..index.clone()
-                    // }),
                     TObjElem::Prop(prop) => TObjElem::Prop(TProp {
                         t: folder.fold_index(&prop.t),
                         ..prop.clone()
@@ -300,5 +253,21 @@ fn walk_type_param<F: Folder>(folder: &mut F, type_param: &TypeParam) -> TypePar
             .default
             .as_ref()
             .map(|default| folder.fold_index(default)),
+    }
+}
+
+fn walk_function<F: Folder>(folder: &mut F, function: &Function) -> Function {
+    let Function {
+        params,
+        ret,
+        type_params,
+        throws,
+    } = function;
+
+    Function {
+        params: walk_func_params(folder, params),
+        ret: folder.fold_index(ret),
+        type_params: walk_type_params(folder, type_params),
+        throws: throws.map(|throws| folder.fold_index(&throws)),
     }
 }

--- a/crates/escalier_hm/src/folder.rs
+++ b/crates/escalier_hm/src/folder.rs
@@ -118,19 +118,23 @@ pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
                         params,
                         ret,
                         type_params,
+                        throws,
                     }) => TObjElem::Constructor(TCallable {
                         params: walk_func_params(folder, params),
                         ret: folder.fold_index(ret),
                         type_params: walk_type_params(folder, type_params),
+                        throws: throws.map(|throws| folder.fold_index(&throws)),
                     }),
                     TObjElem::Call(TCallable {
                         params,
                         ret,
                         type_params,
+                        throws,
                     }) => TObjElem::Call(TCallable {
                         params: walk_func_params(folder, params),
                         ret: folder.fold_index(ret),
                         type_params: walk_type_params(folder, type_params),
+                        throws: throws.map(|throws| folder.fold_index(&throws)),
                     }),
                     TObjElem::Mapped(MappedType {
                         key,

--- a/crates/escalier_hm/src/folder.rs
+++ b/crates/escalier_hm/src/folder.rs
@@ -114,23 +114,23 @@ pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
             let elems: Vec<_> = elems
                 .iter()
                 .map(|elem| match elem {
-                    TObjElem::Constructor(TCallable {
+                    TObjElem::Constructor(Function {
                         params,
                         ret,
                         type_params,
                         throws,
-                    }) => TObjElem::Constructor(TCallable {
+                    }) => TObjElem::Constructor(Function {
                         params: walk_func_params(folder, params),
                         ret: folder.fold_index(ret),
                         type_params: walk_type_params(folder, type_params),
                         throws: throws.map(|throws| folder.fold_index(&throws)),
                     }),
-                    TObjElem::Call(TCallable {
+                    TObjElem::Call(Function {
                         params,
                         ret,
                         type_params,
                         throws,
-                    }) => TObjElem::Call(TCallable {
+                    }) => TObjElem::Call(Function {
                         params: walk_func_params(folder, params),
                         ret: folder.fold_index(ret),
                         type_params: walk_type_params(folder, type_params),

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -250,7 +250,7 @@ pub struct TCallable {
     pub params: Vec<FuncParam>,
     pub ret: Index,
     pub type_params: Option<Vec<TypeParam>>,
-    // TODO: support throws
+    pub throws: Option<Index>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -482,6 +482,7 @@ impl Checker {
                             params,
                             ret,
                             type_params,
+                            throws: _, // TODO
                         }) => {
                             let mut result = "new fn".to_string();
                             match type_params {
@@ -512,6 +513,7 @@ impl Checker {
                             params,
                             ret,
                             type_params,
+                            throws: _, // TODO
                         }) => {
                             let mut result = "fn".to_string();
                             match type_params {

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -74,7 +74,7 @@ impl fmt::Display for Primitive {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Function {
     pub params: Vec<FuncParam>,
     pub ret: Index,
@@ -245,13 +245,13 @@ impl TProp {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TCallable {
-    pub params: Vec<FuncParam>,
-    pub ret: Index,
-    pub type_params: Option<Vec<TypeParam>>,
-    pub throws: Option<Index>,
-}
+// #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// pub struct TCallable {
+//     pub params: Vec<FuncParam>,
+//     pub ret: Index,
+//     pub type_params: Option<Vec<TypeParam>>,
+//     pub throws: Option<Index>,
+// }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MappedModifier {
@@ -274,10 +274,10 @@ pub struct MappedType {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TObjElem {
-    Call(TCallable),
+    Call(Function),
     // NOTE: type_params on constructors should be a subset of type_params on
     // the object scheme in which they live
-    Constructor(TCallable),
+    Constructor(Function),
     // Index(TIndex),
     Prop(TProp),
     Mapped(MappedType),
@@ -478,7 +478,7 @@ impl Checker {
                 let mut fields = vec![];
                 for prop in &object.elems {
                     match prop {
-                        TObjElem::Constructor(TCallable {
+                        TObjElem::Constructor(Function {
                             params,
                             ret,
                             type_params,
@@ -509,7 +509,7 @@ impl Checker {
                             ));
                             fields.push(result);
                         }
-                        TObjElem::Call(TCallable {
+                        TObjElem::Call(Function {
                             params,
                             ret,
                             type_params,

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -383,12 +383,12 @@ impl Checker {
                 // - we should also unify indexers with other named values since
                 //   they can be accessed by name as well but are optional
 
-                let mut calls_1: Vec<&TCallable> = vec![];
-                let mut constructors_1: Vec<&TCallable> = vec![];
+                let mut calls_1: Vec<&Function> = vec![];
+                let mut constructors_1: Vec<&Function> = vec![];
                 let mut mapped_1: Vec<&MappedType> = vec![];
 
-                let mut calls_2: Vec<&TCallable> = vec![];
-                let mut constructors_2: Vec<&TCallable> = vec![];
+                let mut calls_2: Vec<&Function> = vec![];
+                let mut constructors_2: Vec<&Function> = vec![];
                 let mut mapped_2: Vec<&MappedType> = vec![];
 
                 let named_props_1: HashMap<_, _> = object1

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -52,7 +52,7 @@ pub fn walk_index<V: Visitor>(visitor: &mut V, index: &Index) {
         }
         TypeKind::Object(Object { elems }) => {
             elems.iter().for_each(|elem| match elem {
-                TObjElem::Constructor(TCallable {
+                TObjElem::Constructor(Function {
                     params,
                     ret,
                     type_params,
@@ -63,7 +63,7 @@ pub fn walk_index<V: Visitor>(visitor: &mut V, index: &Index) {
                     walk_type_params(visitor, type_params);
                     throws.map(|throws| visitor.visit_index(&throws));
                 }
-                TObjElem::Call(TCallable {
+                TObjElem::Call(Function {
                     params,
                     ret,
                     type_params,

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -39,41 +39,11 @@ pub fn walk_index<V: Visitor>(visitor: &mut V, index: &Index) {
         TypeKind::Keyword(_) => (),
         TypeKind::Primitive(_) => (),
         TypeKind::Literal(_) => (),
-        TypeKind::Function(Function {
-            params,
-            ret,
-            type_params,
-            throws,
-        }) => {
-            walk_func_params(visitor, params);
-            visitor.visit_index(ret);
-            walk_type_params(visitor, type_params);
-            throws.map(|throws| visitor.visit_index(&throws));
-        }
+        TypeKind::Function(function) => walk_function(visitor, function),
         TypeKind::Object(Object { elems }) => {
             elems.iter().for_each(|elem| match elem {
-                TObjElem::Constructor(Function {
-                    params,
-                    ret,
-                    type_params,
-                    throws,
-                }) => {
-                    walk_func_params(visitor, params);
-                    visitor.visit_index(ret);
-                    walk_type_params(visitor, type_params);
-                    throws.map(|throws| visitor.visit_index(&throws));
-                }
-                TObjElem::Call(Function {
-                    params,
-                    ret,
-                    type_params,
-                    throws,
-                }) => {
-                    walk_func_params(visitor, params);
-                    visitor.visit_index(ret);
-                    walk_type_params(visitor, type_params);
-                    throws.map(|throws| visitor.visit_index(&throws));
-                }
+                TObjElem::Constructor(function) => walk_function(visitor, function),
+                TObjElem::Call(function) => walk_function(visitor, function),
                 TObjElem::Mapped(mapped) => {
                     visitor.visit_index(&mapped.key);
                     visitor.visit_index(&mapped.value);
@@ -147,4 +117,18 @@ fn walk_type_param<V: Visitor>(visitor: &mut V, type_param: &TypeParam) {
     if let Some(default) = type_param.default {
         visitor.visit_index(&default);
     }
+}
+
+fn walk_function<V: Visitor>(visitor: &mut V, function: &Function) {
+    let Function {
+        params,
+        ret,
+        type_params,
+        throws,
+    } = function;
+
+    walk_func_params(visitor, params);
+    visitor.visit_index(ret);
+    walk_type_params(visitor, type_params);
+    throws.map(|throws| visitor.visit_index(&throws));
 }

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -56,19 +56,23 @@ pub fn walk_index<V: Visitor>(visitor: &mut V, index: &Index) {
                     params,
                     ret,
                     type_params,
+                    throws,
                 }) => {
                     walk_func_params(visitor, params);
                     visitor.visit_index(ret);
                     walk_type_params(visitor, type_params);
+                    throws.map(|throws| visitor.visit_index(&throws));
                 }
                 TObjElem::Call(TCallable {
                     params,
                     ret,
                     type_params,
+                    throws,
                 }) => {
                     walk_func_params(visitor, params);
                     visitor.visit_index(ret);
                     walk_type_params(visitor, type_params);
+                    throws.map(|throws| visitor.visit_index(&throws));
                 }
                 TObjElem::Mapped(mapped) => {
                     visitor.visit_index(&mapped.key);

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -5358,7 +5358,7 @@ fn test_generalization_inside_function() -> Result<(), TypeError> {
     let binding = my_ctx.values.get("bar").unwrap();
     assert_eq!(
         checker.print_type(&binding.index),
-        r#"[5, "hello", (x: t34) -> t34]"#
+        r#"[5, "hello", (x: t37) -> t37]"#
     );
 
     assert_no_errors(&checker)

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -1,3 +1,4 @@
+use escalier_hm::infer::generalize_callable;
 use generational_arena::Index;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -527,10 +528,7 @@ fn infer_callable(
     let ret = infer_ts_type_ann(checker, ctx, type_ann)?;
     let type_params = get_type_params(checker, ctx, type_params)?;
 
-    // TODO: check signature to see if there are any free type variables that
-    // can be converted to additional type params.
-
-    Ok(TCallable {
+    let callable = TCallable {
         params,
         ret,
         type_params: if type_params.is_empty() {
@@ -538,7 +536,10 @@ fn infer_callable(
         } else {
             Some(type_params)
         },
-    })
+        throws: None,
+    };
+
+    Ok(generalize_callable(checker, &callable))
 }
 
 fn infer_ts_type_element(

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -1,4 +1,4 @@
-use escalier_hm::infer::generalize_callable;
+use escalier_hm::infer::generalize_func;
 use generational_arena::Index;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,7 +15,7 @@ use escalier_hm::checker::Checker;
 use escalier_hm::context::{Binding, Context};
 use escalier_hm::types::{
     self, Conditional, FuncParam, Function, IndexedAccess, Keyword, MappedType, Object, Primitive,
-    RestPat, Scheme, TCallable, TObjElem, TPat, TProp, TPropKey, TypeKind, TypeParam, TypeRef,
+    RestPat, Scheme, TObjElem, TPat, TProp, TPropKey, TypeKind, TypeParam, TypeRef,
 };
 
 // use crate::overrides::maybe_override_string_methods;
@@ -523,12 +523,12 @@ fn infer_callable(
     params: &[TsFnParam],
     type_ann: &TsType,
     type_params: &Option<Box<TsTypeParamDecl>>,
-) -> Result<TCallable, String> {
+) -> Result<Function, String> {
     let params = infer_fn_params(checker, ctx, params)?;
     let ret = infer_ts_type_ann(checker, ctx, type_ann)?;
     let type_params = get_type_params(checker, ctx, type_params)?;
 
-    let callable = TCallable {
+    let callable = Function {
         params,
         ret,
         type_params: if type_params.is_empty() {
@@ -539,7 +539,7 @@ fn infer_callable(
         throws: None,
     };
 
-    Ok(generalize_callable(checker, &callable))
+    Ok(generalize_func(checker, &callable))
 }
 
 fn infer_ts_type_element(

--- a/crates/escalier_interop/src/util.rs
+++ b/crates/escalier_interop/src/util.rs
@@ -3,8 +3,7 @@ use std::collections::HashSet;
 
 use escalier_hm::checker::Checker;
 use escalier_hm::types::{
-    Function, MappedType, Object as TObject, Scheme, TCallable, TObjElem, TPat, TProp, TPropKey,
-    TypeKind,
+    Function, MappedType, Object as TObject, Scheme, TObjElem, TPat, TProp, TPropKey, TypeKind,
 };
 
 pub fn new_merge_schemes(schemes: &[Scheme], checker: &mut Checker) -> Scheme {
@@ -36,7 +35,8 @@ pub fn merge_readonly_and_mutable_schemes(
     checker: &mut Checker,
 ) -> Scheme {
     let mut mapped_types: Vec<MappedType> = vec![];
-    let mut callables: Vec<TCallable> = vec![];
+    let mut callables: Vec<Function> = vec![];
+    let mut newables: Vec<Function> = vec![];
     // BTreeMap is used here to ensure that the props are in alphabetical order
     let mut props: BTreeMap<String, TProp> = BTreeMap::new(); // TODO: figure out how to handle overloads
     let mut mutating_methods: HashSet<String> = HashSet::new();
@@ -64,7 +64,9 @@ pub fn merge_readonly_and_mutable_schemes(
                     };
                     props.insert(key.to_owned(), prop.to_owned());
                 }
-                TObjElem::Constructor(_) => (),
+                TObjElem::Constructor(newable) => {
+                    newables.push(newable.to_owned());
+                }
             }
         }
     }
@@ -109,6 +111,10 @@ pub fn merge_readonly_and_mutable_schemes(
 
     for c in callables {
         elems.push(TObjElem::Call(c));
+    }
+
+    for n in newables {
+        elems.push(TObjElem::Constructor(n));
     }
 
     for m in mapped_types {

--- a/crates/escalier_interop/tests/integration_test.rs
+++ b/crates/escalier_interop/tests/integration_test.rs
@@ -769,7 +769,7 @@ fn parses_constructor_interfaces() {
     assert_eq!(result, "StringConstructor");
     let def = checker.expand_type(&ctx, binding.index).unwrap();
     let result = checker.print_type(&def);
-    eprintln!("result = {}", result);
+    assert_eq!(result, "{new fn<A>(value?: A) -> String, fn<A>(value?: A) -> string, readonly prototype: String, fromCharCode: (...codes: number[]) -> string}");
 }
 
 #[test]

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_declare_let-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_declare_let-2.snap
@@ -26,6 +26,7 @@ expression: "parse(r#\"declare let bar: fn () -> number\"#)"
                             TypeAnn {
                                 kind: Function(
                                     FunctionType {
+                                        span: 17..32,
                                         type_params: None,
                                         params: [],
                                         ret: TypeAnn {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_fn_with_fn_type.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_let_fn_with_fn_type.snap
@@ -103,6 +103,7 @@ expression: "parse(r#\"let add: fn (a: number, b: number) -> number = fn (a, b) 
                             TypeAnn {
                                 kind: Function(
                                     FunctionType {
+                                        span: 9..44,
                                         type_params: None,
                                         params: [
                                             FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_type_alias-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_type_alias-3.snap
@@ -23,6 +23,7 @@ expression: "parse(r#\"\n            type ReturnType<T: fn (...args: Array<_>) -
                                     extends: TypeAnn {
                                         kind: Function(
                                             FunctionType {
+                                                span: 87..118,
                                                 type_params: None,
                                                 params: [
                                                     FuncParam {
@@ -106,6 +107,7 @@ expression: "parse(r#\"\n            type ReturnType<T: fn (...args: Array<_>) -
                                         TypeAnn {
                                             kind: Function(
                                                 FunctionType {
+                                                    span: 32..59,
                                                     type_params: None,
                                                     params: [
                                                         FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_var_decls-4.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__stmt_parser__tests__parse_var_decls-4.snap
@@ -26,6 +26,7 @@ expression: "parse(r#\"declare let scale: fn (mut p: Point, scale: number) -> vo
                             TypeAnn {
                                 kind: Function(
                                     FunctionType {
+                                        span: 19..59,
                                         type_params: None,
                                         params: [
                                             FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_fn_type_ann-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_fn_type_ann-2.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (a: number, b: number) -> number throws string\")"
 TypeAnn {
     kind: Function(
         FunctionType {
+            span: 0..49,
             type_params: None,
             params: [
                 FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_fn_type_ann.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_fn_type_ann.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (a: number, b: number) -> number\")"
 TypeAnn {
     kind: Function(
         FunctionType {
+            span: 0..35,
             type_params: None,
             params: [
                 FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_func_with_rest_param-2.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_func_with_rest_param-2.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (...args: Array<_>) -> _\")"
 TypeAnn {
     kind: Function(
         FunctionType {
+            span: 0..27,
             type_params: None,
             params: [
                 FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_func_with_rest_param-3.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_func_with_rest_param-3.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (...args: _) -> _\")"
 TypeAnn {
     kind: Function(
         FunctionType {
+            span: 0..20,
             type_params: None,
             params: [
                 FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_func_with_rest_param.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_func_with_rest_param.snap
@@ -5,6 +5,7 @@ expression: "parse(\"fn (...args: Array<number>) -> number\")"
 TypeAnn {
     kind: Function(
         FunctionType {
+            span: 0..37,
             type_params: None,
             params: [
                 FuncParam {

--- a/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_type_all_sig_types.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__type_ann_parser__tests__parse_object_type_all_sig_types.snap
@@ -6,8 +6,8 @@ TypeAnn {
     kind: Object(
         [
             Call(
-                ObjCallable {
-                    span: 0..0,
+                FunctionType {
+                    span: 13..55,
                     type_params: None,
                     params: [
                         FuncParam {
@@ -37,6 +37,7 @@ TypeAnn {
                         span: 49..55,
                         inferred_type: None,
                     },
+                    throws: None,
                 },
             ),
             Prop(
@@ -49,6 +50,7 @@ TypeAnn {
                     type_ann: TypeAnn {
                         kind: Function(
                             FunctionType {
+                                span: 78..102,
                                 type_params: None,
                                 params: [
                                     FuncParam {
@@ -96,6 +98,7 @@ TypeAnn {
                     type_ann: TypeAnn {
                         kind: Function(
                             FunctionType {
+                                span: 125..155,
                                 type_params: None,
                                 params: [
                                     FuncParam {
@@ -160,6 +163,7 @@ TypeAnn {
                     type_ann: TypeAnn {
                         kind: Function(
                             FunctionType {
+                                span: 178..198,
                                 type_params: None,
                                 params: [
                                     FuncParam {
@@ -186,7 +190,7 @@ TypeAnn {
                                 throws: None,
                             },
                         ),
-                        span: 0..0,
+                        span: 178..198,
                         inferred_type: None,
                     },
                 },
@@ -203,6 +207,7 @@ TypeAnn {
                     type_ann: TypeAnn {
                         kind: Function(
                             FunctionType {
+                                span: 221..263,
                                 type_params: None,
                                 params: [
                                     FuncParam {
@@ -250,7 +255,7 @@ TypeAnn {
                                 throws: None,
                             },
                         ),
-                        span: 0..0,
+                        span: 221..263,
                         inferred_type: None,
                     },
                 },


### PR DESCRIPTION
Call and constructor signatures should be generalized just like any other function signature.