### PR TITLE
Parse if-else expressions

### DIFF
--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -1705,3 +1705,173 @@
     inferredType: nil,
 }
 ---
+
+[TestParseExprNoErrors/IfElse - 1]
+&ast.IfElseExpr{
+    Cond: &ast.IdentExpr{
+        Name: "cond",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        inferredType: nil,
+    },
+    Cons: ast.Block{
+        Stmts: {
+            &ast.ExprStmt{
+                Expr: &ast.IdentExpr{
+                    Name: "a",
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:11},
+                        End:   ast.Location{Line:1, Column:12},
+                    },
+                    inferredType: nil,
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:11},
+                    End:   ast.Location{Line:1, Column:12},
+                },
+            },
+        },
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:9},
+            End:   ast.Location{Line:1, Column:14},
+        },
+    },
+    Alt: ast.BlockOrExpr{
+        Block: &ast.Block{
+            Stmts: {
+                &ast.ExprStmt{
+                    Expr: &ast.IdentExpr{
+                        Name: "b",
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:22},
+                            End:   ast.Location{Line:1, Column:23},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:22},
+                        End:   ast.Location{Line:1, Column:23},
+                    },
+                },
+            },
+            Span: ast.Span{
+                Start: ast.Location{Line:1, Column:20},
+                End:   ast.Location{Line:1, Column:25},
+            },
+        },
+        Expr: nil,
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:25},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprNoErrors/IfElseChaining - 1]
+&ast.IfElseExpr{
+    Cond: &ast.IdentExpr{
+        Name: "cond1",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:9},
+        },
+        inferredType: nil,
+    },
+    Cons: ast.Block{
+        Stmts: {
+            &ast.ExprStmt{
+                Expr: &ast.IdentExpr{
+                    Name: "a",
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:12},
+                        End:   ast.Location{Line:1, Column:13},
+                    },
+                    inferredType: nil,
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:12},
+                    End:   ast.Location{Line:1, Column:13},
+                },
+            },
+        },
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:10},
+            End:   ast.Location{Line:1, Column:15},
+        },
+    },
+    Alt: ast.BlockOrExpr{
+        Block: (*ast.Block)(nil),
+        Expr:  &ast.IfElseExpr{
+            Cond: &ast.IdentExpr{
+                Name: "cond2",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:24},
+                    End:   ast.Location{Line:1, Column:29},
+                },
+                inferredType: nil,
+            },
+            Cons: ast.Block{
+                Stmts: {
+                    &ast.ExprStmt{
+                        Expr: &ast.IdentExpr{
+                            Name: "b",
+                            span: ast.Span{
+                                Start: ast.Location{Line:1, Column:32},
+                                End:   ast.Location{Line:1, Column:33},
+                            },
+                            inferredType: nil,
+                        },
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:32},
+                            End:   ast.Location{Line:1, Column:33},
+                        },
+                    },
+                },
+                Span: ast.Span{
+                    Start: ast.Location{Line:1, Column:30},
+                    End:   ast.Location{Line:1, Column:35},
+                },
+            },
+            Alt: ast.BlockOrExpr{
+                Block: &ast.Block{
+                    Stmts: {
+                        &ast.ExprStmt{
+                            Expr: &ast.IdentExpr{
+                                Name: "c",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:1, Column:43},
+                                    End:   ast.Location{Line:1, Column:44},
+                                },
+                                inferredType: nil,
+                            },
+                            span: ast.Span{
+                                Start: ast.Location{Line:1, Column:43},
+                                End:   ast.Location{Line:1, Column:44},
+                            },
+                        },
+                    },
+                    Span: ast.Span{
+                        Start: ast.Location{Line:1, Column:41},
+                        End:   ast.Location{Line:1, Column:46},
+                    },
+                },
+                Expr: nil,
+            },
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:20},
+                End:   ast.Location{Line:1, Column:46},
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:46},
+    },
+    inferredType: nil,
+}
+---

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -1052,640 +1052,6 @@
 }
 ---
 
