### PR TITLE
Convert existing parser tests to table-driven tests

### DIFF
--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -1,31 +1,15 @@
 
-[TestParsingAddition - 1]
+[TestParseExprNoErrors/StringLiteral - 1]
 &parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Op:    0,
-        Right: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"b"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:5},
-                End:   parser.Location{Line:1, Column:6},
-            },
-        },
-    },
+    Kind: &parser.EString{Value:"hello"},
     Span: parser.Span{
         Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:6},
+        End:   parser.Location{Line:1, Column:7},
     },
 }
 ---
 
-[TestParsingAddSub - 1]
+[TestParseExprNoErrors/AddSub - 1]
 &parser.Expr{
     Kind: &parser.EBinary{
         Left: &parser.Expr{
@@ -67,7 +51,451 @@
 }
 ---
 
-[TestParsingMulAdd - 1]
+[TestParseExprNoErrors/IndexPrecedence - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Op:    0,
+        Right: &parser.Expr{
+            Kind: &parser.EIndex{
+                Object: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"b"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:5},
+                        End:   parser.Location{Line:1, Column:6},
+                    },
+                },
+                Index: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"c"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:7},
+                        End:   parser.Location{Line:1, Column:8},
+                    },
+                },
+                OptChain: false,
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:5},
+                End:   parser.Location{Line:1, Column:9},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:9},
+    },
+}
+---
+
+[TestParseExprNoErrors/MultipleIndexes - 1]
+&parser.Expr{
+    Kind: &parser.EIndex{
+        Object: &parser.Expr{
+            Kind: &parser.EIndex{
+                Object: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"a"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:1},
+                        End:   parser.Location{Line:1, Column:2},
+                    },
+                },
+                Index: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"i"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:3},
+                        End:   parser.Location{Line:1, Column:4},
+                    },
+                },
+                OptChain: false,
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:5},
+            },
+        },
+        Index: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"j"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:6},
+                End:   parser.Location{Line:1, Column:7},
+            },
+        },
+        OptChain: false,
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:8},
+    },
+}
+---
+
+[TestParseExprNoErrors/OptChainIndex - 1]
+&parser.Expr{
+    Kind: &parser.EIndex{
+        Object: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Index: &parser.Expr{
+            Kind: &parser.EBinary{
+                Left: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"base"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:4},
+                        End:   parser.Location{Line:1, Column:8},
+                    },
+                },
+                Op:    0,
+                Right: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"offset"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:11},
+                        End:   parser.Location{Line:1, Column:17},
+                    },
+                },
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:4},
+                End:   parser.Location{Line:1, Column:17},
+            },
+        },
+        OptChain: true,
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:18},
+    },
+}
+---
+
+[TestParseExprNoErrors/MemberPrecedence - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Op:    0,
+        Right: &parser.Expr{
+            Kind: &parser.EMember{
+                Object: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"b"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:5},
+                        End:   parser.Location{Line:1, Column:6},
+                    },
+                },
+                Prop: &parser.Identifier{
+                    Name: "c",
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:7},
+                        End:   parser.Location{Line:1, Column:8},
+                    },
+                },
+                OptChain: false,
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:5},
+                End:   parser.Location{Line:1, Column:8},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:8},
+    },
+}
+---
+
+[TestParseExprNoErrors/Parens - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Op:    2,
+        Right: &parser.Expr{
+            Kind: &parser.EBinary{
+                Left: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"b"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:6},
+                        End:   parser.Location{Line:1, Column:7},
+                    },
+                },
+                Op:    0,
+                Right: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"c"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:10},
+                        End:   parser.Location{Line:1, Column:11},
+                    },
+                },
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:6},
+                End:   parser.Location{Line:1, Column:11},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:11},
+    },
+}
+---
+
+[TestParseExprNoErrors/NumberLiteral - 1]
+&parser.Expr{
+    Kind: &parser.ENumber{Value:5},
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:2},
+    },
+}
+---
+
+[TestParseExprNoErrors/Index - 1]
+&parser.Expr{
+    Kind: &parser.EIndex{
+        Object: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Index: &parser.Expr{
+            Kind: &parser.EBinary{
+                Left: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"base"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:3},
+                        End:   parser.Location{Line:1, Column:7},
+                    },
+                },
+                Op:    0,
+                Right: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"offset"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:10},
+                        End:   parser.Location{Line:1, Column:16},
+                    },
+                },
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:3},
+                End:   parser.Location{Line:1, Column:16},
+            },
+        },
+        OptChain: false,
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:17},
+    },
+}
+---
+
+[TestParseExprNoErrors/Addition - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Op:    0,
+        Right: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"b"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:5},
+                End:   parser.Location{Line:1, Column:6},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:6},
+    },
+}
+---
+
+[TestParseExprNoErrors/Call - 1]
+&parser.Expr{
+    Kind: &parser.ECall{
+        Callee: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"foo"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:4},
+            },
+        },
+        Args: {
+            &parser.Expr{
+                Kind: &parser.EIdentifier{Name:"a"},
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:5},
+                    End:   parser.Location{Line:1, Column:6},
+                },
+            },
+            &parser.Expr{
+                Kind: &parser.EIdentifier{Name:"b"},
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:8},
+                    End:   parser.Location{Line:1, Column:9},
+                },
+            },
+            &parser.Expr{
+                Kind: &parser.EIdentifier{Name:"c"},
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:11},
+                    End:   parser.Location{Line:1, Column:12},
+                },
+            },
+        },
+        OptChain: false,
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:13},
+    },
+}
+---
+
+[TestParseExprNoErrors/UnaryOps - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EUnary{
+                Op:  0,
+                Arg: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"a"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:2},
+                        End:   parser.Location{Line:1, Column:3},
+                    },
+                },
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:2},
+                End:   parser.Location{Line:1, Column:3},
+            },
+        },
+        Op:    1,
+        Right: &parser.Expr{
+            Kind: &parser.EUnary{
+                Op:  1,
+                Arg: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"b"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:7},
+                        End:   parser.Location{Line:1, Column:8},
+                    },
+                },
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:7},
+                End:   parser.Location{Line:1, Column:8},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:2},
+        End:   parser.Location{Line:1, Column:8},
+    },
+}
+---
+
+[TestParseExprNoErrors/Member - 1]
+&parser.Expr{
+    Kind: &parser.EMember{
+        Object: &parser.Expr{
+            Kind: &parser.EMember{
+                Object: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"a"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:1},
+                        End:   parser.Location{Line:1, Column:2},
+                    },
+                },
+                Prop: &parser.Identifier{
+                    Name: "b",
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:3},
+                        End:   parser.Location{Line:1, Column:4},
+                    },
+                },
+                OptChain: false,
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:4},
+            },
+        },
+        Prop: &parser.Identifier{
+            Name: "c",
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:4},
+                End:   parser.Location{Line:1, Column:6},
+            },
+        },
+        OptChain: true,
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:6},
+    },
+}
+---
+
+[TestParseExprNoErrors/OptChainCall - 1]
+&parser.Expr{
+    Kind: &parser.ECall{
+        Callee: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"foo"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:4},
+            },
+        },
+        Args: {
+            &parser.Expr{
+                Kind: &parser.EIdentifier{Name:"bar"},
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:6},
+                    End:   parser.Location{Line:1, Column:9},
+                },
+            },
+        },
+        OptChain: true,
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:10},
+    },
+}
+---
+
+[TestParseExprNoErrors/MulAdd - 1]
 &parser.Expr{
     Kind: &parser.EBinary{
         Left: &parser.Expr{
@@ -125,219 +553,7 @@
 }
 ---
 
-[TestParsingUnaryOps - 1]
-&parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EUnary{
-                Op:  0,
-                Arg: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"a"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:2},
-                        End:   parser.Location{Line:1, Column:3},
-                    },
-                },
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:2},
-                End:   parser.Location{Line:1, Column:3},
-            },
-        },
-        Op:    1,
-        Right: &parser.Expr{
-            Kind: &parser.EUnary{
-                Op:  1,
-                Arg: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"b"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:7},
-                        End:   parser.Location{Line:1, Column:8},
-                    },
-                },
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:7},
-                End:   parser.Location{Line:1, Column:8},
-            },
-        },
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:2},
-        End:   parser.Location{Line:1, Column:8},
-    },
-}
----
-
-[TestParsingParens - 1]
-&parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Op:    2,
-        Right: &parser.Expr{
-            Kind: &parser.EBinary{
-                Left: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"b"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:6},
-                        End:   parser.Location{Line:1, Column:7},
-                    },
-                },
-                Op:    0,
-                Right: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"c"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:10},
-                        End:   parser.Location{Line:1, Column:11},
-                    },
-                },
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:6},
-                End:   parser.Location{Line:1, Column:11},
-            },
-        },
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:11},
-    },
-}
----
-
-[TestParsingIndex - 1]
-&parser.Expr{
-    Kind: &parser.EIndex{
-        Object: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Index: &parser.Expr{
-            Kind: &parser.EBinary{
-                Left: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"base"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:3},
-                        End:   parser.Location{Line:1, Column:7},
-                    },
-                },
-                Op:    0,
-                Right: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"offset"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:10},
-                        End:   parser.Location{Line:1, Column:16},
-                    },
-                },
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:3},
-                End:   parser.Location{Line:1, Column:16},
-            },
-        },
-        OptChain: false,
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:17},
-    },
-}
----
-
-[TestParsingOptChainIndex - 1]
-&parser.Expr{
-    Kind: &parser.EIndex{
-        Object: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Index: &parser.Expr{
-            Kind: &parser.EBinary{
-                Left: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"base"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:4},
-                        End:   parser.Location{Line:1, Column:8},
-                    },
-                },
-                Op:    0,
-                Right: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"offset"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:11},
-                        End:   parser.Location{Line:1, Column:17},
-                    },
-                },
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:4},
-                End:   parser.Location{Line:1, Column:17},
-            },
-        },
-        OptChain: true,
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:18},
-    },
-}
----
-
-[TestParsingCall - 1]
-&parser.Expr{
-    Kind: &parser.ECall{
-        Callee: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"foo"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:4},
-            },
-        },
-        Args: {
-            &parser.Expr{
-                Kind: &parser.EIdentifier{Name:"a"},
-                Span: parser.Span{
-                    Start: parser.Location{Line:1, Column:5},
-                    End:   parser.Location{Line:1, Column:6},
-                },
-            },
-            &parser.Expr{
-                Kind: &parser.EIdentifier{Name:"b"},
-                Span: parser.Span{
-                    Start: parser.Location{Line:1, Column:8},
-                    End:   parser.Location{Line:1, Column:9},
-                },
-            },
-            &parser.Expr{
-                Kind: &parser.EIdentifier{Name:"c"},
-                Span: parser.Span{
-                    Start: parser.Location{Line:1, Column:11},
-                    End:   parser.Location{Line:1, Column:12},
-                },
-            },
-        },
-        OptChain: false,
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:13},
-    },
-}
----
-
-[TestParsingArrayLiteral - 1]
+[TestParseExprNoErrors/ArrayLiteral - 1]
 &parser.Expr{
     Kind: &parser.EArray{
         Elems: {
@@ -371,7 +587,93 @@
 }
 ---
 
-[TestParsingCurriedCall - 1]
+[TestParseExprNoErrors/CallPrecedence - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Op:    0,
+        Right: &parser.Expr{
+            Kind: &parser.ECall{
+                Callee: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"foo"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:5},
+                        End:   parser.Location{Line:1, Column:8},
+                    },
+                },
+                Args: {
+                    &parser.Expr{
+                        Kind: &parser.EIdentifier{Name:"b"},
+                        Span: parser.Span{
+                            Start: parser.Location{Line:1, Column:9},
+                            End:   parser.Location{Line:1, Column:10},
+                        },
+                    },
+                },
+                OptChain: false,
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:5},
+                End:   parser.Location{Line:1, Column:11},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:11},
+    },
+}
+---
+
+[TestParseExprNoErrors/MulDiv - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EBinary{
+                Left: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"a"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:1},
+                        End:   parser.Location{Line:1, Column:2},
+                    },
+                },
+                Op:    3,
+                Right: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"b"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:5},
+                        End:   parser.Location{Line:1, Column:6},
+                    },
+                },
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:6},
+            },
+        },
+        Op:    2,
+        Right: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"c"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:9},
+                End:   parser.Location{Line:1, Column:10},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:10},
+    },
+}
+---
+
+[TestParseExprNoErrors/CurriedCall - 1]
 &parser.Expr{
     Kind: &parser.ECall{
         Callee: &parser.Expr{
@@ -435,82 +737,24 @@
 }
 ---
 
-[TestParsingMember - 1]
+[TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 1]
 &parser.Expr{
-    Kind: &parser.EMember{
-        Object: &parser.Expr{
-            Kind: &parser.EMember{
-                Object: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"a"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:1},
-                        End:   parser.Location{Line:1, Column:2},
-                    },
-                },
-                Prop: &parser.Identifier{
-                    Name: "b",
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:3},
-                        End:   parser.Location{Line:1, Column:4},
-                    },
-                },
-                OptChain: false,
-            },
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
             Span: parser.Span{
                 Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:4},
