### PR TITLE
Update all optional fields to use go-optional's Option[T] type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/maruel/natural v1.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/moznion/go-optional v0.12.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/moznion/go-optional v0.12.0 h1:gM9YSR7kusSQHiaq2IDHU7WoJNGETT1NbuB15XU4ebA=
+github.com/moznion/go-optional v0.12.0/go.mod h1:UP85Bc+uliSDFDzN7Zw8D6gBO1bdPChKFpNu1DJfCqE=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -1,6 +1,10 @@
 package ast
 
-import "math/big"
+import (
+	"math/big"
+
+	"github.com/moznion/go-optional"
+)
 
 //sumtype:decl
 type Expr interface {
@@ -291,12 +295,12 @@ func (e *ObjectExpr) SetInferredType(t Type) { e.inferredType = t }
 type IfElseExpr struct {
 	Cond         Expr
 	Cons         Block
-	Alt          BlockOrExpr // optional
+	Alt          optional.Option[BlockOrExpr]
 	span         Span
 	inferredType Type
 }
 
-func NewIfElse(cond Expr, cons Block, alt BlockOrExpr, span Span) *IfElseExpr {
+func NewIfElse(cond Expr, cons Block, alt optional.Option[BlockOrExpr], span Span) *IfElseExpr {
 	return &IfElseExpr{Cond: cond, Cons: cons, Alt: alt, span: span, inferredType: nil}
 }
 func (e *IfElseExpr) Span() Span             { return e.span }
@@ -307,12 +311,12 @@ type IfLetExpr struct {
 	Pattern      Pat
 	Target       Expr
 	Cons         Block
-	Alt          BlockOrExpr // optional
+	Alt          optional.Option[BlockOrExpr]
 	span         Span
 	inferredType Type
 }
 
-func NewIfLet(pattern Pat, target Expr, cons Block, alt BlockOrExpr, span Span) *IfLetExpr {
+func NewIfLet(pattern Pat, target Expr, cons Block, alt optional.Option[BlockOrExpr], span Span) *IfLetExpr {
 	return &IfLetExpr{Pattern: pattern, Target: target, Cons: cons, Alt: alt, span: span, inferredType: nil}
 }
 func (e *IfLetExpr) Span() Span             { return e.span }
@@ -321,7 +325,7 @@ func (e *IfLetExpr) SetInferredType(t Type) { e.inferredType = t }
 
 type MatchCase struct {
 	Pattern Pat
-	Guard   Expr // optional
+	Guard   optional.Option[Expr]
 	Body    BlockOrExpr
 	span    Span
 }
@@ -357,12 +361,12 @@ func (e *AssignExpr) SetInferredType(t Type) { e.inferredType = t }
 type TryCatchExpr struct {
 	Try          Block
 	Catch        []*MatchCase // optional
-	Finally      *Block       // optional
+	Finally      optional.Option[*Block]
 	span         Span
 	inferredType Type
 }
 
-func NewTryCatch(try Block, catch []*MatchCase, finally *Block, span Span) *TryCatchExpr {
+func NewTryCatch(try Block, catch []*MatchCase, finally optional.Option[*Block], span Span) *TryCatchExpr {
 	return &TryCatchExpr{Try: try, Catch: catch, Finally: finally, span: span, inferredType: nil}
 }
 func (e *TryCatchExpr) Span() Span             { return e.span }

--- a/internal/ast/obj_elem.go
+++ b/internal/ast/obj_elem.go
@@ -1,5 +1,7 @@
 package ast
 
+import "github.com/moznion/go-optional"
+
 type ObjExprElem interface{ isObjExprElem() }
 
 func (*Callable[FuncExpr]) isObjExprElem()           {}
@@ -71,20 +73,20 @@ func NewProperty[T any, PN any](name PN, value T) *Property[T, PN] {
 	}
 }
 
-type IndexParam[T any] struct {
+type IndexParam[T Node] struct {
 	Name       string
 	Constraint T
 }
 
-type Mapped[T any] struct {
+type Mapped[T Node] struct {
 	TypeParam *IndexParam[T]
-	Name      T // optional, used for renaming keys
+	Name      optional.Option[T]
 	Value     T
 	Optional  *MappedModifier // TODO: replace with `?`, `!`, or nothing
 	ReadOnly  *MappedModifier
 }
 
-type RestSpread[T any] struct {
+type RestSpread[T Node] struct {
 	Value T
 }
 

--- a/internal/ast/pattern.go
+++ b/internal/ast/pattern.go
@@ -1,5 +1,7 @@
 package ast
 
+import "github.com/moznion/go-optional"
+
 type Pat interface {
 	isPat()
 	Node
@@ -17,12 +19,12 @@ func (*WildcardPat) isPat()  {}
 
 type IdentPat struct {
 	Name         string
-	Default      Expr // optional
+	Default      optional.Option[Expr]
 	span         Span
 	inferredType Type
 }
 
-func NewIdentPat(name string, _default Expr, span Span) *IdentPat {
+func NewIdentPat(name string, _default optional.Option[Expr], span Span) *IdentPat {
 	return &IdentPat{Name: name, Default: _default, span: span, inferredType: nil}
 }
 func (p *IdentPat) Span() Span             { return p.span }
@@ -38,23 +40,23 @@ func (*ObjRestPat) isObjPatElem()      {}
 type ObjKeyValuePat struct {
 	Key          string
 	Value        Pat
-	Default      Expr // optional
+	Default      optional.Option[Expr]
 	span         Span
 	inferredType Type
 }
 
-func NewObjKeyValuePat(key string, value Pat, _default Expr, span Span) *ObjKeyValuePat {
+func NewObjKeyValuePat(key string, value Pat, _default optional.Option[Expr], span Span) *ObjKeyValuePat {
 	return &ObjKeyValuePat{Key: key, Value: value, Default: _default, span: span, inferredType: nil}
 }
 func (p *ObjKeyValuePat) Span() Span { return p.span }
 
 type ObjShorthandPat struct {
 	Key     string
-	Default Expr // optional
+	Default optional.Option[Expr]
 	span    Span
 }
 
-func NewObjShorthandPat(key string, _default Expr, span Span) *ObjShorthandPat {
+func NewObjShorthandPat(key string, _default optional.Option[Expr], span Span) *ObjShorthandPat {
 	return &ObjShorthandPat{Key: key, Default: _default, span: span}
 }
 func (p *ObjShorthandPat) Span() Span { return p.span }

--- a/internal/ast/stmt.go
+++ b/internal/ast/stmt.go
@@ -1,5 +1,7 @@
 package ast
 
+import "github.com/moznion/go-optional"
+
 //sumtype:decl
 type Stmt interface {
 	isStmt()
@@ -29,11 +31,11 @@ func (*DeclStmt) isStmt()      {}
 func (s *DeclStmt) Span() Span { return s.span }
 
 type ReturnStmt struct {
-	Expr Expr // optional
+	Expr optional.Option[Expr]
 	span Span
 }
 
-func NewReturnStmt(expr Expr, span Span) *ReturnStmt {
+func NewReturnStmt(expr optional.Option[Expr], span Span) *ReturnStmt {
 	return &ReturnStmt{Expr: expr, span: span}
 }
 func (*ReturnStmt) isStmt()      {}

--- a/internal/codegen/ast.go
+++ b/internal/codegen/ast.go
@@ -1,6 +1,9 @@
 package codegen
 
-import "github.com/escalier-lang/escalier/internal/ast"
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/moznion/go-optional"
+)
 
 type Node interface {
 	Span() *Span
@@ -323,7 +326,7 @@ func (s *DeclStmt) SetSpan(span *Span) { s.span = span }
 func (s *DeclStmt) Source() ast.Node   { return s.source }
 
 type ReturnStmt struct {
-	Expr   Expr
+	Expr   optional.Option[Expr]
 	span   *Span
 	source ast.Node
 }
@@ -350,12 +353,12 @@ func (*RestPat) isPat()   {}
 
 type IdentPat struct {
 	Name    string
-	Default Expr // optional
+	Default optional.Option[Expr]
 	span    *Span
 	source  ast.Node
 }
 
-func NewIdentPat(name string, _default Expr, source ast.Node) *IdentPat {
+func NewIdentPat(name string, _default optional.Option[Expr], source ast.Node) *IdentPat {
 	return &IdentPat{Name: name, Default: _default, source: source, span: nil}
 }
 func (p *IdentPat) Span() *Span        { return p.span }
@@ -374,12 +377,12 @@ func (*ObjRestPat) isObjPatElem()      {}
 type ObjKeyValuePat struct {
 	Key     string
 	Value   Pat
-	Default Expr // optional
+	Default optional.Option[Expr]
 	source  ast.Node
 	span    *Span
 }
 
-func NewObjKeyValuePat(key string, value Pat, _default Expr, source ast.Node) *ObjKeyValuePat {
+func NewObjKeyValuePat(key string, value Pat, _default optional.Option[Expr], source ast.Node) *ObjKeyValuePat {
 	return &ObjKeyValuePat{Key: key, Value: value, Default: _default, source: source, span: nil}
 }
 func (p *ObjKeyValuePat) Span() *Span        { return p.span }
@@ -388,12 +391,12 @@ func (p *ObjKeyValuePat) Source() ast.Node   { return p.source }
 
 type ObjShorthandPat struct {
 	Key     string
-	Default Expr // optional
+	Default optional.Option[Expr]
 	source  ast.Node
 	span    *Span
 }
 
-func NewObjShorthandPat(key string, _default Expr, source ast.Node) *ObjShorthandPat {
+func NewObjShorthandPat(key string, _default optional.Option[Expr], source ast.Node) *ObjShorthandPat {
 	return &ObjShorthandPat{Key: key, Default: _default, source: source, span: nil}
 }
 func (p *ObjShorthandPat) Span() *Span        { return p.span }
@@ -436,12 +439,12 @@ func (*TupleRestPat) isTuplePatElem() {}
 
 type TupleElemPat struct {
 	Pattern Pat
-	Default Expr // optional
+	Default optional.Option[Expr]
 	source  ast.Node
 	span    *Span
 }
 
-func NewTupleElemPat(pattern Pat, _default Expr, source ast.Node) *TupleElemPat {
+func NewTupleElemPat(pattern Pat, _default optional.Option[Expr], source ast.Node) *TupleElemPat {
 	return &TupleElemPat{Pattern: pattern, Default: _default, source: source, span: nil}
 }
 func (p *TupleElemPat) Span() *Span        { return p.span }

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -155,10 +155,10 @@ func (p *Printer) printPattern(pat Pat) {
 	switch pat := pat.(type) {
 	case *IdentPat:
 		p.print(pat.Name)
-		if pat.Default != nil {
+		pat.Default.IfSome(func(e Expr) {
 			p.print(" = ")
-			p.PrintExpr(pat.Default)
-		}
+			p.PrintExpr(e)
+		})
 	case *ObjectPat:
 		p.print("{")
 		for i, elem := range pat.Elems {
@@ -170,16 +170,16 @@ func (p *Printer) printPattern(pat Pat) {
 				p.print(elem.Key)
 				p.print(": ")
 				p.printPattern(elem.Value)
-				if elem.Default != nil {
+				elem.Default.IfSome(func(e Expr) {
 					p.print(" = ")
-					p.PrintExpr(elem.Default)
-				}
+					p.PrintExpr(e)
+				})
 			case *ObjShorthandPat:
 				p.print(elem.Key)
-				if elem.Default != nil {
+				elem.Default.IfSome(func(e Expr) {
 					p.print(" = ")
-					p.PrintExpr(elem.Default)
-				}
+					p.PrintExpr(e)
+				})
 			case *ObjRestPat:
 				p.print("...")
 				p.printPattern(elem.Pattern)
@@ -272,10 +272,10 @@ func (p *Printer) PrintStmt(stmt Stmt) {
 		p.PrintDecl(s.Decl)
 	case *ReturnStmt:
 		p.print("return")
-		if s.Expr != nil {
+		s.Expr.IfSome(func(e Expr) {
 			p.print(" ")
-			p.PrintExpr(s.Expr)
-		}
+			p.PrintExpr(e)
+		})
 		p.print(";")
 	}
 

--- a/internal/codegen/source_map.go
+++ b/internal/codegen/source_map.go
@@ -106,7 +106,9 @@ func (s *SourceMapGenerator) TraverseStmt(stmt Stmt) {
 		s.TraverseDecl(sk.Decl)
 	case *ReturnStmt:
 		s.AddSegmentForNode(stmt)
-		s.TraverseExpr(sk.Expr)
+		sk.Expr.IfSome(func(e Expr) {
+			s.TraverseExpr(e)
+		})
 	}
 }
 
@@ -154,9 +156,9 @@ func (s *SourceMapGenerator) TraversePattern(pattern Pat) {
 			s.TraversePattern(elem)
 			switch elem := elem.(type) {
 			case *IdentPat:
-				if elem.Default != nil {
-					s.TraverseExpr(elem.Default)
-				}
+				elem.Default.IfSome(func(e Expr) {
+					s.TraverseExpr(e)
+				})
 			default:
 				// TODO: handle defaults for other types of patterns
 			}
@@ -167,12 +169,14 @@ func (s *SourceMapGenerator) TraversePattern(pattern Pat) {
 			case *ObjKeyValuePat:
 				// s.AddSegmentForNode(elem.Key)
 				s.TraversePattern(elem.Value)
-				s.TraverseExpr(elem.Default)
+				elem.Default.IfSome(func(e Expr) {
+					s.TraverseExpr(e)
+				})
 			case *ObjShorthandPat:
 				// s.AddSegmentForNode(elem.Key)
-				if elem.Default != nil {
-					s.TraverseExpr(elem.Default)
-				}
+				elem.Default.IfSome(func(e Expr) {
+					s.TraverseExpr(e)
+				})
 			case *ObjRestPat:
 				s.TraversePattern(elem.Pattern)
 			default:

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -24,30 +24,32 @@
             End:   ast.Location{Line:1, Column:9},
         },
     },
-    Alt: ast.BlockOrExpr{
-        Block: &ast.Block{
-            Stmts: {
-                &ast.ExprStmt{
-                    Expr: &ast.IdentExpr{
-                        Name: "b",
+    Alt: {
+        {
+            Block: &ast.Block{
+                Stmts: {
+                    &ast.ExprStmt{
+                        Expr: &ast.IdentExpr{
+                            Name: "b",
+                            span: ast.Span{
+                                Start: ast.Location{Line:1, Column:17},
+                                End:   ast.Location{Line:1, Column:18},
+                            },
+                            inferredType: nil,
+                        },
                         span: ast.Span{
                             Start: ast.Location{Line:1, Column:17},
                             End:   ast.Location{Line:1, Column:18},
                         },
-                        inferredType: nil,
-                    },
-                    span: ast.Span{
-                        Start: ast.Location{Line:1, Column:17},
-                        End:   ast.Location{Line:1, Column:18},
                     },
                 },
+                Span: ast.Span{
+                    Start: ast.Location{Line:1, Column:15},
+                    End:   ast.Location{Line:1, Column:20},
+                },
             },
-            Span: ast.Span{
-                Start: ast.Location{Line:1, Column:15},
-                End:   ast.Location{Line:1, Column:20},
-            },
+            Expr: nil,
         },
-        Expr: nil,
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
@@ -84,7 +86,7 @@
         },
         Span: ast.Span{},
     },
-    Alt:  ast.BlockOrExpr{},
+    Alt:  nil,
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:11},
@@ -790,7 +792,7 @@
             End:   ast.Location{Line:1, Column:9},
         },
     },
-    Alt:  ast.BlockOrExpr{},
+    Alt:  nil,
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
         End:   ast.Location{Line:1, Column:14},
@@ -849,19 +851,21 @@
                 Body:   ast.Block{
                     Stmts: {
                         &ast.ReturnStmt{
-                            Expr: &ast.LiteralExpr{
-                                Lit: &ast.NumLit{
-                                    Value: 5,
-                                    span:  ast.Span{
+                            Expr: {
+                                &ast.LiteralExpr{
+                                    Lit: &ast.NumLit{
+                                        Value: 5,
+                                        span:  ast.Span{
+                                            Start: ast.Location{Line:1, Column:22},
+                                            End:   ast.Location{Line:1, Column:23},
+                                        },
+                                    },
+                                    span: ast.Span{
                                         Start: ast.Location{Line:1, Column:22},
                                         End:   ast.Location{Line:1, Column:23},
                                     },
+                                    inferredType: nil,
                                 },
-                                span: ast.Span{
-                                    Start: ast.Location{Line:1, Column:22},
-                                    End:   ast.Location{Line:1, Column:23},
-                                },
-                                inferredType: nil,
                             },
                             span: ast.Span{
                                 Start: ast.Location{Line:1, Column:15},
@@ -909,28 +913,30 @@
                 Body:   ast.Block{
                     Stmts: {
                         &ast.ReturnStmt{
-                            Expr: &ast.MemberExpr{
-                                Object: &ast.IdentExpr{
-                                    Name: "self",
-                                    span: ast.Span{
+                            Expr: {
+                                &ast.MemberExpr{
+                                    Object: &ast.IdentExpr{
+                                        Name: "self",
+                                        span: ast.Span{
+                                            Start: ast.Location{Line:1, Column:50},
+                                            End:   ast.Location{Line:1, Column:54},
+                                        },
+                                        inferredType: nil,
+                                    },
+                                    Prop: &ast.Ident{
+                                        Name: "x",
+                                        span: ast.Span{
+                                            Start: ast.Location{Line:1, Column:55},
+                                            End:   ast.Location{Line:1, Column:56},
+                                        },
+                                    },
+                                    OptChain: false,
+                                    span:     ast.Span{
                                         Start: ast.Location{Line:1, Column:50},
-                                        End:   ast.Location{Line:1, Column:54},
+                                        End:   ast.Location{Line:1, Column:56},
                                     },
                                     inferredType: nil,
                                 },
-                                Prop: &ast.Ident{
-                                    Name: "x",
-                                    span: ast.Span{
-                                        Start: ast.Location{Line:1, Column:55},
-                                        End:   ast.Location{Line:1, Column:56},
-                                    },
-                                },
-                                OptChain: false,
-                                span:     ast.Span{
-                                    Start: ast.Location{Line:1, Column:50},
-                                    End:   ast.Location{Line:1, Column:56},
-                                },
-                                inferredType: nil,
                             },
                             span: ast.Span{
                                 Start: ast.Location{Line:1, Column:43},
@@ -1482,30 +1488,32 @@
             End:   ast.Location{Line:1, Column:14},
         },
     },
-    Alt: ast.BlockOrExpr{
-        Block: &ast.Block{
-            Stmts: {
-                &ast.ExprStmt{
-                    Expr: &ast.IdentExpr{
-                        Name: "b",
+    Alt: {
+        {
+            Block: &ast.Block{
+                Stmts: {
+                    &ast.ExprStmt{
+                        Expr: &ast.IdentExpr{
+                            Name: "b",
+                            span: ast.Span{
+                                Start: ast.Location{Line:1, Column:22},
+                                End:   ast.Location{Line:1, Column:23},
+                            },
+                            inferredType: nil,
+                        },
                         span: ast.Span{
                             Start: ast.Location{Line:1, Column:22},
                             End:   ast.Location{Line:1, Column:23},
                         },
-                        inferredType: nil,
-                    },
-                    span: ast.Span{
-                        Start: ast.Location{Line:1, Column:22},
-                        End:   ast.Location{Line:1, Column:23},
                     },
                 },
+                Span: ast.Span{
+                    Start: ast.Location{Line:1, Column:20},
+                    End:   ast.Location{Line:1, Column:25},
+                },
             },
-            Span: ast.Span{
-                Start: ast.Location{Line:1, Column:20},
-                End:   ast.Location{Line:1, Column:25},
-            },
+            Expr: nil,
         },
-        Expr: nil,
     },
     span: ast.Span{
         Start: ast.Location{Line:1, Column:1},
@@ -1633,69 +1641,73 @@
             End:   ast.Location{Line:1, Column:15},
         },
     },
-    Alt: ast.BlockOrExpr{
-        Block: (*ast.Block)(nil),
-        Expr:  &ast.IfElseExpr{
-            Cond: &ast.IdentExpr{
-                Name: "cond2",
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:24},
-                    End:   ast.Location{Line:1, Column:29},
-                },
-                inferredType: nil,
-            },
-            Cons: ast.Block{
-                Stmts: {
-                    &ast.ExprStmt{
-                        Expr: &ast.IdentExpr{
-                            Name: "b",
-                            span: ast.Span{
-                                Start: ast.Location{Line:1, Column:32},
-                                End:   ast.Location{Line:1, Column:33},
-                            },
-                            inferredType: nil,
-                        },
-                        span: ast.Span{
-                            Start: ast.Location{Line:1, Column:32},
-                            End:   ast.Location{Line:1, Column:33},
-                        },
+    Alt: {
+        {
+            Block: (*ast.Block)(nil),
+            Expr:  &ast.IfElseExpr{
+                Cond: &ast.IdentExpr{
+                    Name: "cond2",
+                    span: ast.Span{
+                        Start: ast.Location{Line:1, Column:24},
+                        End:   ast.Location{Line:1, Column:29},
                     },
+                    inferredType: nil,
                 },
-                Span: ast.Span{
-                    Start: ast.Location{Line:1, Column:30},
-                    End:   ast.Location{Line:1, Column:35},
-                },
-            },
-            Alt: ast.BlockOrExpr{
-                Block: &ast.Block{
+                Cons: ast.Block{
                     Stmts: {
                         &ast.ExprStmt{
                             Expr: &ast.IdentExpr{
-                                Name: "c",
+                                Name: "b",
                                 span: ast.Span{
-                                    Start: ast.Location{Line:1, Column:43},
-                                    End:   ast.Location{Line:1, Column:44},
+                                    Start: ast.Location{Line:1, Column:32},
+                                    End:   ast.Location{Line:1, Column:33},
                                 },
                                 inferredType: nil,
                             },
                             span: ast.Span{
-                                Start: ast.Location{Line:1, Column:43},
-                                End:   ast.Location{Line:1, Column:44},
+                                Start: ast.Location{Line:1, Column:32},
+                                End:   ast.Location{Line:1, Column:33},
                             },
                         },
                     },
                     Span: ast.Span{
-                        Start: ast.Location{Line:1, Column:41},
-                        End:   ast.Location{Line:1, Column:46},
+                        Start: ast.Location{Line:1, Column:30},
+                        End:   ast.Location{Line:1, Column:35},
                     },
                 },
-                Expr: nil,
+                Alt: {
+                    {
+                        Block: &ast.Block{
+                            Stmts: {
+                                &ast.ExprStmt{
+                                    Expr: &ast.IdentExpr{
+                                        Name: "c",
+                                        span: ast.Span{
+                                            Start: ast.Location{Line:1, Column:43},
+                                            End:   ast.Location{Line:1, Column:44},
+                                        },
+                                        inferredType: nil,
+                                    },
+                                    span: ast.Span{
+                                        Start: ast.Location{Line:1, Column:43},
+                                        End:   ast.Location{Line:1, Column:44},
+                                    },
+                                },
+                            },
+                            Span: ast.Span{
+                                Start: ast.Location{Line:1, Column:41},
+                                End:   ast.Location{Line:1, Column:46},
+                            },
+                        },
+                        Expr: nil,
+                    },
+                },
+                span: ast.Span{
+                    Start: ast.Location{Line:1, Column:20},
+                    End:   ast.Location{Line:1, Column:46},
+                },
+                inferredType: nil,
             },
-            span: ast.Span{
-                Start: ast.Location{Line:1, Column:20},
-                End:   ast.Location{Line:1, Column:46},
-            },
-            inferredType: nil,
         },
     },
     span: ast.Span{

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -104,29 +104,31 @@
         Body: ast.Block{
             Stmts: {
                 &ast.ReturnStmt{
-                    Expr: &ast.BinaryExpr{
-                        Left: &ast.IdentExpr{
-                            Name: "a",
+                    Expr: {
+                        &ast.BinaryExpr{
+                            Left: &ast.IdentExpr{
+                                Name: "a",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:3, Column:13},
+                                    End:   ast.Location{Line:3, Column:14},
+                                },
+                                inferredType: nil,
+                            },
+                            Op:    0,
+                            Right: &ast.IdentExpr{
+                                Name: "b",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:3, Column:17},
+                                    End:   ast.Location{Line:3, Column:18},
+                                },
+                                inferredType: nil,
+                            },
                             span: ast.Span{
                                 Start: ast.Location{Line:3, Column:13},
-                                End:   ast.Location{Line:3, Column:14},
-                            },
-                            inferredType: nil,
-                        },
-                        Op:    0,
-                        Right: &ast.IdentExpr{
-                            Name: "b",
-                            span: ast.Span{
-                                Start: ast.Location{Line:3, Column:17},
                                 End:   ast.Location{Line:3, Column:18},
                             },
                             inferredType: nil,
                         },
-                        span: ast.Span{
-                            Start: ast.Location{Line:3, Column:13},
-                            End:   ast.Location{Line:3, Column:18},
-                        },
-                        inferredType: nil,
                     },
                     span: ast.Span{
                         Start: ast.Location{Line:3, Column:6},
@@ -553,29 +555,31 @@
         Body: ast.Block{
             Stmts: {
                 &ast.ReturnStmt{
-                    Expr: &ast.BinaryExpr{
-                        Left: &ast.IdentExpr{
-                            Name: "a",
+                    Expr: {
+                        &ast.BinaryExpr{
+                            Left: &ast.IdentExpr{
+                                Name: "a",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:6, Column:13},
+                                    End:   ast.Location{Line:6, Column:14},
+                                },
+                                inferredType: nil,
+                            },
+                            Op:    1,
+                            Right: &ast.IdentExpr{
+                                Name: "b",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:6, Column:17},
+                                    End:   ast.Location{Line:6, Column:18},
+                                },
+                                inferredType: nil,
+                            },
                             span: ast.Span{
                                 Start: ast.Location{Line:6, Column:13},
-                                End:   ast.Location{Line:6, Column:14},
-                            },
-                            inferredType: nil,
-                        },
-                        Op:    1,
-                        Right: &ast.IdentExpr{
-                            Name: "b",
-                            span: ast.Span{
-                                Start: ast.Location{Line:6, Column:17},
                                 End:   ast.Location{Line:6, Column:18},
                             },
                             inferredType: nil,
                         },
-                        span: ast.Span{
-                            Start: ast.Location{Line:6, Column:13},
-                            End:   ast.Location{Line:6, Column:18},
-                        },
-                        inferredType: nil,
                     },
                     span: ast.Span{
                         Start: ast.Location{Line:6, Column:6},
@@ -698,60 +702,67 @@
                     End:   ast.Location{Line:5, Column:6},
                 },
             },
-            Alt: ast.BlockOrExpr{
-                Block: &ast.Block{
-                    Stmts: {
-                        &ast.DeclStmt{
-                            Decl: &ast.VarDecl{
-                                Kind:    1,
-                                Pattern: &ast.IdentPat{
-                                    Name:    "b",
-                                    Default: nil,
-                                    span:    ast.Span{
-                                        Start: ast.Location{Line:6, Column:11},
-                                        End:   ast.Location{Line:6, Column:12},
+            Alt: {
+                {
+                    Block: &ast.Block{
+                        Stmts: {
+                            &ast.DeclStmt{
+                                Decl: &ast.VarDecl{
+                                    Kind:    1,
+                                    Pattern: &ast.IdentPat{
+                                        Name:    "b",
+                                        Default: nil,
+                                        span:    ast.Span{
+                                            Start: ast.Location{Line:6, Column:11},
+                                            End:   ast.Location{Line:6, Column:12},
+                                        },
+                                        inferredType: nil,
                                     },
-                                    inferredType: nil,
-                                },
-                                Init: &ast.LiteralExpr{
-                                    Lit: &ast.NumLit{
-                                        Value: 10,
-                                        span:  ast.Span{
+                                    Init: &ast.LiteralExpr{
+                                        Lit: &ast.NumLit{
+                                            Value: 10,
+                                            span:  ast.Span{
+                                                Start: ast.Location{Line:6, Column:15},
+                                                End:   ast.Location{Line:6, Column:17},
+                                            },
+                                        },
+                                        span: ast.Span{
                                             Start: ast.Location{Line:6, Column:15},
                                             End:   ast.Location{Line:6, Column:17},
                                         },
+                                        inferredType: nil,
                                     },
-                                    span: ast.Span{
-                                        Start: ast.Location{Line:6, Column:15},
+                                    export:  false,
+                                    declare: false,
+                                    span:    ast.Span{
+                                        Start: ast.Location{Line:6, Column:7},
                                         End:   ast.Location{Line:6, Column:17},
                                     },
-                                    inferredType: nil,
                                 },
-                                export:  false,
-                                declare: false,
-                                span:    ast.Span{
+                                span: ast.Span{
                                     Start: ast.Location{Line:6, Column:7},
                                     End:   ast.Location{Line:6, Column:17},
                                 },
                             },
-                            span: ast.Span{
-                                Start: ast.Location{Line:6, Column:7},
-                                End:   ast.Location{Line:6, Column:17},
-                            },
-                        },
-                        &ast.ExprStmt{
-                            Expr: &ast.UnaryExpr{
-                                Op:  1,
-                                Arg: &ast.LiteralExpr{
-                                    Lit: &ast.NumLit{
-                                        Value: 5,
-                                        span:  ast.Span{
+                            &ast.ExprStmt{
+                                Expr: &ast.UnaryExpr{
+                                    Op:  1,
+                                    Arg: &ast.LiteralExpr{
+                                        Lit: &ast.NumLit{
+                                            Value: 5,
+                                            span:  ast.Span{
+                                                Start: ast.Location{Line:7, Column:7},
+                                                End:   ast.Location{Line:7, Column:8},
+                                            },
+                                        },
+                                        span: ast.Span{
                                             Start: ast.Location{Line:7, Column:7},
                                             End:   ast.Location{Line:7, Column:8},
                                         },
+                                        inferredType: nil,
                                     },
                                     span: ast.Span{
-                                        Start: ast.Location{Line:7, Column:7},
+                                        Start: ast.Location{Line:7, Column:6},
                                         End:   ast.Location{Line:7, Column:8},
                                     },
                                     inferredType: nil,
@@ -760,20 +771,15 @@
                                     Start: ast.Location{Line:7, Column:6},
                                     End:   ast.Location{Line:7, Column:8},
                                 },
-                                inferredType: nil,
-                            },
-                            span: ast.Span{
-                                Start: ast.Location{Line:7, Column:6},
-                                End:   ast.Location{Line:7, Column:8},
                             },
                         },
+                        Span: ast.Span{
+                            Start: ast.Location{Line:5, Column:12},
+                            End:   ast.Location{Line:8, Column:6},
+                        },
                     },
-                    Span: ast.Span{
-                        Start: ast.Location{Line:5, Column:12},
-                        End:   ast.Location{Line:8, Column:6},
-                    },
+                    Expr: nil,
                 },
-                Expr: nil,
             },
             span: ast.Span{
                 Start: ast.Location{Line:2, Column:12},

--- a/internal/parser/__snapshots__/pattern_test.snap
+++ b/internal/parser/__snapshots__/pattern_test.snap
@@ -38,19 +38,21 @@
         },
         &ast.IdentPat{
             Name:    "b",
-            Default: &ast.LiteralExpr{
-                Lit: &ast.NumLit{
-                    Value: 5,
-                    span:  ast.Span{
+            Default: {
+                &ast.LiteralExpr{
+                    Lit: &ast.NumLit{
+                        Value: 5,
+                        span:  ast.Span{
+                            Start: ast.Location{Line:1, Column:9},
+                            End:   ast.Location{Line:1, Column:10},
+                        },
+                    },
+                    span: ast.Span{
                         Start: ast.Location{Line:1, Column:9},
                         End:   ast.Location{Line:1, Column:10},
                     },
+                    inferredType: nil,
                 },
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:9},
-                    End:   ast.Location{Line:1, Column:10},
-                },
-                inferredType: nil,
             },
             span: ast.Span{
                 Start: ast.Location{Line:1, Column:5},
@@ -244,19 +246,21 @@
     Elems: {
         &ast.ObjShorthandPat{
             Key:     "a",
-            Default: &ast.LiteralExpr{
-                Lit: &ast.NumLit{
-                    Value: 5,
-                    span:  ast.Span{
+            Default: {
+                &ast.LiteralExpr{
+                    Lit: &ast.NumLit{
+                        Value: 5,
+                        span:  ast.Span{
+                            Start: ast.Location{Line:1, Column:6},
+                            End:   ast.Location{Line:1, Column:7},
+                        },
+                    },
+                    span: ast.Span{
                         Start: ast.Location{Line:1, Column:6},
                         End:   ast.Location{Line:1, Column:7},
                     },
+                    inferredType: nil,
                 },
-                span: ast.Span{
-                    Start: ast.Location{Line:1, Column:6},
-                    End:   ast.Location{Line:1, Column:7},
-                },
-                inferredType: nil,
             },
             span: ast.Span{
                 Start: ast.Location{Line:1, Column:2},
@@ -267,19 +271,21 @@
             Key:   "b",
             Value: &ast.IdentPat{
                 Name:    "c",
-                Default: &ast.LiteralExpr{
-                    Lit: &ast.StrLit{
-                        Value: "hello",
-                        span:  ast.Span{
+                Default: {
+                    &ast.LiteralExpr{
+                        Lit: &ast.StrLit{
+                            Value: "hello",
+                            span:  ast.Span{
+                                Start: ast.Location{Line:1, Column:16},
+                                End:   ast.Location{Line:1, Column:22},
+                            },
+                        },
+                        span: ast.Span{
                             Start: ast.Location{Line:1, Column:16},
                             End:   ast.Location{Line:1, Column:22},
                         },
+                        inferredType: nil,
                     },
-                    span: ast.Span{
-                        Start: ast.Location{Line:1, Column:16},
-                        End:   ast.Location{Line:1, Column:22},
-                    },
-                    inferredType: nil,
                 },
                 span: ast.Span{
                     Start: ast.Location{Line:1, Column:12},

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -444,29 +444,31 @@
         Body: ast.Block{
             Stmts: {
                 &ast.ReturnStmt{
-                    Expr: &ast.BinaryExpr{
-                        Left: &ast.IdentExpr{
-                            Name: "a",
+                    Expr: {
+                        &ast.BinaryExpr{
+                            Left: &ast.IdentExpr{
+                                Name: "a",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:1, Column:23},
+                                    End:   ast.Location{Line:1, Column:24},
+                                },
+                                inferredType: nil,
+                            },
+                            Op:    0,
+                            Right: &ast.IdentExpr{
+                                Name: "b",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:1, Column:27},
+                                    End:   ast.Location{Line:1, Column:28},
+                                },
+                                inferredType: nil,
+                            },
                             span: ast.Span{
                                 Start: ast.Location{Line:1, Column:23},
-                                End:   ast.Location{Line:1, Column:24},
-                            },
-                            inferredType: nil,
-                        },
-                        Op:    0,
-                        Right: &ast.IdentExpr{
-                            Name: "b",
-                            span: ast.Span{
-                                Start: ast.Location{Line:1, Column:27},
                                 End:   ast.Location{Line:1, Column:28},
                             },
                             inferredType: nil,
                         },
-                        span: ast.Span{
-                            Start: ast.Location{Line:1, Column:23},
-                            End:   ast.Location{Line:1, Column:28},
-                        },
-                        inferredType: nil,
                     },
                     span: ast.Span{
                         Start: ast.Location{Line:1, Column:16},
@@ -625,29 +627,31 @@
                     },
                 },
                 &ast.ReturnStmt{
-                    Expr: &ast.BinaryExpr{
-                        Left: &ast.IdentExpr{
-                            Name: "a",
+                    Expr: {
+                        &ast.BinaryExpr{
+                            Left: &ast.IdentExpr{
+                                Name: "a",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:4, Column:12},
+                                    End:   ast.Location{Line:4, Column:13},
+                                },
+                                inferredType: nil,
+                            },
+                            Op:    0,
+                            Right: &ast.IdentExpr{
+                                Name: "b",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:4, Column:16},
+                                    End:   ast.Location{Line:4, Column:17},
+                                },
+                                inferredType: nil,
+                            },
                             span: ast.Span{
                                 Start: ast.Location{Line:4, Column:12},
-                                End:   ast.Location{Line:4, Column:13},
-                            },
-                            inferredType: nil,
-                        },
-                        Op:    0,
-                        Right: &ast.IdentExpr{
-                            Name: "b",
-                            span: ast.Span{
-                                Start: ast.Location{Line:4, Column:16},
                                 End:   ast.Location{Line:4, Column:17},
                             },
                             inferredType: nil,
                         },
-                        span: ast.Span{
-                            Start: ast.Location{Line:4, Column:12},
-                            End:   ast.Location{Line:4, Column:17},
-                        },
-                        inferredType: nil,
                     },
                     span: ast.Span{
                         Start: ast.Location{Line:4, Column:5},
@@ -730,19 +734,21 @@
         Body: ast.Block{
             Stmts: {
                 &ast.ReturnStmt{
-                    Expr: &ast.LiteralExpr{
-                        Lit: &ast.NumLit{
-                            Value: 5,
-                            span:  ast.Span{
+                    Expr: {
+                        &ast.LiteralExpr{
+                            Lit: &ast.NumLit{
+                                Value: 5,
+                                span:  ast.Span{
+                                    Start: ast.Location{Line:1, Column:15},
+                                    End:   ast.Location{Line:1, Column:16},
+                                },
+                            },
+                            span: ast.Span{
                                 Start: ast.Location{Line:1, Column:15},
                                 End:   ast.Location{Line:1, Column:16},
                             },
+                            inferredType: nil,
                         },
-                        span: ast.Span{
-                            Start: ast.Location{Line:1, Column:15},
-                            End:   ast.Location{Line:1, Column:16},
-                        },
-                        inferredType: nil,
                     },
                     span: ast.Span{
                         Start: ast.Location{Line:1, Column:8},
@@ -965,28 +971,30 @@ nil
                     },
                 },
                 &ast.ReturnStmt{
-                    Expr: &ast.BinaryExpr{
-                        Left: &ast.IdentExpr{
-                            Name: "a",
+                    Expr: {
+                        &ast.BinaryExpr{
+                            Left: &ast.IdentExpr{
+                                Name: "a",
+                                span: ast.Span{
+                                    Start: ast.Location{Line:4, Column:12},
+                                    End:   ast.Location{Line:4, Column:13},
+                                },
+                                inferredType: nil,
+                            },
+                            Op:    0,
+                            Right: &ast.EmptyExpr{
+                                span: ast.Span{
+                                    Start: ast.Location{Line:5, Column:4},
+                                    End:   ast.Location{Line:5, Column:5},
+                                },
+                                inferredType: nil,
+                            },
                             span: ast.Span{
                                 Start: ast.Location{Line:4, Column:12},
-                                End:   ast.Location{Line:4, Column:13},
-                            },
-                            inferredType: nil,
-                        },
-                        Op:    0,
-                        Right: &ast.EmptyExpr{
-                            span: ast.Span{
-                                Start: ast.Location{Line:5, Column:4},
                                 End:   ast.Location{Line:5, Column:5},
                             },
                             inferredType: nil,
                         },
-                        span: ast.Span{
-                            Start: ast.Location{Line:4, Column:12},
-                            End:   ast.Location{Line:5, Column:5},
-                        },
-                        inferredType: nil,
                     },
                     span: ast.Span{
                         Start: ast.Location{Line:4, Column:5},

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/moznion/go-optional"
 )
 
 var precedence = map[ast.BinaryOp]int{
@@ -595,26 +596,24 @@ func (p *Parser) parseIfElse() ast.Expr {
 				Expr:  expr,
 				Block: nil,
 			}
-			return ast.NewIfElse(cond, body, alt, ast.Span{Start: start, End: expr.Span().End})
+			return ast.NewIfElse(cond, body, optional.Some(alt), ast.Span{Start: start, End: expr.Span().End})
 		case OpenBrace:
 			block := p.parseBlock()
 			alt := ast.BlockOrExpr{
 				Expr:  nil,
 				Block: &block,
 			}
-			return ast.NewIfElse(cond, body, alt, ast.Span{Start: start, End: block.Span.End})
+			return ast.NewIfElse(cond, body, optional.Some(alt), ast.Span{Start: start, End: block.Span.End})
 		default:
 			p.reportError(token.Span, "Expected an if or an opening brace")
-			alt := ast.BlockOrExpr{
-				Expr:  nil,
-				Block: nil,
-			}
-			return ast.NewIfElse(cond, body, alt, ast.Span{Start: start, End: token.Span.Start})
+			return ast.NewIfElse(
+				cond, body, optional.None[ast.BlockOrExpr](),
+				ast.Span{Start: start, End: token.Span.Start},
+			)
 		}
 	}
-	alt := ast.BlockOrExpr{
-		Expr:  nil,
-		Block: nil,
-	}
-	return ast.NewIfElse(cond, body, alt, ast.Span{Start: start, End: token.Span.Start})
+	return ast.NewIfElse(
+		cond, body, optional.None[ast.BlockOrExpr](),
+		ast.Span{Start: start, End: token.Span.Start},
+	)
 }

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -1,6 +1,9 @@
 package parser
 
-import "github.com/escalier-lang/escalier/internal/ast"
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/moznion/go-optional"
+)
 
 func (p *Parser) parseBlock() ast.Block {
 	stmts := []ast.Stmt{}
@@ -50,7 +53,7 @@ func (p *Parser) parseStmt() ast.Stmt {
 		if expr == nil {
 			return ast.NewReturnStmt(nil, token.Span)
 		}
-		return ast.NewReturnStmt(expr, ast.Span{Start: token.Span.Start, End: expr.Span().End})
+		return ast.NewReturnStmt(optional.Some(expr), ast.Span{Start: token.Span.Start, End: expr.Span().End})
 	default:
 		expr := p.parseNonDelimitedExpr()
 		// If no tokens have been consumed then we've encountered something we


### PR DESCRIPTION
Using `Option[T]` for fields that optional makes it easier to know when to check if a field is `nil` or not because it's encoded in the type.