-[TestParseExprErrorHandling/IncompleteTemplateLiteral - 1]
-&ast.TemplateLitExpr{
-    Quasis: {
-        &ast.Quasi{
-            Value: "foo",
-            Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:5},
-            },
-        },
-    },
-    Exprs: nil,
-    span:  ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:5},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/IncompleteMember - 1]
-&ast.BinaryExpr{
-    Left: &ast.IdentExpr{
-        Name: "a",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:2},
-        },
-        inferredType: nil,
-    },
-    Op:    0,
-    Right: &ast.MemberExpr{
-        Object: &ast.IdentExpr{
-            Name: "b",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:6},
-            },
-            inferredType: nil,
-        },
-        Prop: &ast.Ident{
-            Name: "",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:7},
-                End:   ast.Location{Line:1, Column:7},
-            },
-        },
-        OptChain: false,
-        span:     ast.Span{
-            Start: ast.Location{Line:1, Column:5},
-            End:   ast.Location{Line:1, Column:7},
-        },
-        inferredType: nil,
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:7},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/MismatchedBracketsIndex - 1]
-&ast.IndexExpr{
-    Object: &ast.IdentExpr{
-        Name: "foo",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:4},
-        },
-        inferredType: nil,
-    },
-    Index: &ast.IdentExpr{
-        Name: "bar",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:5},
-            End:   ast.Location{Line:1, Column:8},
-        },
-        inferredType: nil,
-    },
-    OptChain: false,
-    span:     ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:9},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/IncompleteMember - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:6},
-            End:   ast.Location{Line:1, Column:7},
-        },
-        Message: "expected an identifier after .",
-    },
-}
----
-
-[TestParseExprErrorHandling/IncompleteBinaryExpr - 1]
-&ast.BinaryExpr{
-    Left: &ast.BinaryExpr{
-        Left: &ast.IdentExpr{
-            Name: "a",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:1},
-                End:   ast.Location{Line:1, Column:2},
-            },
-            inferredType: nil,
-        },
-        Op:    1,
-        Right: &ast.IdentExpr{
-            Name: "b",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:6},
-            },
-            inferredType: nil,
-        },
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:6},
-        },
-        inferredType: nil,
-    },
-    Op:    0,
-    Right: &ast.EmptyExpr{
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:8},
-            End:   ast.Location{Line:1, Column:8},
-        },
-        inferredType: nil,
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:8},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/IncompleteCall - 1]
-&ast.CallExpr{
-    Callee: &ast.IdentExpr{
-        Name: "foo",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:4},
-        },
-        inferredType: nil,
-    },
-    Args: {
-        &ast.IdentExpr{
-            Name: "a",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:6},
-            },
-            inferredType: nil,
-        },
-        &ast.EmptyExpr{
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:7},
-                End:   ast.Location{Line:1, Column:7},
-            },
-            inferredType: nil,
-        },
-    },
-    OptChain: false,
-    span:     ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:7},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/MismatchedParens - 1]
-&ast.BinaryExpr{
-    Left: &ast.IdentExpr{
-        Name: "a",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:2},
-        },
-        inferredType: nil,
-    },
-    Op:    2,
-    Right: &ast.BinaryExpr{
-        Left: &ast.IdentExpr{
-            Name: "b",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:6},
-                End:   ast.Location{Line:1, Column:7},
-            },
-            inferredType: nil,
-        },
-        Op:    0,
-        Right: &ast.IdentExpr{
-            Name: "c",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:10},
-                End:   ast.Location{Line:1, Column:11},
-            },
-            inferredType: nil,
-        },
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:6},
-            End:   ast.Location{Line:1, Column:11},
-        },
-        inferredType: nil,
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:11},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/MismatchedBracketsIndex - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:4},
-            End:   ast.Location{Line:1, Column:5},
-        },
-        Message: "Expected a closing bracket",
-    },
-}
----
-
-[TestParseExprErrorHandling/MismatchedParens - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:5},
-            End:   ast.Location{Line:1, Column:6},
-        },
-        Message: "Expected a closing paren",
-    },
-}
----
-
-[TestParseExprErrorHandling/IncompleteCall - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:7},
-            End:   ast.Location{Line:1, Column:7},
-        },
-        Message: "Expected an expression",
-    },
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:4},
-            End:   ast.Location{Line:1, Column:5},
-        },
-        Message: "Expected a closing paren",
-    },
-}
----
-
-[TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 1]
-&ast.BinaryExpr{
-    Left: &ast.IdentExpr{
-        Name: "a",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:2},
-        },
-        inferredType: nil,
-    },
-    Op:    0,
-    Right: &ast.IdentExpr{
-        Name: "b",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:7},
-            End:   ast.Location{Line:1, Column:8},
-        },
-        inferredType: nil,
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:8},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:5},
-            End:   ast.Location{Line:1, Column:6},
-        },
-        Message: "Unexpected token",
-    },
-}
----
-
-[TestParseExprErrorHandling/MismatchedBracketsArrayLiteral - 1]
-&ast.TupleExpr{
-    Elems: {
-        &ast.LiteralExpr{
-            Lit:  &ast.NumLit{Value:1},
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:2},
-                End:   ast.Location{Line:1, Column:3},
-            },
-            inferredType: nil,
-        },
-        &ast.LiteralExpr{
-            Lit:  &ast.NumLit{Value:2},
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:6},
-            },
-            inferredType: nil,
-        },
-        &ast.LiteralExpr{
-            Lit:  &ast.NumLit{Value:3},
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:8},
-                End:   ast.Location{Line:1, Column:9},
-            },
-            inferredType: nil,
-        },
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:10},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/IncompleteMemberOptChain - 1]
-&ast.BinaryExpr{
-    Left: &ast.IdentExpr{
-        Name: "a",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:2},
-        },
-        inferredType: nil,
-    },
-    Op:    0,
-    Right: &ast.MemberExpr{
-        Object: &ast.IdentExpr{
-            Name: "b",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:6},
-            },
-            inferredType: nil,
-        },
-        Prop: &ast.Ident{
-            Name: "",
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:8},
-                End:   ast.Location{Line:1, Column:8},
-            },
-        },
-        OptChain: true,
-        span:     ast.Span{
-            Start: ast.Location{Line:1, Column:5},
-            End:   ast.Location{Line:1, Column:8},
-        },
-        inferredType: nil,
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:8},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/MismatchedBracketsArrayLiteral - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:2},
-        },
-        Message: "Expected a closing bracket",
-    },
-}
----
-
-[TestParseExprErrorHandling/IncompleteTemplateLiteral - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:5},
-        },
-        Message: "Expected a closing backtick",
-    },
-}
----
-
-[TestParseExprErrorHandling/IncompleteMemberOptChain - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:6},
-            End:   ast.Location{Line:1, Column:8},
-        },
-        Message: "expected an identifier after ?.",
-    },
-}
----
-
-[TestParseExprErrorHandling/IncompleteBinaryExpr - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:8},
-            End:   ast.Location{Line:1, Column:8},
-        },
-        Message: "Expected an expression",
-    },
-}
----
-
-[TestParseExprErrorHandling/IncompleteTaggedTemplateLiteral - 1]
-&ast.TaggedTemplateLitExpr{
-    Tag: &ast.IdentExpr{
-        Name: "foo",
-        span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:4},
-        },
-        inferredType: nil,
-    },
-    Quasis: {
-        &ast.Quasi{
-            Value: "bar",
-            Span:  ast.Span{
-                Start: ast.Location{Line:1, Column:5},
-                End:   ast.Location{Line:1, Column:8},
-            },
-        },
-    },
-    Exprs: nil,
-    span:  ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:8},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/IncompleteTaggedTemplateLiteral - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:4},
-            End:   ast.Location{Line:1, Column:8},
-        },
-        Message: "Expected a closing backtick",
-    },
-}
----
-
-[TestParseExprErrorHandling/ParamsMissingClosingParen - 1]
-&ast.FuncExpr{
-    Params: {
-        &ast.Param{
-            Name: &ast.Ident{
-                Name: "a",
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:5},
-                    End:   ast.Location{Line:1, Column:6},
-                },
-            },
-        },
-        &ast.Param{
-            Name: &ast.Ident{
-                Name: "b",
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:8},
-                    End:   ast.Location{Line:1, Column:9},
-                },
-            },
-        },
-    },
-    Return: nil,
-    Throws: nil,
-    Body:   ast.Block{
-        Stmts: {
-            &ast.ExprStmt{
-                Expr: &ast.BinaryExpr{
-                    Left: &ast.IdentExpr{
-                        Name: "a",
-                        span: ast.Span{
-                            Start: ast.Location{Line:1, Column:12},
-                            End:   ast.Location{Line:1, Column:13},
-                        },
-                        inferredType: nil,
-                    },
-                    Op:    0,
-                    Right: &ast.IdentExpr{
-                        Name: "b",
-                        span: ast.Span{
-                            Start: ast.Location{Line:1, Column:16},
-                            End:   ast.Location{Line:1, Column:17},
-                        },
-                        inferredType: nil,
-                    },
-                    span: ast.Span{
-                        Start: ast.Location{Line:1, Column:12},
-                        End:   ast.Location{Line:1, Column:17},
-                    },
-                    inferredType: nil,
-                },
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:12},
-                    End:   ast.Location{Line:1, Column:17},
-                },
-            },
-        },
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:10},
-            End:   ast.Location{Line:1, Column:19},
-        },
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:19},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/ParamsMissingOpeningParen - 1]
-&ast.FuncExpr{
-    Params: {
-        &ast.Param{
-            Name: &ast.Ident{
-                Name: "a",
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:4},
-                    End:   ast.Location{Line:1, Column:5},
-                },
-            },
-        },
-        &ast.Param{
-            Name: &ast.Ident{
-                Name: "b",
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:7},
-                    End:   ast.Location{Line:1, Column:8},
-                },
-            },
-        },
-    },
-    Return: nil,
-    Throws: nil,
-    Body:   ast.Block{
-        Stmts: {
-            &ast.ExprStmt{
-                Expr: &ast.BinaryExpr{
-                    Left: &ast.IdentExpr{
-                        Name: "a",
-                        span: ast.Span{
-                            Start: ast.Location{Line:1, Column:12},
-                            End:   ast.Location{Line:1, Column:13},
-                        },
-                        inferredType: nil,
-                    },
-                    Op:    0,
-                    Right: &ast.IdentExpr{
-                        Name: "b",
-                        span: ast.Span{
-                            Start: ast.Location{Line:1, Column:16},
-                            End:   ast.Location{Line:1, Column:17},
-                        },
-                        inferredType: nil,
-                    },
-                    span: ast.Span{
-                        Start: ast.Location{Line:1, Column:12},
-                        End:   ast.Location{Line:1, Column:17},
-                    },
-                    inferredType: nil,
-                },
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:12},
-                    End:   ast.Location{Line:1, Column:17},
-                },
-            },
-        },
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:10},
-            End:   ast.Location{Line:1, Column:19},
-        },
-    },
-    span: ast.Span{
-        Start: ast.Location{Line:1, Column:1},
-        End:   ast.Location{Line:1, Column:19},
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprErrorHandling/ParamsMissingClosingParen - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:10},
-            End:   ast.Location{Line:1, Column:11},
-        },
-        Message: "Expected a closing paren",
-    },
-}
----
-
-[TestParseExprErrorHandling/ParamsMissingOpeningParen - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:4},
-            End:   ast.Location{Line:1, Column:5},
-        },
-        Message: "Expected an opening paren",
-    },
-}
----
-
 [TestParseExprNoErrors/TemplateStringMultipleLines - 1]
 &ast.TemplateLitExpr{
     Quasis: {
@@ -1873,5 +1239,752 @@
         End:   ast.Location{Line:1, Column:46},
     },
     inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IfElseMissingCondition - 1]
