### PR TITLE
Add an (inferred) .scheme field on TypeRefs

### DIFF
--- a/crates/escalier_ast/src/class.rs
+++ b/crates/escalier_ast/src/class.rs
@@ -84,6 +84,5 @@ pub enum ClassMember {
     Method(Method),
     Getter(Getter),
     Setter(Setter),
-    Constructor(Constructor),
     Field(Field), // TODO: rename to property?
 }

--- a/crates/escalier_ast/src/visitor.rs
+++ b/crates/escalier_ast/src/visitor.rs
@@ -165,7 +165,6 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr) {
                     ClassMember::Method(_) => {}
                     ClassMember::Getter(_) => {}
                     ClassMember::Setter(_) => {}
-                    ClassMember::Constructor(_) => {}
                     ClassMember::Field(_) => {}
                 }
             }

--- a/crates/escalier_codegen/src/js.rs
+++ b/crates/escalier_codegen/src/js.rs
@@ -1174,64 +1174,13 @@ fn build_jsx_element(
     elem
 }
 
-// fn build_lit(lit: &values::Lit) -> Lit {
-//     match lit {
-//         values::Lit::Num(n) => Lit::Num(Number {
-//             span: DUMMY_SP,
-//             value: n.value.parse().unwrap(),
-//             raw: None,
-//         }),
-//         values::Lit::Bool(b) => Lit::Bool(Bool {
-//             span: DUMMY_SP,
-//             value: b.value,
-//         }),
-//         values::Lit::Str(s) => Lit::Str(Str {
-//             span: DUMMY_SP,
-//             value: JsWord::from(s.value.to_owned()),
-//             raw: None,
-//             // Some would include the quotes around the string
-//             // Some(JsWord::from(s.value.to_owned())),
-//         }),
-//     }
-// }
-
 fn build_class(class: &values::Class, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Class {
     let body: Vec<ClassMember> = class
         .body
         .iter()
         .filter_map(|member| match member {
-            values::ClassMember::Constructor(constructor) => {
-                let body = build_body_block_stmt(&constructor.body, &BlockFinalizer::ExprStmt, ctx);
-                // In Crochet, `self` is always the first param in methods, but
-                // it represents `this` in JavaScript which is implicit so we
-                // ignore it here.
-                let mut iter = constructor.params.iter();
-                iter.next();
-                let params: Vec<ParamOrTsParamProp> = iter
-                    .map(|param| {
-                        let pat = build_pattern(&param.pattern, stmts, ctx).unwrap();
-                        ParamOrTsParamProp::Param(Param {
-                            span: DUMMY_SP,
-                            decorators: vec![],
-                            pat,
-                        })
-                    })
-                    .collect();
-
-                Some(ClassMember::Constructor(Constructor {
-                    span: DUMMY_SP, // TODO
-                    key: PropName::Ident(Ident {
-                        span: DUMMY_SP, // TODO
-                        sym: swc_atoms::JsWord::from(String::from("constructor")),
-                        optional: false,
-                    }),
-                    params,
-                    body: Some(body),
-                    accessibility: None,
-                    is_optional: false,
-                }))
-            }
             values::ClassMember::Method(method) => {
+                // TODO: check if `name` is `constructor`
                 let body = build_body_block_stmt(&method.body, &BlockFinalizer::ExprStmt, ctx);
 
                 // In Escalier, `self` is always the first param in non-static

--- a/crates/escalier_hm/src/context.rs
+++ b/crates/escalier_hm/src/context.rs
@@ -227,6 +227,7 @@ impl<'a> Folder for Instantiate<'a> {
         match &t.kind {
             TypeKind::TypeRef(TypeRef {
                 name,
+                scheme, // TODO: walk the scheme's types as well
                 type_args: types,
             }) => {
                 let new_types = folder::walk_indexes(self, types);
@@ -239,7 +240,8 @@ impl<'a> Folder for Instantiate<'a> {
                     }
                     None => {
                         if &new_types != types {
-                            self.checker.new_type_ref(name, &new_types)
+                            self.checker
+                                .new_type_ref(name, scheme.to_owned(), &new_types)
                         } else {
                             *index
                         }

--- a/crates/escalier_hm/src/folder.rs
+++ b/crates/escalier_hm/src/folder.rs
@@ -35,6 +35,7 @@ pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
         }
         TypeKind::TypeRef(TypeRef {
             name,
+            scheme,
             type_args: types,
         }) => {
             let new_types = walk_indexes(folder, types);
@@ -45,6 +46,16 @@ pub fn walk_index<F: Folder>(folder: &mut F, index: &Index) -> Index {
 
             TypeKind::TypeRef(TypeRef {
                 name: name.to_owned(),
+                scheme: match scheme {
+                    None => None,
+                    Some(scheme) => {
+                        let t = folder.fold_index(&scheme.t);
+                        Some(Scheme {
+                            t,
+                            ..scheme.to_owned()
+                        })
+                    }
+                },
                 type_args: new_types,
             })
         }

--- a/crates/escalier_hm/src/infer_class.rs
+++ b/crates/escalier_hm/src/infer_class.rs
@@ -217,6 +217,7 @@ impl Checker {
             Scheme {
                 t: self_type,
                 type_params: None,
+                is_type_param: false,
             },
         );
 
@@ -243,6 +244,7 @@ impl Checker {
                         Some(Scheme {
                             t: self_type,
                             type_params: None,
+                            is_type_param: false,
                         }),
                         &[],
                     );
@@ -417,6 +419,7 @@ impl Checker {
             // I don't think this is something that can be inferred, by
             // default, each function gets its own type params
             type_params: None,
+            is_type_param: false,
         };
 
         let static_type = self.new_object_type(&static_elems);

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -21,6 +21,9 @@ pub struct TypeVar {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeRef {
     pub name: String,
+    // NOTE: if `scheme` is `None` then we need to look up the type in the
+    // current Context to see if it exists.  If it doesn't, that's a type error.
+    pub scheme: Option<Scheme>,
     pub type_args: Vec<Index>,
 }
 
@@ -462,7 +465,11 @@ impl Checker {
                 format!("[{}]", self.print_types(types).join(", "))
             }
             TypeKind::Array(Array { t }) => format!("{}[]", self.print_type(t)),
-            TypeKind::TypeRef(TypeRef { name, type_args }) => {
+            TypeKind::TypeRef(TypeRef {
+                name,
+                scheme: _, // TODO
+                type_args,
+            }) => {
                 if type_args.is_empty() {
                     name.to_string()
                 } else {
@@ -910,9 +917,10 @@ impl Checker {
         })))
     }
 
-    pub fn new_type_ref(&mut self, name: &str, types: &[Index]) -> Index {
+    pub fn new_type_ref(&mut self, name: &str, scheme: Option<Scheme>, types: &[Index]) -> Index {
         self.arena.insert(Type::from(TypeKind::TypeRef(TypeRef {
             name: name.to_string(),
+            scheme,
             type_args: types.to_vec(),
         })))
     }

--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -422,6 +422,7 @@ impl From<TypeKind> for Type {
 pub struct Scheme {
     pub t: Index,
     pub type_params: Option<Vec<TypeParam>>,
+    pub is_type_param: bool,
 }
 
 /// A type variable standing for an arbitrary type.

--- a/crates/escalier_hm/src/unify.rs
+++ b/crates/escalier_hm/src/unify.rs
@@ -811,8 +811,15 @@ impl Checker {
                     message: "array is not callable".to_string(),
                 })
             }
-            TypeKind::TypeRef(TypeRef { name, type_args }) => {
-                let scheme = ctx.get_scheme(&name)?;
+            TypeKind::TypeRef(TypeRef {
+                name,
+                scheme,
+                type_args,
+            }) => {
+                let scheme = match scheme {
+                    Some(scheme) => scheme,
+                    None => ctx.get_scheme(&name)?,
+                };
                 let mut mapping: HashMap<String, Index> = HashMap::new();
                 if let Some(type_params) = &scheme.type_params {
                     for (param, arg) in type_params.iter().zip(type_args.iter()) {

--- a/crates/escalier_hm/src/util.rs
+++ b/crates/escalier_hm/src/util.rs
@@ -291,6 +291,7 @@ impl Checker {
                         Scheme {
                             type_params: None,
                             t: *arg,
+                            is_type_param: false,
                         },
                     );
                 }

--- a/crates/escalier_hm/src/visitor.rs
+++ b/crates/escalier_hm/src/visitor.rs
@@ -23,9 +23,10 @@ pub fn walk_index<V: Visitor>(visitor: &mut V, index: &Index) {
         }
         TypeKind::TypeRef(TypeRef {
             name: _,
-            type_args: types,
+            scheme: _, // TODO: walk the scheme's types as well
+            type_args,
         }) => {
-            walk_indexes(visitor, types);
+            walk_indexes(visitor, type_args);
         }
         TypeKind::Union(Union { types }) => {
             walk_indexes(visitor, types);

--- a/crates/escalier_hm/tests/exceptions_test.rs
+++ b/crates/escalier_hm/tests/exceptions_test.rs
@@ -11,7 +11,7 @@ fn test_env() -> (Checker, Context) {
     let mut context = Context::default();
 
     let number = checker.new_primitive(Primitive::Number);
-    let type_param_t = checker.new_type_ref("T", &[]);
+    let type_param_t = checker.new_type_ref("T", None, &[]);
 
     let push_t = checker.new_func_type(
         &[types::FuncParam {
@@ -30,8 +30,8 @@ fn test_env() -> (Checker, Context) {
 
     // [P]: T for P in number;
     let mapped = types::TObjElem::Mapped(types::MappedType {
-        key: checker.new_type_ref("P", &[]),
-        value: checker.new_type_ref("T", &[]),
+        key: checker.new_type_ref("P", None, &[]),
+        value: checker.new_type_ref("T", None, &[]),
         target: "P".to_string(),
         source: checker.new_primitive(Primitive::Number),
         optional: None,

--- a/crates/escalier_hm/tests/exceptions_test.rs
+++ b/crates/escalier_hm/tests/exceptions_test.rs
@@ -63,6 +63,7 @@ fn test_env() -> (Checker, Context) {
             default: None,
         }]),
         t: array_interface,
+        is_type_param: false,
     };
 
     context.schemes.insert("Array".to_string(), array_scheme);

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -96,6 +96,7 @@ fn test_env() -> (Checker, Context) {
             default: None,
         }]),
         t: array_interface,
+        is_type_param: false,
     };
 
     context.schemes.insert("Array".to_string(), array_scheme);
@@ -3620,7 +3621,6 @@ fn test_index_access_type_number_mapped() -> Result<(), TypeError> {
 fn test_mapped_type_pick() -> Result<(), TypeError> {
     let (mut checker, mut my_ctx) = test_env();
 
-    // TODO: replace `T` in type variable constraints as well
     let src = r#"   
     type Pick<T, K : keyof T> = {[P]: T[P] for P in K}
     type Obj = {a?: string, b: number, c: boolean}

--- a/crates/escalier_hm/tests/integration_test.rs
+++ b/crates/escalier_hm/tests/integration_test.rs
@@ -44,7 +44,7 @@ fn test_env() -> (Checker, Context) {
     let mut context = Context::default();
 
     let number = checker.new_primitive(Primitive::Number);
-    let type_param_t = checker.new_type_ref("T", &[]);
+    let type_param_t = checker.new_type_ref("T", None, &[]);
 
     let push_t = checker.new_func_type(
         &[types::FuncParam {
@@ -63,8 +63,8 @@ fn test_env() -> (Checker, Context) {
 
     // [P]: T for P in number;
     let mapped = types::TObjElem::Mapped(types::MappedType {
-        key: checker.new_type_ref("P", &[]),
-        value: checker.new_type_ref("T", &[]),
+        key: checker.new_type_ref("P", None, &[]),
+        value: checker.new_type_ref("T", None, &[]),
         target: "P".to_string(),
         source: checker.new_primitive(Primitive::Number),
         optional: None,
@@ -5463,8 +5463,7 @@ fn infer_simple_class() -> Result<(), TypeError> {
     let mut p = new Point(5, 10)
     let q = new Point(1, 0)
     let {x, y} = p
-    // TODO: store a reference to the underlying type on type references
-    // let r = p.add(q)
+    let r = p.add(q)
     "#;
     let mut script = parse_script(src).unwrap();
 
@@ -5473,12 +5472,14 @@ fn infer_simple_class() -> Result<(), TypeError> {
     let binding = my_ctx.values.get("Point").unwrap();
     assert_eq!(
         checker.print_type(&binding.index),
-        r#"{new fn(x: number, y: number) -> {x: number, y: number, add(mut self, other: Self) -> Self}}"#
+        r#"{new fn(x: number, y: number) -> Self}"#
     );
 
     let binding = my_ctx.values.get("p").unwrap();
+    assert_eq!(checker.print_type(&binding.index), r#"Self"#);
+    let t = checker.expand_type(&my_ctx, binding.index)?;
     assert_eq!(
-        checker.print_type(&binding.index),
+        checker.print_type(&t),
         r#"{x: number, y: number, add(mut self, other: Self) -> Self}"#
     );
 
@@ -5507,8 +5508,7 @@ fn infer_simple_class_and_param_types() -> Result<(), TypeError> {
     let mut p = new Point(5, 10)
     let q = new Point(1, 0)
     let {x, y} = p
-    // TODO: store a reference to the underlying type on type references
-    // let r = p.add(q)
+    let r = p.add(q)
     "#;
     let mut script = parse_script(src).unwrap();
 
@@ -5517,14 +5517,68 @@ fn infer_simple_class_and_param_types() -> Result<(), TypeError> {
     let binding = my_ctx.values.get("Point").unwrap();
     assert_eq!(
         checker.print_type(&binding.index),
-        r#"{new fn(x: number, y: number) -> {x: number, y: number, add(mut self, other: Self) -> Self}}"#
+        r#"{new fn(x: number, y: number) -> Self}"#
     );
 
     let binding = my_ctx.values.get("p").unwrap();
+    assert_eq!(checker.print_type(&binding.index), r#"Self"#);
+    let t = checker.expand_type(&my_ctx, binding.index)?;
     assert_eq!(
-        checker.print_type(&binding.index),
+        checker.print_type(&t),
         r#"{x: number, y: number, add(mut self, other: Self) -> Self}"#
     );
+
+    assert_no_errors(&checker)
+}
+
+#[test]
+fn use_value_with_private_type() -> Result<(), TypeError> {
+    let (mut checker, mut my_ctx) = test_env();
+
+    // TODO: Allow comments in class bodies
+    let src = r#"
+    let make_point = fn () {
+        type Point = {x: number, y: number}
+        let p: Point = {x: 5, y: 10}
+        return p
+    }
+    let p = make_point()
+    let {x, y} = p
+    "#;
+    let mut script = parse_script(src).unwrap();
+
+    checker.infer_script(&mut script, &mut my_ctx)?;
+
+    let binding = my_ctx.values.get("p").unwrap();
+    assert_eq!(checker.print_type(&binding.index), r#"Point"#);
+    let t = checker.expand_type(&my_ctx, binding.index)?;
+    assert_eq!(checker.print_type(&t), r#"{x: number, y: number}"#);
+
+    assert_no_errors(&checker)
+}
+
+#[test]
+fn use_value_with_private_type_on_obj() -> Result<(), TypeError> {
+    let (mut checker, mut my_ctx) = test_env();
+
+    // TODO: Allow comments in class bodies
+    let src = r#"
+    let make_point = fn () {
+        type Point = {x: number, y: number}
+        let obj: {p: Point} = {p: {x: 5, y: 10}}
+        return obj
+    }
+    let {p} = make_point()
+    let {x, y} = p
+    "#;
+    let mut script = parse_script(src).unwrap();
+
+    checker.infer_script(&mut script, &mut my_ctx)?;
+
+    let binding = my_ctx.values.get("p").unwrap();
+    assert_eq!(checker.print_type(&binding.index), r#"Point"#);
+    let t = checker.expand_type(&my_ctx, binding.index)?;
+    assert_eq!(checker.print_type(&t), r#"{x: number, y: number}"#);
 
     assert_no_errors(&checker)
 }

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -670,7 +670,11 @@ fn infer_type_alias_decl(
         None => None,
     };
 
-    let scheme = Scheme { t, type_params };
+    let scheme = Scheme {
+        t,
+        type_params,
+        is_type_param: false,
+    };
 
     Ok(scheme)
 }
@@ -696,6 +700,7 @@ fn infer_interface_decl(
         Scheme {
             t: self_type,
             type_params: None,
+            is_type_param: false,
         },
     );
 
@@ -773,7 +778,11 @@ fn infer_interface_decl(
         ])
     }
 
-    let scheme = Scheme { t, type_params };
+    let scheme = Scheme {
+        t,
+        type_params,
+        is_type_param: false,
+    };
 
     Ok(scheme)
 }

--- a/crates/escalier_interop/src/parse.rs
+++ b/crates/escalier_interop/src/parse.rs
@@ -151,12 +151,14 @@ pub fn infer_ts_type_ann(
                         .collect();
                     Ok(checker.from_type_kind(TypeKind::TypeRef(TypeRef {
                         name,
+                        scheme: None,
                         // TODO: Update TypeRef's .types field to be Option<Vec<Index>>
                         type_args: result.ok().unwrap(),
                     })))
                 }
                 None => Ok(checker.from_type_kind(TypeKind::TypeRef(TypeRef {
                     name,
+                    scheme: None,
                     type_args: vec![],
                 }))),
             }
@@ -311,7 +313,7 @@ pub fn infer_ts_type_ann(
             let name = type_param.name.sym.to_string();
 
             let elems = vec![TObjElem::Mapped(MappedType {
-                key: checker.new_type_ref(&name, &[]),
+                key: checker.new_type_ref(&name, None, &[]),
                 target: name,
                 source: constraint,
                 value: type_ann,
@@ -611,7 +613,7 @@ fn infer_ts_type_element(
 
                 if let TPat::Ident(identifier::BindingIdent { name, .. }) = &key.pattern {
                     Ok(TObjElem::Mapped(MappedType {
-                        key: checker.new_type_ref(name.as_str(), &[]),
+                        key: checker.new_type_ref(name.as_str(), None, &[]),
                         target: name.to_owned(),
                         value: t,
                         source: key.t,
@@ -684,10 +686,10 @@ fn infer_interface_decl(
 
     if let Some(type_params) = &decl.type_params {
         for param in &type_params.as_ref().params {
-            type_args.push(checker.new_type_ref(&param.name.sym, &[]));
+            type_args.push(checker.new_type_ref(&param.name.sym, None, &[]));
         }
     }
-    let self_type = checker.new_type_ref(&decl.id.sym, &type_args);
+    let self_type = checker.new_type_ref(&decl.id.sym, None, &type_args);
 
     sig_ctx.schemes.insert(
         "Self".to_string(),

--- a/crates/escalier_interop/src/util.rs
+++ b/crates/escalier_interop/src/util.rs
@@ -27,7 +27,11 @@ pub fn new_merge_schemes(schemes: &[Scheme], checker: &mut Checker) -> Scheme {
 
     let t = checker.from_type_kind(TypeKind::Object(TObject { elems }));
 
-    Scheme { t, type_params }
+    Scheme {
+        t,
+        type_params,
+        is_type_param: false,
+    }
 }
 
 pub fn merge_readonly_and_mutable_schemes(
@@ -163,7 +167,11 @@ pub fn merge_readonly_and_mutable_schemes(
         // is_interface: true,
     }));
 
-    Scheme { t, type_params }
+    Scheme {
+        t,
+        type_params,
+        is_type_param: false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/escalier_parser/src/class.rs
+++ b/crates/escalier_parser/src/class.rs
@@ -240,29 +240,19 @@ impl<'a> Parser<'a> {
         let end = self.scanner.cursor();
         let span = Span { start, end };
 
-        let method = match name {
-            PropName::Ident(ident) if ident.name == "new" => {
-                ClassMember::Constructor(Constructor {
-                    span,
-                    is_public,
-                    params,
-                    body,
-                })
-            }
-            _ => ClassMember::Method(Method {
-                span,
-                name,
-                is_public,
-                is_async,
-                is_gen,
-                is_mutating,
-                is_static,
-                params,
-                body,
-                type_params,
-                type_ann,
-            }),
-        };
+        let method = ClassMember::Method(Method {
+            span,
+            name,
+            is_public,
+            is_async,
+            is_gen,
+            is_mutating,
+            is_static,
+            params,
+            body,
+            type_params,
+            type_ann,
+        });
 
         Ok(method)
     }


### PR DESCRIPTION
This will allow us to use variables whose type is private.  There's still some kinks to work out with type params that reference themselves.