+                End:   parser.Location{Line:1, Column:2},
             },
         },
-        Prop: &parser.Identifier{
-            Name: "c",
+        Op:    0,
+        Right: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"b"},
             Span: parser.Span{
-                Start: parser.Location{Line:1, Column:4},
-                End:   parser.Location{Line:1, Column:6},
+                Start: parser.Location{Line:1, Column:7},
+                End:   parser.Location{Line:1, Column:8},
             },
         },
-        OptChain: true,
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:6},
-    },
-}
----
-
-[TestParsingMultipleIndexes - 1]
-&parser.Expr{
-    Kind: &parser.EIndex{
-        Object: &parser.Expr{
-            Kind: &parser.EIndex{
-                Object: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"a"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:1},
-                        End:   parser.Location{Line:1, Column:2},
-                    },
-                },
-                Index: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"i"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:3},
-                        End:   parser.Location{Line:1, Column:4},
-                    },
-                },
-                OptChain: false,
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:5},
-            },
-        },
-        Index: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"j"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:6},
-                End:   parser.Location{Line:1, Column:7},
-            },
-        },
-        OptChain: false,
     },
     Span: parser.Span{
         Start: parser.Location{Line:1, Column:1},
@@ -519,49 +763,7 @@
 }
 ---
 
-[TestParsingMulDiv - 1]
-&parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EBinary{
-                Left: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"a"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:1},
-                        End:   parser.Location{Line:1, Column:2},
-                    },
-                },
-                Op:    3,
-                Right: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"b"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:5},
-                        End:   parser.Location{Line:1, Column:6},
-                    },
-                },
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:6},
-            },
-        },
-        Op:    2,
-        Right: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"c"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:9},
-                End:   parser.Location{Line:1, Column:10},
-            },
-        },
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:10},
-    },
-}
----
-
-[TestParsingOptChainCall - 1]
+[TestParseExprErrorHandling/IncompleteCall - 1]
 &parser.Expr{
     Kind: &parser.ECall{
         Callee: &parser.Expr{
@@ -573,23 +775,38 @@
         },
         Args: {
             &parser.Expr{
-                Kind: &parser.EIdentifier{Name:"bar"},
+                Kind: &parser.EIdentifier{Name:"a"},
                 Span: parser.Span{
-                    Start: parser.Location{Line:1, Column:6},
-                    End:   parser.Location{Line:1, Column:9},
+                    Start: parser.Location{Line:1, Column:5},
+                    End:   parser.Location{Line:1, Column:6},
+                },
+            },
+            &parser.Expr{
+                Kind: &parser.EIgnore{
+                    Token: &parser.Token{
+                        Data: &parser.TEOF{},
+                        Span: parser.Span{
+                            Start: parser.Location{Line:1, Column:7},
+                            End:   parser.Location{Line:1, Column:7},
+                        },
+                    },
+                },
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:7},
+                    End:   parser.Location{Line:1, Column:7},
                 },
             },
         },
