### PR TITLE
simplify lexer

### DIFF
--- a/internal/ast/jsx.go
+++ b/internal/ast/jsx.go
@@ -2,12 +2,12 @@ package ast
 
 type JSXOpening struct {
 	Name      string
-	Attrs     []JSXAttr
+	Attrs     []*JSXAttr
 	SelfClose bool
 	span      Span
 }
 
-func NewJSXOpening(name string, attrs []JSXAttr, selfClose bool, span Span) *JSXOpening {
+func NewJSXOpening(name string, attrs []*JSXAttr, selfClose bool, span Span) *JSXOpening {
 	return &JSXOpening{Name: name, Attrs: attrs, SelfClose: selfClose, span: span}
 }
 func (n *JSXOpening) Span() Span { return n.span }

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -234,14 +234,14 @@
             Value: "a",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:4},
+                End:   ast.Location{Line:1, Column:5},
             },
         },
         &ast.Quasi{
             Value: "e",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:13},
-                End:   ast.Location{Line:1, Column:15},
+                Start: ast.Location{Line:1, Column:14},
+                End:   ast.Location{Line:1, Column:16},
             },
         },
     },
@@ -251,15 +251,15 @@
                 &ast.Quasi{
                     Value: "b",
                     Span:  ast.Span{
-                        Start: ast.Location{Line:1, Column:5},
-                        End:   ast.Location{Line:1, Column:8},
+                        Start: ast.Location{Line:1, Column:6},
+                        End:   ast.Location{Line:1, Column:9},
                     },
                 },
                 &ast.Quasi{
                     Value: "d",
                     Span:  ast.Span{
-                        Start: ast.Location{Line:1, Column:10},
-                        End:   ast.Location{Line:1, Column:12},
+                        Start: ast.Location{Line:1, Column:11},
+                        End:   ast.Location{Line:1, Column:13},
                     },
                 },
             },
@@ -267,22 +267,22 @@
                 &ast.IdentExpr{
                     Name: "c",
                     span: ast.Span{
-                        Start: ast.Location{Line:1, Column:8},
-                        End:   ast.Location{Line:1, Column:9},
+                        Start: ast.Location{Line:1, Column:9},
+                        End:   ast.Location{Line:1, Column:10},
                     },
                     inferredType: nil,
                 },
             },
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:4},
-                End:   ast.Location{Line:1, Column:12},
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:13},
             },
             inferredType: nil,
         },
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:15},
+        End:   ast.Location{Line:1, Column:16},
     },
     inferredType: nil,
 }
@@ -406,14 +406,14 @@
             Value: "query userId { user { id } }",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:33},
+                End:   ast.Location{Line:1, Column:34},
             },
         },
     },
     Exprs: nil,
     span:  ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:33},
+        End:   ast.Location{Line:1, Column:34},
     },
     inferredType: nil,
 }
@@ -745,14 +745,14 @@
             Value: "hello ",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:9},
+                End:   ast.Location{Line:1, Column:10},
             },
         },
         &ast.Quasi{
             Value: "",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:14},
-                End:   ast.Location{Line:1, Column:15},
+                Start: ast.Location{Line:1, Column:15},
+                End:   ast.Location{Line:1, Column:16},
             },
         },
     },
@@ -760,15 +760,15 @@
         &ast.IdentExpr{
             Name: "name",
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:9},
-                End:   ast.Location{Line:1, Column:13},
+                Start: ast.Location{Line:1, Column:10},
+                End:   ast.Location{Line:1, Column:14},
             },
             inferredType: nil,
         },
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:15},
+        End:   ast.Location{Line:1, Column:16},
     },
     inferredType: nil,
 }
@@ -822,21 +822,21 @@
             Value: "a",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:4},
+                End:   ast.Location{Line:1, Column:5},
             },
         },
         &ast.Quasi{
             Value: "c",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:6},
-                End:   ast.Location{Line:1, Column:9},
+                Start: ast.Location{Line:1, Column:7},
+                End:   ast.Location{Line:1, Column:10},
             },
         },
         &ast.Quasi{
             Value: "e",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:11},
-                End:   ast.Location{Line:1, Column:13},
+                Start: ast.Location{Line:1, Column:12},
+                End:   ast.Location{Line:1, Column:14},
             },
         },
     },
@@ -844,23 +844,23 @@
         &ast.IdentExpr{
             Name: "b",
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:4},
-                End:   ast.Location{Line:1, Column:5},
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:6},
             },
             inferredType: nil,
         },
         &ast.IdentExpr{
             Name: "d",
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:9},
-                End:   ast.Location{Line:1, Column:10},
+                Start: ast.Location{Line:1, Column:10},
+                End:   ast.Location{Line:1, Column:11},
             },
             inferredType: nil,
         },
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:13},
+        End:   ast.Location{Line:1, Column:14},
     },
     inferredType: nil,
 }
@@ -1059,14 +1059,14 @@
             Value: "foo",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:4},
+                End:   ast.Location{Line:1, Column:5},
             },
         },
     },
     Exprs: nil,
     span:  ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:4},
+        End:   ast.Location{Line:1, Column:5},
     },
     inferredType: nil,
 }
@@ -1451,7 +1451,7 @@
     &parser.Error{
         Span: ast.Span{
             Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:5},
         },
         Message: "Expected a closing backtick",
     },
@@ -1497,14 +1497,14 @@
             Value: "bar",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:7},
+                End:   ast.Location{Line:1, Column:8},
             },
         },
     },
     Exprs: nil,
     span:  ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:7},
+        End:   ast.Location{Line:1, Column:8},
     },
     inferredType: nil,
 }
@@ -1515,7 +1515,7 @@
     &parser.Error{
         Span: ast.Span{
             Start: ast.Location{Line:1, Column:4},
-            End:   ast.Location{Line:1, Column:7},
+            End:   ast.Location{Line:1, Column:8},
         },
         Message: "Expected a closing backtick",
     },
@@ -1683,5 +1683,25 @@
         },
         Message: "Expected an opening paren",
     },
+}
+---
+
+[TestParseExprNoErrors/TemplateStringMultipleLines - 1]
+&ast.TemplateLitExpr{
+    Quasis: {
+        &ast.Quasi{
+            Value: "hello\nworld",
+            Span:  ast.Span{
+                Start: ast.Location{Line:1, Column:2},
+                End:   ast.Location{Line:2, Column:7},
+            },
+        },
+    },
+    Exprs: nil,
+    span:  ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:2, Column:7},
+    },
+    inferredType: nil,
 }
 ---

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -234,14 +234,14 @@
             Value: "a",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:4},
             },
         },
         &ast.Quasi{
             Value: "e",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:14},
-                End:   ast.Location{Line:1, Column:16},
+                Start: ast.Location{Line:1, Column:13},
+                End:   ast.Location{Line:1, Column:15},
             },
         },
     },
@@ -251,15 +251,15 @@
                 &ast.Quasi{
                     Value: "b",
                     Span:  ast.Span{
-                        Start: ast.Location{Line:1, Column:6},
-                        End:   ast.Location{Line:1, Column:9},
+                        Start: ast.Location{Line:1, Column:5},
+                        End:   ast.Location{Line:1, Column:8},
                     },
                 },
                 &ast.Quasi{
                     Value: "d",
                     Span:  ast.Span{
-                        Start: ast.Location{Line:1, Column:11},
-                        End:   ast.Location{Line:1, Column:13},
+                        Start: ast.Location{Line:1, Column:10},
+                        End:   ast.Location{Line:1, Column:12},
                     },
                 },
             },
@@ -267,22 +267,22 @@
                 &ast.IdentExpr{
                     Name: "c",
                     span: ast.Span{
-                        Start: ast.Location{Line:1, Column:9},
-                        End:   ast.Location{Line:1, Column:10},
+                        Start: ast.Location{Line:1, Column:8},
+                        End:   ast.Location{Line:1, Column:9},
                     },
                     inferredType: nil,
                 },
             },
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:13},
+                Start: ast.Location{Line:1, Column:4},
+                End:   ast.Location{Line:1, Column:12},
             },
             inferredType: nil,
         },
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:16},
+        End:   ast.Location{Line:1, Column:15},
     },
     inferredType: nil,
 }
@@ -406,14 +406,14 @@
             Value: "query userId { user { id } }",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:34},
+                End:   ast.Location{Line:1, Column:33},
             },
         },
     },
     Exprs: nil,
     span:  ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:34},
+        End:   ast.Location{Line:1, Column:33},
     },
     inferredType: nil,
 }
@@ -745,14 +745,14 @@
             Value: "hello ",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:10},
+                End:   ast.Location{Line:1, Column:9},
             },
         },
         &ast.Quasi{
             Value: "",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:15},
-                End:   ast.Location{Line:1, Column:16},
+                Start: ast.Location{Line:1, Column:14},
+                End:   ast.Location{Line:1, Column:15},
             },
         },
     },
@@ -760,15 +760,15 @@
         &ast.IdentExpr{
             Name: "name",
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:10},
-                End:   ast.Location{Line:1, Column:14},
+                Start: ast.Location{Line:1, Column:9},
+                End:   ast.Location{Line:1, Column:13},
             },
             inferredType: nil,
         },
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:16},
+        End:   ast.Location{Line:1, Column:15},
     },
     inferredType: nil,
 }
@@ -822,21 +822,21 @@
             Value: "a",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:4},
             },
         },
         &ast.Quasi{
             Value: "c",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:7},
-                End:   ast.Location{Line:1, Column:10},
+                Start: ast.Location{Line:1, Column:6},
+                End:   ast.Location{Line:1, Column:9},
             },
         },
         &ast.Quasi{
             Value: "e",
             Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:12},
-                End:   ast.Location{Line:1, Column:14},
+                Start: ast.Location{Line:1, Column:11},
+                End:   ast.Location{Line:1, Column:13},
             },
         },
     },
@@ -844,23 +844,23 @@
         &ast.IdentExpr{
             Name: "b",
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:6},
+                Start: ast.Location{Line:1, Column:4},
+                End:   ast.Location{Line:1, Column:5},
             },
             inferredType: nil,
         },
         &ast.IdentExpr{
             Name: "d",
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:10},
-                End:   ast.Location{Line:1, Column:11},
+                Start: ast.Location{Line:1, Column:9},
+                End:   ast.Location{Line:1, Column:10},
             },
             inferredType: nil,
         },
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:14},
+        End:   ast.Location{Line:1, Column:13},
     },
     inferredType: nil,
 }
@@ -1059,14 +1059,14 @@
             Value: "foo",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:7},
+                End:   ast.Location{Line:1, Column:4},
             },
         },
     },
     Exprs: nil,
     span:  ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:7},
+        End:   ast.Location{Line:1, Column:4},
     },
     inferredType: nil,
 }
@@ -1451,7 +1451,7 @@
     &parser.Error{
         Span: ast.Span{
             Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:7},
+            End:   ast.Location{Line:1, Column:4},
         },
         Message: "Expected a closing backtick",
     },
@@ -1497,14 +1497,14 @@
             Value: "bar",
             Span:  ast.Span{
                 Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:10},
+                End:   ast.Location{Line:1, Column:7},
             },
         },
     },
     Exprs: nil,
     span:  ast.Span{
         Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:10},
+        End:   ast.Location{Line:1, Column:7},
     },
     inferredType: nil,
 }