+&ast.IfElseExpr{
+    Cond: nil,
+    Cons: ast.Block{
+        Stmts: {
+            &ast.ExprStmt{
+                Expr: &ast.IdentExpr{
+                    Name: "a",
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:6},
+                        End:   ast.Location{Line:1, Column:7},
+                    },
+                    inferredType: nil,
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:6},
+                    End:   ast.Location{Line:1, Column:7},
+                },
+            },
+        },
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:9},
+        },
+    },
+    Alt: ast.BlockOrExpr{
+        Block: &ast.Block{
+            Stmts: {
+                &ast.ExprStmt{
+                    Expr: &ast.IdentExpr{
+                        Name: "b",
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:17},
+                            End:   ast.Location{Line:1, Column:18},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:17},
+                        End:   ast.Location{Line:1, Column:18},
+                    },
+                },
+            },
+            Span: ast.Span{
+                Start: ast.Location{Line:1, Column:15},
+                End:   ast.Location{Line:1, Column:20},
+            },
+        },
+        Expr: nil,
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:20},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IfElseMissingCondition - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:5},
+        },
+        Message: "Expected a condition",
+    },
+}
+---
+
+[TestParseExprErrorHandling/IfElseMissingOpeningBraces - 1]
+&ast.IfElseExpr{
+    Cond: &ast.IdentExpr{
+        Name: "cond",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        inferredType: nil,
+    },
+    Cons: ast.Block{
+        Stmts: {
+        },
+        Span: ast.Span{},
+    },
+    Alt:  ast.BlockOrExpr{},
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:11},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteCall - 1]
+&ast.CallExpr{
+    Callee: &ast.IdentExpr{
+        Name: "foo",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:4},
+        },
+        inferredType: nil,
+    },
+    Args: {
+        &ast.IdentExpr{
+            Name: "a",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:6},
+            },
+            inferredType: nil,
+        },
+        &ast.EmptyExpr{
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:7},
+                End:   ast.Location{Line:1, Column:7},
+            },
+            inferredType: nil,
+        },
+    },
+    OptChain: false,
+    span:     ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:7},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteTaggedTemplateLiteral - 1]
+&ast.TaggedTemplateLitExpr{
+    Tag: &ast.IdentExpr{
+        Name: "foo",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:4},
+        },
+        inferredType: nil,
+    },
+    Quasis: {
+        &ast.Quasi{
+            Value: "bar",
+            Span:  ast.Span{
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:8},
+            },
+        },
+    },
+    Exprs: nil,
+    span:  ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:8},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsArrayLiteral - 1]
+&ast.TupleExpr{
+    Elems: {
+        &ast.LiteralExpr{
+            Lit:  &ast.NumLit{Value:1},
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:2},
+                End:   ast.Location{Line:1, Column:3},
+            },
+            inferredType: nil,
+        },
+        &ast.LiteralExpr{
+            Lit:  &ast.NumLit{Value:2},
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:6},
+            },
+            inferredType: nil,
+        },
+        &ast.LiteralExpr{
+            Lit:  &ast.NumLit{Value:3},
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:8},
+                End:   ast.Location{Line:1, Column:9},
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:10},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteCall - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:7},
+            End:   ast.Location{Line:1, Column:7},
+        },
+        Message: "Expected an expression",
+    },
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:5},
+        },
+        Message: "Expected a closing paren",
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsArrayLiteral - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:2},
+        },
+        Message: "Expected a closing bracket",
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedParens - 1]
+&ast.BinaryExpr{
+    Left: &ast.IdentExpr{
+        Name: "a",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:2},
+        },
+        inferredType: nil,
+    },
+    Op:    2,
+    Right: &ast.BinaryExpr{
+        Left: &ast.IdentExpr{
+            Name: "b",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:6},
+                End:   ast.Location{Line:1, Column:7},
+            },
+            inferredType: nil,
+        },
+        Op:    0,
+        Right: &ast.IdentExpr{
+            Name: "c",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:10},
+                End:   ast.Location{Line:1, Column:11},
+            },
+            inferredType: nil,
+        },
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:6},
+            End:   ast.Location{Line:1, Column:11},
+        },
+        inferredType: nil,
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:11},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IfElseMissingOpeningBraces - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:9},
+            End:   ast.Location{Line:1, Column:10},
+        },
+        Message: "Expected an opening brace",
+    },
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:9},
+            End:   ast.Location{Line:1, Column:10},
+        },
+        Message: "Expected an opening brace",
+    },
+}
+---
+
+[TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 1]
+&ast.BinaryExpr{
+    Left: &ast.IdentExpr{
+        Name: "a",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:2},
+        },
+        inferredType: nil,
+    },
+    Op:    0,
+    Right: &ast.IdentExpr{
+        Name: "b",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:7},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        inferredType: nil,
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:8},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/MismatchedParens - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:6},
+        },
+        Message: "Expected a closing paren",
+    },
+}
+---
+
+[TestParseExprErrorHandling/IncompleteBinaryExpr - 1]
+&ast.BinaryExpr{
+    Left: &ast.BinaryExpr{
+        Left: &ast.IdentExpr{
+            Name: "a",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:1},
+                End:   ast.Location{Line:1, Column:2},
+            },
+            inferredType: nil,
+        },
+        Op:    1,
+        Right: &ast.IdentExpr{
+            Name: "b",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:6},
+            },
+            inferredType: nil,
+        },
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:6},
+        },
+        inferredType: nil,
+    },
+    Op:    0,
+    Right: &ast.EmptyExpr{
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:8},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        inferredType: nil,
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:8},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteTemplateLiteral - 1]
+&ast.TemplateLitExpr{
+    Quasis: {
+        &ast.Quasi{
+            Value: "foo",
+            Span:  ast.Span{
+                Start: ast.Location{Line:1, Column:2},
+                End:   ast.Location{Line:1, Column:5},
+            },
+        },
+    },
+    Exprs: nil,
+    span:  ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:5},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteTaggedTemplateLiteral - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        Message: "Expected a closing backtick",
+    },
+}
+---
+
+[TestParseExprErrorHandling/ParamsMissingClosingParen - 1]
+&ast.FuncExpr{
+    Params: {
+        &ast.Param{
+            Name: &ast.Ident{
+                Name: "a",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:5},
+                    End:   ast.Location{Line:1, Column:6},
+                },
+            },
+        },
+        &ast.Param{
+            Name: &ast.Ident{
+                Name: "b",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:8},
+                    End:   ast.Location{Line:1, Column:9},
+                },
+            },
+        },
+    },
+    Return: nil,
+    Throws: nil,
+    Body:   ast.Block{
+        Stmts: {
+            &ast.ExprStmt{
+                Expr: &ast.BinaryExpr{
+                    Left: &ast.IdentExpr{
+                        Name: "a",
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:12},
+                            End:   ast.Location{Line:1, Column:13},
+                        },
+                        inferredType: nil,
+                    },
+                    Op:    0,
+                    Right: &ast.IdentExpr{
+                        Name: "b",
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:16},
+                            End:   ast.Location{Line:1, Column:17},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:12},
+                        End:   ast.Location{Line:1, Column:17},
+                    },
+                    inferredType: nil,
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:12},
+                    End:   ast.Location{Line:1, Column:17},
+                },
+            },
+        },
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:10},
+            End:   ast.Location{Line:1, Column:19},
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:19},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsIndex - 1]
+&ast.IndexExpr{
+    Object: &ast.IdentExpr{
+        Name: "foo",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:4},
+        },
+        inferredType: nil,
+    },
+    Index: &ast.IdentExpr{
+        Name: "bar",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        inferredType: nil,
+    },
+    OptChain: false,
+    span:     ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:9},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteMember - 1]
+&ast.BinaryExpr{
+    Left: &ast.IdentExpr{
+        Name: "a",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:2},
+        },
+        inferredType: nil,
+    },
+    Op:    0,
+    Right: &ast.MemberExpr{
+        Object: &ast.IdentExpr{
+            Name: "b",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:6},
+            },
+            inferredType: nil,
+        },
+        Prop: &ast.Ident{
+            Name: "",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:7},
+                End:   ast.Location{Line:1, Column:7},
+            },
+        },
+        OptChain: false,
+        span:     ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:7},
+        },
+        inferredType: nil,
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:7},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteBinaryExpr - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:8},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        Message: "Expected an expression",
+    },
+}
+---
+
+[TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:6},
+        },
+        Message: "Unexpected token",
+    },
+}
+---
+
+[TestParseExprErrorHandling/MismatchedBracketsIndex - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:5},
+        },
+        Message: "Expected a closing bracket",
+    },
+}
+---
+
+[TestParseExprErrorHandling/IncompleteMember - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:6},
+            End:   ast.Location{Line:1, Column:7},
+        },
+        Message: "expected an identifier after .",
+    },
+}
+---
+
+[TestParseExprErrorHandling/IncompleteTemplateLiteral - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:5},
+        },
+        Message: "Expected a closing backtick",
+    },
+}
+---
+
+[TestParseExprErrorHandling/ParamsMissingClosingParen - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:10},
+            End:   ast.Location{Line:1, Column:11},
+        },
+        Message: "Expected a closing paren",
+    },
+}
+---
+
+[TestParseExprErrorHandling/ParamsMissingOpeningParen - 1]
+&ast.FuncExpr{
+    Params: {
+        &ast.Param{
+            Name: &ast.Ident{
+                Name: "a",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:4},
+                    End:   ast.Location{Line:1, Column:5},
+                },
+            },
+        },
+        &ast.Param{
+            Name: &ast.Ident{
+                Name: "b",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:7},
+                    End:   ast.Location{Line:1, Column:8},
+                },
+            },
+        },
+    },
+    Return: nil,
+    Throws: nil,
+    Body:   ast.Block{
+        Stmts: {
+            &ast.ExprStmt{
+                Expr: &ast.BinaryExpr{
+                    Left: &ast.IdentExpr{
+                        Name: "a",
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:12},
+                            End:   ast.Location{Line:1, Column:13},
+                        },
+                        inferredType: nil,
+                    },
+                    Op:    0,
+                    Right: &ast.IdentExpr{
+                        Name: "b",
+                        span: ast.Span{
+                            Start: ast.Location{Line:1, Column:16},
+                            End:   ast.Location{Line:1, Column:17},
+                        },
+                        inferredType: nil,
+                    },
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:12},
+                        End:   ast.Location{Line:1, Column:17},
+                    },
+                    inferredType: nil,
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:12},
+                    End:   ast.Location{Line:1, Column:17},
+                },
+            },
+        },
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:10},
+            End:   ast.Location{Line:1, Column:19},
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:19},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteMemberOptChain - 1]
+&ast.BinaryExpr{
+    Left: &ast.IdentExpr{
+        Name: "a",
+        span: ast.Span{
+            Start: ast.Location{Line:1, Column:1},
+            End:   ast.Location{Line:1, Column:2},
+        },
+        inferredType: nil,
+    },
+    Op:    0,
+    Right: &ast.MemberExpr{
+        Object: &ast.IdentExpr{
+            Name: "b",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:5},
+                End:   ast.Location{Line:1, Column:6},
+            },
+            inferredType: nil,
+        },
+        Prop: &ast.Ident{
+            Name: "",
+            span: ast.Span{
+                Start: ast.Location{Line:1, Column:8},
+                End:   ast.Location{Line:1, Column:8},
+            },
+        },
+        OptChain: true,
+        span:     ast.Span{
+            Start: ast.Location{Line:1, Column:5},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        inferredType: nil,
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:8},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/ParamsMissingOpeningParen - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:5},
+        },
+        Message: "Expected an opening paren",
+    },
+}
+---
+
+[TestParseExprErrorHandling/IncompleteMemberOptChain - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:6},
+            End:   ast.Location{Line:1, Column:8},
+        },
+        Message: "expected an identifier after ?.",
+    },
 }
 ---

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -1988,3 +1988,56 @@
     },
 }
 ---