-        OptChain: true,
+        OptChain: false,
     },
     Span: parser.Span{
         Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:10},
+        End:   parser.Location{Line:1, Column:8},
     },
 }
 ---
 
-[TestParsingIncompleteMember - 1]
+[TestParseExprErrorHandling/IncompleteMemberOptChain - 1]
 &parser.Expr{
     Kind: &parser.EBinary{
         Left: &parser.Expr{
@@ -612,97 +829,11 @@
                 Prop: &parser.Identifier{
                     Name: "",
                     Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:7},
-                        End:   parser.Location{Line:1, Column:7},
-                    },
-                },
-                OptChain: false,
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:5},
-                End:   parser.Location{Line:1, Column:7},
-            },
-        },
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:7},
-    },
-}
----
-
-[TestParsingCallPrecedence - 1]
-&parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Op:    0,
-        Right: &parser.Expr{
-            Kind: &parser.ECall{
-                Callee: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"foo"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:5},
+                        Start: parser.Location{Line:1, Column:8},
                         End:   parser.Location{Line:1, Column:8},
                     },
                 },
-                Args: {
-                    &parser.Expr{
-                        Kind: &parser.EIdentifier{Name:"b"},
-                        Span: parser.Span{
-                            Start: parser.Location{Line:1, Column:9},
-                            End:   parser.Location{Line:1, Column:10},
-                        },
-                    },
-                },
-                OptChain: false,
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:5},
-                End:   parser.Location{Line:1, Column:11},
-            },
-        },
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:11},
-    },
-}
----
-
-[TestParsingMemberPrecedence - 1]
-&parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Op:    0,
-        Right: &parser.Expr{
-            Kind: &parser.EMember{
-                Object: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"b"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:5},
-                        End:   parser.Location{Line:1, Column:6},
-                    },
-                },
-                Prop: &parser.Identifier{
-                    Name: "c",
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:7},
-                        End:   parser.Location{Line:1, Column:8},
-                    },
-                },
-                OptChain: false,
+                OptChain: true,
             },
             Span: parser.Span{
                 Start: parser.Location{Line:1, Column:5},
@@ -717,59 +848,17 @@
 }
 ---
 