@@ -1515,7 +1515,7 @@
     &parser.Error{
         Span: ast.Span{
             Start: ast.Location{Line:1, Column:4},
-            End:   ast.Location{Line:1, Column:10},
+            End:   ast.Location{Line:1, Column:7},
         },
         Message: "Expected a closing backtick",
     },

--- a/internal/parser/__snapshots__/jsx_test.snap
+++ b/internal/parser/__snapshots__/jsx_test.snap
@@ -533,3 +533,60 @@
     },
 }
 ---
+
+[TestParseJSXNoErrors/MultipleLines - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "Foo",
+        Attrs: {
+            &ast.JSXAttr{
+                Name:  "bar",
+                Value: &&ast.JSXExprContainer{
+                    Expr: &ast.LiteralExpr{
+                        Lit:  &ast.NumLit{Value:5},
+                        span: ast.Span{
+                            Start: ast.Location{Line:2, Column:8},
+                            End:   ast.Location{Line:2, Column:9},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:2, Column:7},
+                        End:   ast.Location{Line:2, Column:8},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:2, Column:9},
+                    End:   ast.Location{Line:2, Column:10},
+                },
+            },
+            &ast.JSXAttr{
+                Name:  "baz",
+                Value: &&ast.JSXString{
+                    Value: "hello",
+                    span:  ast.Span{
+                        Start: ast.Location{Line:3, Column:7},
+                        End:   ast.Location{Line:3, Column:13},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:3, Column:7},
+                    End:   ast.Location{Line:3, Column:13},
+                },
+            },
+        },
+        SelfClose: true,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:4, Column:3},
+        },
+    },
+    Closing:  (*ast.JSXClosing)(nil),
+    Children: nil,
+    span:     ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:4, Column:3},
+    },
+    inferredType: nil,
+}
+---

--- a/internal/parser/__snapshots__/jsx_test.snap
+++ b/internal/parser/__snapshots__/jsx_test.snap
@@ -7,14 +7,14 @@
         },
         SelfClose: true,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:6},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:8},
         },
     },
     Closing:  (*ast.JSXClosing)(nil),
     Children: nil,
     span:     ast.Span{
-        Start: ast.Location{Line:1, Column:6},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:8},
     },
     inferredType: nil,
@@ -29,21 +29,21 @@
         },
         SelfClose: false,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:5},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:6},
         },
     },
     Closing: &ast.JSXClosing{
         Name: "Foo",
         span: ast.Span{
-            Start: ast.Location{Line:1, Column:11},
+            Start: ast.Location{Line:1, Column:6},
             End:   ast.Location{Line:1, Column:12},
         },
     },
     Children: {
     },
     span: ast.Span{
-        Start: ast.Location{Line:1, Column:5},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:12},
     },
     inferredType: nil,
@@ -93,14 +93,14 @@
         },
         SelfClose: true,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:25},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:27},
         },
     },
     Closing:  (*ast.JSXClosing)(nil),
     Children: nil,
     span:     ast.Span{
-        Start: ast.Location{Line:1, Column:25},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:27},
     },
     inferredType: nil,
@@ -150,21 +150,21 @@
         },
         SelfClose: false,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:24},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:25},
         },
     },
     Closing: &ast.JSXClosing{
         Name: "Foo",
         span: ast.Span{
-            Start: ast.Location{Line:1, Column:30},
+            Start: ast.Location{Line:1, Column:25},
             End:   ast.Location{Line:1, Column:31},
         },
     },
     Children: {
     },
     span: ast.Span{
-        Start: ast.Location{Line:1, Column:24},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:31},
     },
     inferredType: nil,
@@ -179,14 +179,14 @@
         },
         SelfClose: false,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:5},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:6},
         },
     },
     Closing: &ast.JSXClosing{
         Name: "div",
         span: ast.Span{
-            Start: ast.Location{Line:1, Column:34},
+            Start: ast.Location{Line:1, Column:29},
             End:   ast.Location{Line:1, Column:35},
         },
     },
@@ -198,14 +198,14 @@
                 },
                 SelfClose: false,
                 span:      ast.Span{
-                    Start: ast.Location{Line:1, Column:11},
+                    Start: ast.Location{Line:1, Column:6},
                     End:   ast.Location{Line:1, Column:12},
                 },
             },
             Closing: &ast.JSXClosing{
                 Name: "span",
                 span: ast.Span{
-                    Start: ast.Location{Line:1, Column:23},
+                    Start: ast.Location{Line:1, Column:17},
                     End:   ast.Location{Line:1, Column:24},
                 },
             },
@@ -219,7 +219,7 @@
                 },
             },
             span: ast.Span{
-                Start: ast.Location{Line:1, Column:11},
+                Start: ast.Location{Line:1, Column:6},
                 End:   ast.Location{Line:1, Column:24},
             },
             inferredType: nil,
@@ -233,7 +233,7 @@
         },
     },
     span: ast.Span{
-        Start: ast.Location{Line:1, Column:5},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:35},
     },
     inferredType: nil,
@@ -248,14 +248,14 @@
         },
         SelfClose: false,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:5},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:6},
         },
     },
     Closing: &ast.JSXClosing{
         Name: "div",
         span: ast.Span{
-            Start: ast.Location{Line:1, Column:23},
+            Start: ast.Location{Line:1, Column:18},
             End:   ast.Location{Line:1, Column:24},
         },
     },
@@ -283,7 +283,7 @@
         },
     },
     span: ast.Span{
-        Start: ast.Location{Line:1, Column:5},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:24},
     },
     inferredType: nil,
@@ -298,14 +298,14 @@
         },
         SelfClose: false,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:5},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:6},
         },
     },
     Closing: &ast.JSXClosing{
         Name: "div",
         span: ast.Span{
-            Start: ast.Location{Line:1, Column:31},
+            Start: ast.Location{Line:1, Column:26},
             End:   ast.Location{Line:1, Column:32},
         },
     },
@@ -318,14 +318,14 @@
                     },
                     SelfClose: false,
                     span:      ast.Span{
-                        Start: ast.Location{Line:1, Column:12},
+                        Start: ast.Location{Line:1, Column:7},
                         End:   ast.Location{Line:1, Column:13},
                     },
                 },
                 Closing: &ast.JSXClosing{
                     Name: "span",
                     span: ast.Span{
-                        Start: ast.Location{Line:1, Column:24},
+                        Start: ast.Location{Line:1, Column:18},
                         End:   ast.Location{Line:1, Column:25},
                     },
                 },
@@ -346,7 +346,7 @@
                     },
                 },
                 span: ast.Span{
-                    Start: ast.Location{Line:1, Column:12},
+                    Start: ast.Location{Line:1, Column:7},
                     End:   ast.Location{Line:1, Column:25},
                 },
                 inferredType: nil,
@@ -358,7 +358,7 @@
         },
     },
     span: ast.Span{
-        Start: ast.Location{Line:1, Column:5},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:32},
     },
     inferredType: nil,
@@ -372,14 +372,14 @@
         Attrs:     nil,
         SelfClose: false,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:2},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:3},
         },
     },
     Closing: &ast.JSXClosing{
         Name: "",
         span: ast.Span{
-            Start: ast.Location{Line:1, Column:19},
+            Start: ast.Location{Line:1, Column:17},
             End:   ast.Location{Line:1, Column:20},
         },
     },
@@ -391,14 +391,14 @@
                 },
                 SelfClose: true,
                 span:      ast.Span{
-                    Start: ast.Location{Line:1, Column:8},
+                    Start: ast.Location{Line:1, Column:3},
                     End:   ast.Location{Line:1, Column:10},
                 },
             },
             Closing:  (*ast.JSXClosing)(nil),
             Children: nil,
             span:     ast.Span{
-                Start: ast.Location{Line:1, Column:8},
+                Start: ast.Location{Line:1, Column:3},
                 End:   ast.Location{Line:1, Column:10},
             },
             inferredType: nil,
@@ -410,21 +410,21 @@
                 },
                 SelfClose: true,
                 span:      ast.Span{
-                    Start: ast.Location{Line:1, Column:15},
+                    Start: ast.Location{Line:1, Column:10},
                     End:   ast.Location{Line:1, Column:17},
                 },
             },
             Closing:  (*ast.JSXClosing)(nil),
             Children: nil,
             span:     ast.Span{
-                Start: ast.Location{Line:1, Column:15},
+                Start: ast.Location{Line:1, Column:10},
                 End:   ast.Location{Line:1, Column:17},
             },
             inferredType: nil,
         },
     },
     span: ast.Span{
-        Start: ast.Location{Line:1, Column:2},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:20},
     },
     inferredType: nil,
@@ -453,14 +453,14 @@
         },
         SelfClose: true,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:17},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:19},
         },
     },
     Closing:  (*ast.JSXClosing)(nil),
     Children: nil,
     span:     ast.Span{
-        Start: ast.Location{Line:1, Column:17},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:19},
     },
     inferredType: nil,
@@ -496,14 +496,14 @@
         },
         SelfClose: true,
         span:      ast.Span{
-            Start: ast.Location{Line:1, Column:14},
+            Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:16},
         },
     },
     Closing:  (*ast.JSXClosing)(nil),
     Children: nil,
     span:     ast.Span{
-        Start: ast.Location{Line:1, Column:14},
+        Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:16},
     },
     inferredType: nil,

--- a/internal/parser/__snapshots__/jsx_test.snap
+++ b/internal/parser/__snapshots__/jsx_test.snap
@@ -364,3 +364,172 @@
     inferredType: nil,
 }
 ---
