### PR TITLE
Update parser methods so they don't return terminating token

### DIFF
--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -849,12 +849,14 @@
 ---
 
 [TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 2]
-&parser.Error{
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:5},
-        End:   parser.Location{Line:1, Column:6},
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:5},
+            End:   parser.Location{Line:1, Column:6},
+        },
+        Message: "Unexpected token",
     },
-    Message: "Unexpected token",
 }
 ---
 
@@ -909,32 +911,45 @@
 ---
 
 [TestParseExprErrorHandling/IncompleteCall - 2]
-&parser.Error{
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:7},
-        End:   parser.Location{Line:1, Column:7},
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:7},
+            End:   parser.Location{Line:1, Column:7},
+        },
+        Message: "Unexpected token",
     },
-    Message: "Unexpected token",
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:4},
+            End:   parser.Location{Line:1, Column:5},
+        },
+        Message: "Expected a closing paren",
+    },
 }
 ---
 
 [TestParseExprErrorHandling/IncompleteMemberOptChain - 2]
-&parser.Error{
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:6},
-        End:   parser.Location{Line:1, Column:8},
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:6},
+            End:   parser.Location{Line:1, Column:8},
+        },
+        Message: "expected an identifier after ?.",
     },
-    Message: "expected an identifier after ?.",
 }
 ---
 
 [TestParseExprErrorHandling/IncompleteBinaryExpr - 2]
-&parser.Error{
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:8},
-        End:   parser.Location{Line:1, Column:8},
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:8},
+            End:   parser.Location{Line:1, Column:8},
+        },
+        Message: "Unexpected token",
     },
-    Message: "Unexpected token",
 }
 ---
 
@@ -981,12 +996,14 @@
 ---
 
 [TestParseExprErrorHandling/IncompleteMember - 2]
-&parser.Error{
-    Span: parser.Span{
-        Start: parser.Location{Line:1, Column:6},
-        End:   parser.Location{Line:1, Column:7},
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:6},
+            End:   parser.Location{Line:1, Column:7},
+        },
+        Message: "expected an identifier after .",
     },