-[TestParsingIndexPrecedence - 1]
-&parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Op:    0,
-        Right: &parser.Expr{
-            Kind: &parser.EIndex{
-                Object: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"b"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:5},
-                        End:   parser.Location{Line:1, Column:6},
-                    },
-                },
-                Index: &parser.Expr{
-                    Kind: &parser.EIdentifier{Name:"c"},
-                    Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:7},
-                        End:   parser.Location{Line:1, Column:8},
-                    },
-                },
-                OptChain: false,
-            },
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:5},
-                End:   parser.Location{Line:1, Column:9},
-            },
-        },
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:9},
-    },
-}
----
-
-[TestParsingIncompleteMember - 2]
+[TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 2]
 &parser.Error{
     Span: parser.Span{
-        Start: parser.Location{Line:1, Column:6},
-        End:   parser.Location{Line:1, Column:7},
+        Start: parser.Location{Line:1, Column:5},
+        End:   parser.Location{Line:1, Column:6},
     },
-    Message: "expected an identifier after .",
+    Message: "Unexpected token",
 }
 ---
 
-[TestParsingIncompleteBinaryExpr - 1]
+[TestParseExprErrorHandling/IncompleteBinaryExpr - 1]
 &parser.Expr{
     Kind: &parser.EBinary{
         Left: &parser.Expr{
@@ -819,96 +908,7 @@
 }
 ---
 
-[TestParsingExtraOperatorsInBinaryExpr - 1]
-&parser.Expr{
-    Kind: &parser.EBinary{
-        Left: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"a"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:2},
-            },
-        },
-        Op:    0,
-        Right: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"b"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:7},
-                End:   parser.Location{Line:1, Column:8},
-            },
-        },
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:8},
-    },
-}
----
-
-[TestParsingExtraOperatorsInBinaryExpr - 2]
-&parser.Error{
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:5},
-        End:   parser.Location{Line:1, Column:6},
-    },
-    Message: "Unexpected token",
-}
----
-
-[TestParsingIncompleteBinaryExpr - 2]
-&parser.Error{
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:8},
-        End:   parser.Location{Line:1, Column:8},
-    },
-    Message: "Unexpected token",
-}
----
-
-[TestParsingIncompleteCall - 1]
-&parser.Expr{
-    Kind: &parser.ECall{
-        Callee: &parser.Expr{
-            Kind: &parser.EIdentifier{Name:"foo"},
-            Span: parser.Span{
-                Start: parser.Location{Line:1, Column:1},
-                End:   parser.Location{Line:1, Column:4},
-            },
-        },
-        Args: {
-            &parser.Expr{
-                Kind: &parser.EIdentifier{Name:"a"},
-                Span: parser.Span{
-                    Start: parser.Location{Line:1, Column:5},
-                    End:   parser.Location{Line:1, Column:6},
-                },
-            },
-            &parser.Expr{
-                Kind: &parser.EIgnore{
-                    Token: &parser.Token{
-                        Data: &parser.TEOF{},
-                        Span: parser.Span{
-                            Start: parser.Location{Line:1, Column:7},
-                            End:   parser.Location{Line:1, Column:7},
-                        },
-                    },
-                },
-                Span: parser.Span{
-                    Start: parser.Location{Line:1, Column:7},
-                    End:   parser.Location{Line:1, Column:7},
-                },
-            },
-        },
-        OptChain: false,
-    },
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:8},
-    },
-}
----
-
-[TestParsingIncompleteCall - 2]
+[TestParseExprErrorHandling/IncompleteCall - 2]
 &parser.Error{
     Span: parser.Span{
         Start: parser.Location{Line:1, Column:7},
@@ -918,27 +918,27 @@
 }
 ---
 
-[TestParsingStringLiteral - 1]
-&parser.Expr{
-    Kind: &parser.EString{Value:"hello"},
+[TestParseExprErrorHandling/IncompleteMemberOptChain - 2]
+&parser.Error{
     Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:7},
+        Start: parser.Location{Line:1, Column:6},
+        End:   parser.Location{Line:1, Column:8},
     },
+    Message: "expected an identifier after ?.",
 }
 ---
 