+
+[TestParseJSXNoErrors/Fragment - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:      "",
+        Attrs:     nil,
+        SelfClose: false,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:2},
+            End:   ast.Location{Line:1, Column:3},
+        },
+    },
+    Closing: &ast.JSXClosing{
+        Name: "",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:19},
+            End:   ast.Location{Line:1, Column:20},
+        },
+    },
+    Children: {
+        &ast.JSXElementExpr{
+            Opening: &ast.JSXOpening{
+                Name:  "Foo",
+                Attrs: {
+                },
+                SelfClose: true,
+                span:      ast.Span{
+                    Start: ast.Location{Line:1, Column:8},
+                    End:   ast.Location{Line:1, Column:10},
+                },
+            },
+            Closing:  (*ast.JSXClosing)(nil),
+            Children: nil,
+            span:     ast.Span{
+                Start: ast.Location{Line:1, Column:8},
+                End:   ast.Location{Line:1, Column:10},
+            },
+            inferredType: nil,
+        },
+        &ast.JSXElementExpr{
+            Opening: &ast.JSXOpening{
+                Name:  "Bar",
+                Attrs: {
+                },
+                SelfClose: true,
+                span:      ast.Span{
+                    Start: ast.Location{Line:1, Column:15},
+                    End:   ast.Location{Line:1, Column:17},
+                },
+            },
+            Closing:  (*ast.JSXClosing)(nil),
+            Children: nil,
+            span:     ast.Span{
+                Start: ast.Location{Line:1, Column:15},
+                End:   ast.Location{Line:1, Column:17},
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:2},
+        End:   ast.Location{Line:1, Column:20},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXErrors/MissingEqualsInStringAttr - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "Foo",
+        Attrs: {
+            &ast.JSXAttr{
+                Name:  "bar",
+                Value: &&ast.JSXString{
+                    Value: "hello",
+                    span:  ast.Span{
+                        Start: ast.Location{Line:1, Column:10},
+                        End:   ast.Location{Line:1, Column:16},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:10},
+                    End:   ast.Location{Line:1, Column:16},
+                },
+            },
+        },
+        SelfClose: true,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:17},
+            End:   ast.Location{Line:1, Column:19},
+        },
+    },
+    Closing:  (*ast.JSXClosing)(nil),
+    Children: nil,
+    span:     ast.Span{
+        Start: ast.Location{Line:1, Column:17},
+        End:   ast.Location{Line:1, Column:19},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXErrors/MissingEqualsInExprAttr - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "Foo",
+        Attrs: {
+            &ast.JSXAttr{
+                Name:  "bar",
+                Value: &&ast.JSXExprContainer{
+                    Expr: &ast.LiteralExpr{
+                        Lit:  &ast.NumLit{Value:5},
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:11},
+                            End:   ast.Location{Line:1, Column:12},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:10},
+                        End:   ast.Location{Line:1, Column:11},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:12},
+                    End:   ast.Location{Line:1, Column:13},
+                },
+            },
+        },
+        SelfClose: true,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:14},
+            End:   ast.Location{Line:1, Column:16},
+        },
+    },
+    Closing:  (*ast.JSXClosing)(nil),
+    Children: nil,
+    span:     ast.Span{
+        Start: ast.Location{Line:1, Column:14},
+        End:   ast.Location{Line:1, Column:16},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXErrors/MissingEqualsInStringAttr - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:10},
+            End:   ast.Location{Line:1, Column:16},
+        },
+        Message: "Expected '='",
+    },
+}
+---
+
+[TestParseJSXErrors/MissingEqualsInExprAttr - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:10},
+            End:   ast.Location{Line:1, Column:11},
+        },
+        Message: "Expected '='",
+    },
+}
+---

--- a/internal/parser/__snapshots__/jsx_test.snap
+++ b/internal/parser/__snapshots__/jsx_test.snap
@@ -1,0 +1,366 @@
+
+[TestParseJSXNoErrors/SelfClosingNoAttrs - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "Foo",
+        Attrs: {
+        },
+        SelfClose: true,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:6},
+            End:   ast.Location{Line:1, Column:8},
+        },
+    },
+    Closing:  (*ast.JSXClosing)(nil),
+    Children: nil,
+    span:     ast.Span{
+        Start: ast.Location{Line:1, Column:6},
+        End:   ast.Location{Line:1, Column:8},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXNoErrors/NoAttrsNoChildren - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "Foo",
+        Attrs: {
+        },
+        SelfClose: false,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:6},
+        },
+    },
+    Closing: &ast.JSXClosing{
+        Name: "Foo",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:11},
+            End:   ast.Location{Line:1, Column:12},
+        },
+    },
+    Children: {
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:5},
+        End:   ast.Location{Line:1, Column:12},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXNoErrors/SelfClosingAttrs - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "Foo",
+        Attrs: {
+            &ast.JSXAttr{
+                Name:  "bar",
+                Value: &&ast.JSXExprContainer{
+                    Expr: &ast.LiteralExpr{
+                        Lit:  &ast.NumLit{Value:5},
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:11},
+                            End:   ast.Location{Line:1, Column:12},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:10},
+                        End:   ast.Location{Line:1, Column:11},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:12},
+                    End:   ast.Location{Line:1, Column:13},
+                },
+            },
+            &ast.JSXAttr{
+                Name:  "baz",
+                Value: &&ast.JSXString{
+                    Value: "hello",
+                    span:  ast.Span{
+                        Start: ast.Location{Line:1, Column:18},
+                        End:   ast.Location{Line:1, Column:24},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:18},
+                    End:   ast.Location{Line:1, Column:24},
+                },
+            },
+        },
+        SelfClose: true,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:25},
+            End:   ast.Location{Line:1, Column:27},
+        },
+    },
+    Closing:  (*ast.JSXClosing)(nil),
+    Children: nil,
+    span:     ast.Span{
+        Start: ast.Location{Line:1, Column:25},
+        End:   ast.Location{Line:1, Column:27},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXNoErrors/AttrsNoChildren - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "Foo",
+        Attrs: {
+            &ast.JSXAttr{
+                Name:  "bar",
+                Value: &&ast.JSXExprContainer{
+                    Expr: &ast.LiteralExpr{
+                        Lit:  &ast.NumLit{Value:5},
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:11},
+                            End:   ast.Location{Line:1, Column:12},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:10},
+                        End:   ast.Location{Line:1, Column:11},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:12},
+                    End:   ast.Location{Line:1, Column:13},
+                },
+            },
+            &ast.JSXAttr{
+                Name:  "baz",
+                Value: &&ast.JSXString{
+                    Value: "hello",
+                    span:  ast.Span{
+                        Start: ast.Location{Line:1, Column:18},
+                        End:   ast.Location{Line:1, Column:24},
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:18},
+                    End:   ast.Location{Line:1, Column:24},
+                },
+            },
+        },
+        SelfClose: false,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:24},
+            End:   ast.Location{Line:1, Column:25},
+        },
+    },
+    Closing: &ast.JSXClosing{
+        Name: "Foo",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:30},
+            End:   ast.Location{Line:1, Column:31},
+        },
+    },
+    Children: {
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:24},
+        End:   ast.Location{Line:1, Column:31},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXNoErrors/ChildElements - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "div",
+        Attrs: {
+        },
+        SelfClose: false,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:6},
+        },
+    },
+    Closing: &ast.JSXClosing{
+        Name: "div",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:34},
+            End:   ast.Location{Line:1, Column:35},
+        },
+    },
+    Children: {
+        &ast.JSXElementExpr{
+            Opening: &ast.JSXOpening{
+                Name:  "span",
+                Attrs: {
+                },
+                SelfClose: false,
+                span:      ast.Span{
+                    Start: ast.Location{Line:1, Column:11},
+                    End:   ast.Location{Line:1, Column:12},
+                },
+            },
+            Closing: &ast.JSXClosing{
+                Name: "span",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:23},
+                    End:   ast.Location{Line:1, Column:24},
+                },
+            },
+            Children: {
+                &ast.JSXText{
+                    Value: "hello",
+                    span:  ast.Span{
+                        Start: ast.Location{Line:1, Column:12},
+                        End:   ast.Location{Line:1, Column:17},
+                    },
+                },
+            },
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:11},
+                End:   ast.Location{Line:1, Column:24},
+            },
+            inferredType: nil,
+        },
+        &ast.JSXText{
+            Value: "world",
+            span:  ast.Span{
+                Start: ast.Location{Line:1, Column:24},
+                End:   ast.Location{Line:1, Column:29},
+            },
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:5},
+        End:   ast.Location{Line:1, Column:35},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXNoErrors/ChildExpr - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "div",
+        Attrs: {
+        },
+        SelfClose: false,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:6},
+        },
+    },
+    Closing: &ast.JSXClosing{
+        Name: "div",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:23},
+            End:   ast.Location{Line:1, Column:24},
+        },
+    },
+    Children: {
+        &ast.JSXText{
+            Value: "hello, ",
+            span:  ast.Span{
+                Start: ast.Location{Line:1, Column:6},
+                End:   ast.Location{Line:1, Column:13},
+            },
+        },
+        &ast.JSXExprContainer{
+            Expr: &ast.IdentExpr{
+                Name: "msg",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:14},
+                    End:   ast.Location{Line:1, Column:17},
+                },
+                inferredType: nil,
+            },
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:17},
+                End:   ast.Location{Line:1, Column:18},
+            },
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:5},
+        End:   ast.Location{Line:1, Column:24},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseJSXNoErrors/Nesting - 1]
+&ast.JSXElementExpr{
+    Opening: &ast.JSXOpening{
+        Name:  "div",
+        Attrs: {
+        },
+        SelfClose: false,
+        span:      ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:6},
+        },
+    },
+    Closing: &ast.JSXClosing{
+        Name: "div",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:31},
+            End:   ast.Location{Line:1, Column:32},
+        },
+    },
+    Children: {
+        &ast.JSXExprContainer{
+            Expr: &ast.JSXElementExpr{
+                Opening: &ast.JSXOpening{
+                    Name:  "span",
+                    Attrs: {
+                    },
+                    SelfClose: false,
+                    span:      ast.Span{
+                        Start: ast.Location{Line:1, Column:12},
+                        End:   ast.Location{Line:1, Column:13},
+                    },
+                },
+                Closing: &ast.JSXClosing{
+                    Name: "span",
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:24},
+                        End:   ast.Location{Line:1, Column:25},
+                    },
+                },
+                Children: {
+                    &ast.JSXExprContainer{
+                        Expr: &ast.IdentExpr{
+                            Name: "foo",
+                            span: ast.Span{
+                                Start: ast.Location{Line:1, Column:14},
+                                End:   ast.Location{Line:1, Column:17},
+                            },
+                            inferredType: nil,
+                        },
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:17},
+                            End:   ast.Location{Line:1, Column:18},
+                        },
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:12},
+                    End:   ast.Location{Line:1, Column:25},
+                },
+                inferredType: nil,
+            },
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:25},
+                End:   ast.Location{Line:1, Column:26},
+            },
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:5},
+        End:   ast.Location{Line:1, Column:32},
+    },
+    inferredType: nil,
+}
+---

--- a/internal/parser/__snapshots__/lexer_test.snap
+++ b/internal/parser/__snapshots__/lexer_test.snap
@@ -1,139 +1,169 @@
 
 [TestLexingKeywords - 1]
-[]parser.Token{
-    &parser.TFn{
-        span: ast.Span{
+[]*parser.Token{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:3},
         },
+        Type:  5,
+        Value: "fn",
     },
-    &parser.TVar{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:4},
             End:   ast.Location{Line:1, Column:7},
         },
+        Type:  6,
+        Value: "var",
     },
-    &parser.TVal{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:8},
             End:   ast.Location{Line:1, Column:11},
         },
+        Type:  7,
+        Value: "val",
     },
 }
 ---
 
 [TestLexingOperators - 1]
-[]parser.Token{
-    &parser.TPlus{
-        span: ast.Span{
+[]*parser.Token{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:2},
         },
+        Type:  12,
+        Value: "+",
     },
-    &parser.TMinus{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:3},
             End:   ast.Location{Line:1, Column:4},
         },
+        Type:  13,
+        Value: "-",
     },
-    &parser.TAsterisk{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:5},
             End:   ast.Location{Line:1, Column:6},
         },
+        Type:  14,
+        Value: "*",
     },
-    &parser.TSlash{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:7},
             End:   ast.Location{Line:1, Column:8},
         },
+        Type:  15,
+        Value: "/",
     },
-    &parser.TEquals{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:9},
             End:   ast.Location{Line:1, Column:10},
         },
+        Type:  17,
+        Value: "=",
     },
 }
 ---
 
 [TestLexingIdentifiers - 1]
-[]parser.Token{
-    &parser.TIdentifier{
-        Value: "foo",
-        span:  ast.Span{
+[]*parser.Token{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:4},
         },
+        Type:  4,
+        Value: "foo",
     },
-    &parser.TIdentifier{
-        Value: "bar",
-        span:  ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:2, Column:1},
             End:   ast.Location{Line:2, Column:4},
         },
