### PR TITLE
Better inference of methods in classes

### DIFF
--- a/crates/escalier_hm/src/types.rs
+++ b/crates/escalier_hm/src/types.rs
@@ -81,6 +81,8 @@ pub struct Function {
     pub params: Vec<FuncParam>,
     pub ret: Index,
     pub type_params: Option<Vec<TypeParam>>,
+    // TODO: make this `Index` and if the function doesn't throw,
+    // this should be `never`.
     pub throws: Option<Index>,
 }
 

--- a/crates/escalier_parser/src/expr_parser.rs
+++ b/crates/escalier_parser/src/expr_parser.rs
@@ -1540,4 +1540,9 @@ mod tests {
         insta::assert_debug_snapshot!(parse("new Array(1, 2, 3)"));
         insta::assert_debug_snapshot!(parse("new Foo.Bar(baz)"));
     }
+
+    #[test]
+    fn parse_ambiguous_generics() {
+        insta::assert_debug_snapshot!(parse("F(G<A, B>(7))"));
+    }
 }

--- a/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_ambiguous_generics.snap
+++ b/crates/escalier_parser/src/snapshots/escalier_parser__expr_parser__tests__parse_ambiguous_generics.snap
@@ -1,0 +1,78 @@
+---
+source: crates/escalier_parser/src/expr_parser.rs
+expression: "parse(\"F(G<A, B>(7))\")"
+---
+Expr {
+    kind: Call(
+        Call {
+            callee: Expr {
+                kind: Ident(
+                    Ident {
+                        name: "F",
+                        span: 0..1,
+                    },
+                ),
+                span: 0..1,
+                inferred_type: None,
+            },
+            type_args: None,
+            args: [
+                Expr {
+                    kind: Call(
+                        Call {
+                            callee: Expr {
+                                kind: Ident(
+                                    Ident {
+                                        name: "G",
+                                        span: 2..3,
+                                    },
+                                ),
+                                span: 2..3,
+                                inferred_type: None,
+                            },
+                            type_args: Some(
+                                [
+                                    TypeAnn {
+                                        kind: TypeRef(
+                                            "A",
+                                            None,
+                                        ),
+                                        span: 4..5,
+                                        inferred_type: None,
+                                    },
+                                    TypeAnn {
+                                        kind: TypeRef(
+                                            "B",
+                                            None,
+                                        ),
+                                        span: 7..8,
+                                        inferred_type: None,
+                                    },
+                                ],
+                            ),
+                            args: [
+                                Expr {
+                                    kind: Num(
+                                        Num {
+                                            value: "7",
+                                        },
+                                    ),
+                                    span: 10..11,
+                                    inferred_type: None,
+                                },
+                            ],
+                            opt_chain: false,
+                            throws: None,
+                        },
+                    ),
+                    span: 2..12,
+                    inferred_type: None,
+                },
+            ],
+            opt_chain: false,
+            throws: None,
+        },
+    ),
+    span: 0..13,
+    inferred_type: None,
+}


### PR DESCRIPTION
This PR updates the inferred interface (instance scheme) by unifying each method's params and return type with those inferred from the body of each method.

This doesn't handle methods that throw correctly.  I'll do that in a separate PR once I fix an ordering issue with `thows` in regular non-method functions.