+
+[TestParseExprErrorHandling/IncompleteElse - 1]
+&ast.IfElseExpr{
+    Cond: nil,
+    Cons: ast.Block{
+        Stmts: {
+            &ast.ExprStmt{
+                Expr: &ast.IdentExpr{
+                    Name: "a",
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:6},
+                        End:   ast.Location{Line:1, Column:7},
+                    },
+                    inferredType: nil,
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:6},
+                    End:   ast.Location{Line:1, Column:7},
+                },
+            },
+        },
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:9},
+        },
+    },
+    Alt:  ast.BlockOrExpr{},
+    span: ast.Span{
+        Start: ast.Location{Line:1, Column:1},
+        End:   ast.Location{Line:1, Column:14},
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseExprErrorHandling/IncompleteElse - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:4},
+            End:   ast.Location{Line:1, Column:5},
+        },
+        Message: "Expected a condition",
+    },
+    &parser.Error{
+        Span: ast.Span{
+            Start: ast.Location{Line:1, Column:14},
+            End:   ast.Location{Line:1, Column:14},
+        },
+        Message: "Expected an if or an opening brace",
+    },
+}
+---

--- a/internal/parser/__snapshots__/lexer_test.snap
+++ b/internal/parser/__snapshots__/lexer_test.snap
@@ -35,7 +35,7 @@
             Start: ast.Location{Line:1, Column:1},
             End:   ast.Location{Line:1, Column:2},
         },