+        Type:  4,
+        Value: "bar",
     },
 }
 ---
 
 [TestLexingLiterals - 1]
-[]parser.Token{
-    &parser.TString{
-        Value: "hello",
-        span:  ast.Span{
+[]*parser.Token{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:7},
         },
+        Type:  1,
+        Value: "hello",
     },
 }
 ---
 
 [TestLexingParens - 1]
-[]parser.Token{
-    &parser.TIdentifier{
-        Value: "a",
-        span:  ast.Span{
+[]*parser.Token{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:2},
         },
+        Type:  4,
+        Value: "a",
     },
-    &parser.TAsterisk{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:3},
             End:   ast.Location{Line:1, Column:4},
         },
+        Type:  14,
+        Value: "*",
     },
-    &parser.TOpenParen{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:5},
             End:   ast.Location{Line:1, Column:6},
         },
+        Type:  28,
+        Value: "(",
     },
-    &parser.TIdentifier{
-        Value: "b",
-        span:  ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:6},
             End:   ast.Location{Line:1, Column:7},
         },
+        Type:  4,
+        Value: "b",
     },
-    &parser.TPlus{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:8},
             End:   ast.Location{Line:1, Column:9},
         },
+        Type:  12,
+        Value: "+",
     },
-    &parser.TIdentifier{
-        Value: "c",
-        span:  ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:10},
             End:   ast.Location{Line:1, Column:11},
         },
+        Type:  4,
+        Value: "c",
     },