-    Message: "expected an identifier after .",
 }
 ---
 

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -784,7 +784,7 @@
             &parser.Expr{
                 Kind: &parser.EIgnore{
                     Token: &parser.Token{
-                        Data: &parser.TEOF{},
+                        Data: &parser.TEndOfFile{},
                         Span: parser.Span{
                             Start: parser.Location{Line:1, Column:7},
                             End:   parser.Location{Line:1, Column:7},
@@ -890,7 +890,7 @@
         Right: &parser.Expr{
             Kind: &parser.EIgnore{
                 Token: &parser.Token{
-                    Data: &parser.TEOF{},
+                    Data: &parser.TEndOfFile{},
                     Span: parser.Span{
                         Start: parser.Location{Line:1, Column:8},
                         End:   parser.Location{Line:1, Column:8},

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -801,7 +801,7 @@
     },
     Span: parser.Span{
         Start: parser.Location{Line:1, Column:1},
-        End:   parser.Location{Line:1, Column:8},
+        End:   parser.Location{Line:1, Column:7},
     },
 }
 ---

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -1174,3 +1174,173 @@
     },
 }
 ---
+
+[TestParseExprErrorHandling/MismatchedParens - 1]
+&parser.Expr{
+    Kind: &parser.EBinary{
+        Left: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"a"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:2},
+            },
+        },
+        Op:    2,
+        Right: &parser.Expr{
+            Kind: &parser.EBinary{
+                Left: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"b"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:6},
+                        End:   parser.Location{Line:1, Column:7},
+                    },
+                },
+                Op:    0,
+                Right: &parser.Expr{
+                    Kind: &parser.EIdentifier{Name:"c"},
+                    Span: parser.Span{
+                        Start: parser.Location{Line:1, Column:10},
+                        End:   parser.Location{Line:1, Column:11},
+                    },
+                },
+            },
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:6},
+                End:   parser.Location{Line:1, Column:11},
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:11},
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedParens - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:5},
+            End:   parser.Location{Line:1, Column:6},
+        },
+        Message: "Expected a closing paren",
+    },
+}
+---
+
+[TestParseStmtErrorHandling/VarDeclMissingIdent - 1]
+(*parser.Stmt)(nil)
+---
+
+[TestParseStmtErrorHandling/VarDeclMissingIdent - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:5},
+            End:   parser.Location{Line:1, Column:6},
+        },
+        Message: "Expected identifier",
+    },
+}
+---
+
+[TestParseStmtErrorHandling/VarDeclMissingEquals - 1]
+(*parser.Stmt)(nil)
+---
+
+[TestParseStmtErrorHandling/VarDeclMissingEquals - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:7},
+            End:   parser.Location{Line:1, Column:8},
+        },
+        Message: "Expected equals sign",
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsArrayLiteral - 1]
+&parser.Expr{
+    Kind: &parser.EArray{
+        Elems: {
+            &parser.Expr{
+                Kind: &parser.ENumber{Value:1},
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:2},
+                    End:   parser.Location{Line:1, Column:3},
+                },
+            },
+            &parser.Expr{
+                Kind: &parser.ENumber{Value:2},
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:5},
+                    End:   parser.Location{Line:1, Column:6},
+                },
+            },
+            &parser.Expr{
+                Kind: &parser.ENumber{Value:3},
+                Span: parser.Span{
+                    Start: parser.Location{Line:1, Column:8},
+                    End:   parser.Location{Line:1, Column:9},
+                },
+            },
+        },
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:10},
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsArrayLiteral - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:1},
+            End:   parser.Location{Line:1, Column:2},
+        },
+        Message: "Expected a closing bracket",
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsIndex - 1]
+&parser.Expr{
+    Kind: &parser.EIndex{
+        Object: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"foo"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:1},
+                End:   parser.Location{Line:1, Column:4},
+            },
+        },
+        Index: &parser.Expr{
+            Kind: &parser.EIdentifier{Name:"bar"},
+            Span: parser.Span{
+                Start: parser.Location{Line:1, Column:5},
+                End:   parser.Location{Line:1, Column:8},
+            },
+        },
+        OptChain: false,
+    },
+    Span: parser.Span{
+        Start: parser.Location{Line:1, Column:1},
+        End:   parser.Location{Line:1, Column:9},
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsIndex - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: parser.Span{
+            Start: parser.Location{Line:1, Column:4},
+            End:   parser.Location{Line:1, Column:5},
+        },
+        Message: "Expected a closing bracket",
+    },
+}
+---

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -225,7 +225,7 @@ func (lexer *Lexer) peekAndMaybeConsume(consume bool) Token {
 	default:
 		if startOffset >= len(lexer.source.Contents) {
 			token = Token{
-				Data: &TEOF{},
+				Data: &TEndOfFile{},
 				Span: Span{Start: start, End: start},
 			}
 		} else {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -55,7 +55,7 @@ loop:
 			nextOp = Times
 		case *TSlash:
 			nextOp = Divide
-		case *TCloseParen, *TCloseBracket, *TCloseBrace, *TComma, *TEOF:
+		case *TCloseParen, *TCloseBracket, *TCloseBrace, *TComma, *TEndOfFile:
 			break loop
 		default:
 			parser.reportError(token.Span, "Unexpected token")
@@ -290,7 +290,7 @@ func (parser *Parser) parsePrimary() *Expr {
 				Kind: &EArray{Elems: elems},
 				Span: Span{Start: token.Span.Start, End: final.Span.End},
 			}
-		case *TCloseBrace, *TComma, *TCloseParen, *TEOF:
+		case *TEndOfFile:
 			expr = &Expr{
 				Kind: &EIgnore{Token: &token},
 				Span: token.Span,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -80,7 +80,7 @@ func TestParseExprNoErrors(t *testing.T) {
 			}
 
 			parser := NewParser(source)
-			expr, _ := parser.parseExpr()
+			expr := parser.parseExpr()
 
 			snaps.MatchSnapshot(t, expr)
 			assert.Len(t, parser.errors, 0)
@@ -118,11 +118,11 @@ func TestParseExprErrorHandling(t *testing.T) {
 			}
 
 			parser := NewParser(source)
-			expr, _ := parser.parseExpr()
+			expr := parser.parseExpr()
 
 			snaps.MatchSnapshot(t, expr)
-			assert.Len(t, parser.errors, 1)
-			snaps.MatchSnapshot(t, parser.errors[0])
+			assert.Greater(t, len(parser.errors), 0)
+			snaps.MatchSnapshot(t, parser.errors)
 		})
 	}
 }

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -78,8 +78,8 @@ type TCloseBrace struct{}
 type TOpenBracket struct{}
 type TCloseBracket struct{}
 
-func (*TEOF) isToken()     {}
-func (*TInvalid) isToken() {}
+func (*TEndOfFile) isToken() {}
+func (*TInvalid) isToken()   {}
 
-type TEOF struct{}
+type TEndOfFile struct{}
 type TInvalid struct{}


### PR DESCRIPTION
- Update parser methods to not return the terminating token
- Add checks to make sure that closing delimiters are the same type as the opening delimeters