-[TestParsingNumberLiteral - 1]
-&parser.Expr{
-    Kind: &parser.ENumber{Value:5},
+[TestParseExprErrorHandling/IncompleteBinaryExpr - 2]
+&parser.Error{
     Span: parser.Span{
-        Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:2},
+        Start: parser.Location{Line:1, Column:8},
+        End:   parser.Location{Line:1, Column:8},
     },
+    Message: "Unexpected token",
 }
 ---
 
-[TestParsingIncompleteMemberOptChain - 1]
+[TestParseExprErrorHandling/IncompleteMember - 1]
 &parser.Expr{
     Kind: &parser.EBinary{
         Left: &parser.Expr{
@@ -961,31 +961,31 @@
                 Prop: &parser.Identifier{
                     Name: "",
                     Span: parser.Span{
-                        Start: parser.Location{Line:1, Column:8},
-                        End:   parser.Location{Line:1, Column:8},
+                        Start: parser.Location{Line:1, Column:7},
+                        End:   parser.Location{Line:1, Column:7},
                     },
                 },
-                OptChain: true,
+                OptChain: false,
             },
             Span: parser.Span{
                 Start: parser.Location{Line:1, Column:5},
-                End:   parser.Location{Line:1, Column:8},
+                End:   parser.Location{Line:1, Column:7},
             },
         },
     },
     Span: parser.Span{
         Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:8},