-    &parser.TCloseParen{
-        span: ast.Span{
+    &parser.Token{
+        Span: ast.Span{
             Start: ast.Location{Line:1, Column:11},
             End:   ast.Location{Line:1, Column:12},
         },
+        Type:  29,
+        Value: ")",
     },
 }
 ---

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -7,45 +7,44 @@ func (parser *Parser) parseDecl() ast.Decl {
 	declare := false
 
 	token := parser.lexer.next()
-	start := token.Span().Start
-	if _, ok := token.(*TExport); ok {
+	start := token.Span.Start
+	if token.Type == Export {
 		export = true
 		token = parser.lexer.next()
 	}
 
-	if _, ok := token.(*TDeclare); ok {
+	if token.Type == Declare {
 		declare = true
 		token = parser.lexer.next()
 	}
 
-	switch token.(type) {
-	case *TVal, *TVar:
+	//nolint: exhaustive
+	switch token.Type {
+	case Val, Var:
 		kind := ast.ValKind
-		if _, ok := token.(*TVar); ok {
+		if token.Type == Var {
 			kind = ast.VarKind
 		}
 
 		token := parser.lexer.peek()
-		_ident, ok := token.(*TIdentifier)
 		var ident *ast.Ident
-		if ok {
+		if token.Type == Identifier {
 			parser.lexer.consume()
-			ident = ast.NewIdentifier(_ident.Value, token.Span())
+			ident = ast.NewIdentifier(token.Value, token.Span)
 		} else {
-			parser.reportError(token.Span(), "Expected identifier")
+			parser.reportError(token.Span, "Expected identifier")
 			ident = ast.NewIdentifier(
 				"",
-				ast.Span{Start: token.Span().Start, End: token.Span().Start},
+				ast.Span{Start: token.Span.Start, End: token.Span.Start},
 			)
 		}
-		end := token.Span().End
+		end := token.Span.End
 
 		token = parser.lexer.peek()
 		var init ast.Expr
 		if !declare {
-			_, ok = token.(*TEquals)
-			if !ok {
-				parser.reportError(token.Span(), "Expected equals sign")
+			if token.Type != Equals {
+				parser.reportError(token.Span, "Expected equals sign")
 				return nil
 			}
 			parser.lexer.consume()
@@ -54,24 +53,23 @@ func (parser *Parser) parseDecl() ast.Decl {
 		}
 
 		return ast.NewVarDecl(kind, ident, init, declare, export, ast.Span{Start: start, End: end})
-	case *TFn:
+	case Fn:
 		token := parser.lexer.peek()
-		_ident, ok := token.(*TIdentifier)
 		var ident *ast.Ident
-		if ok {
+		if token.Type == Identifier {
 			parser.lexer.consume()
-			ident = ast.NewIdentifier(_ident.Value, token.Span())
+			ident = ast.NewIdentifier(token.Value, token.Span)
 		} else {
-			parser.reportError(token.Span(), "Expected identifier")
+			parser.reportError(token.Span, "Expected identifier")
 			ident = ast.NewIdentifier(
 				"",
-				ast.Span{Start: token.Span().Start, End: token.Span().Start},
+				ast.Span{Start: token.Span.Start, End: token.Span.Start},
 			)
 		}
 
 		token = parser.lexer.peek()
-		if _, ok := token.(*TOpenParen); !ok {
-			parser.reportError(token.Span(), "Expected an opening paren")
+		if token.Type != OpenParen {
+			parser.reportError(token.Span, "Expected an opening paren")
 		} else {
 			parser.lexer.consume()
 		}
@@ -79,13 +77,13 @@ func (parser *Parser) parseDecl() ast.Decl {
 		params := parser.parseParamSeq()
 
 		token = parser.lexer.peek()
-		if _, ok := token.(*TCloseParen); !ok {
-			parser.reportError(token.Span(), "Expected a closing paren")
+		if token.Type != CloseParen {
+			parser.reportError(token.Span, "Expected a closing paren")
 		} else {
 			parser.lexer.consume()
 		}
 
-		end := token.Span().End
+		end := token.Span.End
 
 		var body ast.Block
 		if !declare {
@@ -95,7 +93,7 @@ func (parser *Parser) parseDecl() ast.Decl {
 
 		return ast.NewFuncDecl(ident, params, body, declare, export, ast.Span{Start: start, End: end})
 	default:
-		parser.reportError(token.Span(), "Unexpected token")
+		parser.reportError(token.Span, "Unexpected token")
 		return nil
 	}
 }

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -250,6 +250,8 @@ func (parser *Parser) parsePrimary() ast.Expr {
 
 			// TODO: parse return and throws types
 			return ast.NewFuncExpr(params, nil, nil, body, ast.Span{Start: start, End: end})
+		case *TLessThan:
+			return parser.parseJSXElement()
 		case
 			*TVal, *TVar, *TReturn,
 			*TCloseBrace, *TCloseParen, *TCloseBracket,

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -188,7 +189,11 @@ func (parser *Parser) parsePrimary() ast.Expr {
 		switch t := token.(type) {
 		case *TNumber:
 			parser.lexer.consume()
-			expr = ast.NewNumber(t.Value, token.Span())
+			value, err := strconv.ParseFloat(t.Value, 64)
+			if err != nil {
+				// TODO: handle parsing errors
+			}
+			expr = ast.NewNumber(value, token.Span())
 		case *TString:
 			parser.lexer.consume()
 			expr = ast.NewString(t.Value, token.Span())

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -17,6 +17,9 @@ func TestParseExprNoErrors(t *testing.T) {
 		"TemplateStringLiteralWithExprs": {
 			input: "`hello ${name}`",
 		},
+		"TemplateStringMultipleLines": {
+			input: "`hello\nworld`",
+		},
 		"TemplateStringLiteralWithMultipleExprs": {
 			input: "`a${b}c${d}e`",
 		},

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -1,0 +1,160 @@
+package parser
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+func (p *Parser) parseJSXElement() *ast.JSXElementExpr {
+	opening := p.parseJSXOpening()
+
+	span := ast.Span{
+		Start: opening.Span().Start,
+		End:   opening.Span().End,
+	}
+
+	var children []ast.JSXChild
+	var closing *ast.JSXClosing
+
+	if !opening.SelfClose {
+		children = p.parseJSXChildren()
+		closing = p.parseJSXClosing()
+		span.End = closing.Span().End
+	}
+
+	return ast.NewJSXElement(opening, closing, children, span)
+}
+
+func (p *Parser) parseJSXOpening() *ast.JSXOpening {
+	token := p.lexer.next()
+	if _, ok := token.(*TLessThan); !ok {
+		p.reportError(token.Span(), "Expected '<'")
+	}
+
+	var name string
+	token = p.lexer.next()
+	if ident, ok := token.(*TIdentifier); ok {
+		p.lexer.consume() // consume identifier
+		name = ident.Value
+	} else {
+		p.reportError(token.Span(), "Expected an identifier")
+	}
+
+	attrs := p.parseJSXAttrs()
+
+	var selfClosing bool
+
+	token = p.lexer.next()
+	switch token.(type) {
+	case *TSlashGreaterThan:
+		selfClosing = true
+	case *TGreaterThan:
+		// do nothing
+	default:
+		p.reportError(token.Span(), "Expected '/' or '/>'")
+	}
+
+	return ast.NewJSXOpening(name, attrs, selfClosing, token.Span())
+}
+
+func (p *Parser) parseJSXAttrs() []*ast.JSXAttr {
+	attrs := []*ast.JSXAttr{}
+
+	for {
+		token := p.lexer.peek()
+		name := ""
+		if ident, ok := token.(*TIdentifier); ok {
+			p.lexer.consume() // consume identifier
+			name = ident.Value
+		} else {
+			break
+		}
+
+		// parse attribute value
+		token = p.lexer.peek()
+		if _, ok := token.(*TEquals); ok {
+			p.lexer.consume() // consume equals
+		} else {
+			p.reportError(token.Span(), "Expected '='")
+		}
+
+		var value ast.JSXAttrValue
+
+		// parse attribute value
+		token = p.lexer.peek()
+		switch t := token.(type) {
+		case *TString:
+			p.lexer.consume() // consume string
+			value = ast.NewJSXString(t.Value, token.Span())
+		case *TOpenBrace:
+			p.lexer.consume() // consume '{'
+			expr := p.ParseExpr()
+			value = ast.NewJSXExprContainer(expr, token.Span())
+			token = p.lexer.peek()
+			if _, ok := token.(*TCloseBrace); ok {
+				p.lexer.consume() // consume '}'
+			} else {
+				p.reportError(token.Span(), "Expected '}'")
+			}
+		default:
+			p.reportError(token.Span(), "Expected a string or an expression")
+		}
+
+		attr := ast.NewJSXAttr(name, &value, token.Span())
+		attrs = append(attrs, attr)
+	}
+
+	return attrs
+}
+
+func (p *Parser) parseJSXClosing() *ast.JSXClosing {
+	token := p.lexer.next()
+	if _, ok := token.(*TLessThanSlash); !ok {
+		p.reportError(token.Span(), "Expected '</'")
+	}
+
+	var name string
+	token = p.lexer.next()
+	if ident, ok := token.(*TIdentifier); ok {
+		p.lexer.consume() // consume identifier
+		name = ident.Value
+	} else {
+		p.reportError(token.Span(), "Expected an identifier")
+	}
+
+	token = p.lexer.next()
+	if _, ok := token.(*TGreaterThan); !ok {
+		p.reportError(token.Span(), "Expected '>'")
+	}
+
+	return ast.NewJSXClosing(name, token.Span())
+}
+
+func (p *Parser) parseJSXChildren() []ast.JSXChild {
+	children := []ast.JSXChild{}
+
+	for {
+		token := p.lexer.peek()
+
+		switch token.(type) {
+		case *TLessThanSlash, *TEndOfFile:
+			return children
+		case *TLessThan:
+			jsxElement := p.parseJSXElement()
+			children = append(children, jsxElement)
+		case *TOpenBrace:
+			p.lexer.consume()
+			expr := p.ParseExpr()
+			token = p.lexer.peek()
+			if _, ok := token.(*TCloseBrace); ok {
+				p.lexer.consume()
+			} else {
+				p.reportError(token.Span(), "Expected '}'")
+			}
+			children = append(children, ast.NewJSXExprContainer(expr, token.Span()))
+		default:
+			token := p.lexer.lexJSXText()
+			text := ast.NewJSXText(token.Value, token.Span())
+			children = append(children, text)
+		}
+	}
+}

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -26,26 +26,28 @@ func (p *Parser) parseJSXElement() *ast.JSXElementExpr {
 
 func (p *Parser) parseJSXOpening() *ast.JSXOpening {
 	token := p.lexer.next()
-	if _, ok := token.(*TLessThan); !ok {
-		p.reportError(token.Span(), "Expected '<'")
+	if token.Type != LessThan {
+		p.reportError(token.Span, "Expected '<'")
 	}
 
-	start := token.Span().Start
+	start := token.Span.Start
 
 	var name string
 	token = p.lexer.next()
-	switch t := token.(type) {
-	case *TIdentifier:
-		name = t.Value
-	case *TGreaterThan:
-		end := token.Span().End
+
+	//nolint: exhaustive
+	switch token.Type {
+	case Identifier:
+		name = token.Value
+	case GreaterThan:
+		end := token.Span.End
 		span := ast.Span{
 			Start: start,
 			End:   end,
 		}
 		return ast.NewJSXOpening("", nil, false, span)
 	default:
-		p.reportError(token.Span(), "Expected an identifier or '>'")
+		p.reportError(token.Span, "Expected an identifier or '>'")
 	}
 
 	attrs := p.parseJSXAttrs()
@@ -53,16 +55,18 @@ func (p *Parser) parseJSXOpening() *ast.JSXOpening {
 	var selfClosing bool
 
 	token = p.lexer.next()
-	switch token.(type) {
-	case *TSlashGreaterThan:
+
+	//nolint: exhaustive
+	switch token.Type {
+	case SlashGreaterThan:
 		selfClosing = true
-	case *TGreaterThan:
+	case GreaterThan:
 		// do nothing
 	default:
-		p.reportError(token.Span(), "Expected '/' or '/>'")
+		p.reportError(token.Span, "Expected '/' or '/>'")
 	}
 
-	end := token.Span().End
+	end := token.Span.End
 
 	span := ast.Span{
 		Start: start,
@@ -78,44 +82,46 @@ func (p *Parser) parseJSXAttrs() []*ast.JSXAttr {
 	for {
 		token := p.lexer.peek()
 		name := ""
-		if ident, ok := token.(*TIdentifier); ok {
+		if token.Type == Identifier {
 			p.lexer.consume() // consume identifier
-			name = ident.Value
+			name = token.Value
 		} else {
 			break
 		}
 
 		// parse attribute value
 		token = p.lexer.peek()
-		if _, ok := token.(*TEquals); ok {
+		if token.Type == Equals {
 			p.lexer.consume() // consume equals
 		} else {
-			p.reportError(token.Span(), "Expected '='")
+			p.reportError(token.Span, "Expected '='")
 		}
 
 		var value ast.JSXAttrValue
 
 		// parse attribute value
 		token = p.lexer.peek()
-		switch t := token.(type) {
-		case *TString:
+
+		//nolint: exhaustive
+		switch token.Type {
+		case String:
 			p.lexer.consume() // consume string
-			value = ast.NewJSXString(t.Value, token.Span())
-		case *TOpenBrace:
+			value = ast.NewJSXString(token.Value, token.Span)
+		case OpenBrace:
 			p.lexer.consume() // consume '{'
 			expr := p.ParseExpr()
-			value = ast.NewJSXExprContainer(expr, token.Span())
+			value = ast.NewJSXExprContainer(expr, token.Span)
 			token = p.lexer.peek()
-			if _, ok := token.(*TCloseBrace); ok {
+			if token.Type == CloseBrace {
 				p.lexer.consume() // consume '}'
 			} else {
-				p.reportError(token.Span(), "Expected '}'")
+				p.reportError(token.Span, "Expected '}'")
 			}
 		default:
-			p.reportError(token.Span(), "Expected a string or an expression")
+			p.reportError(token.Span, "Expected a string or an expression")
 		}
 
-		attr := ast.NewJSXAttr(name, &value, token.Span())
+		attr := ast.NewJSXAttr(name, &value, token.Span)
 		attrs = append(attrs, attr)
 	}
 
@@ -124,34 +130,36 @@ func (p *Parser) parseJSXAttrs() []*ast.JSXAttr {
 
 func (p *Parser) parseJSXClosing() *ast.JSXClosing {
 	token := p.lexer.next()
-	if _, ok := token.(*TLessThanSlash); !ok {
-		p.reportError(token.Span(), "Expected '</'")
+	if token.Type != LessThanSlash {
+		p.reportError(token.Span, "Expected '</'")
 	}
 
-	start := token.Span().Start
+	start := token.Span.Start
 
 	var name string
 	token = p.lexer.next()
-	switch t := token.(type) {
-	case *TIdentifier:
-		name = t.Value
-	case *TGreaterThan:
-		end := token.Span().End
+
+	//nolint: exhaustive
+	switch token.Type {
+	case Identifier:
+		name = token.Value
+	case GreaterThan:
+		end := token.Span.End
 		span := ast.Span{
 			Start: start,
 			End:   end,
 		}
 		return ast.NewJSXClosing("", span)
 	default:
-		p.reportError(token.Span(), "Expected an identifier or '>'")
+		p.reportError(token.Span, "Expected an identifier or '>'")
 	}
 
 	token = p.lexer.next()
-	if _, ok := token.(*TGreaterThan); !ok {
-		p.reportError(token.Span(), "Expected '>'")
+	if token.Type != GreaterThan {
+		p.reportError(token.Span, "Expected '>'")
 	}
 
-	end := token.Span().End
+	end := token.Span.End
 	span := ast.Span{
 		Start: start,
 		End:   end,
@@ -166,25 +174,26 @@ func (p *Parser) parseJSXChildren() []ast.JSXChild {
 	for {
 		token := p.lexer.peek()
 
-		switch token.(type) {
-		case *TLessThanSlash, *TEndOfFile:
+		//nolint: exhaustive
+		switch token.Type {
+		case LessThanSlash, EndOfFile:
 			return children
-		case *TLessThan:
+		case LessThan:
 			jsxElement := p.parseJSXElement()
 			children = append(children, jsxElement)
-		case *TOpenBrace:
+		case OpenBrace:
 			p.lexer.consume()
 			expr := p.ParseExpr()
 			token = p.lexer.peek()
-			if _, ok := token.(*TCloseBrace); ok {
+			if token.Type == CloseBrace {
 				p.lexer.consume()
 			} else {
-				p.reportError(token.Span(), "Expected '}'")
+				p.reportError(token.Span, "Expected '}'")
 			}
-			children = append(children, ast.NewJSXExprContainer(expr, token.Span()))
+			children = append(children, ast.NewJSXExprContainer(expr, token.Span))
 		default:
 			token := p.lexer.lexJSXText()
-			text := ast.NewJSXText(token.Value, token.Span())
+			text := ast.NewJSXText(token.Value, token.Span)
 			children = append(children, text)
 		}
 	}

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -32,11 +32,15 @@ func (p *Parser) parseJSXOpening() *ast.JSXOpening {
 
 	var name string
 	token = p.lexer.next()
-	if ident, ok := token.(*TIdentifier); ok {
+	switch t := token.(type) {
+	case *TIdentifier:
 		p.lexer.consume() // consume identifier
-		name = ident.Value
-	} else {
-		p.reportError(token.Span(), "Expected an identifier")
+		name = t.Value
+	case *TGreaterThan:
+		p.lexer.consume() // consume '>'
+		return ast.NewJSXOpening("", nil, false, token.Span())
+	default:
+		p.reportError(token.Span(), "Expected an identifier or '>'")
 	}
 
 	attrs := p.parseJSXAttrs()
@@ -114,11 +118,15 @@ func (p *Parser) parseJSXClosing() *ast.JSXClosing {
 
 	var name string
 	token = p.lexer.next()
-	if ident, ok := token.(*TIdentifier); ok {
+	switch token.(type) {
+	case *TIdentifier:
 		p.lexer.consume() // consume identifier
-		name = ident.Value
-	} else {
-		p.reportError(token.Span(), "Expected an identifier")
+		name = token.(*TIdentifier).Value
+	case *TGreaterThan:
+		p.lexer.consume() // consume '>'
+		return ast.NewJSXClosing("", token.Span())
+	default:
+		p.reportError(token.Span(), "Expected an identifier or '>'")
 	}
 
 	token = p.lexer.next()

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -30,15 +30,20 @@ func (p *Parser) parseJSXOpening() *ast.JSXOpening {
 		p.reportError(token.Span(), "Expected '<'")
 	}
 
+	start := token.Span().Start
+
 	var name string
 	token = p.lexer.next()
 	switch t := token.(type) {
 	case *TIdentifier:
-		p.lexer.consume() // consume identifier
 		name = t.Value
 	case *TGreaterThan:
-		p.lexer.consume() // consume '>'
-		return ast.NewJSXOpening("", nil, false, token.Span())
+		end := token.Span().End
+		span := ast.Span{
+			Start: start,
+			End:   end,
+		}
+		return ast.NewJSXOpening("", nil, false, span)
 	default:
 		p.reportError(token.Span(), "Expected an identifier or '>'")
 	}
@@ -57,7 +62,14 @@ func (p *Parser) parseJSXOpening() *ast.JSXOpening {
 		p.reportError(token.Span(), "Expected '/' or '/>'")
 	}
 
-	return ast.NewJSXOpening(name, attrs, selfClosing, token.Span())
+	end := token.Span().End
+
+	span := ast.Span{
+		Start: start,
+		End:   end,
+	}
+
+	return ast.NewJSXOpening(name, attrs, selfClosing, span)
 }
 
 func (p *Parser) parseJSXAttrs() []*ast.JSXAttr {
@@ -116,15 +128,20 @@ func (p *Parser) parseJSXClosing() *ast.JSXClosing {
 		p.reportError(token.Span(), "Expected '</'")
 	}
 
+	start := token.Span().Start
+
 	var name string
 	token = p.lexer.next()
-	switch token.(type) {
+	switch t := token.(type) {
 	case *TIdentifier:
-		p.lexer.consume() // consume identifier
-		name = token.(*TIdentifier).Value
+		name = t.Value
 	case *TGreaterThan:
-		p.lexer.consume() // consume '>'
-		return ast.NewJSXClosing("", token.Span())
+		end := token.Span().End
+		span := ast.Span{
+			Start: start,
+			End:   end,
+		}
+		return ast.NewJSXClosing("", span)
 	default:
 		p.reportError(token.Span(), "Expected an identifier or '>'")
 	}
@@ -134,7 +151,13 @@ func (p *Parser) parseJSXClosing() *ast.JSXClosing {
 		p.reportError(token.Span(), "Expected '>'")
 	}
 
-	return ast.NewJSXClosing(name, token.Span())
+	end := token.Span().End
+	span := ast.Span{
+		Start: start,
+		End:   end,
+	}
+
+	return ast.NewJSXClosing(name, span)
 }
 
 func (p *Parser) parseJSXChildren() []ast.JSXChild {

--- a/internal/parser/jsx_test.go
+++ b/internal/parser/jsx_test.go
@@ -17,6 +17,9 @@ func TestParseJSXNoErrors(t *testing.T) {
 		"SelfClosingAttrs": {
 			input: "<Foo bar={5} baz=\"hello\" />",
 		},
+		"MultipleLines": {
+			input: "<Foo\n  bar={5}\n  baz=\"hello\"\n/>",
+		},
 		"NoAttrsNoChildren": {
 			input: "<Foo></Foo>",
 		},

--- a/internal/parser/jsx_test.go
+++ b/internal/parser/jsx_test.go
@@ -1,0 +1,52 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseJSXNoErrors(t *testing.T) {
+	tests := map[string]struct {
+		input string
+	}{
+		"SelfClosingNoAttrs": {
+			input: "<Foo />",
+		},
+		"SelfClosingAttrs": {
+			input: "<Foo bar={5} baz=\"hello\" />",
+		},
+		"NoAttrsNoChildren": {
+			input: "<Foo></Foo>",
+		},
+		"AttrsNoChildren": {
+			input: "<Foo bar={5} baz=\"hello\"></Foo>",
+		},
+		"ChildElements": {
+			input: "<div><span>hello</span>world</div>",
+		},
+		"ChildExpr": {
+			input: "<div>hello, {msg}</div>",
+		},
+		"Nesting": {
+			input: "<div>{<span>{foo}</span>}</div>",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := Source{
+				Path:     "input.esc",
+				Contents: test.input,
+			}
+
+			parser := NewParser(source)
+			expr := parser.parseJSXElement()
+
+			snaps.MatchSnapshot(t, expr)
+			assert.Len(t, parser.Errors, 0)
+		})
+	}
+}

--- a/internal/parser/jsx_test.go
+++ b/internal/parser/jsx_test.go
@@ -32,6 +32,9 @@ func TestParseJSXNoErrors(t *testing.T) {
 		"Nesting": {
 			input: "<div>{<span>{foo}</span>}</div>",
 		},
+		"Fragment": {
+			input: "<><Foo /><Bar /></>",
+		},
 	}
 
 	for name, test := range tests {
@@ -43,10 +46,40 @@ func TestParseJSXNoErrors(t *testing.T) {
 			}
 
 			parser := NewParser(source)
-			expr := parser.parseJSXElement()
+			jsx := parser.parseJSXElement()
 
-			snaps.MatchSnapshot(t, expr)
+			snaps.MatchSnapshot(t, jsx)
 			assert.Len(t, parser.Errors, 0)
+		})
+	}
+}
+
+func TestParseJSXErrors(t *testing.T) {
+	tests := map[string]struct {
+		input string
+	}{
+		"MissingEqualsInExprAttr": {
+			input: "<Foo bar {5} />",
+		},
+		"MissingEqualsInStringAttr": {
+			input: "<Foo bar \"hello\" />",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := Source{
+				Path:     "input.esc",
+				Contents: test.input,
+			}
+
+			parser := NewParser(source)
+			jsx := parser.parseJSXElement()
+
+			snaps.MatchSnapshot(t, jsx)
+			assert.Greater(t, len(parser.Errors), 0)
+			snaps.MatchSnapshot(t, parser.Errors)
 		})
 	}
 }

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"strconv"
 	"unicode/utf8"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -182,12 +181,8 @@ func (lexer *Lexer) next() Token {
 		if isDecimal && i == startOffset+1 {
 			token = NewDot(ast.Span{Start: start, End: end})
 		} else {
-			value, err := strconv.ParseFloat(contents[startOffset:i], 64)
-			if err != nil {
-				// TODO: handle parsing errors
-			}
 			end.Column = start.Column + (i - startOffset)
-			token = NewNumber(value, ast.Span{Start: start, End: end})
+			token = NewNumber(contents[startOffset:i], ast.Span{Start: start, End: end})
 		}
 	case '_', '$',
 		'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -25,22 +25,22 @@ func NewLexer(source Source) *Lexer {
 	}
 }
 
-var KEYWORDS = map[string](func(span ast.Span) Token){
-	"fn":      NewFn,
-	"var":     NewVar,
-	"val":     NewVal,
-	"return":  NewReturn,
-	"import":  NewImport,
-	"export":  NewExport,
-	"declare": NewDeclare,
-}
+// var KEYWORDS = map[string](func(span ast.Span) Token){
+// 	"fn":      NewToken,
+// 	"var":     NewVar,
+// 	"val":     NewVal,
+// 	"return":  NewReturn,
+// 	"import":  NewImport,
+// 	"export":  NewExport,
+// 	"declare": NewDeclare,
+// }
 
-func (lexer *Lexer) next() Token {
+func (lexer *Lexer) next() *Token {
 	startOffset := lexer.currentOffset
 	start := lexer.currentLocation
 
 	if startOffset >= len(lexer.source.Contents) {
-		return NewEndOfFile(ast.Span{Start: start, End: start})
+		return NewToken(EndOfFile, "", ast.Span{Start: start, End: start})
 	}
 
 	codePoint, width := utf8.DecodeRuneInString(lexer.source.Contents[startOffset:])
@@ -60,44 +60,44 @@ func (lexer *Lexer) next() Token {
 	endOffset := startOffset + width
 	end := ast.Location{Line: start.Line, Column: start.Column + 1}
 
-	var token Token
+	var token *Token
 	switch codePoint {
 	case '+':
-		token = NewPlus(ast.Span{Start: start, End: end})
+		token = NewToken(Plus, "+", ast.Span{Start: start, End: end})
 	case '-':
-		token = NewMinus(ast.Span{Start: start, End: end})
+		token = NewToken(Minus, "-", ast.Span{Start: start, End: end})
 	case '*':
-		token = NewAsterisk(ast.Span{Start: start, End: end})
+		token = NewToken(Asterisk, "*", ast.Span{Start: start, End: end})
 	case '/':
 		if startOffset+1 < len(lexer.source.Contents) {
 			nextCodePoint, _ := utf8.DecodeRuneInString(lexer.source.Contents[startOffset+1:])
 			if nextCodePoint == '>' {
 				endOffset++
 				end.Column++
-				token = NewSlashGreaterThan(ast.Span{Start: start, End: end})
+				token = NewToken(SlashGreaterThan, "/>", ast.Span{Start: start, End: end})
 			} else {
-				token = NewSlash(ast.Span{Start: start, End: end})
+				token = NewToken(Slash, "/", ast.Span{Start: start, End: end})
 			}
 		} else {
-			token = NewSlash(ast.Span{Start: start, End: end})
+			token = NewToken(Slash, "/", ast.Span{Start: start, End: end})
 		}
 	case '=':
 		// TODO: handle ==, =>, etc.
-		token = NewEquals(ast.Span{Start: start, End: end})
+		token = NewToken(Equals, "=", ast.Span{Start: start, End: end})
 	case ',':
-		token = NewComma(ast.Span{Start: start, End: end})
+		token = NewToken(Comma, ",", ast.Span{Start: start, End: end})
 	case '(':
-		token = NewOpenParen(ast.Span{Start: start, End: end})
+		token = NewToken(OpenParen, "(", ast.Span{Start: start, End: end})
 	case ')':
-		token = NewCloseParen(ast.Span{Start: start, End: end})
+		token = NewToken(CloseParen, ")", ast.Span{Start: start, End: end})
 	case '{':
-		token = NewOpenBrace(ast.Span{Start: start, End: end})
+		token = NewToken(OpenBrace, "{", ast.Span{Start: start, End: end})
 	case '}':
-		token = NewCloseBrace(ast.Span{Start: start, End: end})
+		token = NewToken(CloseBrace, "}", ast.Span{Start: start, End: end})
 	case '[':
-		token = NewOpenBracket(ast.Span{Start: start, End: end})
+		token = NewToken(OpenBracket, "[", ast.Span{Start: start, End: end})
 	case ']':
-		token = NewCloseBracket(ast.Span{Start: start, End: end})
+		token = NewToken(CloseBracket, "]", ast.Span{Start: start, End: end})
 	case '<':
 		if startOffset+1 < len(lexer.source.Contents) {
 			nextCodePoint, _ := utf8.DecodeRuneInString(lexer.source.Contents[startOffset+1:])
@@ -105,22 +105,22 @@ func (lexer *Lexer) next() Token {
 			case '=':
 				endOffset++
 				end.Column++
-				token = NewLessThanEqual(ast.Span{Start: start, End: end})
+				token = NewToken(LessThanEqual, "<=", ast.Span{Start: start, End: end})
 			case '/':
 				endOffset++
 				end.Column++
-				token = NewLessThanSlash(ast.Span{Start: start, End: end})
+				token = NewToken(LessThanSlash, "</", ast.Span{Start: start, End: end})
 			default:
-				token = NewLessThan(ast.Span{Start: start, End: end})
+				token = NewToken(LessThan, "<", ast.Span{Start: start, End: end})
 			}
 		} else {
-			token = NewLessThan(ast.Span{Start: start, End: end})
+			token = NewToken(LessThan, "<", ast.Span{Start: start, End: end})
 		}
 	case '>':
 		// TODO: handle >=
-		token = NewGreaterThan(ast.Span{Start: start, End: end})
+		token = NewToken(GreaterThan, ">", ast.Span{Start: start, End: end})
 	case '`':
-		token = NewBackTick(ast.Span{Start: start, End: end})
+		token = NewToken(BackTick, "`", ast.Span{Start: start, End: end})
 	case '?':
 		nextCodePoint, width := utf8.DecodeRuneInString(lexer.source.Contents[startOffset+width:])
 		endOffset += width
@@ -128,13 +128,13 @@ func (lexer *Lexer) next() Token {
 
 		switch nextCodePoint {
 		case '.':
-			token = NewQuestionDot(ast.Span{Start: start, End: end})
+			token = NewToken(QuestionDot, ".", ast.Span{Start: start, End: end})
 		case '(':
-			token = NewQuestionOpenParen(ast.Span{Start: start, End: end})
+			token = NewToken(QuestionOpenParen, "(", ast.Span{Start: start, End: end})
 		case '[':
-			token = NewQuestionOpenBracket(ast.Span{Start: start, End: end})
+			token = NewToken(QuestionOpenBracket, "[", ast.Span{Start: start, End: end})
 		default:
-			token = NewInvalid(ast.Span{Start: start, End: end})
+			token = NewToken(Invalid, "", ast.Span{Start: start, End: end})
 		}
 	case '"':
 		contents := lexer.source.Contents
@@ -150,7 +150,7 @@ func (lexer *Lexer) next() Token {
 		endOffset = i + 1                    // + 1 to include the closing quote
 		value := contents[startOffset+1 : i] // without the quotes
 		end.Column = start.Column + (i - startOffset)
-		token = NewString(value, ast.Span{Start: start, End: end})
+		token = NewToken(String, value, ast.Span{Start: start, End: end})
 	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.':
 		contents := lexer.source.Contents
 		n := len(contents)
@@ -179,10 +179,10 @@ func (lexer *Lexer) next() Token {
 
 		endOffset = i
 		if isDecimal && i == startOffset+1 {
-			token = NewDot(ast.Span{Start: start, End: end})
+			token = NewToken(Dot, ".", ast.Span{Start: start, End: end})
 		} else {
 			end.Column = start.Column + (i - startOffset)
-			token = NewNumber(contents[startOffset:i], ast.Span{Start: start, End: end})
+			token = NewToken(Number, contents[startOffset:i], ast.Span{Start: start, End: end})
 		}
 	case '_', '$',
 		'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -205,16 +205,29 @@ func (lexer *Lexer) next() Token {
 		end.Column = start.Column + i - startOffset
 		span := ast.Span{Start: start, End: end}
 
-		if keyword, ok := KEYWORDS[value]; ok {
-			token = keyword(span)
-		} else {
-			token = NewIdentifier(value, span)
+		switch value {
+		case "fn":
+			token = NewToken(Fn, "fn", span)
+		case "var":
+			token = NewToken(Var, "var", span)
+		case "val":
+			token = NewToken(Val, "val", span)
+		case "return":
+			token = NewToken(Return, "return", span)
+		case "import":
+			token = NewToken(Import, "import", span)
+		case "export":
+			token = NewToken(Export, "export", span)
+		case "declare":
+			token = NewToken(Declare, "declare", span)
+		default:
+			token = NewToken(Identifier, value, span)
 		}
 	default:
 		if startOffset >= len(lexer.source.Contents) {
-			token = NewEndOfFile(ast.Span{Start: start, End: start})
+			token = NewToken(EndOfFile, "", ast.Span{Start: start, End: start})
 		} else {
-			token = NewInvalid(ast.Span{Start: start, End: start})
+			token = NewToken(Invalid, "", ast.Span{Start: start, End: start})
 		}
 	}
 
@@ -224,7 +237,7 @@ func (lexer *Lexer) next() Token {
 	return token
 }
 
-func (lexer *Lexer) peek() Token {
+func (lexer *Lexer) peek() *Token {
 	// save the lexer state
 	offset := lexer.currentOffset
 	location := lexer.currentLocation
@@ -239,7 +252,7 @@ func (lexer *Lexer) consume() {
 	lexer.next()
 }
 
-func (lexer *Lexer) lexQuasi() *TQuasi {
+func (lexer *Lexer) lexQuasi() *Token {
 	startOffset := lexer.currentOffset
 	start := lexer.currentLocation
 	end := start
@@ -281,10 +294,10 @@ func (lexer *Lexer) lexQuasi() *TQuasi {
 		value = contents[startOffset:i]
 	}
 
-	return NewQuasi(value, ast.Span{Start: start, End: end})
+	return NewToken(Quasi, value, ast.Span{Start: start, End: end})
 }
 
-func (lexer *Lexer) lexJSXText() *TJSXText {
+func (lexer *Lexer) lexJSXText() *Token {
 	startOffset := lexer.currentOffset
 	start := lexer.currentLocation
 	end := start
@@ -312,11 +325,11 @@ func (lexer *Lexer) lexJSXText() *TJSXText {
 	lexer.currentLocation = end
 
 	value := contents[startOffset:endOffset]
-	return NewJSXText(value, ast.Span{Start: start, End: end})
+	return NewToken(JSXText, value, ast.Span{Start: start, End: end})
 }
 
-func (lexer *Lexer) Lex() []Token {
-	var tokens []Token
+func (lexer *Lexer) Lex() []*Token {
+	var tokens []*Token
 
 	for lexer.currentOffset < len(lexer.source.Contents) {
 		tokens = append(tokens, lexer.next())

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -265,23 +265,26 @@ func (lexer *Lexer) lexQuasi() *Token {
 		if c == '$' {
 			if i+1 < n && contents[i+1] == '{' {
 				i += 2
+				end.Column += 2
 				break
 			}
 		}
 		if c == '`' {
 			i++
+			end.Column++
 			break
 		}
+
 		if c == '\n' {
 			end.Line++
 			end.Column = 1
 		} else {
 			end.Column++
 		}
+
 		i++
 	}
 	endOffset := i
-	end.Column = endOffset
 
 	lexer.currentOffset = endOffset
 	lexer.currentLocation = end

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -252,16 +252,16 @@ func (lexer *Lexer) lexQuasi() *TQuasi {
 	contents := lexer.source.Contents
 	n := len(contents)
 	i := startOffset
-	last := false
 	for i < n {
 		c := contents[i]
 		if c == '$' {
 			if i+1 < n && contents[i+1] == '{' {
+				i += 2
 				break
 			}
 		}
 		if c == '`' {
-			last = true
+			i++
 			break
 		}
 		if c == '\n' {
@@ -272,28 +272,21 @@ func (lexer *Lexer) lexQuasi() *TQuasi {
 		}
 		i++
 	}
-	endOffset := i + 2
-	end.Column += 2
-	if last {
-		endOffset--
-		end.Column--
-	}
+	endOffset := i
+	end.Column = endOffset
 
 	lexer.currentOffset = endOffset
 	lexer.currentLocation = end
 
-	incomplete := false
 	var value string
 	if i >= n {
-		last = true
-		incomplete = true
 		value = contents[startOffset:]
 		// TODO: report an error
 	} else {
 		value = contents[startOffset:i]
 	}
 
-	return NewQuasi(value, last, incomplete, ast.Span{Start: start, End: end})
+	return NewQuasi(value, ast.Span{Start: start, End: end})
 }
 
 func (lexer *Lexer) lexJSXText() *TJSXText {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -25,8 +25,9 @@ func (parser *Parser) ParseModule() *ast.Module {
 
 	token := parser.lexer.peek()
 	for {
-		switch token.(type) {
-		case *TEndOfFile:
+		//nolint: exhaustive
+		switch token.Type {
+		case EndOfFile:
 			return &ast.Module{Stmts: stmts}
 		default:
 			stmt := parser.parseStmt()

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -19,12 +19,12 @@ func (*TJSXText) isToken()    {}
 func (*TIdentifier) isToken() {}
 
 type TNumber struct {
-	Value float64
+	Value string
 	span  ast.Span
 }
 
-func NewNumber(value float64, span ast.Span) *TNumber { return &TNumber{Value: value, span: span} }
-func (t *TNumber) Span() ast.Span                     { return t.span }
+func NewNumber(value string, span ast.Span) *TNumber { return &TNumber{Value: value, span: span} }
+func (t *TNumber) Span() ast.Span                    { return t.span }
 
 type TString struct {
 	Value string

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -15,6 +15,7 @@ type Token interface {
 func (*TNumber) isToken()     {}
 func (*TString) isToken()     {}
 func (*TQuasi) isToken()      {}
+func (*TJSXText) isToken()    {}
 func (*TIdentifier) isToken() {}
 
 type TNumber struct {
@@ -44,6 +45,14 @@ func NewQuasi(value string, last bool, incomplete bool, span ast.Span) *TQuasi {
 	return &TQuasi{Value: value, Last: last, Incomplete: incomplete, span: span}
 }
 func (t *TQuasi) Span() ast.Span { return t.span }
+
+type TJSXText struct {
+	Value string
+	span  ast.Span
+}
+
+func NewJSXText(value string, span ast.Span) *TJSXText { return &TJSXText{Value: value, span: span} }
+func (t *TJSXText) Span() ast.Span                     { return t.span }
 
 type TIdentifier struct {
 	Value string
@@ -100,14 +109,19 @@ func NewDeclare(span ast.Span) Token { return &TDeclare{span: span} }
 func (t *TDeclare) Span() ast.Span   { return t.span }
 
 // operators
-func (*TPlus) isToken()     {}
-func (*TMinus) isToken()    {}
-func (*TAsterisk) isToken() {}
-func (*TSlash) isToken()    {}
-func (*TEquals) isToken()   {}
-func (*TDot) isToken()      {}
-func (*TComma) isToken()    {}
-func (*TBackTick) isToken() {}
+func (*TPlus) isToken()             {}
+func (*TMinus) isToken()            {}
+func (*TAsterisk) isToken()         {}
+func (*TSlash) isToken()            {}
+func (*TSlashGreaterThan) isToken() {}
+func (*TEquals) isToken()           {}
+func (*TDot) isToken()              {}
+func (*TComma) isToken()            {}
+func (*TBackTick) isToken()         {}
+func (*TLessThan) isToken()         {}
+func (*TLessThanEqual) isToken()    {}
+func (*TLessThanSlash) isToken()    {}
+func (*TGreaterThan) isToken()      {}
 
 type TPlus struct{ span ast.Span }
 
@@ -129,6 +143,11 @@ type TSlash struct{ span ast.Span }
 func NewSlash(span ast.Span) *TSlash { return &TSlash{span: span} }
 func (t *TSlash) Span() ast.Span     { return t.span }
 
+type TSlashGreaterThan struct{ span ast.Span }
+
+func NewSlashGreaterThan(span ast.Span) *TSlashGreaterThan { return &TSlashGreaterThan{span: span} }
+func (t *TSlashGreaterThan) Span() ast.Span                { return t.span }
+
 type TEquals struct{ span ast.Span }
 
 func NewEquals(span ast.Span) *TEquals { return &TEquals{span: span} }
@@ -148,6 +167,26 @@ type TBackTick struct{ span ast.Span }
 
 func NewBackTick(span ast.Span) *TBackTick { return &TBackTick{span: span} }
 func (t *TBackTick) Span() ast.Span        { return t.span }
+
+type TLessThan struct{ span ast.Span }
+
+func NewLessThan(span ast.Span) *TLessThan { return &TLessThan{span: span} }
+func (t *TLessThan) Span() ast.Span        { return t.span }
+
+type TLessThanEqual struct{ span ast.Span }
+
+func NewLessThanEqual(span ast.Span) *TLessThanEqual { return &TLessThanEqual{span: span} }
+func (t *TLessThanEqual) Span() ast.Span             { return t.span }
+
+type TLessThanSlash struct{ span ast.Span }
+
+func NewLessThanSlash(span ast.Span) *TLessThanSlash { return &TLessThanSlash{span: span} }
+func (t *TLessThanSlash) Span() ast.Span             { return t.span }
+
+type TGreaterThan struct{ span ast.Span }
+
+func NewGreaterThan(span ast.Span) *TGreaterThan { return &TGreaterThan{span: span} }
+func (t *TGreaterThan) Span() ast.Span           { return t.span }
 
 // optional chaining
 func (*TQuestionOpenParen) isToken()   {}

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -2,258 +2,63 @@ package parser
 
 import "github.com/escalier-lang/escalier/internal/ast"
 
-// This interface is never called. Its purpose is to encode a variant type in
-// Go's type system.
-//
-//sumtype:decl
-type Token interface {
-	isToken()
-	Span() ast.Span
-}
+type TokenType int
 
-// literals
-func (*TNumber) isToken()     {}
-func (*TString) isToken()     {}
-func (*TQuasi) isToken()      {}
-func (*TJSXText) isToken()    {}
-func (*TIdentifier) isToken() {}
+const (
+	// Token types
+	Number TokenType = iota
+	String
+	Quasi
+	JSXText
+	Identifier
 
-type TNumber struct {
+	// keywords
+	Fn
+	Var
+	Val
+	Return
+	Import
+	Export
+	Declare
+
+	// operators
+	Plus
+	Minus
+	Asterisk
+	Slash
+	SlashGreaterThan
+	Equals
+	Dot
+	Comma
+	BackTick
+	LessThan
+	LessThanEqual
+	LessThanSlash
+	GreaterThan
+
+	// optional chaining
+	QuestionOpenParen
+	QuestionDot
+	QuestionOpenBracket
+
+	// grouping
+	OpenParen
+	CloseParen
+	OpenBrace
+	CloseBrace
+	OpenBracket
+	CloseBracket
+
+	Invalid
+	EndOfFile
+)
+
+type Token struct {
+	Span  ast.Span
+	Type  TokenType
 	Value string
-	span  ast.Span
 }
 
-func NewNumber(value string, span ast.Span) *TNumber { return &TNumber{Value: value, span: span} }
-func (t *TNumber) Span() ast.Span                    { return t.span }
-
-type TString struct {
-	Value string
-	span  ast.Span
+func NewToken(kind TokenType, value string, span ast.Span) *Token {
+	return &Token{Type: kind, Value: value, Span: span}
 }
-
-func NewString(value string, span ast.Span) *TString { return &TString{Value: value, span: span} }
-func (t *TString) Span() ast.Span                    { return t.span }
-
-type TQuasi struct {
-	Value string
-	span  ast.Span
-}
-
-func NewQuasi(value string, span ast.Span) *TQuasi {
-	return &TQuasi{Value: value, span: span}
-}
-func (t *TQuasi) Span() ast.Span { return t.span }
-
-type TJSXText struct {
-	Value string
-	span  ast.Span
-}
-
-func NewJSXText(value string, span ast.Span) *TJSXText { return &TJSXText{Value: value, span: span} }
-func (t *TJSXText) Span() ast.Span                     { return t.span }
-
-type TIdentifier struct {
-	Value string
-	span  ast.Span
-}
-
-func NewIdentifier(value string, span ast.Span) *TIdentifier {
-	return &TIdentifier{Value: value, span: span}
-}
-func (t *TIdentifier) Span() ast.Span { return t.span }
-
-// keywords
-func (*TFn) isToken()      {}
-func (*TVar) isToken()     {}
-func (*TVal) isToken()     {}
-func (*TReturn) isToken()  {}
-func (*TImport) isToken()  {}
-func (*TExport) isToken()  {}
-func (*TDeclare) isToken() {}
-
-type TFn struct{ span ast.Span }
-
-func NewFn(span ast.Span) Token { return &TFn{span: span} }
-func (t *TFn) Span() ast.Span   { return t.span }
-
-type TVar struct{ span ast.Span }
-
-func NewVar(span ast.Span) Token { return &TVar{span: span} }
-func (t *TVar) Span() ast.Span   { return t.span }
-
-type TVal struct{ span ast.Span }
-
-func NewVal(span ast.Span) Token { return &TVal{span: span} }
-func (t *TVal) Span() ast.Span   { return t.span }
-
-type TReturn struct{ span ast.Span }
-
-func NewReturn(span ast.Span) Token { return &TReturn{span: span} }
-func (t *TReturn) Span() ast.Span   { return t.span }
-
-type TImport struct{ span ast.Span }
-
-func NewImport(span ast.Span) Token { return &TImport{span: span} }
-func (t *TImport) Span() ast.Span   { return t.span }
-
-type TExport struct{ span ast.Span }
-
-func NewExport(span ast.Span) Token { return &TExport{span: span} }
-func (t *TExport) Span() ast.Span   { return t.span }
-
-type TDeclare struct{ span ast.Span }
-
-func NewDeclare(span ast.Span) Token { return &TDeclare{span: span} }
-func (t *TDeclare) Span() ast.Span   { return t.span }
-
-// operators
-func (*TPlus) isToken()             {}
-func (*TMinus) isToken()            {}
-func (*TAsterisk) isToken()         {}
-func (*TSlash) isToken()            {}
-func (*TSlashGreaterThan) isToken() {}
-func (*TEquals) isToken()           {}
-func (*TDot) isToken()              {}
-func (*TComma) isToken()            {}
-func (*TBackTick) isToken()         {}
-func (*TLessThan) isToken()         {}
-func (*TLessThanEqual) isToken()    {}
-func (*TLessThanSlash) isToken()    {}
-func (*TGreaterThan) isToken()      {}
-
-type TPlus struct{ span ast.Span }
-
-func NewPlus(span ast.Span) *TPlus { return &TPlus{span: span} }
-func (t *TPlus) Span() ast.Span    { return t.span }
-
-type TMinus struct{ span ast.Span }
-
-func NewMinus(span ast.Span) *TMinus { return &TMinus{span: span} }
-func (t *TMinus) Span() ast.Span     { return t.span }
-
-type TAsterisk struct{ span ast.Span }
-
-func NewAsterisk(span ast.Span) *TAsterisk { return &TAsterisk{span: span} }
-func (t *TAsterisk) Span() ast.Span        { return t.span }
-
-type TSlash struct{ span ast.Span }
-
-func NewSlash(span ast.Span) *TSlash { return &TSlash{span: span} }
-func (t *TSlash) Span() ast.Span     { return t.span }
-
-type TSlashGreaterThan struct{ span ast.Span }
-
-func NewSlashGreaterThan(span ast.Span) *TSlashGreaterThan { return &TSlashGreaterThan{span: span} }
-func (t *TSlashGreaterThan) Span() ast.Span                { return t.span }
-
-type TEquals struct{ span ast.Span }
-
-func NewEquals(span ast.Span) *TEquals { return &TEquals{span: span} }
-func (t *TEquals) Span() ast.Span      { return t.span }
-
-type TDot struct{ span ast.Span }
-
-func NewDot(span ast.Span) *TDot { return &TDot{span: span} }
-func (t *TDot) Span() ast.Span   { return t.span }
-
-type TComma struct{ span ast.Span }
-
-func NewComma(span ast.Span) *TComma { return &TComma{span: span} }
-func (t *TComma) Span() ast.Span     { return t.span }
-
-type TBackTick struct{ span ast.Span }
-
-func NewBackTick(span ast.Span) *TBackTick { return &TBackTick{span: span} }
-func (t *TBackTick) Span() ast.Span        { return t.span }
-
-type TLessThan struct{ span ast.Span }
-
-func NewLessThan(span ast.Span) *TLessThan { return &TLessThan{span: span} }
-func (t *TLessThan) Span() ast.Span        { return t.span }
-
-type TLessThanEqual struct{ span ast.Span }
-
-func NewLessThanEqual(span ast.Span) *TLessThanEqual { return &TLessThanEqual{span: span} }
-func (t *TLessThanEqual) Span() ast.Span             { return t.span }
-
-type TLessThanSlash struct{ span ast.Span }
-
-func NewLessThanSlash(span ast.Span) *TLessThanSlash { return &TLessThanSlash{span: span} }
-func (t *TLessThanSlash) Span() ast.Span             { return t.span }
-
-type TGreaterThan struct{ span ast.Span }
-
-func NewGreaterThan(span ast.Span) *TGreaterThan { return &TGreaterThan{span: span} }
-func (t *TGreaterThan) Span() ast.Span           { return t.span }
-
-// optional chaining
-func (*TQuestionOpenParen) isToken()   {}
-func (*TQuestionDot) isToken()         {}
-func (*TQuestionOpenBracket) isToken() {}
-
-type TQuestionOpenParen struct{ span ast.Span }
-
-func NewQuestionOpenParen(span ast.Span) *TQuestionOpenParen { return &TQuestionOpenParen{span: span} }
-func (t *TQuestionOpenParen) Span() ast.Span                 { return t.span }
-
-type TQuestionDot struct{ span ast.Span }
-
-func NewQuestionDot(span ast.Span) *TQuestionDot { return &TQuestionDot{span: span} }
-func (t *TQuestionDot) Span() ast.Span           { return t.span }
-
-type TQuestionOpenBracket struct{ span ast.Span }
-
-func NewQuestionOpenBracket(span ast.Span) *TQuestionOpenBracket {
-	return &TQuestionOpenBracket{span: span}
-}
-func (t *TQuestionOpenBracket) Span() ast.Span { return t.span }
-
-// grouping
-func (*TOpenParen) isToken()    {}
-func (*TCloseParen) isToken()   {}
-func (*TOpenBrace) isToken()    {}
-func (*TCloseBrace) isToken()   {}
-func (*TOpenBracket) isToken()  {}
-func (*TCloseBracket) isToken() {}
-
-type TOpenParen struct{ span ast.Span }
-
-func NewOpenParen(span ast.Span) *TOpenParen { return &TOpenParen{span: span} }
-func (t *TOpenParen) Span() ast.Span         { return t.span }
-
-type TCloseParen struct{ span ast.Span }
-
-func NewCloseParen(span ast.Span) *TCloseParen { return &TCloseParen{span: span} }
-func (t *TCloseParen) Span() ast.Span          { return t.span }
-
-type TOpenBrace struct{ span ast.Span }
-
-func NewOpenBrace(span ast.Span) *TOpenBrace { return &TOpenBrace{span: span} }
-func (t *TOpenBrace) Span() ast.Span         { return t.span }
-
-type TCloseBrace struct{ span ast.Span }
-
-func NewCloseBrace(span ast.Span) *TCloseBrace { return &TCloseBrace{span: span} }
-func (t *TCloseBrace) Span() ast.Span          { return t.span }
-
-type TOpenBracket struct{ span ast.Span }
-
-func NewOpenBracket(span ast.Span) *TOpenBracket { return &TOpenBracket{span: span} }
-func (t *TOpenBracket) Span() ast.Span           { return t.span }
-
-type TCloseBracket struct{ span ast.Span }
-
-func NewCloseBracket(span ast.Span) *TCloseBracket { return &TCloseBracket{span: span} }
-func (t *TCloseBracket) Span() ast.Span            { return t.span }
-
-func (*TEndOfFile) isToken() {}
-func (*TInvalid) isToken()   {}
-
-type TEndOfFile struct{ span ast.Span }
-type TInvalid struct{ span ast.Span }
-
-func NewEndOfFile(span ast.Span) *TEndOfFile { return &TEndOfFile{span: span} }
-func (t *TEndOfFile) Span() ast.Span         { return t.span }
-
-func NewInvalid(span ast.Span) *TInvalid { return &TInvalid{span: span} }
-func (t *TInvalid) Span() ast.Span       { return t.span }

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -35,14 +35,12 @@ func NewString(value string, span ast.Span) *TString { return &TString{Value: va
 func (t *TString) Span() ast.Span                    { return t.span }
 
 type TQuasi struct {
-	Value      string
-	Last       bool
-	Incomplete bool
-	span       ast.Span
+	Value string
+	span  ast.Span
 }
 
-func NewQuasi(value string, last bool, incomplete bool, span ast.Span) *TQuasi {
-	return &TQuasi{Value: value, Last: last, Incomplete: incomplete, span: span}
+func NewQuasi(value string, span ast.Span) *TQuasi {
+	return &TQuasi{Value: value, span: span}
 }
 func (t *TQuasi) Span() ast.Span { return t.span }
 


### PR DESCRIPTION
Refactor the lexer by replacing the Token interface with a Token struct and getting rid of all of the token-specific structs.
