### PR TITLE
Codegen extract patterns

### DIFF
--- a/cmd/escalier/build_test.go
+++ b/cmd/escalier/build_test.go
@@ -73,7 +73,7 @@ func TestBuild(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, fixture := range fixtures {
-			// if fixture.Name() != "destructuring" {
+			// if fixture.Name() != "nested" {
 			// 	continue
 			// }
 			name := group.Name() + "/" + fixture.Name()

--- a/fixtures/extractors/arg_with_init/arg_with_init.esc
+++ b/fixtures/extractors/arg_with_init/arg_with_init.esc
@@ -1,0 +1,2 @@
+val subject = C(undefined, 5)
+val C(x = "hello", y) = subject

--- a/fixtures/extractors/arg_with_init/arg_with_init.esc.map
+++ b/fixtures/extractors/arg_with_init/arg_with_init.esc.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./arg_with_init.js","sources":["./arg_with_init.esc"],"sourcesContent":["val subject = C(undefined, 5)\nval C(x = \"hello\", y) = subject\n"],"names":[],"mappings":"MAAI,AAAA,UAAU,AAAA,EAAa;eACjB,6CAAN,GAAmB;MAAjB,AAAA;MAAY,AAAA"}

--- a/fixtures/extractors/arg_with_init/arg_with_init.js
+++ b/fixtures/extractors/arg_with_init/arg_with_init.js
@@ -1,0 +1,5 @@
+const subject = C(5);
+const [temp1 = "hello", temp2] = InvokeCustomMatcherOrThrow(C, subject, undefined);
+const x = temp1;
+const y = temp2;
+//# sourceMappingURL=./arg_with_init.esc.map

--- a/fixtures/extractors/basic/basic.esc
+++ b/fixtures/extractors/basic/basic.esc
@@ -1,0 +1,2 @@
+val subject = C("hello")
+val C(msg) = subject

--- a/fixtures/extractors/basic/basic.esc.map
+++ b/fixtures/extractors/basic/basic.esc.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./basic.js","sources":["./basic.esc"],"sourcesContent":["val subject = C(\"hello\")\nval C(msg) = subject\n"],"names":[],"mappings":"MAAI,AAAA,UAAU,AAAA,EAAE;2CACZ,GAAS;MAAP,AAAA"}

--- a/fixtures/extractors/basic/basic.js
+++ b/fixtures/extractors/basic/basic.js
@@ -1,0 +1,4 @@
+const subject = C("hello");
+const [temp1] = InvokeCustomMatcherOrThrow(C, subject, undefined);
+const msg = temp1;
+//# sourceMappingURL=./basic.esc.map

--- a/fixtures/extractors/nested/nested.esc
+++ b/fixtures/extractors/nested/nested.esc
@@ -1,0 +1,2 @@
+val subject = C(D("hello"), E([5, 10]))
+val C(D(msg), E([x, y])) = subject

--- a/fixtures/extractors/nested/nested.esc.map
+++ b/fixtures/extractors/nested/nested.esc.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./nested.js","sources":["./nested.esc"],"sourcesContent":["val subject = C(D(\"hello\"), E([5, 10]))\nval C(D(msg), E([x, y])) = subject\n"],"names":[],"mappings":"MAAI,AAAA,UAAU,AAAA,EAAE,AAAA,EAAE,UAAS,AAAA,EAAE,CAAC,GAAG;kDAC7B,GAAuB;2CAArB;MAAE,AAAA;2CAAM;MAAE,CAAC,AAAA,GAAG,AAAA"}

--- a/fixtures/extractors/nested/nested.js
+++ b/fixtures/extractors/nested/nested.js
@@ -1,0 +1,7 @@
+const subject = C(D("hello"), E([5, 10]));
+const [temp1, temp2] = InvokeCustomMatcherOrThrow(C, subject, undefined);
+const [temp3] = InvokeCustomMatcherOrThrow(D, temp1, undefined);
+const msg = temp3;
+const [temp4] = InvokeCustomMatcherOrThrow(E, temp2, undefined);
+const [x, y] = temp4;
+//# sourceMappingURL=./nested.esc.map

--- a/fixtures/extractors/rest_arg/rest_arg.esc
+++ b/fixtures/extractors/rest_arg/rest_arg.esc
@@ -1,0 +1,2 @@
+val subject = C("hello", 5, true)
+val C(x, ...y) = subject

