### PR TITLE
wasm lsp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			],
 			"devDependencies": {
 				"@eslint/js": "^9.13.0",
-				"@types/node": "^20",
+				"@types/node": "^22",
 				"@vitest/coverage-v8": "^3.0.7",
 				"@vitest/ui": "^3.0.7",
 				"eslint": "^9.13.0",
@@ -1573,13 +1573,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.17.19",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.19.tgz",
-			"integrity": "sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==",
+			"version": "22.13.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+			"integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.19.2"
+				"undici-types": "~6.20.0"
 			}
 		},
 		"node_modules/@types/react": {
@@ -4897,9 +4897,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
 	],
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "go build -o ./bin/lsp-server ./cmd/lsp-server && tsc -b",
+		"lsp-server:native": "go build -o ./bin/lsp-server ./cmd/lsp-server",
+		"lsp-server:wasm": "GOOS=js GOARCH=wasm go build -o ./bin/lsp-server.wasm ./cmd/lsp-server",
+		"compile": "npm run lsp-server:native && tsc -b",
 		"watch": "tsc -b -w",
 		"lint": "eslint",
 		"test": "vitest run",
@@ -26,7 +28,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.13.0",
-		"@types/node": "^20",
+		"@types/node": "^22",
 		"@vitest/coverage-v8": "^3.0.7",
 		"@vitest/ui": "^3.0.7",
 		"eslint": "^9.13.0",

--- a/packages/lsp-client/package.json
+++ b/packages/lsp-client/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
+    "wasm_exec": "cp $(go env GOROOT)/lib/wasm/wasm_exec.js src/wasm_exec.js",
     "run": "vite-node --script src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/lsp-client/src/client.ts
+++ b/packages/lsp-client/src/client.ts
@@ -23,7 +23,7 @@ export class Client {
             const value = await this.endpoint.send('initialize', params);
             return Result.Ok(value);
         } catch (e) {
-            return Result.Err(e);
+            return Result.Err(e as Error);
         }
     }
 
@@ -32,7 +32,7 @@ export class Client {
             const value = await this.endpoint.send('textDocument/didOpen', params);
             return Result.Ok(value);
         } catch (e) {
-            return Result.Err(e);
+            return Result.Err(e as Error);
         }
     }
 
@@ -41,7 +41,7 @@ export class Client {
             const value = await this.endpoint.send('textDocument/didChange', params);
             return Result.Ok(value);
         } catch (e) {
-            return Result.Err(e);
+            return Result.Err(e as Error);
         }
     }
 

--- a/packages/lsp-client/src/index.ts
+++ b/packages/lsp-client/src/index.ts
@@ -1,0 +1,163 @@
+import * as fs from "fs";
+import * as path from "path";
+import { EventEmitter } from "stream";
+
+import './wasm_exec_prelude'; // run for side-effects
+import "./wasm_exec"; // run for side-effects
+
+import * as lsp from 'vscode-languageserver-protocol'
+
+const Go = globalThis.Go;
+
+class SimpleStream {
+    chunks: Array<Buffer>;
+    emitter: EventEmitter;
+
+    constructor() {
+        this.chunks = [];
+        this.emitter = new EventEmitter();
+    }
+
+    emit(event: string, chunk: Buffer) {
+        this.chunks.push(chunk);
+        this.emitter.emit(event, chunk);
+    }
+
+    on(event: string, listener: (chunk: Buffer) => void) {
+        this.emitter.on(event, listener);
+    }
+
+    read() {
+        return this.chunks.shift();
+    }
+}
+
+const stdin = new SimpleStream();
+const stdout = new SimpleStream();
+
+stdout.on('data', (chunk) => {
+    console.log("stdout.on('data') - chunk =", chunk.toString());
+});
+
+const fsWrapper = {
+    ...fs,
+    read: (
+        fd: number,
+        buffer: Uint8Array,
+        offset: number,
+        length: number,
+        position: number | null | undefined,
+        callback,
+    ) => {
+        if (fd === 0) {
+            const srcBuffer: Buffer = stdin.read();
+            if (srcBuffer) {
+                // TODO: handle the case where srcBuffer is larger than buffer
+                srcBuffer.copy(buffer, offset, 0, length);
+                callback(null, srcBuffer.length, srcBuffer);
+                return;
+            }
+        }
+        return fs.read(fd, buffer, offset, length, position, callback);
+    },
+
+    write: (
+        fd: number,
+        buffer: Uint8Array,
+        offset: number,
+        length: number,
+        position: number | null | undefined,
+        callback: (err: NodeJS.ErrnoException | null, written: number, buffer: Uint8Array<ArrayBufferLike>) => void,
+    ) => {
+        console.log("fs.write - fd =", fd);
+        if (fd === 1) {
+            stdout.emit("data", Buffer.from(buffer));
+            callback(null, length, buffer);
+            return;
+        }
+        return fs.write(fd, buffer, offset, length, position, callback);
+    },
+};
+
+const go = new Go(fsWrapper);
+const buffer = fs.readFileSync(path.join(__dirname, '../../../bin/lsp-server.wasm'));
+
+async function sleep(duration: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, duration);
+    });
+}
+
+WebAssembly.instantiate(buffer, go.importObject).then(async (result) => {
+    go.run(result.instance);
+
+    console.log("running...");
+
+    let requestID = 0;
+    const initParams: lsp.InitializeParams = {
+        processId: process.pid,
+        rootUri: "file:///home/user/project",
+        capabilities: {},
+    };
+    const initPaylod = JSON.stringify({
+        jsonrpc: "2.0",
+        id: requestID++,
+        method: "initialize",
+        params: initParams,
+    });
+    const initMessage = `Content-Length: ${initPaylod.length}\r\n\r\n${initPaylod}`;
+    stdin.emit("data", Buffer.from(initMessage, 'utf-8'));
+
+    await sleep(500);
+
+    const initResponse = stdout.read();
+    console.log("initialize response =", initResponse.toString());
+
+    const didChangeParams: lsp.DidChangeTextDocumentParams = {
+        textDocument: {
+            uri: 'file:///home/user/project/foo.esc',
+            version: 2,
+        },
+        contentChanges: [
+            { text: 'console.log("Hello, world!")\nval x =\n' }
+        ]
+    };
+    const didChangePayload = JSON.stringify({
+        jsonrpc: "2.0",
+        id: requestID++,
+        method: "textDocument/didChange",
+        params: didChangeParams,
+    });
+    console.log("didChangePayload =", didChangePayload);
+    const didChangeMessage = `Content-Length: ${didChangePayload.length}\r\n\r\n${didChangePayload}`;
+
+    stdin.emit("data", Buffer.from(didChangeMessage, 'utf-8'));
+   
+    await sleep(1000);
+    
+    console.log("---- RESPONSE ----");
+    while (true) {
+        const response = stdout.read();
+        if (!response) {
+            break;
+        }
+        console.log(response.toString());
+    }
+    // const didChangeResponse = stdout.read();
+    // console.log("didChangeResponse response =", didChangeResponse);
+    // console.log("didChangeResponse response =", didChangeResponse.toString());
+
+    // Each request and respone have matching IDs
+    // We'll need a way to wait for a response for a given request ID so that we
+    // can have a nice API for sending requests and getting responses.
+
+    // const endpoint = new JSONRPCEndpoint(stdin, stdout);
+
+    // const value = await endpoint.send('initialize', {
+    //     processId: process.pid,
+    //     rootUri: 'file:///home/user/project',
+    //     capabilities: {},
+    // });
+
+    // console.log("initialize result =", value);
+});