+        End:   parser.Location{Line:1, Column:7},
     },
 }
 ---
 
-[TestParsingIncompleteMemberOptChain - 2]
+[TestParseExprErrorHandling/IncompleteMember - 2]
 &parser.Error{
     Span: parser.Span{
         Start: parser.Location{Line:1, Column:6},
-        End:   parser.Location{Line:1, Column:8},
+        End:   parser.Location{Line:1, Column:7},
     },
-    Message: "expected an identifier after ?.",
+    Message: "expected an identifier after .",
 }
 ---

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -7,316 +7,121 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParsingStringLiteral(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "\"hello\"",
+func TestParseExprNoErrors(t *testing.T) {
+	tests := map[string]struct {
+		input string
+	}{
+		"StringLiteral": {
+			input: "\"hello\"",
+		},
+		"NumberLiteral": {
+			input: "5",
+		},
+		"Addition": {
+			input: "a + b",
+		},
+		"AddSub": {
+			input: "a - b + c",
+		},
+		"MulAdd": {
+			input: "a * b + c * d",
+		},
+		"MulDiv": {
+			input: "a / b * c",
+		},
+		"UnaryOps": {
+			input: "+a - -b",
+		},
+		"Parens": {
+			input: "a * (b + c)",
+		},
+		"Call": {
+			input: "foo(a, b, c)",
+		},
+		"CallPrecedence": {
+			input: "a + foo(b)",
+		},
+		"CurriedCall": {
+			input: "foo(a)(b)(c)",
+		},
+		"OptChainCall": {
+			input: "foo?(bar)",
+		},
+		"ArrayLiteral": {
+			input: "[1, 2, 3]",
+		},
+		"Member": {
+			input: "a.b?.c",
+		},
+		"MemberPrecedence": {
+			input: "a + b.c",
+		},
+		"Index": {
+			input: "a[base + offset]",
+		},
+		"IndexPrecedence": {
+			input: "a + b[c]",
+		},
+		"MultipleIndexes": {
+			input: "a[i][j]",
+		},
+		"OptChainIndex": {
+			input: "a?[base + offset]",
+		},
 	}
 
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := Source{
+				path:     "input.esc",
+				Contents: test.input,
+			}
 
-	snaps.MatchSnapshot(t, expr)
+			parser := NewParser(source)
+			expr, _ := parser.parseExpr()
+
+			snaps.MatchSnapshot(t, expr)
+			assert.Len(t, parser.errors, 0)
+		})
+	}
 }
 