-        Type:  12,
+        Type:  23,
         Value: "+",
     },
     &parser.Token{
@@ -43,7 +43,7 @@
             Start: ast.Location{Line:1, Column:3},
             End:   ast.Location{Line:1, Column:4},
         },
-        Type:  13,
+        Type:  24,
         Value: "-",
     },
     &parser.Token{
@@ -51,7 +51,7 @@
             Start: ast.Location{Line:1, Column:5},
             End:   ast.Location{Line:1, Column:6},
         },
-        Type:  14,
+        Type:  25,
         Value: "*",
     },
     &parser.Token{
@@ -59,7 +59,7 @@
             Start: ast.Location{Line:1, Column:7},
             End:   ast.Location{Line:1, Column:8},
         },
-        Type:  15,
+        Type:  26,
         Value: "/",
     },
     &parser.Token{
@@ -67,7 +67,7 @@
             Start: ast.Location{Line:1, Column:9},
             End:   ast.Location{Line:1, Column:10},
         },
-        Type:  17,
+        Type:  31,
         Value: "=",
     },
 }
@@ -122,7 +122,7 @@
             Start: ast.Location{Line:1, Column:3},
             End:   ast.Location{Line:1, Column:4},
         },
-        Type:  14,
+        Type:  25,
         Value: "*",
     },
     &parser.Token{
@@ -130,7 +130,7 @@
             Start: ast.Location{Line:1, Column:5},
             End:   ast.Location{Line:1, Column:6},
         },