--- a/packages/lsp-client/src/index.ts
+++ b/packages/lsp-client/src/index.ts
@@ -35,10 +35,6 @@ class SimpleStream {
 const stdin = new SimpleStream();
 const stdout = new SimpleStream();
 
-stdout.on('data', (chunk) => {
-    console.log("stdout.on('data') - chunk =", chunk.toString());
-});
-
 const fsWrapper = {
     ...fs,
     read: (
@@ -47,7 +43,7 @@ const fsWrapper = {
         offset: number,
         length: number,
         position: number | null | undefined,
-        callback,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: Uint8Array<ArrayBufferLike>) => void,
     ) => {
         if (fd === 0) {
             const srcBuffer: Buffer = stdin.read();
@@ -69,7 +65,7 @@ const fsWrapper = {
         position: number | null | undefined,
         callback: (err: NodeJS.ErrnoException | null, written: number, buffer: Uint8Array<ArrayBufferLike>) => void,
     ) => {
-        console.log("fs.write - fd =", fd);
+        // TODO: also handle stderr
         if (fd === 1) {
             stdout.emit("data", Buffer.from(buffer));
             callback(null, length, buffer);
@@ -82,36 +78,70 @@ const fsWrapper = {
 const go = new Go(fsWrapper);
 const buffer = fs.readFileSync(path.join(__dirname, '../../../bin/lsp-server.wasm'));
 
-async function sleep(duration: number) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, duration);
+let requestID = 0;
+
+const serverEmitter = new EventEmitter();
+const resolvers = new Map<number, (value: any) => void>();
+
+// Receives messages from the server via STDOUT
+stdout.on('data', (chunk) => {
+    const message = chunk.toString("utf-8");
+    const headerRegex = /Content-Length: (\d+)/;
+    const payload = message.replace(headerRegex, "").trim();
+    const object = JSON.parse(payload);
+
+    // TODO: validate the the object being returned is a valid RPC JSON response
+    if (object.id != null) {
+        const resolver = resolvers.get(object.id);
+        if (resolver) {
+            resolver(object.result);
+        }
+    } else {
+        serverEmitter.emit(object.method, object.params);
+    }
+});
+
+async function sendRequest(method: "initialize", params: lsp.InitializeParams): Promise<lsp.InitializeResult>;
+async function sendRequest(method: "shutdown", params: null): Promise<void>;
+async function sendRequest(method: "exit", params: null): Promise<void>;
+async function sendRequest(method: "textDocument/didChange", params: lsp.DidChangeTextDocumentParams): Promise<void>;
+async function sendRequest(method: string, params: any) {
+    const initPaylod = JSON.stringify({
+        jsonrpc: "2.0",
+        id: requestID,
+        method,
+        params,
     });
+    const initMessage = `Content-Length: ${initPaylod.length}\r\n\r\n${initPaylod}`;
+
+    stdin.emit("data", Buffer.from(initMessage, 'utf-8'));
+    const promise1 = new Promise((resolve) => {
+        resolvers.set(requestID, resolve);
+    });
+    const response = await promise1;
+    requestID += 1;
+    return response;
 }
 
-WebAssembly.instantiate(buffer, go.importObject).then(async (result) => {
+async function main() {
+    const result = await WebAssembly.instantiate(buffer, go.importObject);
     go.run(result.instance);
 
     console.log("running...");
 
-    let requestID = 0;
+    serverEmitter.on("textDocument/publishDiagnostics", (params: lsp.PublishDiagnosticsParams) => {
+        console.log("Received diagnostics");
+        console.log(JSON.stringify(params, null, 4));
+    });
+
     const initParams: lsp.InitializeParams = {
         processId: process.pid,
         rootUri: "file:///home/user/project",
         capabilities: {},
     };
-    const initPaylod = JSON.stringify({
-        jsonrpc: "2.0",
-        id: requestID++,
-        method: "initialize",
-        params: initParams,
-    });
-    const initMessage = `Content-Length: ${initPaylod.length}\r\n\r\n${initPaylod}`;
-    stdin.emit("data", Buffer.from(initMessage, 'utf-8'));
-
-    await sleep(500);
-
-    const initResponse = stdout.read();
-    console.log("initialize response =", initResponse.toString());
+    const initResponse = await sendRequest("initialize", initParams);
+    console.log("Initial response");
+    console.log(JSON.stringify(initResponse, null, 4));
 
     const didChangeParams: lsp.DidChangeTextDocumentParams = {
         textDocument: {
@@ -122,42 +152,10 @@ WebAssembly.instantiate(buffer, go.importObject).then(async (result) => {
             { text: 'console.log("Hello, world!")\nval x =\n' }
         ]
     };
-    const didChangePayload = JSON.stringify({
-        jsonrpc: "2.0",
-        id: requestID++,
-        method: "textDocument/didChange",
-        params: didChangeParams,
-    });
-    console.log("didChangePayload =", didChangePayload);
-    const didChangeMessage = `Content-Length: ${didChangePayload.length}\r\n\r\n${didChangePayload}`;
+    await sendRequest("textDocument/didChange", didChangeParams);
 
-    stdin.emit("data", Buffer.from(didChangeMessage, 'utf-8'));
-   
-    await sleep(1000);
-    
-    console.log("---- RESPONSE ----");
-    while (true) {
-        const response = stdout.read();
-        if (!response) {
-            break;
-        }
-        console.log(response.toString());
-    }
-    // const didChangeResponse = stdout.read();
-    // console.log("didChangeResponse response =", didChangeResponse);
-    // console.log("didChangeResponse response =", didChangeResponse.toString());
+    await sendRequest("shutdown", null);
+    await sendRequest("exit", null);
+}
 
-    // Each request and respone have matching IDs
-    // We'll need a way to wait for a response for a given request ID so that we
-    // can have a nice API for sending requests and getting responses.
-
-    // const endpoint = new JSONRPCEndpoint(stdin, stdout);
-
-    // const value = await endpoint.send('initialize', {
-    //     processId: process.pid,
-    //     rootUri: 'file:///home/user/project',
-    //     capabilities: {},
-    // });
-
-    // console.log("initialize result =", value);
-});
+main();

--- a/packages/lsp-client/src/index.ts
+++ b/packages/lsp-client/src/index.ts
@@ -1,135 +1,17 @@
 import * as fs from "fs";
 import * as path from "path";
-import { EventEmitter } from "stream";
-
-import './wasm_exec_prelude'; // run for side-effects
-import "./wasm_exec"; // run for side-effects
 
 import * as lsp from 'vscode-languageserver-protocol'
 
-const Go = globalThis.Go;
-
-class SimpleStream {
-    chunks: Array<Buffer>;
-    emitter: EventEmitter;
-
-    constructor() {
-        this.chunks = [];
-        this.emitter = new EventEmitter();
-    }
-
-    emit(event: string, chunk: Buffer) {
-        this.chunks.push(chunk);
-        this.emitter.emit(event, chunk);
-    }
-
-    on(event: string, listener: (chunk: Buffer) => void) {
-        this.emitter.on(event, listener);
-    }
-
-    read() {
-        return this.chunks.shift();
-    }
-}
-
-const stdin = new SimpleStream();
-const stdout = new SimpleStream();
-
-const fsWrapper = {
-    ...fs,
-    read: (
-        fd: number,
-        buffer: Uint8Array,
-        offset: number,
-        length: number,
-        position: number | null | undefined,
-        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: Uint8Array<ArrayBufferLike>) => void,
-    ) => {
-        if (fd === 0) {
-            const srcBuffer: Buffer = stdin.read();
-            if (srcBuffer) {
-                // TODO: handle the case where srcBuffer is larger than buffer
-                srcBuffer.copy(buffer, offset, 0, length);
-                callback(null, srcBuffer.length, srcBuffer);
-                return;
-            }
-        }
-        return fs.read(fd, buffer, offset, length, position, callback);
-    },
-
-    write: (
-        fd: number,
-        buffer: Uint8Array,
-        offset: number,
-        length: number,
-        position: number | null | undefined,
-        callback: (err: NodeJS.ErrnoException | null, written: number, buffer: Uint8Array<ArrayBufferLike>) => void,
-    ) => {
-        // TODO: also handle stderr
-        if (fd === 1) {
-            stdout.emit("data", Buffer.from(buffer));
-            callback(null, length, buffer);
-            return;
-        }
-        return fs.write(fd, buffer, offset, length, position, callback);
-    },
-};
-
-const go = new Go(fsWrapper);
-const buffer = fs.readFileSync(path.join(__dirname, '../../../bin/lsp-server.wasm'));
-
-let requestID = 0;
-
-const serverEmitter = new EventEmitter();
-const resolvers = new Map<number, (value: any) => void>();
-
-// Receives messages from the server via STDOUT
-stdout.on('data', (chunk) => {
-    const message = chunk.toString("utf-8");
-    const headerRegex = /Content-Length: (\d+)/;
-    const payload = message.replace(headerRegex, "").trim();
-    const object = JSON.parse(payload);
-
-    // TODO: validate the the object being returned is a valid RPC JSON response
-    if (object.id != null) {
-        const resolver = resolvers.get(object.id);
-        if (resolver) {
-            resolver(object.result);
-        }
-    } else {
-        serverEmitter.emit(object.method, object.params);
-    }
-});
-
-async function sendRequest(method: "initialize", params: lsp.InitializeParams): Promise<lsp.InitializeResult>;
-async function sendRequest(method: "shutdown", params: null): Promise<void>;
-async function sendRequest(method: "exit", params: null): Promise<void>;
-async function sendRequest(method: "textDocument/didChange", params: lsp.DidChangeTextDocumentParams): Promise<void>;
-async function sendRequest(method: string, params: any) {
-    const initPaylod = JSON.stringify({
-        jsonrpc: "2.0",
-        id: requestID,
-        method,
-        params,
-    });
-    const initMessage = `Content-Length: ${initPaylod.length}\r\n\r\n${initPaylod}`;
-
-    stdin.emit("data", Buffer.from(initMessage, 'utf-8'));
-    const promise1 = new Promise((resolve) => {
-        resolvers.set(requestID, resolve);
-    });
-    const response = await promise1;
-    requestID += 1;
-    return response;
-}
+import { WasmClient } from './wasm-client';
 
 async function main() {
-    const result = await WebAssembly.instantiate(buffer, go.importObject);
-    go.run(result.instance);
+    const buffer = fs.readFileSync(path.join(__dirname, '../../../bin/lsp-server.wasm'));
+    const client = new WasmClient(buffer);
 
-    console.log("running...");
+    client.run();
 
-    serverEmitter.on("textDocument/publishDiagnostics", (params: lsp.PublishDiagnosticsParams) => {
+    client.on("textDocument/publishDiagnostics", (params: lsp.PublishDiagnosticsParams) => {
         console.log("Received diagnostics");
         console.log(JSON.stringify(params, null, 4));
     });
@@ -139,7 +21,7 @@ async function main() {
         rootUri: "file:///home/user/project",
         capabilities: {},
     };
-    const initResponse = await sendRequest("initialize", initParams);
+    const initResponse = await client.sendRequest("initialize", initParams);
     console.log("Initial response");
     console.log(JSON.stringify(initResponse, null, 4));
 
@@ -152,10 +34,9 @@ async function main() {
             { text: 'console.log("Hello, world!")\nval x =\n' }
         ]
     };
-    await sendRequest("textDocument/didChange", didChangeParams);
+    await client.sendRequest("textDocument/didChange", didChangeParams);
 
-    await sendRequest("shutdown", null);
-    await sendRequest("exit", null);
+    await client.stop();
 }
 
 main();

--- a/packages/lsp-client/src/wasm-client.ts
+++ b/packages/lsp-client/src/wasm-client.ts
@@ -1,0 +1,147 @@
+import * as fs from "fs";
+import { EventEmitter } from "stream";
+import * as lsp from 'vscode-languageserver-protocol'
+
+import './wasm_exec_prelude'; // run for side-effects
+import "./wasm_exec"; // run for side-effects
+
+import { Result, type AsyncResult } from './result'
+
+declare global {
+    var Go: any;
+}
+
+const Go = globalThis.Go;
+
+class SimpleStream {
+    private chunks: Array<Buffer>;
+    private emitter: EventEmitter;
+
+    constructor() {
+        this.chunks = [];
+        this.emitter = new EventEmitter();
+    }
+
+    on(event: string, listener: (chunk: Buffer) => void) {
+        this.emitter.on(event, listener);
+    }
+
+    write(chunk: Buffer) {
+        this.chunks.push(chunk);
+        this.emitter.emit('data', chunk);
+    }
+
+    read() {
+        return this.chunks.shift();
+    }
+}
+
+export class WasmClient {
+    private go: any;
+    private stdin: SimpleStream;
+    private stdout: SimpleStream;
+    private emitter: EventEmitter;
+    private resolvers: Map<number, (value: Result<any, Error>) => void>;
+    private requestID: number;
+    private wasmBuf: Buffer;
+    
+    constructor(wasmBuf: Buffer) {
+        this.stdin = new SimpleStream();
+        this.stdout = new SimpleStream();
+        this.emitter = new EventEmitter();
+        this.resolvers = new Map();
+        this.requestID = 0;
+        this.wasmBuf = wasmBuf;
+
+        this.stdout.on('data', (chunk) => {
+            const message = chunk.toString("utf-8");
+            const headerRegex = /Content-Length: (\d+)/;
+            const payload = message.replace(headerRegex, "").trim();
+            const object = JSON.parse(payload);
+        
+            // TODO: validate the the object being returned is a valid RPC JSON response
+            if (object.id != null) {
+                const resolver = this.resolvers.get(object.id);
+                if (resolver) {
+                    resolver(object.result);
+                }
+            } else {
+                this.emitter.emit(object.method, object.params);
+            }
+        });
+
+        this.go = new Go({
+            ...fs,
+            read: (
+                fd: number,
+                buffer: Uint8Array,
+                offset: number,
+                length: number,
+                position: fs.ReadPosition | null,
+                callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: Uint8Array<ArrayBufferLike>) => void,
+            ) => {
+                if (fd === 0) {
+                    const srcBuf = this.stdin.read();
+                    if (srcBuf) {
+                        // TODO: handle the case where srcBuffer is larger than buffer
+                        srcBuf.copy(buffer, offset, 0, length);
+                        callback(null, srcBuf.length, srcBuf);
+                        return;
+                    }
+                }
+                fs.read(fd, buffer, offset, length, position, (err, bytesRead, buffer) => {
+                    callback(err, bytesRead, buffer);
+                });
+            },
+        
+            write: (
+                fd: number,
+                buffer: Uint8Array,
+                offset: number,
+                length: number,
+                position: number | null | undefined,
+                callback: (err: NodeJS.ErrnoException | null, written: number, buffer: Uint8Array<ArrayBufferLike>) => void,
+            ) => {
+                // TODO: also handle stderr
+                if (fd === 1) {
+                    this.stdout.write(Buffer.from(buffer));
+                    callback(null, length, buffer);
+                    return;
+                }
+                return fs.write(fd, buffer, offset, length, position, callback);
+            },
+        });
+    }
+
+    async run() {
+        const {instance} = await WebAssembly.instantiate(this.wasmBuf, this.go.importObject);
+        return this.go.run(instance);
+    }
+
+    async stop() {
+        await this.sendRequest("shutdown", null);
+        await this.sendRequest("exit", null);
+    }
+
+    async sendRequest(method: "initialize", params: lsp.InitializeParams): AsyncResult<lsp.InitializeResult, Error>;
+    async sendRequest(method: "$/setTrace", params: lsp.SetTraceParams): AsyncResult<lsp.InitializeResult, Error>;
+    async sendRequest(method: "shutdown", params: null): AsyncResult<void, Error>;
+    async sendRequest(method: "exit", params: null): AsyncResult<void, Error>;
+    async sendRequest(method: "textDocument/didChange", params: lsp.DidChangeTextDocumentParams): AsyncResult<void, Error>;
+    async sendRequest(method: string, params: any): AsyncResult<any, Error> {
+        const id = this.requestID++;
+        const payload = JSON.stringify({jsonrpc: "2.0", id, method, params});
+        const message = `Content-Length: ${payload.length}\r\n\r\n${payload}`;
+
+        this.stdin.write(Buffer.from(message, 'utf-8'));
+        return new Promise((resolve) => {
+            this.resolvers.set(id, resolve);
+        });
+    }
+
+    on(method: "textDocument/publishDiagnostics", callback: (params: lsp.PublishDiagnosticsParams) => void): void;
+    on(method: "window/logMessage", callback: (params: lsp.LogMessageParams) => void): void;
+    on(method: string, callback: (params: any) => void) {
+        this.emitter.on(method, callback);
+    }
+}

--- a/packages/lsp-client/src/wasm_exec.js
+++ b/packages/lsp-client/src/wasm_exec.js
@@ -555,10 +555,9 @@
 		}
 
 		_resume() {
-			if (this.exited) {
-				throw new Error("Go program has already exited");
+			if (!this.exited) {
+				this._inst.exports.resume();
 			}
-			this._inst.exports.resume();
 			if (this.exited) {
 				this._resolveExitPromise();
 			}

--- a/packages/lsp-client/src/wasm_exec.js
+++ b/packages/lsp-client/src/wasm_exec.js
@@ -1,0 +1,577 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+"use strict";
+
+(() => {
+	const enosys = () => {
+		const err = new Error("not implemented");
+		err.code = "ENOSYS";
+		return err;
+	};
+
+	// if (!globalThis.fs) {
+	// 	let outputBuf = "";
+	// 	globalThis.fs = {
+	// 		constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1, O_DIRECTORY: -1 }, // unused
+	// 		writeSync(fd, buf) {
+	// 			outputBuf += decoder.decode(buf);
+	// 			const nl = outputBuf.lastIndexOf("\n");
+	// 			if (nl != -1) {
+	// 				console.log(outputBuf.substring(0, nl));
+	// 				outputBuf = outputBuf.substring(nl + 1);
+	// 			}
+	// 			return buf.length;
+	// 		},
+	// 		write(fd, buf, offset, length, position, callback) {
+	// 			if (offset !== 0 || length !== buf.length || position !== null) {
+	// 				callback(enosys());
+	// 				return;
+	// 			}
+	// 			const n = this.writeSync(fd, buf);
+	// 			callback(null, n);
+	// 		},
+	// 		chmod(path, mode, callback) { callback(enosys()); },
+	// 		chown(path, uid, gid, callback) { callback(enosys()); },
+	// 		close(fd, callback) { callback(enosys()); },
+	// 		fchmod(fd, mode, callback) { callback(enosys()); },
+	// 		fchown(fd, uid, gid, callback) { callback(enosys()); },
+	// 		fstat(fd, callback) { callback(enosys()); },
+	// 		fsync(fd, callback) { callback(null); },
+	// 		ftruncate(fd, length, callback) { callback(enosys()); },
+	// 		lchown(path, uid, gid, callback) { callback(enosys()); },
+	// 		link(path, link, callback) { callback(enosys()); },
+	// 		lstat(path, callback) { callback(enosys()); },
+	// 		mkdir(path, perm, callback) { callback(enosys()); },
+	// 		open(path, flags, mode, callback) { callback(enosys()); },
+	// 		read(fd, buffer, offset, length, position, callback) { callback(enosys()); },
+	// 		readdir(path, callback) { callback(enosys()); },
+	// 		readlink(path, callback) { callback(enosys()); },
+	// 		rename(from, to, callback) { callback(enosys()); },
+	// 		rmdir(path, callback) { callback(enosys()); },
+	// 		stat(path, callback) { callback(enosys()); },
+	// 		symlink(path, link, callback) { callback(enosys()); },
+	// 		truncate(path, length, callback) { callback(enosys()); },
+	// 		unlink(path, callback) { callback(enosys()); },
+	// 		utimes(path, atime, mtime, callback) { callback(enosys()); },
+	// 	};
+	// }
+
+	if (!globalThis.process) {
+		globalThis.process = {
+			getuid() { return -1; },
+			getgid() { return -1; },
+			geteuid() { return -1; },
+			getegid() { return -1; },
+			getgroups() { throw enosys(); },
+			pid: -1,
+			ppid: -1,
+			umask() { throw enosys(); },
+			cwd() { throw enosys(); },
+			chdir() { throw enosys(); },
+		}
+	}
+
+	if (!globalThis.path) {
+		globalThis.path = {
+			resolve(...pathSegments) {
+				return pathSegments.join("/");
+			}
+		}
+	}
+
+	if (!globalThis.crypto) {
+		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");
+	}
+
+	if (!globalThis.performance) {
+		throw new Error("globalThis.performance is not available, polyfill required (performance.now only)");
+	}
+
+	if (!globalThis.TextEncoder) {
+		throw new Error("globalThis.TextEncoder is not available, polyfill required");
+	}
+
+	if (!globalThis.TextDecoder) {
+		throw new Error("globalThis.TextDecoder is not available, polyfill required");
+	}
+
+	const encoder = new TextEncoder("utf-8");
+	const decoder = new TextDecoder("utf-8");
+
+	globalThis.Go = class {
+		constructor(fs) {
+			globalThis.fs = fs
+
+			this.argv = ["js"];
+			this.env = {};
+			this.exit = (code) => {
+				if (code !== 0) {
+					console.warn("exit code:", code);
+				}
+			};
+			this._exitPromise = new Promise((resolve) => {
+				this._resolveExitPromise = resolve;
+			});
+			this._pendingEvent = null;
+			this._scheduledTimeouts = new Map();
+			this._nextCallbackTimeoutID = 1;
+
+			const setInt64 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
+			}
+
+			const setInt32 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+			}
+
+			const getInt64 = (addr) => {
+				const low = this.mem.getUint32(addr + 0, true);
+				const high = this.mem.getInt32(addr + 4, true);
+				return low + high * 4294967296;
+			}
+
+			const loadValue = (addr) => {
+				const f = this.mem.getFloat64(addr, true);
+				if (f === 0) {
+					return undefined;
+				}
+				if (!isNaN(f)) {
+					return f;
+				}
+
+				const id = this.mem.getUint32(addr, true);
+				return this._values[id];
+			}
+
+			const storeValue = (addr, v) => {
+				const nanHead = 0x7FF80000;
+
+				if (typeof v === "number" && v !== 0) {
+					if (isNaN(v)) {
+						this.mem.setUint32(addr + 4, nanHead, true);
+						this.mem.setUint32(addr, 0, true);
+						return;
+					}
+					this.mem.setFloat64(addr, v, true);
+					return;
+				}
+
+				if (v === undefined) {
+					this.mem.setFloat64(addr, 0, true);
+					return;
+				}
+
+				let id = this._ids.get(v);
+				if (id === undefined) {
+					id = this._idPool.pop();
+					if (id === undefined) {
+						id = this._values.length;
+					}
+					this._values[id] = v;
+					this._goRefCounts[id] = 0;
+					this._ids.set(v, id);
+				}
+				this._goRefCounts[id]++;
+				let typeFlag = 0;
+				switch (typeof v) {
+					case "object":
+						if (v !== null) {
+							typeFlag = 1;
+						}
+						break;
+					case "string":
+						typeFlag = 2;
+						break;
+					case "symbol":
+						typeFlag = 3;
+						break;
+					case "function":
+						typeFlag = 4;
+						break;
+				}
+				this.mem.setUint32(addr + 4, nanHead | typeFlag, true);
+				this.mem.setUint32(addr, id, true);
+			}
+
+			const loadSlice = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return new Uint8Array(this._inst.exports.mem.buffer, array, len);
+			}
+
+			const loadSliceOfValues = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				const a = new Array(len);
+				for (let i = 0; i < len; i++) {
+					a[i] = loadValue(array + i * 8);
+				}
+				return a;
+			}
+
+			const loadString = (addr) => {
+				const saddr = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len));
+			}
+
+			const testCallExport = (a, b) => {
+				this._inst.exports.testExport0();
+				return this._inst.exports.testExport(a, b);
+			}
+
+			const timeOrigin = Date.now() - performance.now();
+			this.importObject = {
+				_gotest: {
+					add: (a, b) => a + b,
+					callExport: testCallExport,
+				},
+				gojs: {
+					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
+					// may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
+					// function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
+					// This changes the SP, thus we have to update the SP used by the imported function.
+
+					// func wasmExit(code int32)
+					"runtime.wasmExit": (sp) => {
+						sp >>>= 0;
+						const code = this.mem.getInt32(sp + 8, true);
+						this.exited = true;
+						delete this._inst;
+						delete this._values;
+						delete this._goRefCounts;
+						delete this._ids;
+						delete this._idPool;
+						this.exit(code);
+					},
+
+					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
+					"runtime.wasmWrite": (sp) => {
+						sp >>>= 0;
+						const fd = getInt64(sp + 8);
+						const p = getInt64(sp + 16);
+						const n = this.mem.getInt32(sp + 24, true);
+						fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
+					},
+
+					// func resetMemoryDataView()
+					"runtime.resetMemoryDataView": (sp) => {
+						sp >>>= 0;
+						this.mem = new DataView(this._inst.exports.mem.buffer);
+					},
+
+					// func nanotime1() int64
+					"runtime.nanotime1": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
+					},
+
+					// func walltime() (sec int64, nsec int32)
+					"runtime.walltime": (sp) => {
+						sp >>>= 0;
+						const msec = (new Date).getTime();
+						setInt64(sp + 8, msec / 1000);
+						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
+					},
+
+					// func scheduleTimeoutEvent(delay int64) int32
+					"runtime.scheduleTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this._nextCallbackTimeoutID;
+						this._nextCallbackTimeoutID++;
+						this._scheduledTimeouts.set(id, setTimeout(
+							() => {
+								this._resume();
+								while (this._scheduledTimeouts.has(id)) {
+									// for some reason Go failed to register the timeout event, log and try again
+									// (temporary workaround for https://github.com/golang/go/issues/28975)
+									console.warn("scheduleTimeoutEvent: missed timeout event");
+									this._resume();
+								}
+							},
+							getInt64(sp + 8),
+						));
+						this.mem.setInt32(sp + 16, id, true);
+					},
+
+					// func clearTimeoutEvent(id int32)
+					"runtime.clearTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getInt32(sp + 8, true);
+						clearTimeout(this._scheduledTimeouts.get(id));
+						this._scheduledTimeouts.delete(id);
+					},
+
+					// func getRandomData(r []byte)
+					"runtime.getRandomData": (sp) => {
+						sp >>>= 0;
+						crypto.getRandomValues(loadSlice(sp + 8));
+					},
+
+					// func finalizeRef(v ref)
+					"syscall/js.finalizeRef": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getUint32(sp + 8, true);
+						this._goRefCounts[id]--;
+						if (this._goRefCounts[id] === 0) {
+							const v = this._values[id];
+							this._values[id] = null;
+							this._ids.delete(v);
+							this._idPool.push(id);
+						}
+					},
+
+					// func stringVal(value string) ref
+					"syscall/js.stringVal": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, loadString(sp + 8));
+					},
+
+					// func valueGet(v ref, p string) ref
+					"syscall/js.valueGet": (sp) => {
+						sp >>>= 0;
+						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
+						sp = this._inst.exports.getsp() >>> 0; // see comment above
+						storeValue(sp + 32, result);
+					},
+
+					// func valueSet(v ref, p string, x ref)
+					"syscall/js.valueSet": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32));
+					},
+
+					// func valueDelete(v ref, p string)
+					"syscall/js.valueDelete": (sp) => {
+						sp >>>= 0;
+						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
+					},
+
+					// func valueIndex(v ref, i int) ref
+					"syscall/js.valueIndex": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)));
+					},
+
+					// valueSetIndex(v ref, i int, x ref)
+					"syscall/js.valueSetIndex": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24));
+					},
+
+					// func valueCall(v ref, m string, args []ref) (ref, bool)
+					"syscall/js.valueCall": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const m = Reflect.get(v, loadString(sp + 16));
+							const args = loadSliceOfValues(sp + 32);
+							const result = Reflect.apply(m, v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, result);
+							this.mem.setUint8(sp + 64, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, err);
+							this.mem.setUint8(sp + 64, 0);
+						}
+					},
+
+					// func valueInvoke(v ref, args []ref) (ref, bool)
+					"syscall/js.valueInvoke": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.apply(v, undefined, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueNew(v ref, args []ref) (ref, bool)
+					"syscall/js.valueNew": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.construct(v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueLength(v ref) int
+					"syscall/js.valueLength": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
+					},
+
+					// valuePrepareString(v ref) (ref, int)
+					"syscall/js.valuePrepareString": (sp) => {
+						sp >>>= 0;
+						const str = encoder.encode(String(loadValue(sp + 8)));
+						storeValue(sp + 16, str);
+						setInt64(sp + 24, str.length);
+					},
+
+					// valueLoadString(v ref, b []byte)
+					"syscall/js.valueLoadString": (sp) => {
+						sp >>>= 0;
+						const str = loadValue(sp + 8);
+						loadSlice(sp + 16).set(str);
+					},
+
+					// func valueInstanceOf(v ref, t ref) bool
+					"syscall/js.valueInstanceOf": (sp) => {
+						sp >>>= 0;
+						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0);
+					},
+
+					// func copyBytesToGo(dst []byte, src ref) (int, bool)
+					"syscall/js.copyBytesToGo": (sp) => {
+						sp >>>= 0;
+						const dst = loadSlice(sp + 8);
+						const src = loadValue(sp + 32);
+						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					// func copyBytesToJS(dst ref, src []byte) (int, bool)
+					"syscall/js.copyBytesToJS": (sp) => {
+						sp >>>= 0;
+						const dst = loadValue(sp + 8);
+						const src = loadSlice(sp + 16);
+						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					"debug": (value) => {
+						console.log(value);
+					},
+				}
+			};
+		}
+
+		async run(instance) {
+			if (!(instance instanceof WebAssembly.Instance)) {
+				throw new Error("Go.run: WebAssembly.Instance expected");
+			}
+			this._inst = instance;
+			this.mem = new DataView(this._inst.exports.mem.buffer);
+			this._values = [ // JS values that Go currently has references to, indexed by reference id
+				NaN,
+				0,
+				null,
+				true,
+				false,
+				globalThis,
+				this,
+			];
+			this._goRefCounts = new Array(this._values.length).fill(Infinity); // number of references that Go has to a JS value, indexed by reference id
+			this._ids = new Map([ // mapping from JS values to reference ids
+				[0, 1],
+				[null, 2],
+				[true, 3],
+				[false, 4],
+				[globalThis, 5],
+				[this, 6],
+			]);
+			this._idPool = [];   // unused ids that have been garbage collected
+			this.exited = false; // whether the Go program has exited
+
+			// Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
+			let offset = 4096;
+
+			const strPtr = (str) => {
+				const ptr = offset;
+				const bytes = encoder.encode(str + "\0");
+				new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes);
+				offset += bytes.length;
+				if (offset % 8 !== 0) {
+					offset += 8 - (offset % 8);
+				}
+				return ptr;
+			};
+
+			const argc = this.argv.length;
+
+			const argvPtrs = [];
+			this.argv.forEach((arg) => {
+				argvPtrs.push(strPtr(arg));
+			});
+			argvPtrs.push(0);
+
+			const keys = Object.keys(this.env).sort();
+			keys.forEach((key) => {
+				argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
+			});
+			argvPtrs.push(0);
+
+			const argv = offset;
+			argvPtrs.forEach((ptr) => {
+				this.mem.setUint32(offset, ptr, true);
+				this.mem.setUint32(offset + 4, 0, true);
+				offset += 8;
+			});
+
+			// The linker guarantees global data starts from at least wasmMinDataAddr.
+			// Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
+			const wasmMinDataAddr = 4096 + 8192;
+			if (offset >= wasmMinDataAddr) {
+				throw new Error("total length of command line and environment variables exceeds limit");
+			}
+
+			this._inst.exports.run(argc, argv);
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+			await this._exitPromise;
+		}
+
+		_resume() {
+			if (this.exited) {
+				throw new Error("Go program has already exited");
+			}
+			this._inst.exports.resume();
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+		}
+
+		_makeFuncWrapper(id) {
+			const go = this;
+			return function () {
+				const event = { id: id, this: this, args: arguments };
+				go._pendingEvent = event;
+				go._resume();
+				return event.result;
+			};
+		}
+	}
+})();