--- a/fixtures/extractors/rest_arg/rest_arg.esc.map
+++ b/fixtures/extractors/rest_arg/rest_arg.esc.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./rest_arg.js","sources":["./rest_arg.esc"],"sourcesContent":["val subject = C(\"hello\", 5, true)\nval C(x, ...y) = subject\n"],"names":[],"mappings":"MAAI,AAAA,UAAU,AAAA,EAAE,SAAQ,GAAG;qDACvB,GAAa;MAAX,AAAA;MAAM,AAAA"}

--- a/fixtures/extractors/rest_arg/rest_arg.js
+++ b/fixtures/extractors/rest_arg/rest_arg.js
@@ -1,0 +1,5 @@
+const subject = C("hello", 5, true);
+const [temp1, ...temp2] = InvokeCustomMatcherOrThrow(C, subject, undefined);
+const x = temp1;
+const y = temp2;
+//# sourceMappingURL=./rest_arg.esc.map

--- a/internal/ast/pattern.go
+++ b/internal/ast/pattern.go
@@ -119,14 +119,42 @@ func (p *TuplePat) Span() Span             { return p.span }
 func (p *TuplePat) InferredType() Type     { return p.inferredType }
 func (p *TuplePat) SetInferredType(t Type) { p.inferredType = t }
 
+type ExtractPatArg interface {
+	isExtractPatArg()
+}
+
+func (*ExtractArgPat) isExtractPatArg()     {}
+func (*ExtractRestArgPat) isExtractPatArg() {}
+
+type ExtractArgPat struct {
+	Pattern Pat
+	Default Expr // optional
+	span    Span
+}
+
+func NewExtractArgPat(pattern Pat, _default Expr, span Span) *ExtractArgPat {
+	return &ExtractArgPat{Pattern: pattern, Default: _default, span: span}
+}
+func (p *ExtractArgPat) Span() Span { return p.span }
+
+type ExtractRestArgPat struct {
+	Pattern Pat
+	span    Span
+}
+
+func NewExtractRestArgPat(pattern Pat, span Span) *ExtractRestArgPat {
+	return &ExtractRestArgPat{Pattern: pattern, span: span}
+}
+func (p *ExtractRestArgPat) Span() Span { return p.span }
+
 type ExtractPat struct {
 	Name         string // TODO: QualIdent
-	Args         []Pat
+	Args         []ExtractPatArg
 	span         Span
 	inferredType Type
 }
 
-func NewExtractPat(name string, args []Pat, span Span) *ExtractPat {
+func NewExtractPat(name string, args []ExtractPatArg, span Span) *ExtractPat {
 	return &ExtractPat{Name: name, Args: args, span: span, inferredType: nil}
 }
 func (p *ExtractPat) Span() Span             { return p.span }

--- a/internal/parser/__snapshots__/pattern_test.snap
+++ b/internal/parser/__snapshots__/pattern_test.snap
@@ -99,21 +99,35 @@
 &ast.ExtractPat{
     Name: "Foo",
     Args: {
-        &ast.IdentPat{
-            Name: "a",
-            span: ast.Span{
+        &ast.ExtractArgPat{
+            Pattern: &ast.IdentPat{
+                Name: "a",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:5},
+                    End:   ast.Location{Line:1, Column:6},
+                },
+                inferredType: nil,
+            },
+            Default: nil,
+            span:    ast.Span{
                 Start: ast.Location{Line:1, Column:5},
                 End:   ast.Location{Line:1, Column:6},
             },
-            inferredType: nil,
         },
-        &ast.IdentPat{
-            Name: "b",
-            span: ast.Span{
+        &ast.ExtractArgPat{
+            Pattern: &ast.IdentPat{
+                Name: "b",
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:8},
+                    End:   ast.Location{Line:1, Column:9},
+                },
+                inferredType: nil,
+            },
+            Default: nil,
+            span:    ast.Span{
                 Start: ast.Location{Line:1, Column:8},
                 End:   ast.Location{Line:1, Column:9},
             },
-            inferredType: nil,
         },
     },
     span: ast.Span{


### PR DESCRIPTION
This PR converts "extract" patterns in Escalier to Extractors in JavaScript.  Extractors are a TC39 proposal which are described in the following way by the proposal:
> Extractors would augment the syntax for BindingPattern and AssignmentPattern to allow for new destructuring forms, as in the following example:

The plan is to use these as the basis for enums in Escalier.

NOTE: This needs and implementation of `InvokeCustomMatcherOrThrow` before the code will be able to run.  I'll do that in a future PR.