-        Type:  28,
+        Type:  42,
         Value: "(",
     },
     &parser.Token{
@@ -146,7 +146,7 @@
             Start: ast.Location{Line:1, Column:8},
             End:   ast.Location{Line:1, Column:9},
         },
-        Type:  12,
+        Type:  23,
         Value: "+",
     },
     &parser.Token{
@@ -162,7 +162,7 @@
             Start: ast.Location{Line:1, Column:11},
             End:   ast.Location{Line:1, Column:12},
         },
-        Type:  29,
+        Type:  43,
         Value: ")",
     },
 }

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -592,3 +592,166 @@
     },
 }
 ---
+
+[TestParseModuleNoErrors/IfElse - 1]
+&ast.DeclStmt{
+    Decl: &ast.VarDecl{
+        Kind: 0,
+        Name: &ast.Ident{
+            Name: "x",
+            span: ast.Span{
+                Start: ast.Location{Line:2, Column:9},
+                End:   ast.Location{Line:2, Column:10},
+            },
+        },
+        Init: &ast.IfElseExpr{
+            Cond: &ast.IdentExpr{
+                Name: "cond",
+                span: ast.Span{
+                    Start: ast.Location{Line:2, Column:16},
+                    End:   ast.Location{Line:2, Column:20},
+                },
+                inferredType: nil,
+            },
+            Cons: ast.Block{
+                Stmts: {
+                    &ast.DeclStmt{
+                        Decl: &ast.VarDecl{
+                            Kind: 1,
+                            Name: &ast.Ident{
+                                Name: "a",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:3, Column:10},
+                                    End:   ast.Location{Line:3, Column:11},
+                                },
+                            },
+                            Init: &ast.LiteralExpr{
+                                Lit:  &ast.NumLit{Value:5},
+                                span: ast.Span{
+                                    Start: ast.Location{Line:3, Column:14},
+                                    End:   ast.Location{Line:3, Column:15},
+                                },
+                                inferredType: nil,
+                            },
+                            export:  false,
+                            declare: false,
+                            span:    ast.Span{
+                                Start: ast.Location{Line:3, Column:6},
+                                End:   ast.Location{Line:3, Column:15},
+                            },
+                        },
+                        span: ast.Span{
+                            Start: ast.Location{Line:3, Column:6},
+                            End:   ast.Location{Line:3, Column:15},
+                        },
+                    },
+                    &ast.ExprStmt{
+                        Expr: &ast.UnaryExpr{
+                            Op:  1,
+                            Arg: &ast.LiteralExpr{
+                                Lit:  &ast.NumLit{Value:10},
+                                span: ast.Span{
+                                    Start: ast.Location{Line:4, Column:7},
+                                    End:   ast.Location{Line:4, Column:9},
+                                },
+                                inferredType: nil,
+                            },
+                            span: ast.Span{
+                                Start: ast.Location{Line:4, Column:6},
+                                End:   ast.Location{Line:4, Column:9},
+                            },
+                            inferredType: nil,
+                        },
+                        span: ast.Span{
+                            Start: ast.Location{Line:4, Column:6},
+                            End:   ast.Location{Line:4, Column:9},
+                        },
+                    },
+                },
+                Span: ast.Span{
+                    Start: ast.Location{Line:2, Column:21},
+                    End:   ast.Location{Line:5, Column:6},
+                },
+            },
+            Alt: ast.BlockOrExpr{
+                Block: &ast.Block{
+                    Stmts: {
+                        &ast.DeclStmt{
+                            Decl: &ast.VarDecl{
+                                Kind: 1,
+                                Name: &ast.Ident{
+                                    Name: "b",
+                                    span: ast.Span{
+                                        Start: ast.Location{Line:6, Column:11},
+                                        End:   ast.Location{Line:6, Column:12},
+                                    },
+                                },
+                                Init: &ast.LiteralExpr{
+                                    Lit:  &ast.NumLit{Value:10},
+                                    span: ast.Span{
+                                        Start: ast.Location{Line:6, Column:15},
+                                        End:   ast.Location{Line:6, Column:17},
+                                    },
+                                    inferredType: nil,
+                                },
+                                export:  false,
+                                declare: false,
+                                span:    ast.Span{
+                                    Start: ast.Location{Line:6, Column:7},
+                                    End:   ast.Location{Line:6, Column:17},
+                                },
+                            },
+                            span: ast.Span{
+                                Start: ast.Location{Line:6, Column:7},
+                                End:   ast.Location{Line:6, Column:17},
+                            },
+                        },
+                        &ast.ExprStmt{
+                            Expr: &ast.UnaryExpr{
+                                Op:  1,
+                                Arg: &ast.LiteralExpr{
+                                    Lit:  &ast.NumLit{Value:5},
+                                    span: ast.Span{
+                                        Start: ast.Location{Line:7, Column:7},
+                                        End:   ast.Location{Line:7, Column:8},
+                                    },
+                                    inferredType: nil,
+                                },
+                                span: ast.Span{
+                                    Start: ast.Location{Line:7, Column:6},
+                                    End:   ast.Location{Line:7, Column:8},
+                                },
+                                inferredType: nil,
+                            },
+                            span: ast.Span{
+                                Start: ast.Location{Line:7, Column:6},
+                                End:   ast.Location{Line:7, Column:8},
+                            },
+                        },
+                    },
+                    Span: ast.Span{
+                        Start: ast.Location{Line:5, Column:12},
+                        End:   ast.Location{Line:8, Column:6},
+                    },
+                },
+                Expr: nil,
+            },
+            span: ast.Span{
+                Start: ast.Location{Line:2, Column:12},
+                End:   ast.Location{Line:8, Column:6},
+            },
+            inferredType: nil,
+        },
+        export:  false,
+        declare: false,
+        span:    ast.Span{
+            Start: ast.Location{Line:2, Column:5},
+            End:   ast.Location{Line:8, Column:6},
+        },
+    },
+    span: ast.Span{
+        Start: ast.Location{Line:2, Column:5},
+        End:   ast.Location{Line:8, Column:6},
+    },
+}
+---

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -43,7 +43,7 @@ func (parser *Parser) parseDecl() ast.Decl {
 		token = parser.lexer.peek()
 		var init ast.Expr
 		if !declare {
-			if token.Type != Equals {
+			if token.Type != Equal {
 				parser.reportError(token.Span, "Expected equals sign")
 				return nil
 			}

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -417,11 +417,19 @@ func (parser *Parser) parseTemplateLitExpr(token *Token, tag ast.Expr) ast.Expr 
 func (p *Parser) parseIfElse() ast.Expr {
 	start := p.lexer.currentLocation
 
-	token := p.lexer.next() // consume 'if'
-	cond := p.ParseExprWithMarker(MarkerDelim)
-	if cond == nil {
-		p.reportError(token.Span, "Expected an expression")
+	p.lexer.consume() // consume 'if'
+
+	token := p.lexer.peek()
+	var cond ast.Expr
+	if token.Type == OpenBrace {
+		p.reportError(token.Span, "Expected a condition")
+	} else {
+		cond = p.ParseExprWithMarker(MarkerDelim)
+		if cond == nil {
+			p.reportError(token.Span, "Expected a condition")
+		}
 	}
+
 	token = p.lexer.peek()
 	if token.Type != OpenBrace {
 		p.reportError(token.Span, "Expected an opening brace")

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -425,9 +425,6 @@ func (p *Parser) parseIfElse() ast.Expr {
 		p.reportError(token.Span, "Expected a condition")
 	} else {
 		cond = p.ParseExprWithMarker(MarkerDelim)
-		if cond == nil {
-			p.reportError(token.Span, "Expected a condition")
-		}
 	}
 
 	token = p.lexer.peek()

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -169,6 +169,9 @@ func TestParseExprErrorHandling(t *testing.T) {
 		"IfElseMissingCondition": {
 			input: "if { a } else { b }",
 		},
+		"IncompleteElse": {
+			input: "if { a } else",
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -163,6 +163,12 @@ func TestParseExprErrorHandling(t *testing.T) {
 		"ParamsMissingClosingParen": {
 			input: "fn (a, b { a + b }",
 		},
+		"IfElseMissingOpeningBraces": {
+			input: "if cond a } else b }",
+		},
+		"IfElseMissingCondition": {
+			input: "if { a } else { b }",
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -98,6 +98,12 @@ func TestParseExprNoErrors(t *testing.T) {
 		"FuncExpr": {
 			input: "fn (a, b) { a + b }",
 		},
+		"IfElse": {
+			input: "if cond { a } else { b }",
+		},
+		"IfElseChaining": {
+			input: "if cond1 { a } else if cond2 { b } else { c }",
+		},
 	}
 
 	for name, test := range tests {
@@ -112,7 +118,7 @@ func TestParseExprNoErrors(t *testing.T) {
 			expr := parser.ParseExpr()
 
 			snaps.MatchSnapshot(t, expr)
-			assert.Len(t, parser.Errors, 0)
+			assert.Equal(t, parser.Errors, []*Error{})
 		})
 	}
 }

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -91,7 +91,7 @@ func (p *Parser) parseJSXAttrs() []*ast.JSXAttr {
 
 		// parse attribute value
 		token = p.lexer.peek()
-		if token.Type == Equals {
+		if token.Type == Equal {
 			p.lexer.consume() // consume equals
 		} else {
 			p.reportError(token.Span, "Expected '='")

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -63,6 +63,17 @@ func TestParseModuleNoErrors(t *testing.T) {
 				]
 			`,
 		},
+		"IfElse": {
+			input: `
+				val x = if cond {
+					var a = 5
+					-10
+				} else {
+				 	var b = 10
+					-5
+				}
+			`,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -16,6 +16,17 @@ const (
 	Fn
 	Var
 	Val
+	If
+	Else
+	Match
+	Try
+	Catch
+	Finally
+	Throw
+	Async
+	Await
+	Gen
+	Yield
 	Return
 	Import
 	Export
@@ -27,14 +38,17 @@ const (
 	Asterisk
 	Slash
 	SlashGreaterThan
-	Equals
 	Dot
 	Comma
 	BackTick
+	Equal
+	EqualEqual
+	NotEqual
 	LessThan
 	LessThanEqual
-	LessThanSlash
 	GreaterThan
+	GreaterThanEqual
+	LessThanSlash // Used for JSX
 
 	// optional chaining
 	QuestionOpenParen


### PR DESCRIPTION
`if-else` are expressions in Escalier, e.g.
```ts
val res = if cond {
   console.log("if-branch")
   a
} else {
   console.log("else-branch")
   b
}
```
`res` will be set to `a` or `b` depending on `cond`.  `if-else` can also be chained.