--- a/packages/lsp-client/src/wasm_exec_prelude.js
+++ b/packages/lsp-client/src/wasm_exec_prelude.js
@@ -1,0 +1,7 @@
+import * as path from "path"
+import { TextEncoder, TextDecoder } from "util";
+
+globalThis.require = require
+globalThis.path = path
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;

--- a/packages/lsp-client/src/web-assembly.d.ts
+++ b/packages/lsp-client/src/web-assembly.d.ts
@@ -1,0 +1,159 @@
+// Extracted from lib.dom.d.ts
+declare namespace WebAssembly {
+    interface CompileError extends Error {
+    }
+
+    var CompileError: {
+        prototype: CompileError;
+        new(message?: string): CompileError;
+        (message?: string): CompileError;
+    };
+
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global) */
+    interface Global<T extends ValueType = ValueType> {
+        value: ValueTypeMap[T];
+        valueOf(): ValueTypeMap[T];
+    }
+
+    var Global: {
+        prototype: Global;
+        new<T extends ValueType = ValueType>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T]): Global<T>;
+    };
+
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Instance) */
+    interface Instance {
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Instance/exports) */
+        readonly exports: Exports;
+    }
+
+    var Instance: {
+        prototype: Instance;
+        new(module: Module, importObject?: Imports): Instance;
+    };
+
+    interface LinkError extends Error {
+    }
+
+    var LinkError: {
+        prototype: LinkError;
+        new(message?: string): LinkError;
+        (message?: string): LinkError;
+    };
+
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory) */
+    interface Memory {
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory/buffer) */
+        readonly buffer: ArrayBuffer;
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory/grow) */
+        grow(delta: number): number;
+    }
+
+    var Memory: {
+        prototype: Memory;
+        new(descriptor: MemoryDescriptor): Memory;
+    };
+
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module) */
+    interface Module {
+    }
+
+    var Module: {
+        prototype: Module;
+        new(bytes: BufferSource): Module;
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/customSections_static) */
+        customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/exports_static) */
+        exports(moduleObject: Module): ModuleExportDescriptor[];
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/imports_static) */
+        imports(moduleObject: Module): ModuleImportDescriptor[];
+    };
+
+    interface RuntimeError extends Error {
+    }
+
+    var RuntimeError: {
+        prototype: RuntimeError;
+        new(message?: string): RuntimeError;
+        (message?: string): RuntimeError;
+    };
+
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table) */
+    interface Table {
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/length) */
+        readonly length: number;
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/get) */
+        get(index: number): any;
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/grow) */
+        grow(delta: number, value?: any): number;
+        /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/set) */
+        set(index: number, value?: any): void;
+    }
+
+    var Table: {
+        prototype: Table;
+        new(descriptor: TableDescriptor, value?: any): Table;
+    };
+
+    interface GlobalDescriptor<T extends ValueType = ValueType> {
+        mutable?: boolean;
+        value: T;
+    }
+
+    interface MemoryDescriptor {
+        initial: number;
+        maximum?: number;
+        shared?: boolean;
+    }
+
+    interface ModuleExportDescriptor {
+        kind: ImportExportKind;
+        name: string;
+    }
+
+    interface ModuleImportDescriptor {
+        kind: ImportExportKind;
+        module: string;
+        name: string;
+    }
+
+    interface TableDescriptor {
+        element: TableKind;
+        initial: number;
+        maximum?: number;
+    }
+
+    interface ValueTypeMap {
+        anyfunc: Function;
+        externref: any;
+        f32: number;
+        f64: number;
+        i32: number;
+        i64: bigint;
+        v128: never;
+    }
+
+    interface WebAssemblyInstantiatedSource {
+        instance: Instance;
+        module: Module;
+    }
+
+    type ImportExportKind = "function" | "global" | "memory" | "table";
+    type TableKind = "anyfunc" | "externref";
+    type ExportValue = Function | Global | Memory | Table;
+    type Exports = Record<string, ExportValue>;
+    type ImportValue = ExportValue | number;
+    type Imports = Record<string, ModuleImports>;
+    type ModuleImports = Record<string, ImportValue>;
+    type ValueType = keyof ValueTypeMap;
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compile_static) */
+    function compile(bytes: BufferSource): Promise<Module>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compileStreaming_static) */
+    function compileStreaming(source: Response | PromiseLike<Response>): Promise<Module>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiate_static) */
+    function instantiate(bytes: BufferSource, importObject?: Imports): Promise<WebAssemblyInstantiatedSource>;
+    function instantiate(moduleObject: Module, importObject?: Imports): Promise<Instance>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiateStreaming_static) */
+    function instantiateStreaming(source: Response | PromiseLike<Response>, importObject?: Imports): Promise<WebAssemblyInstantiatedSource>;
+    /** [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/validate_static) */
+    function validate(bytes: BufferSource): boolean;
+}

--- a/packages/lsp-client/tsconfig.json
+++ b/packages/lsp-client/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": "src",
     "sourceMap": true,
     "skipLibCheck": true,
+    "strict": true,
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- basic communication with wasm build of lsp-server
- add sendRequest() method, patch _resume() to not throw

TODO:
- [ ] remove wasm_exec.js from coverage
- [ ] document changes made to wasm_exec.js and which version is being used
- [ ] package everything in index.ts into a class in a new file named wasm-client.ts
- [ ] write unit tests