### PR TITLE
Add 'expect' helper function in Parser, refactor expr.go to use (p *Parser)

### DIFF
--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -234,10 +234,10 @@
 []*parser.Error{
     &parser.Error{
         Span: ast.Span{
-            Start: ast.Location{Line:1, Column:1},
-            End:   ast.Location{Line:1, Column:2},
+            Start: ast.Location{Line:1, Column:9},
+            End:   ast.Location{Line:1, Column:10},
         },
-        Message: "Expected a closing bracket",
+        Message: "Expected ] but got )",
     },
 }
 ---
@@ -294,13 +294,6 @@
         },
         Message: "Expected an opening brace",
     },
-    &parser.Error{
-        Span: ast.Span{
-            Start: ast.Location{Line:1, Column:9},
-            End:   ast.Location{Line:1, Column:10},
-        },
-        Message: "Expected an opening brace",
-    },
 }
 ---
 
@@ -335,10 +328,10 @@
 []*parser.Error{
     &parser.Error{
         Span: ast.Span{
-            Start: ast.Location{Line:1, Column:5},
-            End:   ast.Location{Line:1, Column:6},
+            Start: ast.Location{Line:1, Column:11},
+            End:   ast.Location{Line:1, Column:12},
         },
-        Message: "Expected a closing paren",
+        Message: "Expected ) but got ]",
     },
 }
 ---
@@ -625,7 +618,7 @@
             Start: ast.Location{Line:1, Column:10},
             End:   ast.Location{Line:1, Column:11},
         },
-        Message: "Expected a closing paren",
+        Message: "Expected ) but got {",
     },
 }
 ---
@@ -751,7 +744,7 @@
             Start: ast.Location{Line:1, Column:4},
             End:   ast.Location{Line:1, Column:5},
         },
-        Message: "Expected an opening paren",
+        Message: "Expected ( but got identifier",
     },
 }
 ---
@@ -2554,7 +2547,7 @@
             Start: ast.Location{Line:1, Column:10},
             End:   ast.Location{Line:1, Column:13},
         },
-        Message: "Expected a comma",
+        Message: "Expected , but got identifier",
     },
 }
 ---

--- a/internal/parser/expect.go
+++ b/internal/parser/expect.go
@@ -1,0 +1,75 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+var TokenMap = map[TokenType]string{
+	Identifier:          "identifier",
+	Number:              "number",
+	String:              "string",
+	True:                "true",
+	False:               "false",
+	Asterisk:            "*",
+	Plus:                "+",
+	Minus:               "-",
+	OpenParen:           "(",
+	CloseParen:          ")",
+	OpenBracket:         "[",
+	CloseBracket:        "]",
+	OpenBrace:           "{",
+	CloseBrace:          "}",
+	Comma:               ",",
+	Dot:                 ".",
+	Colon:               ":",
+	Question:            "?",
+	QuestionDot:         "?.",
+	QuestionOpenParen:   "?(",
+	QuestionOpenBracket: "?[",
+	Fn:                  "fn",
+	Val:                 "val",
+	Var:                 "var",
+	Return:              "return",
+	Declare:             "declare",
+	Export:              "export",
+	Import:              "import",
+	If:                  "if",
+	Else:                "else",
+	Match:               "match",
+	Try:                 "try",
+	Catch:               "catch",
+	Finally:             "finally",
+	Throw:               "throw",
+	Async:               "async",
+	Await:               "await",
+	Gen:                 "gen",
+	Yield:               "yield",
+}
+
+type Consume int
+
+const (
+	AlwaysConsume Consume = iota
+	ConsumeOnMatch
+	ConsumeOnMismatch
+)
+
+func (p *Parser) expect(tt TokenType, consume Consume) ast.Location {
+	token := p.lexer.peek()
+	if consume == AlwaysConsume {
+		p.lexer.consume()
+	}
+	if token.Type != tt {
+		if consume == ConsumeOnMismatch {
+			p.lexer.consume()
+		}
+		p.reportError(token.Span, fmt.Sprintf("Expected %s but got %s", TokenMap[tt], TokenMap[token.Type]))
+		return token.Span.End
+	}
+	if consume == ConsumeOnMatch {
+		p.lexer.consume()
+	}
+	return token.Span.End
+}


### PR DESCRIPTION
This dedupes some of the logic, but the error recovery is still quite _ad hoc_.