### PR TITLE
Refactor the parser a bit more

### DIFF
--- a/cmd/lsp-server/main.go
+++ b/cmd/lsp-server/main.go
@@ -128,7 +128,7 @@ func (*Server) validate(lspContext *glsp.Context, uri protocol.DocumentUri, cont
 		Path:     uri,
 		Contents: contents,
 	})
-	_, errors := p.ParseModule()
+	_, errors := p.Parse()
 
 	diagnotics := []protocol.Diagnostic{}
 	for _, err := range errors {

--- a/internal/codegen/printer_test.go
+++ b/internal/codegen/printer_test.go
@@ -46,7 +46,7 @@ fn sub(a, b) { return a - b }`,
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	p := parser.NewParser(ctx, source)
-	m1, _ := p.ParseModule()
+	m1, _ := p.Parse()
 	builder := &Builder{
 		tempId: 0,
 	}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -20,7 +20,7 @@ func Compile(source parser.Source) CompilerOutput {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	p := parser.NewParser(ctx, source)
-	escMod, escErrors := p.ParseModule()
+	escMod, escErrors := p.Parse()
 
 	if len(escErrors) > 0 {
 		return CompilerOutput{

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -5,7 +5,8 @@ import (
 	"github.com/moznion/go-optional"
 )
 
-func (p *Parser) parseDecl() (optional.Option[ast.Decl], [](*Error)) {
+// decl = 'export'? 'declare'? (varDecl | fnDecl)
+func (p *Parser) decl() (optional.Option[ast.Decl], [](*Error)) {
 	errors := [](*Error){}
 
 	export := false
@@ -23,103 +24,113 @@ func (p *Parser) parseDecl() (optional.Option[ast.Decl], [](*Error)) {
 		token = p.lexer.next()
 	}
 
-	//nolint: exhaustive
+	// nolint: exhaustive
 	switch token.Type {
 	case Val, Var:
-		kind := ast.ValKind
-		if token.Type == Var {
-			kind = ast.VarKind
-		}
-
-		patOption, patErrors := p.parsePattern(false)
-		errors = append(errors, patErrors...)
-		pat := patOption.TakeOrElse(func() ast.Pat {
-			errors = append(errors, NewError(token.Span, "Expected pattern"))
-			return ast.NewIdentPat(
-				"",
-				nil,
-				ast.Span{Start: token.Span.Start, End: token.Span.Start},
-			)
-		})
-		end := pat.Span().End
-
-		token = p.lexer.peek()
-		init := optional.None[ast.Expr]()
-		if !declare {
-			if token.Type != Equal {
-				errors = append(errors, NewError(token.Span, "Expected equals sign"))
-				return optional.None[ast.Decl](), errors
-			}
-			p.lexer.consume()
-			initOption, initErrors := p.parseNonDelimitedExpr()
-			errors = append(errors, initErrors...)
-			init = initOption.OrElse(func() optional.Option[ast.Expr] {
-				token := p.lexer.peek()
-				errors = append(errors, NewError(token.Span, "Expected an expression"))
-				return optional.Some[ast.Expr](ast.NewEmpty(token.Span))
-			})
-			init.IfSome(func(e ast.Expr) {
-				end = e.Span().End
-			})
-		}
-
-		return optional.Some[ast.Decl](
-			ast.NewVarDecl(kind, pat, init, declare, export, ast.Span{Start: start, End: end}),
-		), errors
+		return p.varDecl(start, token, declare, export)
 	case Fn:
-		token := p.lexer.peek()
-		var ident *ast.Ident
-		if token.Type == Identifier {
-			p.lexer.consume()
-			ident = ast.NewIdentifier(token.Value, token.Span)
-		} else {
-			errors = append(errors, NewError(token.Span, "Expected identifier"))
-			ident = ast.NewIdentifier(
-				"",
-				ast.Span{Start: token.Span.Start, End: token.Span.Start},
-			)
-		}
-
-		token = p.lexer.peek()
-		if token.Type != OpenParen {
-			errors = append(errors, NewError(token.Span, "Expected an opening paren"))
-		} else {
-			p.lexer.consume()
-		}
-
-		params, seqErrors := parseDelimSeq(p, CloseParen, Comma, p.parseParam)
-		errors = append(errors, seqErrors...)
-
-		token = p.lexer.peek()
-		if token.Type != CloseParen {
-			errors = append(errors, NewError(token.Span, "Expected a closing paren"))
-		} else {
-			p.lexer.consume()
-		}
-
-		end := token.Span.End
-
-		if !declare {
-			body, bodyErrors := p.parseBlock()
-			errors = append(errors, bodyErrors...)
-			end = body.Span.End
-
-			return optional.Some[ast.Decl](
-				ast.NewFuncDecl(
-					ident, params, optional.Some(body), declare, export,
-					ast.NewSpan(start, end),
-				),
-			), errors
-		}
-
-		return optional.Some[ast.Decl](
-			ast.NewFuncDecl(
-				ident, params, optional.None[ast.Block](), declare, export,
-				ast.NewSpan(start, end),
-			),
-		), errors
+		return p.fnDecl(start, declare, export)
 	default:
 		errors = append(errors, NewError(token.Span, "Unexpected token"))
 		return optional.None[ast.Decl](), errors
 	}
+}
+
+// valDecl = 'val' pat '=' expr
+// NOTE: '=' `expr` is optional for valDecl when `declare` is true.
+func (p *Parser) varDecl(start ast.Location, token *Token, declare bool, export bool) (optional.Option[ast.Decl], []*Error) {
+	errors := []*Error{}
+	kind := ast.ValKind
+	if token.Type == Var {
+		kind = ast.VarKind
+	}
+
+	patOption, patErrors := p.pattern(false)
+	errors = append(errors, patErrors...)
+	pat := patOption.TakeOrElse(func() ast.Pat {
+		errors = append(errors, NewError(token.Span, "Expected pattern"))
+		return ast.NewIdentPat(
+			"",
+			nil,
+			ast.Span{Start: token.Span.Start, End: token.Span.Start},
+		)
+	})
+	end := pat.Span().End
+
+	token = p.lexer.peek()
+	init := optional.None[ast.Expr]()
+	if !declare {
+		if token.Type != Equal {
+			errors = append(errors, NewError(token.Span, "Expected equals sign"))
+			return optional.None[ast.Decl](), errors
+		}
+		p.lexer.consume()
+		initOption, initErrors := p.nonDelimitedExpr()
+		errors = append(errors, initErrors...)
+		init = initOption.OrElse(func() optional.Option[ast.Expr] {
+			token := p.lexer.peek()
+			errors = append(errors, NewError(token.Span, "Expected an expression"))
+			return optional.Some[ast.Expr](ast.NewEmpty(token.Span))
+		})
+		init.IfSome(func(e ast.Expr) {
+			end = e.Span().End
+		})
+	}
+
+	return optional.Some[ast.Decl](
+		ast.NewVarDecl(kind, pat, init, declare, export, ast.Span{Start: start, End: end}),
+	), errors
+}
+
+// fnDecl = 'fn' ident '(' param* ')' block
+// NOTE: `block` is optional for fnDecl when `declare` is true.
+// TODO: dedupe with `fnExpr`
+func (p *Parser) fnDecl(start ast.Location, declare bool, export bool) (optional.Option[ast.Decl], []*Error) {
+	errors := []*Error{}
+	token := p.lexer.peek()
+	var ident *ast.Ident
+	if token.Type == Identifier {
+		p.lexer.consume()
+		ident = ast.NewIdentifier(token.Value, token.Span)
+	} else {
+		errors = append(errors, NewError(token.Span, "Expected identifier"))
+		ident = ast.NewIdentifier(
+			"",
+			ast.Span{Start: token.Span.Start, End: token.Span.Start},
+		)
+	}
+
+	token = p.lexer.peek()
+	if token.Type != OpenParen {
+		errors = append(errors, NewError(token.Span, "Expected an opening paren"))
+	} else {
+		p.lexer.consume()
+	}
+
+	params, seqErrors := parseDelimSeq(p, CloseParen, Comma, p.param)
+	errors = append(errors, seqErrors...)
+
+	token = p.lexer.peek()
+	if token.Type != CloseParen {
+		errors = append(errors, NewError(token.Span, "Expected a closing paren"))
+	} else {
+		p.lexer.consume()
+	}
+
+	end := token.Span.End
+
+	bodyOption := optional.None[ast.Block]()
+	if !declare {
+		body, bodyErrors := p.block()
+		errors = append(errors, bodyErrors...)
+		end = body.Span.End
+		bodyOption = optional.Some(body)
+	}
+
+	return optional.Some[ast.Decl](
+		ast.NewFuncDecl(
+			ident, params, bodyOption, declare, export,
+			ast.NewSpan(start, end),
+		),
+	), errors
 }

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -152,7 +152,7 @@ func TestParseExprNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			expr, errors := parser.parseExpr()
+			expr, errors := parser.expr()
 
 			snaps.MatchSnapshot(t, expr)
 			assert.Equal(t, []*Error{}, errors)
@@ -228,7 +228,7 @@ func TestParseExprErrorHandling(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			expr, errors := parser.parseExpr()
+			expr, errors := parser.expr()
 
 			snaps.MatchSnapshot(t, expr)
 			assert.Greater(t, len(errors), 0)

--- a/internal/parser/jsx_test.go
+++ b/internal/parser/jsx_test.go
@@ -53,7 +53,7 @@ func TestParseJSXNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			jsx, errors := parser.parseJSXElement()
+			jsx, errors := parser.jsxElement()
 
 			snaps.MatchSnapshot(t, jsx)
 			assert.Len(t, errors, 0)
@@ -84,7 +84,7 @@ func TestParseJSXErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			jsx, errors := parser.parseJSXElement()
+			jsx, errors := parser.jsxElement()
 
 			snaps.MatchSnapshot(t, jsx)
 			assert.Greater(t, len(errors), 0)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -27,7 +27,7 @@ func NewParser(ctx context.Context, source Source) *Parser {
 	}
 }
 
-func (p *Parser) ParseModule() (*ast.Module, []*Error) {
+func (p *Parser) Parse() (*ast.Module, []*Error) {
 	stmts := []ast.Stmt{}
 	errors := []*Error{}
 
@@ -41,7 +41,7 @@ func (p *Parser) ParseModule() (*ast.Module, []*Error) {
 			p.lexer.consume()
 			token = p.lexer.peek()
 		default:
-			stmt, stmtErrors := p.parseStmt()
+			stmt, stmtErrors := p.stmt()
 			errors = append(errors, stmtErrors...)
 			stmt.IfSome(func(stmt ast.Stmt) {
 				stmts = append(stmts, stmt)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -89,7 +89,7 @@ func TestParseModuleNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			module, errors := parser.ParseModule()
+			module, errors := parser.Parse()
 
 			for _, stmt := range module.Stmts {
 				snaps.MatchSnapshot(t, stmt)

--- a/internal/parser/pattern.go
+++ b/internal/parser/pattern.go
@@ -7,83 +7,128 @@ import (
 	"github.com/moznion/go-optional"
 )
 
-func (p *Parser) parsePattern(allowIdentDefault bool) (optional.Option[ast.Pat], []*Error) {
+// pattern = identifier | wildcard | tuple | object | rest | literal
+func (p *Parser) pattern(allowIdentDefault bool) (optional.Option[ast.Pat], []*Error) {
 	token := p.lexer.peek()
-	start := token.Span.Start
-
 	errors := []*Error{}
 
 	// nolint: exhaustive
 	switch token.Type {
 	case Identifier:
 		p.lexer.consume()
-		name := token.Value // TODO: support qualified identifiers
-		span := token.Span
-
-		token = p.lexer.peek()
-		if token.Type == OpenParen { // Extractor
-			p.lexer.consume() // consume '('
-			patArgs, patErrors := parseDelimSeq(p, CloseParen, Comma, func() (optional.Option[ast.Pat], []*Error) {
-				return p.parsePattern(true)
-			})
-			errors = append(errors, patErrors...)
-			end, endErrors := p.expect(CloseParen, AlwaysConsume)
-			errors = append(errors, endErrors...)
-			return optional.Some[ast.Pat](
-				ast.NewExtractorPat(name, patArgs, ast.NewSpan(start, end)),
-			), errors
-		} else { // Ident
-			_default := optional.None[ast.Expr]()
-			if allowIdentDefault && token.Type == Equal {
-				p.lexer.consume()
-				exprOption, exprErrors := p.parseExpr()
-				errors = append(errors, exprErrors...)
-				exprOption.IfSome(func(e ast.Expr) {
-					span = ast.MergeSpans(span, e.Span())
-					_default = optional.Some(e)
-				})
-			}
-			return optional.Some[ast.Pat](
-				ast.NewIdentPat(name, _default, span),
-			), errors
+		next := p.lexer.peek()
+		if next.Type == OpenParen {
+			return p.extractorPat(token)
+		} else {
+			return p.identPat(token, allowIdentDefault)
 		}
-	case Underscore: // Wildcard
+	case Underscore:
 		p.lexer.consume()
 		return optional.Some[ast.Pat](
 			ast.NewWildcardPat(token.Span),
 		), errors
-	case OpenBracket: // Tuple
-		p.lexer.consume() // consume '['
-		patElems, patElemsErrors := parseDelimSeq(p, CloseBracket, Comma, func() (optional.Option[ast.Pat], []*Error) {
-			return p.parsePattern(true)
+	case OpenBracket:
+		return p.tuplePat()
+	case OpenBrace:
+		return p.objectPat()
+	case DotDotDot:
+		return p.restPat()
+	default:
+		return p.literalPat()
+	}
+}
+
+// extractorPat = identifier '(' (pattern (',' pattern)*)? ')'
+func (p *Parser) extractorPat(nameToken *Token) (optional.Option[ast.Pat], []*Error) {
+	errors := []*Error{}
+	p.lexer.consume() // consume '('
+	patArgs, patErrors := parseDelimSeq(p, CloseParen, Comma, func() (optional.Option[ast.Pat], []*Error) {
+		return p.pattern(true)
+	})
+	errors = append(errors, patErrors...)
+	end, endErrors := p.expect(CloseParen, AlwaysConsume)
+	errors = append(errors, endErrors...)
+	return optional.Some[ast.Pat](
+		ast.NewExtractorPat(nameToken.Value, patArgs, ast.NewSpan(nameToken.Span.Start, end)),
+	), errors
+}
+
+// identPat = identifier ('=' expr)?
+func (p *Parser) identPat(nameToken *Token, allowIdentDefault bool) (optional.Option[ast.Pat], []*Error) {
+	errors := []*Error{}
+	span := nameToken.Span
+	token := p.lexer.peek()
+	_default := optional.None[ast.Expr]()
+	if allowIdentDefault && token.Type == Equal {
+		p.lexer.consume()
+		exprOption, exprErrors := p.expr()
+		errors = append(errors, exprErrors...)
+		exprOption.IfSome(func(e ast.Expr) {
+			span = ast.MergeSpans(span, e.Span())
+			_default = optional.Some(e)
 		})
-		errors = append(errors, patElemsErrors...)
-		end, endErrors := p.expect(CloseBracket, AlwaysConsume)
-		errors = append(errors, endErrors...)
-		return optional.Some[ast.Pat](
-			ast.NewTuplePat(patElems, ast.NewSpan(start, end)),
-		), errors
-	case OpenBrace: // Object
-		p.lexer.consume() // consume '{'
-		patElems, patElemsErrors := parseDelimSeq(p, CloseBrace, Comma, p.parseObjPatElem)
-		errors = append(errors, patElemsErrors...)
-		end, endErrors := p.expect(CloseBrace, AlwaysConsume)
-		errors = append(errors, endErrors...)
-		return optional.Some[ast.Pat](
-			ast.NewObjectPat(patElems, ast.NewSpan(start, end)),
-		), errors
-	case DotDotDot: // Rest
-		p.lexer.consume() // consume '...'
-		pat, patErrors := p.parsePattern(true)
-		errors = append(errors, patErrors...)
-		span := token.Span
-		pat.IfNone(func() {
-			errors = append(errors, NewError(token.Span, "Expected pattern"))
-		})
-		return optional.Map(pat, func(pat ast.Pat) ast.Pat {
-			span = ast.MergeSpans(span, pat.Span())
-			return ast.NewRestPat(pat, span)
-		}), errors
+	}
+	return optional.Some[ast.Pat](
+		ast.NewIdentPat(nameToken.Value, _default, span),
+	), errors
+}
+
+// tuplePat = '[' (pattern (',' pattern)*)? ']'
+func (p *Parser) tuplePat() (optional.Option[ast.Pat], []*Error) {
+	errors := []*Error{}
+	token := p.lexer.peek()
+	start := token.Span.Start
+	p.lexer.consume() // consume '['
+	patElems, patElemsErrors := parseDelimSeq(p, CloseBracket, Comma, func() (optional.Option[ast.Pat], []*Error) {
+		return p.pattern(true)
+	})
+	errors = append(errors, patElemsErrors...)
+	end, endErrors := p.expect(CloseBracket, AlwaysConsume)
+	errors = append(errors, endErrors...)
+	return optional.Some[ast.Pat](
+		ast.NewTuplePat(patElems, ast.NewSpan(start, end)),
+	), errors
+}
+
+// objectPat = '{' (objPatElem (',' objPatElem)*)? '}'
+func (p *Parser) objectPat() (optional.Option[ast.Pat], []*Error) {
+	errors := []*Error{}
+	token := p.lexer.peek()
+	start := token.Span.Start
+	p.lexer.consume() // consume '{'
+	patElems, patElemsErrors := parseDelimSeq(p, CloseBrace, Comma, p.objPatElem)
+	errors = append(errors, patElemsErrors...)
+	end, endErrors := p.expect(CloseBrace, AlwaysConsume)
+	errors = append(errors, endErrors...)
+	return optional.Some[ast.Pat](
+		ast.NewObjectPat(patElems, ast.NewSpan(start, end)),
+	), errors
+}
+
+// restPat = '...' pattern
+func (p *Parser) restPat() (optional.Option[ast.Pat], []*Error) {
+	errors := []*Error{}
+	token := p.lexer.peek()
+	p.lexer.consume() // consume '...'
+	pat, patErrors := p.pattern(true)
+	errors = append(errors, patErrors...)
+	span := token.Span
+	pat.IfNone(func() {
+		errors = append(errors, NewError(token.Span, "Expected pattern"))
+	})
+	return optional.Map(pat, func(pat ast.Pat) ast.Pat {
+		span = ast.MergeSpans(span, pat.Span())
+		return ast.NewRestPat(pat, span)
+	}), errors
+}
+
+// literalPat = string | number | 'true' | 'false' | 'null' | 'undefined'
+func (p *Parser) literalPat() (optional.Option[ast.Pat], []*Error) {
+	errors := []*Error{}
+	token := p.lexer.peek()
+
+	// nolint: exhaustive
+	switch token.Type {
 	case String:
 		p.lexer.consume()
 		return optional.Some[ast.Pat](
@@ -126,7 +171,7 @@ func (p *Parser) parsePattern(allowIdentDefault bool) (optional.Option[ast.Pat],
 	}
 }
 
-func (p *Parser) parseObjPatElem() (optional.Option[ast.ObjPatElem], []*Error) {
+func (p *Parser) objPatElem() (optional.Option[ast.ObjPatElem], []*Error) {
 	token := p.lexer.peek()
 	errors := []*Error{}
 
@@ -138,7 +183,7 @@ func (p *Parser) parseObjPatElem() (optional.Option[ast.ObjPatElem], []*Error) {
 		token = p.lexer.peek()
 		if token.Type == Colon {
 			p.lexer.consume()
-			value, valueError := p.parsePattern(true)
+			value, valueError := p.pattern(true)
 			errors = append(errors, valueError...)
 			value.IfSome(func(v ast.Pat) {
 				span = ast.MergeSpans(span, v.Span())
@@ -148,7 +193,7 @@ func (p *Parser) parseObjPatElem() (optional.Option[ast.ObjPatElem], []*Error) {
 			token = p.lexer.peek()
 			if token.Type == Equal {
 				p.lexer.consume()
-				exprOption, exprError := p.parseExpr()
+				exprOption, exprError := p.expr()
 				init = exprOption
 				errors = append(errors, exprError...)
 				init.IfSome(func(e ast.Expr) {
@@ -165,7 +210,7 @@ func (p *Parser) parseObjPatElem() (optional.Option[ast.ObjPatElem], []*Error) {
 			token = p.lexer.peek()
 			if token.Type == Equal {
 				p.lexer.consume()
-				exprOption, exprError := p.parseExpr()
+				exprOption, exprError := p.expr()
 				errors = append(errors, exprError...)
 				exprOption.IfSome(func(e ast.Expr) {
 					span = ast.MergeSpans(span, e.Span())
@@ -180,7 +225,7 @@ func (p *Parser) parseObjPatElem() (optional.Option[ast.ObjPatElem], []*Error) {
 	} else if token.Type == DotDotDot {
 		p.lexer.consume()
 
-		pat, patErrors := p.parsePattern(true)
+		pat, patErrors := p.pattern(true)
 		errors = append(errors, patErrors...)
 		return optional.Map(pat, func(pat ast.Pat) ast.ObjPatElem {
 			span := ast.MergeSpans(token.Span, pat.Span())

--- a/internal/parser/pattern_test.go
+++ b/internal/parser/pattern_test.go
@@ -65,7 +65,7 @@ func TestParsePatternNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			expr, errors := parser.parsePattern(false)
+			expr, errors := parser.pattern(false)
 
 			snaps.MatchSnapshot(t, expr)
 			assert.Equal(t, errors, []*Error{})

--- a/internal/parser/stmt_test.go
+++ b/internal/parser/stmt_test.go
@@ -70,7 +70,7 @@ func TestParseStmtNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			stmt, errors := parser.parseStmt()
+			stmt, errors := parser.stmt()
 
 			snaps.MatchSnapshot(t, stmt)
 			if len(errors) > 0 {
@@ -123,7 +123,7 @@ func TestParseStmtErrorHandling(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			stmt, errors := parser.parseStmt()
+			stmt, errors := parser.stmt()
 
 			snaps.MatchSnapshot(t, stmt)
 			assert.Greater(t, len(errors), 0)


### PR DESCRIPTION
- remove 'parse' prefix from all parser methods
- split some large methods up
- document grammar for some of the parser methods