-func TestParsingNumberLiteral(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "5",
+func TestParseExprErrorHandling(t *testing.T) {
+	tests := map[string]struct {
+		input string
+	}{
+		"IncompleteBinaryExpr": {
+			input: "a - b +",
+		},
+		"ExtraOperatorsInBinaryExpr": {
+			input: "a + * b",
+		},
+		"IncompleteCall": {
+			input: "foo(a,",
+		},
+		"IncompleteMember": {
+			input: "a + b.",
+		},
+		"IncompleteMemberOptChain": {
+			input: "a + b?.",
+		},
 	}
 
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := Source{
+				path:     "input.esc",
+				Contents: test.input,
+			}
 
-	snaps.MatchSnapshot(t, expr)
-}
+			parser := NewParser(source)
+			expr, _ := parser.parseExpr()
 
-func TestParsingAddition(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a + b",
+			snaps.MatchSnapshot(t, expr)
+			assert.Len(t, parser.errors, 1)
+			snaps.MatchSnapshot(t, parser.errors[0])
+		})
 	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-}
-
-func TestParsingAddSub(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a - b + c",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingIncompleteBinaryExpr(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a - b +",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 1)
-	snaps.MatchSnapshot(t, parser.errors[0])
-}
-
-func TestParsingExtraOperatorsInBinaryExpr(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a + * b",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 1)
-	snaps.MatchSnapshot(t, parser.errors[0])
-}
-
-func TestParsingMulAdd(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a * b + c * d",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingMulDiv(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a / b * c",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingUnaryOps(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "+a - -b",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingParens(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a * (b + c)",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingCall(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "foo(a, b, c)",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingIncompleteCall(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "foo(a,",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 1)
-	snaps.MatchSnapshot(t, parser.errors[0])
-}
-
-func TestParsingCallPrecedence(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a + foo(b)",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingCurriedCall(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "foo(a)(b)(c)",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingOptChainCall(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "foo?(bar)",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingArrayLiteral(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "[1, 2, 3]",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingMember(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a.b?.c",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingMemberPrecedence(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a + b.c",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingIncompleteMember(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a + b.",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 1)
-	snaps.MatchSnapshot(t, parser.errors[0])
-}
-
-func TestParsingIncompleteMemberOptChain(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a + b?.",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 1)
-	snaps.MatchSnapshot(t, parser.errors[0])
-}
-
-func TestParsingIndex(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a[base + offset]",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingIndexPrecedence(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a + b[c]",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingMultipleIndexes(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a[i][j]",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
-}
-
-func TestParsingOptChainIndex(t *testing.T) {
-	source := Source{
-		path:     "input.esc",
-		Contents: "a?[base + offset]",
-	}
-
-	parser := NewParser(source)
-	expr, _ := parser.parseExpr()
-
-	snaps.MatchSnapshot(t, expr)
-	assert.Len(t, parser.errors, 0)
 }


### PR DESCRIPTION
The table driven tests are bit more succinct and should be easier to maintain.