### PR TITLE
Record errors using an 'errors' field on the 'Parser' struct

### DIFF
--- a/internal/parser/combinators.go
+++ b/internal/parser/combinators.go
@@ -6,21 +6,19 @@ func parseDelimSeq[T interface{}](
 	separator TokenType,
 	// TODO: update this to return `nil` instead of `optional.None` when there
 	// is no item
-	parserCombinator func() (T, []*Error),
-) ([]T, []*Error) {
+	parserCombinator func() T,
+) []T {
 	items := []T{}
-	errors := []*Error{}
 
 	// Empty sequence
 	token := p.lexer.peek()
 	if token.Type == terminator {
-		return items, errors
+		return items
 	}
 
-	item, itemErrors := parserCombinator()
-	errors = append(errors, itemErrors...)
+	item := parserCombinator()
 	if interface{}(item) == nil {
-		return items, errors
+		return items
 	}
 	items = append(items, item)
 
@@ -31,17 +29,16 @@ func parseDelimSeq[T interface{}](
 
 			token = p.lexer.peek()
 			if token.Type == terminator {
-				return items, errors
+				return items
 			}
 
-			item, itemErrors := parserCombinator()
-			errors = append(errors, itemErrors...)
+			item := parserCombinator()
 			if interface{}(item) == nil {
-				return items, errors
+				return items
 			}
 			items = append(items, item)
 		} else {
-			return items, errors
+			return items
 		}
 	}
 }

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -30,7 +30,7 @@ func (p *Parser) decl() ast.Decl {
 	case Type:
 		return p.typeDecl(start, export, declare)
 	default:
-		p.errors = append(p.errors, NewError(token.Span, "Unexpected token"))
+		p.reportError(token.Span, "Unexpected token")
 		return nil
 	}
 }
@@ -50,7 +50,7 @@ func (p *Parser) varDecl(
 
 	pat := p.pattern(false)
 	if pat == nil {
-		p.errors = append(p.errors, NewError(token.Span, "Expected pattern"))
+		p.reportError(token.Span, "Expected pattern")
 		pat = ast.NewIdentPat(
 			"",
 			nil,
@@ -71,14 +71,14 @@ func (p *Parser) varDecl(
 	var init ast.Expr
 	if !declare {
 		if token.Type != Equal {
-			p.errors = append(p.errors, NewError(token.Span, "Expected equals sign"))
+			p.reportError(token.Span, "Expected equals sign")
 			return nil
 		}
 		p.lexer.consume()
 		init = p.nonDelimitedExpr()
 		if init == nil {
 			token := p.lexer.peek()
-			p.errors = append(p.errors, NewError(token.Span, "Expected an expression"))
+			p.reportError(token.Span, "Expected an expression")
 			init = ast.NewEmpty(token.Span)
 		}
 		end = init.Span().End
@@ -98,7 +98,7 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool) ast.Decl 
 		p.lexer.consume()
 		ident = ast.NewIdentifier(token.Value, token.Span)
 	} else {
-		p.errors = append(p.errors, NewError(token.Span, "Expected identifier"))
+		p.reportError(token.Span, "Expected identifier")
 		ident = ast.NewIdentifier(
 			"",
 			ast.Span{Start: token.Span.Start, End: token.Span.Start},
@@ -107,7 +107,7 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool) ast.Decl 
 
 	token = p.lexer.peek()
 	if token.Type != OpenParen {
-		p.errors = append(p.errors, NewError(token.Span, "Expected an opening paren"))
+		p.reportError(token.Span, "Expected an opening paren")
 	} else {
 		p.lexer.consume()
 	}
@@ -116,7 +116,7 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool) ast.Decl 
 
 	token = p.lexer.peek()
 	if token.Type != CloseParen {
-		p.errors = append(p.errors, NewError(token.Span, "Expected a closing paren"))
+		p.reportError(token.Span, "Expected a closing paren")
 	} else {
 		p.lexer.consume()
 	}
@@ -138,7 +138,7 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool) ast.Decl 
 func (p *Parser) typeDecl(start ast.Location, export bool, declare bool) ast.Decl {
 	token := p.lexer.peek()
 	if token.Type != Identifier {
-		p.errors = append(p.errors, NewError(token.Span, "Expected identifier"))
+		p.reportError(token.Span, "Expected identifier")
 		return nil
 	}
 	p.lexer.consume()

--- a/internal/parser/error.go
+++ b/internal/parser/error.go
@@ -13,3 +13,11 @@ func NewError(span ast.Span, message string) *Error {
 		Message: message,
 	}
 }
+
+func (p *Parser) reportError(span ast.Span, message string) {
+	// _, _, line, _ := p.ctx.Value("caller").(ast.Location).LineInfo()
+	// if p.ctx.Value("debug") == true {
+	// 	message = message + " at line " + string(line)
+	// }
+	p.errors = append(p.errors, NewError(span, message))
+}

--- a/internal/parser/expect.go
+++ b/internal/parser/expect.go
@@ -68,7 +68,7 @@ func (p *Parser) expect(tt TokenType, consume Consume) ast.Location {
 		if consume == ConsumeOnMismatch {
 			p.lexer.consume()
 		}
-		p.errors = append(p.errors, NewError(token.Span, fmt.Sprintf("Expected %s but got %s", TokenMap[tt], TokenMap[token.Type])))
+		p.reportError(token.Span, fmt.Sprintf("Expected %s but got %s", TokenMap[tt], TokenMap[token.Type]))
 		return token.Span.End
 	}
 	if consume == ConsumeOnMatch {

--- a/internal/parser/expect.go
+++ b/internal/parser/expect.go
@@ -59,8 +59,7 @@ const (
 	ConsumeOnMismatch
 )
 
-func (p *Parser) expect(tt TokenType, consume Consume) (ast.Location, []*Error) {
-	errors := []*Error{}
+func (p *Parser) expect(tt TokenType, consume Consume) ast.Location {
 	token := p.lexer.peek()
 	if consume == AlwaysConsume {
 		p.lexer.consume()
@@ -69,11 +68,11 @@ func (p *Parser) expect(tt TokenType, consume Consume) (ast.Location, []*Error) 
 		if consume == ConsumeOnMismatch {
 			p.lexer.consume()
 		}
-		errors = append(errors, NewError(token.Span, fmt.Sprintf("Expected %s but got %s", TokenMap[tt], TokenMap[token.Type])))
-		return token.Span.End, errors
+		p.errors = append(p.errors, NewError(token.Span, fmt.Sprintf("Expected %s but got %s", TokenMap[tt], TokenMap[token.Type])))
+		return token.Span.End
 	}
 	if consume == ConsumeOnMatch {
 		p.lexer.consume()
 	}
-	return token.Span.End, errors
+	return token.Span.End
 }

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -26,28 +26,27 @@ var precedence = map[ast.BinaryOp]int{
 	ast.NullishCoalescing: 3,
 }
 
-func (p *Parser) exprWithMarker(marker Marker) (ast.Expr, []*Error) {
+func (p *Parser) exprWithMarker(marker Marker) ast.Expr {
 	p.markers.Push(marker)
 	defer p.markers.Pop()
 	return p.exprInternal()
 }
 
-func (p *Parser) nonDelimitedExpr() (ast.Expr, []*Error) {
-	expr, exprError := p.exprWithMarker(MarkerExpr)
-	return expr, exprError
+func (p *Parser) nonDelimitedExpr() ast.Expr {
+	return p.exprWithMarker(MarkerExpr)
 }
 
-func (p *Parser) expr() (ast.Expr, []*Error) {
-	expr, errors := p.exprWithMarker(MarkerDelim)
+func (p *Parser) expr() ast.Expr {
+	expr := p.exprWithMarker(MarkerDelim)
 	if expr == nil {
 		token := p.lexer.peek()
-		errors = append(errors, NewError(token.Span, "Expected an expression"))
-		return ast.NewEmpty(token.Span), errors
+		p.errors = append(p.errors, NewError(token.Span, "Expected an expression"))
+		return ast.NewEmpty(token.Span)
 	}
-	return expr, errors
+	return expr
 }
 
-func (p *Parser) exprInternal() (ast.Expr, []*Error) {
+func (p *Parser) exprInternal() ast.Expr {
 	select {
 	case <-p.ctx.Done():
 		fmt.Println("Taking too long to parse")
@@ -58,13 +57,11 @@ func (p *Parser) exprInternal() (ast.Expr, []*Error) {
 	values := NewStack[ast.Expr]()
 	ops := NewStack[ast.BinaryOp]()
 
-	primary, primaryErrors := p.primaryExpr()
+	primary := p.primaryExpr()
 	if primary == nil {
-		return nil, primaryErrors
+		return nil
 	}
 
-	errors := []*Error{}
-	errors = append(errors, primaryErrors...)
 	values = append(values, primary)
 
 loop:
@@ -105,7 +102,7 @@ loop:
 
 		if token.Span.Start.Line != p.lexer.currentLocation.Line {
 			if len(p.markers) == 0 || p.markers.Peek() != MarkerDelim {
-				return values.Pop(), errors
+				return values.Pop()
 			}
 		}
 
@@ -123,11 +120,10 @@ loop:
 		}
 
 		ops.Push(nextOp)
-		expr, primaryErrors := p.primaryExpr()
-		errors = append(errors, primaryErrors...)
+		expr := p.primaryExpr()
 		if expr == nil {
 			token := p.lexer.peek()
-			errors = append(errors, NewError(token.Span, "Expected an expression"))
+			p.errors = append(p.errors, NewError(token.Span, "Expected an expression"))
 			expr = ast.NewEmpty(token.Span)
 		}
 		values.Push(expr)
@@ -144,7 +140,7 @@ loop:
 	if len(values) != 1 {
 		panic("parseExpr - expected one value on the stack")
 	}
-	return values.Pop(), errors
+	return values.Pop()
 }
 
 type TokenAndOp struct {
@@ -174,9 +170,8 @@ loop:
 	return result
 }
 
-func (p *Parser) exprSuffix(expr ast.Expr) (ast.Expr, []*Error) {
+func (p *Parser) exprSuffix(expr ast.Expr) ast.Expr {
 	token := p.lexer.peek()
-	errors := []*Error{}
 
 loop:
 	for {
@@ -184,11 +179,10 @@ loop:
 		switch token.Type {
 		case OpenParen, QuestionOpenParen:
 			p.lexer.consume()
-			args, argsErrors := parseDelimSeq(p, CloseParen, Comma, p.expr)
-			errors = append(errors, argsErrors...)
+			args := parseDelimSeq(p, CloseParen, Comma, p.expr)
 			terminator := p.lexer.next()
 			if terminator.Type != CloseParen {
-				errors = append(errors, NewError(token.Span, "Expected a closing paren"))
+				p.errors = append(p.errors, NewError(token.Span, "Expected a closing paren"))
 			}
 			callee := expr
 			optChain := false
@@ -202,15 +196,14 @@ loop:
 		case OpenBracket, QuestionOpenBracket:
 			p.lexer.consume()
 			// TODO: handle the case when parseExpr() return None correctly
-			index, indexErrors := p.expr()
-			errors = append(errors, indexErrors...)
+			index := p.expr()
 			if index == nil {
-				errors = append(errors, NewError(token.Span, "Expected an expression after '['"))
+				p.errors = append(p.errors, NewError(token.Span, "Expected an expression after '['"))
 				break loop
 			}
 			terminator := p.lexer.next()
 			if terminator.Type != CloseBracket {
-				errors = append(errors, NewError(token.Span, "Expected a closing bracket"))
+				p.errors = append(p.errors, NewError(token.Span, "Expected a closing bracket"))
 			}
 			obj := expr
 			optChain := false
@@ -248,14 +241,13 @@ loop:
 					ast.Span{Start: obj.Span().Start, End: prop.Span().End},
 				)
 				if token.Type == Dot {
-					errors = append(errors, NewError(token.Span, "expected an identifier after ."))
+					p.errors = append(p.errors, NewError(token.Span, "expected an identifier after ."))
 				} else {
-					errors = append(errors, NewError(token.Span, "expected an identifier after ?."))
+					p.errors = append(p.errors, NewError(token.Span, "expected an identifier after ?."))
 				}
 			}
 		case BackTick:
-			temp, tempErrors := p.templateLitExpr(token, expr)
-			errors = append(errors, tempErrors...)
+			temp := p.templateLitExpr(token, expr)
 			expr = temp
 		default:
 			break loop
@@ -263,47 +255,44 @@ loop:
 		token = p.lexer.peek()
 	}
 
-	return expr, errors
+	return expr
 }
 
-func (p *Parser) objExprKey() (ast.ObjKey, []*Error) {
+func (p *Parser) objExprKey() ast.ObjKey {
 	token := p.lexer.peek()
-	errors := []*Error{}
 
 	// nolint: exhaustive
 	switch token.Type {
 	case Identifier, Underscore:
 		p.lexer.consume()
-		return ast.NewIdent(token.Value, token.Span), errors
+		return ast.NewIdent(token.Value, token.Span)
 	case StrLit:
 		p.lexer.consume()
-		return ast.NewString(token.Value, token.Span), errors
+		return ast.NewString(token.Value, token.Span)
 	case NumLit:
 		p.lexer.consume()
 		value, err := strconv.ParseFloat(token.Value, 64)
 		if err != nil {
-			errors = append(errors, NewError(token.Span, "Expected a number"))
+			p.errors = append(p.errors, NewError(token.Span, "Expected a number"))
 		}
-		return ast.NewNumber(value, token.Span), errors
+		return ast.NewNumber(value, token.Span)
 	case OpenBracket:
 		p.lexer.consume()
-		expr, exprErrors := p.expr()
-		errors = append(errors, exprErrors...)
-		_, expectErrors := p.expect(CloseBracket, AlwaysConsume)
-		errors = append(errors, expectErrors...)
+		expr := p.expr()
+		p.expect(CloseBracket, AlwaysConsume)
 		if expr != nil {
-			return &ast.ComputedKey{Expr: expr}, errors
+			return &ast.ComputedKey{Expr: expr}
 		}
-		return nil, errors
+		return nil
 	default:
-		return nil, []*Error{NewError(token.Span, "Expected a property name")}
+		p.errors = append(p.errors, NewError(token.Span, "Expected a property name"))
+		return nil
 	}
 }
 
-func (p *Parser) primaryExpr() (ast.Expr, []*Error) {
+func (p *Parser) primaryExpr() ast.Expr {
 	ops := p.parsePrefix()
 	token := p.lexer.peek()
-	errors := []*Error{}
 
 	var expr ast.Expr
 
@@ -318,9 +307,9 @@ func (p *Parser) primaryExpr() (ast.Expr, []*Error) {
 			p.lexer.consume()
 			value, err := strconv.ParseFloat(token.Value, 64)
 			if err != nil {
-				errors = append(errors, NewError(token.Span, "Expected a number"))
+				p.errors = append(p.errors, NewError(token.Span, "Expected a number"))
 				// TODO: return an EmptyExpr instead of nil
-				return nil, errors
+				return nil
 			}
 			expr = ast.NewLitExpr(ast.NewNumber(value, token.Span))
 		case StrLit:
@@ -344,44 +333,34 @@ func (p *Parser) primaryExpr() (ast.Expr, []*Error) {
 		case OpenParen:
 			p.lexer.consume()
 			// TODO: handle the case when parseExpr() return None
-			var exprErrors []*Error
-			expr, exprErrors = p.expr()
-			errors = append(errors, exprErrors...)
+			expr = p.expr()
 			if expr == nil {
-				errors = append(errors, NewError(token.Span, "Expected an expression after '('"))
-				return nil, errors
+				p.errors = append(p.errors, NewError(token.Span, "Expected an expression after '('"))
+				return nil
 			}
-			_, expectErrors := p.expect(CloseParen, AlwaysConsume)
-			errors = append(errors, expectErrors...)
+			p.expect(CloseParen, AlwaysConsume)
 		case OpenBracket:
 			p.lexer.consume()
-			elems, seqErrors := parseDelimSeq(p, CloseBracket, Comma, p.expr)
-			errors = append(errors, seqErrors...)
-			end, endErrors := p.expect(CloseBracket, AlwaysConsume)
-			errors = append(errors, endErrors...)
+			elems := parseDelimSeq(p, CloseBracket, Comma, p.expr)
+			end := p.expect(CloseBracket, AlwaysConsume)
 			expr = ast.NewArray(elems, ast.Span{Start: token.Span.Start, End: end})
 		case OpenBrace:
 			p.lexer.consume()
-			elems, seqErrors := parseDelimSeq(p, CloseBrace, Comma, p.objExprElem)
-			errors = append(errors, seqErrors...)
-			end, endErrors := p.expect(CloseBrace, AlwaysConsume)
-			errors = append(errors, endErrors...)
+			elems := parseDelimSeq(p, CloseBrace, Comma, p.objExprElem)
+			end := p.expect(CloseBrace, AlwaysConsume)
 			expr = ast.NewObject(elems, ast.Span{Start: token.Span.Start, End: end})
 		case BackTick:
-			temp, tempErrors := p.templateLitExpr(token, nil)
-			errors = append(errors, tempErrors...)
+			temp := p.templateLitExpr(token, nil)
 			expr = temp
 		case Fn:
-			fnExpr, fnError := p.fnExpr(token.Span.Start)
-			errors = append(errors, fnError...)
-			return fnExpr, errors
+			fnExpr := p.fnExpr(token.Span.Start)
+			return fnExpr
 		case If:
 			return p.ifElse()
 		case LessThan:
 			// TODO: figure out how to cast this more directly.
-			jsx, jsxErrors := p.jsxElement()
-			errors = append(errors, jsxErrors...)
-			return jsx, errors
+			jsx := p.jsxElement()
+			return jsx
 		case
 			Val, Var, Return,
 			CloseBrace, CloseParen, CloseBracket,
@@ -391,32 +370,30 @@ func (p *Parser) primaryExpr() (ast.Expr, []*Error) {
 			// We could also have a function like `maybeParseExpr()` that is okay
 			// with return `nil` whereas `parseExpr()` would return an error if
 			// `nil` is returned.
-			return nil, errors
+			return nil
 		default:
 			p.lexer.consume()
-			errors = append(
-				errors,
+			p.errors = append(
+				p.errors,
 				NewError(token.Span, fmt.Sprintf("Unexpected token, '%s'", token.Value)),
 			)
 			token = p.lexer.peek()
 		}
 	}
 
-	expr, suffixErrors := p.exprSuffix(expr)
-	errors = append(errors, suffixErrors...)
+	expr = p.exprSuffix(expr)
 
 	for !ops.IsEmpty() {
 		tokenAndOp := ops.Pop()
 		expr = ast.NewUnary(tokenAndOp.Op, expr, ast.Span{Start: tokenAndOp.Token.Span.Start, End: expr.Span().End})
 	}
 
-	return expr, errors
+	return expr
 }
 
 // fnExpr = 'fn' '(' param (',' param)* ')' block
 // TODO: dedupe with `fnDecl`
-func (p *Parser) fnExpr(start ast.Location) (ast.Expr, []*Error) {
-	errors := []*Error{}
+func (p *Parser) fnExpr(start ast.Location) ast.Expr {
 	// TODO: allow an optional identifier
 	// token := parser.lexer.peek()
 	// _ident, ok := token.(*TIdentifier)
@@ -433,15 +410,11 @@ func (p *Parser) fnExpr(start ast.Location) (ast.Expr, []*Error) {
 	// }
 	p.lexer.consume() // consume the fn keyword
 
-	_, expectErrors := p.expect(OpenParen, ConsumeOnMatch)
-	errors = append(errors, expectErrors...)
-	params, seqErrors := parseDelimSeq(p, CloseParen, Comma, p.param)
-	errors = append(errors, seqErrors...)
-	_, expectErrors = p.expect(CloseParen, ConsumeOnMatch)
-	errors = append(errors, expectErrors...)
+	p.expect(OpenParen, ConsumeOnMatch)
+	params := parseDelimSeq(p, CloseParen, Comma, p.param)
+	p.expect(CloseParen, ConsumeOnMatch)
 
-	body, bodyErrors := p.block()
-	errors = append(errors, bodyErrors...)
+	body := p.block()
 	end := body.Span.End
 
 	return ast.NewFuncExpr(
@@ -451,22 +424,20 @@ func (p *Parser) fnExpr(start ast.Location) (ast.Expr, []*Error) {
 		nil, // TODO: parse throws type
 		body,
 		ast.NewSpan(start, end),
-	), errors
+	)
 }
 
-func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
+func (p *Parser) objExprElem() ast.ObjExprElem {
 	token := p.lexer.peek()
-	errors := []*Error{}
 
 	if token.Type == DotDotDot {
 		p.lexer.consume() // consume '...'
-		arg, argErrors := p.expr()
-		errors = append(errors, argErrors...)
+		arg := p.expr()
 		if arg == nil {
-			errors = append(errors, NewError(token.Span, "Expected an expression after '...'"))
+			p.errors = append(p.errors, NewError(token.Span, "Expected an expression after '...'"))
 		}
 		if arg != nil {
-			return ast.NewRestSpread(arg, ast.MergeSpans(token.Span, arg.Span())), errors
+			return ast.NewRestSpread(arg, ast.MergeSpans(token.Span, arg.Span()))
 		}
 	}
 
@@ -481,10 +452,9 @@ func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
 		mod = "set"
 	}
 
-	objKey, objKeyErrors := p.objExprKey()
-	errors = append(errors, objKeyErrors...)
+	objKey := p.objExprKey()
 	if objKey == nil {
-		return nil, errors
+		return nil
 	}
 	token = p.lexer.peek()
 
@@ -495,8 +465,7 @@ func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
 	switch token.Type {
 	case Colon:
 		p.lexer.consume() // consume ':'
-		value, valueErrors := p.expr()
-		errors = append(errors, valueErrors...)
+		value := p.expr()
 		if value != nil {
 			property := ast.NewProperty(
 				objKey,
@@ -505,15 +474,13 @@ func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
 				value,
 				ast.MergeSpans(objKey.Span(), value.Span()),
 			)
-			return property, errors
+			return property
 		}
-		return nil, errors
+		return nil
 	case Question:
 		p.lexer.consume() // consume '?'
-		_, expectErrors := p.expect(Colon, ConsumeOnMatch)
-		errors = append(errors, expectErrors...)
-		value, valueErrors := p.expr()
-		errors = append(errors, valueErrors...)
+		p.expect(Colon, ConsumeOnMatch)
+		value := p.expr()
 		if value != nil {
 			property := ast.NewProperty(
 				objKey,
@@ -522,18 +489,15 @@ func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
 				value,
 				ast.MergeSpans(objKey.Span(), value.Span()),
 			)
-			return property, errors
+			return property
 		}
-		return nil, errors
+		return nil
 	case OpenParen:
 		p.lexer.consume() // consume '('
-		params, seqErrors := parseDelimSeq(p, CloseParen, Comma, p.param)
-		errors = append(errors, seqErrors...)
-		_, expectErrors := p.expect(CloseParen, ConsumeOnMatch)
-		errors = append(errors, expectErrors...)
+		params := parseDelimSeq(p, CloseParen, Comma, p.param)
+		p.expect(CloseParen, ConsumeOnMatch)
 
-		body, bodyErrors := p.block()
-		errors = append(errors, bodyErrors...)
+		body := p.block()
 		end := body.Span.End
 
 		span := ast.Span{Start: objKey.Span().Start, End: end}
@@ -552,19 +516,19 @@ func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
 				objKey,
 				fn,
 				ast.MergeSpans(token.Span, span),
-			), errors
+			)
 		} else if mod == "set" {
 			return ast.NewSetter(
 				objKey,
 				fn,
 				ast.MergeSpans(token.Span, span),
-			), errors
+			)
 		} else {
 			return ast.NewMethod(
 				objKey,
 				fn,
 				ast.MergeSpans(token.Span, span),
-			), errors
+			)
 		}
 	default:
 		switch objKey.(type) {
@@ -578,15 +542,14 @@ func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
 					nil, // shorthand property
 					objKey.Span(),
 				)
-				return property, errors
+				return property
 			default:
-				value, valueErrors := p.expr()
-				errors = append(errors, valueErrors...)
+				value := p.expr()
 				if value == nil {
-					errors = append(errors, NewError(token.Span, "Expected a comma, closing brace, or expression"))
-					return nil, errors
+					p.errors = append(p.errors, NewError(token.Span, "Expected a comma, closing brace, or expression"))
+					return nil
 				} else {
-					errors = append(errors, NewError(token.Span, "Expected a comma or closing brace"))
+					p.errors = append(p.errors, NewError(token.Span, "Expected a comma or closing brace"))
 				}
 				if value != nil {
 					property := ast.NewProperty(
@@ -596,25 +559,25 @@ func (p *Parser) objExprElem() (ast.ObjExprElem, []*Error) {
 						value,
 						objKey.Span(),
 					)
-					return property, errors
+					return property
 				}
-				return nil, errors
+				return nil
 			}
 		default:
-			errors = append(errors, NewError(token.Span, "Expected a comma or closing brace"))
+			p.errors = append(p.errors, NewError(token.Span, "Expected a comma or closing brace"))
 		}
 	}
-	return nil, errors
+	return nil
 }
 
 // <pattern>: <type annotation>
 // <pattern>?: <type annotation>
 // <pattern>?
 // <pattern>
-func (p *Parser) param() (*ast.Param, []*Error) {
-	pat, errors := p.pattern(true)
+func (p *Parser) param() *ast.Param {
+	pat := p.pattern(true)
 	if pat == nil {
-		return nil, errors
+		return nil
 	}
 	token := p.lexer.peek()
 
@@ -626,27 +589,25 @@ func (p *Parser) param() (*ast.Param, []*Error) {
 
 	if token.Type == Colon {
 		p.lexer.consume() // consume ':'
-		typeAnn, typeAnnErrors := p.typeAnn()
-		errors = append(errors, typeAnnErrors...)
+		typeAnn := p.typeAnn()
 		return &ast.Param{
 			Pattern:  pat,
 			TypeAnn:  typeAnn,
 			Optional: opt,
-		}, errors
+		}
 	}
 
 	return &ast.Param{
 		Pattern:  pat,
 		TypeAnn:  nil,
 		Optional: opt,
-	}, errors
+	}
 }
 
-func (p *Parser) templateLitExpr(token *Token, tag ast.Expr) (ast.Expr, []*Error) {
+func (p *Parser) templateLitExpr(token *Token, tag ast.Expr) ast.Expr {
 	p.lexer.consume()
 	quasis := []*ast.Quasi{}
 	exprs := []ast.Expr{}
-	errors := []*Error{}
 	for {
 		quasi := p.lexer.lexQuasi()
 
@@ -658,8 +619,7 @@ func (p *Parser) templateLitExpr(token *Token, tag ast.Expr) (ast.Expr, []*Error
 		} else if strings.HasSuffix(quasi.Value, "${") {
 			raw = quasi.Value[:len(quasi.Value)-2]
 			quasis = append(quasis, &ast.Quasi{Value: raw, Span: quasi.Span})
-			expr, exprErrors := p.expr()
-			errors = append(errors, exprErrors...)
+			expr := p.expr()
 			if expr != nil {
 				exprs = append(exprs, expr)
 			}
@@ -670,41 +630,37 @@ func (p *Parser) templateLitExpr(token *Token, tag ast.Expr) (ast.Expr, []*Error
 			raw = quasi.Value
 			quasis = append(quasis, &ast.Quasi{Value: raw, Span: quasi.Span})
 			span := ast.Span{Start: token.Span.Start, End: quasi.Span.End}
-			errors = append(errors, NewError(span, "Expected a closing backtick"))
+			p.errors = append(p.errors, NewError(span, "Expected a closing backtick"))
 			break
 		}
 	}
 	if tag != nil {
 		span := ast.Span{Start: tag.Span().Start, End: p.lexer.currentLocation}
-		return ast.NewTaggedTemplateLit(tag, quasis, exprs, span), errors
+		return ast.NewTaggedTemplateLit(tag, quasis, exprs, span)
 	} else {
 		span := ast.NewSpan(token.Span.Start, p.lexer.currentLocation)
-		return ast.NewTemplateLit(quasis, exprs, span), errors
+		return ast.NewTemplateLit(quasis, exprs, span)
 	}
 }
 
-func (p *Parser) ifElse() (ast.Expr, []*Error) {
+func (p *Parser) ifElse() ast.Expr {
 	start := p.lexer.currentLocation
 
 	p.lexer.consume() // consume 'if'
 
 	token := p.lexer.peek()
 	var cond ast.Expr
-	errors := []*Error{}
 	if token.Type == OpenBrace {
-		errors = append(errors, NewError(token.Span, "Expected a condition"))
+		p.errors = append(p.errors, NewError(token.Span, "Expected a condition"))
 	} else {
-		var condErrors []*Error
-		cond, condErrors = p.expr()
-		errors = append(errors, condErrors...)
+		cond = p.expr()
 		if cond == nil {
-			errors = append(errors, NewError(token.Span, "Expected a valid condition expression"))
-			return nil, errors
+			p.errors = append(p.errors, NewError(token.Span, "Expected a valid condition expression"))
+			return nil
 		}
 	}
 
-	body, bodyErrors := p.block()
-	errors = append(errors, bodyErrors...)
+	body := p.block()
 	token = p.lexer.peek()
 	if token.Type == Else {
 		p.lexer.consume()
@@ -712,14 +668,13 @@ func (p *Parser) ifElse() (ast.Expr, []*Error) {
 		// nolint: exhaustive
 		switch token.Type {
 		case If:
-			ifElseResult, ifElseErrors := p.ifElse()
-			errors = append(errors, ifElseErrors...)
+			ifElseResult := p.ifElse()
 			if ifElseResult == nil {
-				errors = append(errors, NewError(token.Span, "Expected a valid expression after 'if'"))
+				p.errors = append(p.errors, NewError(token.Span, "Expected a valid expression after 'if'"))
 				return ast.NewIfElse(
 					cond, body, nil,
 					ast.Span{Start: start, End: token.Span.Start},
-				), errors
+				)
 			}
 			expr := ifElseResult
 			alt := &ast.BlockOrExpr{
@@ -728,27 +683,26 @@ func (p *Parser) ifElse() (ast.Expr, []*Error) {
 			}
 			return ast.NewIfElse(
 				cond, body, alt, ast.Span{Start: start, End: expr.Span().End},
-			), errors
+			)
 		case OpenBrace:
-			block, blockErrors := p.block()
-			errors = append(errors, blockErrors...)
+			block := p.block()
 			alt := &ast.BlockOrExpr{
 				Expr:  nil,
 				Block: &block,
 			}
 			return ast.NewIfElse(
 				cond, body, alt, ast.Span{Start: start, End: block.Span.End},
-			), errors
+			)
 		default:
-			errors = append(errors, NewError(token.Span, "Expected an if or an opening brace"))
+			p.errors = append(p.errors, NewError(token.Span, "Expected an if or an opening brace"))
 			return ast.NewIfElse(
 				cond, body, nil,
 				ast.Span{Start: start, End: token.Span.Start},
-			), errors
+			)
 		}
 	}
 	return ast.NewIfElse(
 		cond, body, nil,
 		ast.Span{Start: start, End: token.Span.Start},
-	), errors
+	)
 }

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -152,10 +152,10 @@ func TestParseExprNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			expr, errors := parser.expr()
+			expr := parser.expr()
 
 			snaps.MatchSnapshot(t, expr)
-			assert.Equal(t, []*Error{}, errors)
+			assert.Equal(t, []*Error{}, parser.errors)
 		})
 	}
 }
@@ -228,11 +228,11 @@ func TestParseExprErrorHandling(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			expr, errors := parser.expr()
+			expr := parser.expr()
 
 			snaps.MatchSnapshot(t, expr)
-			assert.Greater(t, len(errors), 0)
-			snaps.MatchSnapshot(t, errors)
+			assert.Greater(t, len(parser.errors), 0)
+			snaps.MatchSnapshot(t, parser.errors)
 		})
 	}
 }

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -27,7 +27,7 @@ func (p *Parser) jsxElement() *ast.JSXElementExpr {
 func (p *Parser) jsxOpening() *ast.JSXOpening {
 	token := p.lexer.next()
 	if token.Type != LessThan {
-		p.errors = append(p.errors, NewError(token.Span, "Expected '<'"))
+		p.reportError(token.Span, "Expected '<'")
 	}
 
 	start := token.Span.Start
@@ -47,7 +47,7 @@ func (p *Parser) jsxOpening() *ast.JSXOpening {
 		}
 		return ast.NewJSXOpening("", []*ast.JSXAttr{}, false, span)
 	default:
-		p.errors = append(p.errors, NewError(token.Span, "Expected an identifier or '>'"))
+		p.reportError(token.Span, "Expected an identifier or '>'")
 	}
 
 	attrs := p.jsxAttrs()
@@ -63,7 +63,7 @@ func (p *Parser) jsxOpening() *ast.JSXOpening {
 	case GreaterThan:
 		// do nothing
 	default:
-		p.errors = append(p.errors, NewError(token.Span, "Expected '>' or '/>'"))
+		p.reportError(token.Span, "Expected '>' or '/>'")
 	}
 
 	end := token.Span.End
@@ -94,7 +94,7 @@ func (p *Parser) jsxAttrs() []*ast.JSXAttr {
 		if token.Type == Equal {
 			p.lexer.consume() // consume equals
 		} else {
-			p.errors = append(p.errors, NewError(token.Span, "Expected '='"))
+			p.reportError(token.Span, "Expected '='")
 		}
 
 		var value ast.JSXAttrValue
@@ -111,7 +111,7 @@ func (p *Parser) jsxAttrs() []*ast.JSXAttr {
 			p.lexer.consume() // consume '{'
 			expr := p.expr()
 			if expr == nil {
-				p.errors = append(p.errors, NewError(token.Span, "Expected an expression after '{'"))
+				p.reportError(token.Span, "Expected an expression after '{'")
 				return attrs
 			}
 			value = ast.NewJSXExprContainer(expr, token.Span)
@@ -119,10 +119,10 @@ func (p *Parser) jsxAttrs() []*ast.JSXAttr {
 			if token.Type == CloseBrace {
 				p.lexer.consume() // consume '}'
 			} else {
-				p.errors = append(p.errors, NewError(token.Span, "Expected '}'"))
+				p.reportError(token.Span, "Expected '}'")
 			}
 		default:
-			p.errors = append(p.errors, NewError(token.Span, "Expected a string or an expression"))
+			p.reportError(token.Span, "Expected a string or an expression")
 		}
 
 		attr := ast.NewJSXAttr(name, &value, token.Span)
@@ -135,7 +135,7 @@ func (p *Parser) jsxAttrs() []*ast.JSXAttr {
 func (p *Parser) jsxClosing() *ast.JSXClosing {
 	token := p.lexer.next()
 	if token.Type != LessThanSlash {
-		p.errors = append(p.errors, NewError(token.Span, "Expected '</'"))
+		p.reportError(token.Span, "Expected '</'")
 	}
 
 	start := token.Span.Start
@@ -155,12 +155,12 @@ func (p *Parser) jsxClosing() *ast.JSXClosing {
 		}
 		return ast.NewJSXClosing("", span)
 	default:
-		p.errors = append(p.errors, NewError(token.Span, "Expected an identifier or '>'"))
+		p.reportError(token.Span, "Expected an identifier or '>'")
 	}
 
 	token = p.lexer.next()
 	if token.Type != GreaterThan {
-		p.errors = append(p.errors, NewError(token.Span, "Expected '>'"))
+		p.reportError(token.Span, "Expected '>'")
 	}
 
 	end := token.Span.End
@@ -195,7 +195,7 @@ func (p *Parser) jsxChildren() []ast.JSXChild {
 			if token.Type == CloseBrace {
 				p.lexer.consume()
 			} else {
-				p.errors = append(p.errors, NewError(token.Span, "Expected '}'"))
+				p.reportError(token.Span, "Expected '}'")
 			}
 			children = append(children, ast.NewJSXExprContainer(expr, token.Span))
 		default:

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -4,11 +4,8 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 )
 
-func (p *Parser) jsxElement() (*ast.JSXElementExpr, []*Error) {
-	errors := []*Error{}
-
-	opening, openErrors := p.jsxOpening()
-	errors = append(errors, openErrors...)
+func (p *Parser) jsxElement() *ast.JSXElementExpr {
+	opening := p.jsxOpening()
 
 	span := ast.Span{
 		Start: opening.Span().Start,
@@ -16,26 +13,21 @@ func (p *Parser) jsxElement() (*ast.JSXElementExpr, []*Error) {
 	}
 
 	if !opening.SelfClose {
-		children, childrenErrors := p.jsxChildren()
-		errors = append(errors, childrenErrors...)
-		closing, closingErrors := p.jsxClosing()
-		errors = append(errors, closingErrors...)
+		children := p.jsxChildren()
+		closing := p.jsxClosing()
 
 		return ast.NewJSXElement(
 			opening, closing, children, ast.MergeSpans(span, closing.Span()),
-		), errors
+		)
 	}
 
-	return ast.NewJSXElement(
-		opening, nil, []ast.JSXChild{}, span,
-	), errors
+	return ast.NewJSXElement(opening, nil, []ast.JSXChild{}, span)
 }
 
-func (p *Parser) jsxOpening() (*ast.JSXOpening, []*Error) {
-	errors := []*Error{}
+func (p *Parser) jsxOpening() *ast.JSXOpening {
 	token := p.lexer.next()
 	if token.Type != LessThan {
-		errors = append(errors, NewError(token.Span, "Expected '<'"))
+		p.errors = append(p.errors, NewError(token.Span, "Expected '<'"))
 	}
 
 	start := token.Span.Start
@@ -53,13 +45,12 @@ func (p *Parser) jsxOpening() (*ast.JSXOpening, []*Error) {
 			Start: start,
 			End:   end,
 		}
-		return ast.NewJSXOpening("", []*ast.JSXAttr{}, false, span), errors
+		return ast.NewJSXOpening("", []*ast.JSXAttr{}, false, span)
 	default:
-		errors = append(errors, NewError(token.Span, "Expected an identifier or '>'"))
+		p.errors = append(p.errors, NewError(token.Span, "Expected an identifier or '>'"))
 	}
 
-	attrs, attrsErrors := p.jsxAttrs()
-	errors = append(errors, attrsErrors...)
+	attrs := p.jsxAttrs()
 
 	var selfClosing bool
 
@@ -72,7 +63,7 @@ func (p *Parser) jsxOpening() (*ast.JSXOpening, []*Error) {
 	case GreaterThan:
 		// do nothing
 	default:
-		errors = append(errors, NewError(token.Span, "Expected '>' or '/>'"))
+		p.errors = append(p.errors, NewError(token.Span, "Expected '>' or '/>'"))
 	}
 
 	end := token.Span.End
@@ -82,12 +73,11 @@ func (p *Parser) jsxOpening() (*ast.JSXOpening, []*Error) {
 		End:   end,
 	}
 
-	return ast.NewJSXOpening(name, attrs, selfClosing, span), errors
+	return ast.NewJSXOpening(name, attrs, selfClosing, span)
 }
 
-func (p *Parser) jsxAttrs() ([]*ast.JSXAttr, []*Error) {
+func (p *Parser) jsxAttrs() []*ast.JSXAttr {
 	attrs := []*ast.JSXAttr{}
-	errors := []*Error{}
 
 	for {
 		token := p.lexer.peek()
@@ -104,7 +94,7 @@ func (p *Parser) jsxAttrs() ([]*ast.JSXAttr, []*Error) {
 		if token.Type == Equal {
 			p.lexer.consume() // consume equals
 		} else {
-			errors = append(errors, NewError(token.Span, "Expected '='"))
+			p.errors = append(p.errors, NewError(token.Span, "Expected '='"))
 		}
 
 		var value ast.JSXAttrValue
@@ -119,36 +109,33 @@ func (p *Parser) jsxAttrs() ([]*ast.JSXAttr, []*Error) {
 			value = ast.NewJSXString(token.Value, token.Span)
 		case OpenBrace:
 			p.lexer.consume() // consume '{'
-			expr, exprErrors := p.expr()
-			errors = append(errors, exprErrors...)
+			expr := p.expr()
 			if expr == nil {
-				errors := append(errors, NewError(token.Span, "Expected an expression after '{'"))
-				return attrs, errors
+				p.errors = append(p.errors, NewError(token.Span, "Expected an expression after '{'"))
+				return attrs
 			}
 			value = ast.NewJSXExprContainer(expr, token.Span)
 			token = p.lexer.peek()
 			if token.Type == CloseBrace {
 				p.lexer.consume() // consume '}'
 			} else {
-				errors = append(errors, NewError(token.Span, "Expected '}'"))
+				p.errors = append(p.errors, NewError(token.Span, "Expected '}'"))
 			}
 		default:
-			errors = append(errors, NewError(token.Span, "Expected a string or an expression"))
+			p.errors = append(p.errors, NewError(token.Span, "Expected a string or an expression"))
 		}
 
 		attr := ast.NewJSXAttr(name, &value, token.Span)
 		attrs = append(attrs, attr)
 	}
 
-	return attrs, errors
+	return attrs
 }
 
-func (p *Parser) jsxClosing() (*ast.JSXClosing, []*Error) {
-	errors := []*Error{}
-
+func (p *Parser) jsxClosing() *ast.JSXClosing {
 	token := p.lexer.next()
 	if token.Type != LessThanSlash {
-		errors = append(errors, NewError(token.Span, "Expected '</'"))
+		p.errors = append(p.errors, NewError(token.Span, "Expected '</'"))
 	}
 
 	start := token.Span.Start
@@ -166,14 +153,14 @@ func (p *Parser) jsxClosing() (*ast.JSXClosing, []*Error) {
 			Start: start,
 			End:   end,
 		}
-		return ast.NewJSXClosing("", span), errors
+		return ast.NewJSXClosing("", span)
 	default:
-		errors = append(errors, NewError(token.Span, "Expected an identifier or '>'"))
+		p.errors = append(p.errors, NewError(token.Span, "Expected an identifier or '>'"))
 	}
 
 	token = p.lexer.next()
 	if token.Type != GreaterThan {
-		errors = append(errors, NewError(token.Span, "Expected '>'"))
+		p.errors = append(p.errors, NewError(token.Span, "Expected '>'"))
 	}
 
 	end := token.Span.End
@@ -182,12 +169,11 @@ func (p *Parser) jsxClosing() (*ast.JSXClosing, []*Error) {
 		End:   end,
 	}
 
-	return ast.NewJSXClosing(name, span), errors
+	return ast.NewJSXClosing(name, span)
 }
 
-func (p *Parser) jsxChildren() ([]ast.JSXChild, []*Error) {
+func (p *Parser) jsxChildren() []ast.JSXChild {
 	children := []ast.JSXChild{}
-	errors := []*Error{}
 
 	for {
 		token := p.lexer.peek()
@@ -195,23 +181,21 @@ func (p *Parser) jsxChildren() ([]ast.JSXChild, []*Error) {
 		//nolint: exhaustive
 		switch token.Type {
 		case LessThanSlash, EndOfFile:
-			return children, errors
+			return children
 		case LessThan:
-			jsxElement, jsxErrors := p.jsxElement()
-			errors = append(errors, jsxErrors...)
+			jsxElement := p.jsxElement()
 			if jsxElement != nil {
 				children = append(children, jsxElement)
 			}
 		case OpenBrace:
 			p.lexer.consume()
-			expr, exprErrors := p.expr()
-			errors = append(errors, exprErrors...)
+			expr := p.expr()
 			// TODO: handle the case when parseExpr() returns nil
 			token = p.lexer.peek()
 			if token.Type == CloseBrace {
 				p.lexer.consume()
 			} else {
-				errors = append(errors, NewError(token.Span, "Expected '}'"))
+				p.errors = append(p.errors, NewError(token.Span, "Expected '}'"))
 			}
 			children = append(children, ast.NewJSXExprContainer(expr, token.Span))
 		default:

--- a/internal/parser/jsx_test.go
+++ b/internal/parser/jsx_test.go
@@ -53,10 +53,10 @@ func TestParseJSXNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			jsx, errors := parser.jsxElement()
+			jsx := parser.jsxElement()
 
 			snaps.MatchSnapshot(t, jsx)
-			assert.Len(t, errors, 0)
+			assert.Len(t, parser.errors, 0)
 		})
 	}
 }
@@ -84,11 +84,11 @@ func TestParseJSXErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			jsx, errors := parser.jsxElement()
+			jsx := parser.jsxElement()
 
 			snaps.MatchSnapshot(t, jsx)
-			assert.Greater(t, len(errors), 0)
-			snaps.MatchSnapshot(t, errors)
+			assert.Greater(t, len(parser.errors), 0)
+			snaps.MatchSnapshot(t, parser.errors)
 		})
 	}
 }

--- a/internal/parser/pattern.go
+++ b/internal/parser/pattern.go
@@ -7,9 +7,8 @@ import (
 )
 
 // pattern = identifier | wildcard | tuple | object | rest | literal
-func (p *Parser) pattern(allowIdentDefault bool) (ast.Pat, []*Error) {
+func (p *Parser) pattern(allowIdentDefault bool) ast.Pat {
 	token := p.lexer.peek()
-	errors := []*Error{}
 
 	// nolint: exhaustive
 	switch token.Type {
@@ -23,7 +22,7 @@ func (p *Parser) pattern(allowIdentDefault bool) (ast.Pat, []*Error) {
 		}
 	case Underscore:
 		p.lexer.consume()
-		return ast.NewWildcardPat(token.Span), errors
+		return ast.NewWildcardPat(token.Span)
 	case OpenBracket:
 		return p.tuplePat()
 	case OpenBrace:
@@ -36,120 +35,105 @@ func (p *Parser) pattern(allowIdentDefault bool) (ast.Pat, []*Error) {
 }
 
 // extractorPat = identifier '(' (pattern (',' pattern)*)? ')'
-func (p *Parser) extractorPat(nameToken *Token) (ast.Pat, []*Error) {
-	errors := []*Error{}
+func (p *Parser) extractorPat(nameToken *Token) ast.Pat {
 	p.lexer.consume() // consume '('
-	patArgs, patErrors := parseDelimSeq(p, CloseParen, Comma, func() (ast.Pat, []*Error) {
+	patArgs := parseDelimSeq(p, CloseParen, Comma, func() ast.Pat {
 		return p.pattern(true)
 	})
-	errors = append(errors, patErrors...)
-	end, endErrors := p.expect(CloseParen, AlwaysConsume)
-	errors = append(errors, endErrors...)
-	return ast.NewExtractorPat(nameToken.Value, patArgs, ast.NewSpan(nameToken.Span.Start, end)), errors
+	end := p.expect(CloseParen, AlwaysConsume)
+	return ast.NewExtractorPat(nameToken.Value, patArgs, ast.NewSpan(nameToken.Span.Start, end))
 }
 
 // identPat = identifier ('=' expr)?
-func (p *Parser) identPat(nameToken *Token, allowIdentDefault bool) (ast.Pat, []*Error) {
-	errors := []*Error{}
+func (p *Parser) identPat(nameToken *Token, allowIdentDefault bool) ast.Pat {
 	span := nameToken.Span
 	token := p.lexer.peek()
 	var _default ast.Expr
 	if allowIdentDefault && token.Type == Equal {
 		p.lexer.consume()
-		expr, exprErrors := p.expr()
-		errors = append(errors, exprErrors...)
+		expr := p.expr()
 		if expr != nil {
 			span = ast.MergeSpans(span, expr.Span())
 			_default = expr
 		}
 	}
-	return ast.NewIdentPat(nameToken.Value, _default, span), errors
+	return ast.NewIdentPat(nameToken.Value, _default, span)
 }
 
 // tuplePat = '[' (pattern (',' pattern)*)? ']'
-func (p *Parser) tuplePat() (ast.Pat, []*Error) {
-	errors := []*Error{}
+func (p *Parser) tuplePat() ast.Pat {
 	token := p.lexer.peek()
 	start := token.Span.Start
 	p.lexer.consume() // consume '['
-	patElems, patElemsErrors := parseDelimSeq(p, CloseBracket, Comma, func() (ast.Pat, []*Error) {
+	patElems := parseDelimSeq(p, CloseBracket, Comma, func() ast.Pat {
 		return p.pattern(true)
 	})
-	errors = append(errors, patElemsErrors...)
-	end, endErrors := p.expect(CloseBracket, AlwaysConsume)
-	errors = append(errors, endErrors...)
-	return ast.NewTuplePat(patElems, ast.NewSpan(start, end)), errors
+	end := p.expect(CloseBracket, AlwaysConsume)
+	return ast.NewTuplePat(patElems, ast.NewSpan(start, end))
 }
 
 // objectPat = '{' (objPatElem (',' objPatElem)*)? '}'
-func (p *Parser) objectPat() (ast.Pat, []*Error) {
-	errors := []*Error{}
+func (p *Parser) objectPat() ast.Pat {
 	token := p.lexer.peek()
 	start := token.Span.Start
 	p.lexer.consume() // consume '{'
-	patElems, patElemsErrors := parseDelimSeq(p, CloseBrace, Comma, p.objPatElem)
-	errors = append(errors, patElemsErrors...)
-	end, endErrors := p.expect(CloseBrace, AlwaysConsume)
-	errors = append(errors, endErrors...)
-	return ast.NewObjectPat(patElems, ast.NewSpan(start, end)), errors
+	patElems := parseDelimSeq(p, CloseBrace, Comma, p.objPatElem)
+	end := p.expect(CloseBrace, AlwaysConsume)
+	return ast.NewObjectPat(patElems, ast.NewSpan(start, end))
 }
 
 // restPat = '...' pattern
-func (p *Parser) restPat() (ast.Pat, []*Error) {
-	errors := []*Error{}
+func (p *Parser) restPat() ast.Pat {
 	token := p.lexer.peek()
 	p.lexer.consume() // consume '...'
-	pat, patErrors := p.pattern(true)
-	errors = append(errors, patErrors...)
+	pat := p.pattern(true)
 	span := token.Span
 	if pat == nil {
-		errors = append(errors, NewError(token.Span, "Expected pattern"))
-		return nil, errors
+		p.errors = append(p.errors, NewError(token.Span, "Expected pattern"))
+		return nil
 	}
 	span = ast.MergeSpans(span, pat.Span())
-	return ast.NewRestPat(pat, span), errors
+	return ast.NewRestPat(pat, span)
 }
 
 // literalPat = string | number | 'true' | 'false' | 'null' | 'undefined'
-func (p *Parser) literalPat() (ast.Pat, []*Error) {
-	errors := []*Error{}
+func (p *Parser) literalPat() ast.Pat {
 	token := p.lexer.peek()
 
 	// nolint: exhaustive
 	switch token.Type {
 	case StrLit:
 		p.lexer.consume()
-		return ast.NewLitPat(&ast.StrLit{Value: token.Value}, token.Span), errors
+		return ast.NewLitPat(&ast.StrLit{Value: token.Value}, token.Span)
 	case NumLit:
 		p.lexer.consume()
 		value, err := strconv.ParseFloat(token.Value, 64)
 		if err != nil {
-			errors = append(errors, NewError(token.Span, "Invalid number"))
-			return nil, errors
+			p.errors = append(p.errors, NewError(token.Span, "Invalid number"))
+			return nil
 		}
-		return ast.NewLitPat(&ast.NumLit{Value: value}, token.Span), errors
+		return ast.NewLitPat(&ast.NumLit{Value: value}, token.Span)
 	case True:
 		p.lexer.consume()
-		return ast.NewLitPat(&ast.BoolLit{Value: true}, token.Span), errors
+		return ast.NewLitPat(&ast.BoolLit{Value: true}, token.Span)
 	case False:
 		p.lexer.consume()
-		return ast.NewLitPat(&ast.BoolLit{Value: false}, token.Span), errors
+		return ast.NewLitPat(&ast.BoolLit{Value: false}, token.Span)
 	case Null:
 		p.lexer.consume()
-		return ast.NewLitPat(&ast.NullLit{}, token.Span), errors
+		return ast.NewLitPat(&ast.NullLit{}, token.Span)
 	case Undefined:
 		p.lexer.consume()
-		return ast.NewLitPat(&ast.UndefinedLit{}, token.Span), errors
+		return ast.NewLitPat(&ast.UndefinedLit{}, token.Span)
 	default:
 		// TODO: return an invalid pattern
-		errors = append(errors, NewError(token.Span, "Expected a pattern"))
-		return nil, errors
+		p.errors = append(p.errors, NewError(token.Span, "Expected a pattern"))
+		return nil
 	}
 }
 
-func (p *Parser) objPatElem() (ast.ObjPatElem, []*Error) {
+func (p *Parser) objPatElem() ast.ObjPatElem {
 	token := p.lexer.peek()
-	errors := []*Error{}
 
 	if token.Type == Identifier {
 		p.lexer.consume()
@@ -159,8 +143,7 @@ func (p *Parser) objPatElem() (ast.ObjPatElem, []*Error) {
 		token = p.lexer.peek()
 		if token.Type == Colon {
 			p.lexer.consume()
-			value, valueError := p.pattern(true)
-			errors = append(errors, valueError...)
+			value := p.pattern(true)
 			if value != nil {
 				span = ast.MergeSpans(span, value.Span())
 			}
@@ -169,47 +152,44 @@ func (p *Parser) objPatElem() (ast.ObjPatElem, []*Error) {
 			token = p.lexer.peek()
 			if token.Type == Equal {
 				p.lexer.consume()
-				expr, exprError := p.expr()
+				expr := p.expr()
 				init = expr
-				errors = append(errors, exprError...)
 				if init != nil {
 					span = ast.MergeSpans(span, init.Span())
 				}
 			}
 
 			if value == nil {
-				return nil, errors
+				return nil
 			}
 
 			span = ast.MergeSpans(span, value.Span())
-			return ast.NewObjKeyValuePat(key, value, init, span), errors
+			return ast.NewObjKeyValuePat(key, value, init, span)
 		} else {
 			var init ast.Expr
 			token = p.lexer.peek()
 			if token.Type == Equal {
 				p.lexer.consume()
-				expr, exprError := p.expr()
-				errors = append(errors, exprError...)
+				expr := p.expr()
 				if expr != nil {
 					span = ast.MergeSpans(span, expr.Span())
 					init = expr
 				}
 			}
 
-			return ast.NewObjShorthandPat(key, init, span), errors
+			return ast.NewObjShorthandPat(key, init, span)
 		}
 	} else if token.Type == DotDotDot {
 		p.lexer.consume()
 
-		pat, patErrors := p.pattern(true)
-		errors = append(errors, patErrors...)
+		pat := p.pattern(true)
 		if pat == nil {
-			return nil, errors
+			return nil
 		}
 		span := ast.MergeSpans(token.Span, pat.Span())
-		return ast.NewObjRestPat(pat, span), errors
+		return ast.NewObjRestPat(pat, span)
 	} else {
-		errors = append(errors, NewError(token.Span, "Expected identifier or '...'"))
-		return nil, errors
+		p.errors = append(p.errors, NewError(token.Span, "Expected identifier or '...'"))
+		return nil
 	}
 }

--- a/internal/parser/pattern.go
+++ b/internal/parser/pattern.go
@@ -89,7 +89,7 @@ func (p *Parser) restPat() ast.Pat {
 	pat := p.pattern(true)
 	span := token.Span
 	if pat == nil {
-		p.errors = append(p.errors, NewError(token.Span, "Expected pattern"))
+		p.reportError(token.Span, "Expected pattern")
 		return nil
 	}
 	span = ast.MergeSpans(span, pat.Span())
@@ -109,7 +109,7 @@ func (p *Parser) literalPat() ast.Pat {
 		p.lexer.consume()
 		value, err := strconv.ParseFloat(token.Value, 64)
 		if err != nil {
-			p.errors = append(p.errors, NewError(token.Span, "Invalid number"))
+			p.reportError(token.Span, "Invalid number")
 			return nil
 		}
 		return ast.NewLitPat(&ast.NumLit{Value: value}, token.Span)
@@ -127,7 +127,7 @@ func (p *Parser) literalPat() ast.Pat {
 		return ast.NewLitPat(&ast.UndefinedLit{}, token.Span)
 	default:
 		// TODO: return an invalid pattern
-		p.errors = append(p.errors, NewError(token.Span, "Expected a pattern"))
+		p.reportError(token.Span, "Expected a pattern")
 		return nil
 	}
 }
@@ -189,7 +189,7 @@ func (p *Parser) objPatElem() ast.ObjPatElem {
 		span := ast.MergeSpans(token.Span, pat.Span())
 		return ast.NewObjRestPat(pat, span)
 	} else {
-		p.errors = append(p.errors, NewError(token.Span, "Expected identifier or '...'"))
+		p.reportError(token.Span, "Expected identifier or '...'")
 		return nil
 	}
 }

--- a/internal/parser/pattern_test.go
+++ b/internal/parser/pattern_test.go
@@ -65,10 +65,10 @@ func TestParsePatternNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			expr, errors := parser.pattern(false)
+			expr := parser.pattern(false)
 
 			snaps.MatchSnapshot(t, expr)
-			assert.Equal(t, errors, []*Error{})
+			assert.Equal(t, parser.errors, []*Error{})
 		})
 	}
 }

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -11,7 +11,7 @@ func (p *Parser) block() ast.Block {
 
 	token := p.lexer.next()
 	if token.Type != OpenBrace {
-		p.errors = append(p.errors, NewError(token.Span, "Expected an opening brace"))
+		p.reportError(token.Span, "Expected an opening brace")
 		return ast.Block{Stmts: stmts, Span: token.Span}
 	} else {
 		start = token.Span.Start

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -5,14 +5,14 @@ import (
 )
 
 // block = '{' stmt* '}'
-func (p *Parser) block() (ast.Block, []*Error) {
+func (p *Parser) block() ast.Block {
 	stmts := []ast.Stmt{}
-	errors := []*Error{}
 	var start ast.Location
 
 	token := p.lexer.next()
 	if token.Type != OpenBrace {
-		return ast.Block{Stmts: stmts, Span: token.Span}, []*Error{NewError(token.Span, "Expected an opening brace")}
+		p.errors = append(p.errors, NewError(token.Span, "Expected an opening brace"))
+		return ast.Block{Stmts: stmts, Span: token.Span}
 	} else {
 		start = token.Span.Start
 	}
@@ -23,13 +23,12 @@ func (p *Parser) block() (ast.Block, []*Error) {
 		switch token.Type {
 		case CloseBrace:
 			p.lexer.consume()
-			return ast.Block{Stmts: stmts, Span: ast.Span{Start: start, End: token.Span.End}}, errors
+			return ast.Block{Stmts: stmts, Span: ast.Span{Start: start, End: token.Span.End}}
 		case LineComment, BlockComment:
 			p.lexer.consume()
 			token = p.lexer.peek()
 		default:
-			stmt, stmtErrors := p.stmt()
-			errors = append(errors, stmtErrors...)
+			stmt := p.stmt()
 			if stmt != nil {
 				stmts = append(stmts, stmt)
 			}
@@ -39,29 +38,29 @@ func (p *Parser) block() (ast.Block, []*Error) {
 }
 
 // stmt = decl | ('return' expr?) | expr
-func (p *Parser) stmt() (ast.Stmt, []*Error) {
+func (p *Parser) stmt() ast.Stmt {
 	token := p.lexer.peek()
 
 	// nolint: exhaustive
 	switch token.Type {
 	case Fn, Var, Val, Type, Declare, Export:
-		decl, declErrors := p.decl()
+		decl := p.decl()
 		if decl == nil {
-			return nil, declErrors
+			return nil
 		}
 		stmt := ast.NewDeclStmt(decl, decl.Span())
-		return stmt, declErrors
+		return stmt
 	case Return:
 		p.lexer.consume()
-		expr, exprErrors := p.nonDelimitedExpr()
+		expr := p.nonDelimitedExpr()
 		if expr == nil {
-			return ast.NewReturnStmt(nil, token.Span), exprErrors
+			return ast.NewReturnStmt(nil, token.Span)
 		}
 		return ast.NewReturnStmt(
 			expr, ast.MergeSpans(token.Span, expr.Span()),
-		), exprErrors
+		)
 	default:
-		expr, exprErrors := p.nonDelimitedExpr()
+		expr := p.nonDelimitedExpr()
 		// If no tokens have been consumed then we've encountered something we
 		// don't know how to parse.
 		nextToken := p.lexer.peek()
@@ -70,8 +69,8 @@ func (p *Parser) stmt() (ast.Stmt, []*Error) {
 			p.lexer.consume()
 		}
 		if expr == nil {
-			return nil, exprErrors
+			return nil
 		}
-		return ast.NewExprStmt(expr, expr.Span()), exprErrors
+		return ast.NewExprStmt(expr, expr.Span())
 	}
 }

--- a/internal/parser/stmt_test.go
+++ b/internal/parser/stmt_test.go
@@ -86,13 +86,13 @@ func TestParseStmtNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			stmt, errors := parser.stmt()
+			stmt := parser.stmt()
 
 			snaps.MatchSnapshot(t, stmt)
-			if len(errors) > 0 {
-				fmt.Printf("Error[0]: %#v", errors[0])
+			if len(parser.errors) > 0 {
+				fmt.Printf("Error[0]: %#v", parser.errors[0])
 			}
-			assert.Len(t, errors, 0)
+			assert.Len(t, parser.errors, 0)
 		})
 	}
 }
@@ -139,11 +139,11 @@ func TestParseStmtErrorHandling(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			stmt, errors := parser.stmt()
+			stmt := parser.stmt()
 
 			snaps.MatchSnapshot(t, stmt)
-			assert.Greater(t, len(errors), 0)
-			snaps.MatchSnapshot(t, errors)
+			assert.Greater(t, len(parser.errors), 0)
+			snaps.MatchSnapshot(t, parser.errors)
 		})
 	}
 }

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -119,7 +119,7 @@ loop:
 		typeAnn := p.primaryTypeAnn()
 		if typeAnn == nil {
 			token := p.lexer.peek()
-			p.errors = append(p.errors, NewError(token.Span, "Expected an type annotation"))
+			p.reportError(token.Span, "Expected an type annotation")
 
 			// TODO: add an EmptyTypeAnn to the AST
 			// For now, we panic to indicate that something went wrong
@@ -194,7 +194,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 			p.lexer.consume()
 			value, err := strconv.ParseFloat(token.Value, 64)
 			if err != nil {
-				p.errors = append(p.errors, NewError(token.Span, "Expected a number"))
+				p.reportError(token.Span, "Expected a number")
 				return nil
 			}
 			typeAnn = ast.NewLitTypeAnn(ast.NewNumber(value, token.Span), token.Span)
@@ -225,10 +225,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 
 			retType := p.typeAnn()
 			if retType == nil {
-				p.errors = append(p.errors, &Error{
-					Span:    token.Span,
-					Message: "expected return type annotation",
-				})
+				p.reportError(token.Span, "expected return type annotation")
 				return nil
 			}
 
@@ -262,10 +259,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 
 			typeAnn = ast.NewRefTypeAnn(token.Value, []ast.TypeAnn{}, token.Span)
 		default:
-			p.errors = append(p.errors, &Error{
-				Span:    token.Span,
-				Message: "expected type annotation",
-			})
+			p.reportError(token.Span, "expected type annotation")
 			p.lexer.consume()
 			return nil
 		}
@@ -292,12 +286,12 @@ loop:
 			// TODO: handle the case when parseExpr() return None correctly
 			index := p.typeAnn()
 			if index == nil {
-				p.errors = append(p.errors, NewError(token.Span, "Expected an expression after '['"))
+				p.reportError(token.Span, "Expected an expression after '['")
 				break loop
 			}
 			terminator := p.lexer.next()
 			if terminator.Type != CloseBracket {
-				p.errors = append(p.errors, NewError(token.Span, "Expected a closing bracket"))
+				p.reportError(token.Span, "Expected a closing bracket")
 			}
 			obj := typeAnn
 			typeAnn = ast.NewIndexTypeAnn(
@@ -326,9 +320,9 @@ loop:
 					ast.Span{Start: obj.Span().Start, End: prop.Span().End},
 				)
 				if token.Type == Dot {
-					p.errors = append(p.errors, NewError(token.Span, "expected an identifier after ."))
+					p.reportError(token.Span, "expected an identifier after .")
 				} else {
-					p.errors = append(p.errors, NewError(token.Span, "expected an identifier after ?."))
+					p.reportError(token.Span, "expected an identifier after ?.")
 				}
 			}
 		default:
@@ -361,10 +355,7 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 	// nolint: exhaustive
 	switch token.Type {
 	case CloseBrace:
-		p.errors = append(p.errors, &Error{
-			Span:    token.Span,
-			Message: "expected type annotation",
-		})
+		p.reportError(token.Span, "expected type annotation")
 
 		var property ast.ObjTypeAnnElem = &ast.PropertyTypeAnn{
 			Name:     objKey,
@@ -374,10 +365,7 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 		}
 		return property
 	case Comma:
-		p.errors = append(p.errors, &Error{
-			Span:    token.Span,
-			Message: "expected type annotation",
-		})
+		p.reportError(token.Span, "expected type annotation")
 
 		var property ast.ObjTypeAnnElem = &ast.PropertyTypeAnn{
 			Name:     objKey,
@@ -398,10 +386,7 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 
 		token = p.lexer.peek()
 		if token.Type == Comma {
-			p.errors = append(p.errors, &Error{
-				Span:    token.Span,
-				Message: "expected type annotation",
-			})
+			p.reportError(token.Span, "expected type annotation")
 			return property
 		}
 
@@ -436,10 +421,7 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 
 		retType := p.typeAnn()
 		if retType == nil {
-			p.errors = append(p.errors, &Error{
-				Span:    token.Span,
-				Message: "expected return type annotation",
-			})
+			p.reportError(token.Span, "expected return type annotation")
 			return nil
 		}
 
@@ -477,10 +459,7 @@ func (p *Parser) typeParam() *ast.TypeParam {
 	token := p.lexer.peek()
 
 	if token.Type != Identifier {
-		p.errors = append(p.errors, &Error{
-			Span:    token.Span,
-			Message: "expected type parameter",
-		})
+		p.reportError(token.Span, "expected type parameter")
 		p.lexer.consume()
 		return nil
 	}

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -65,10 +65,10 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			parser := NewParser(ctx, source)
-			typeAnn, errors := parser.typeAnn()
+			typeAnn := parser.typeAnn()
 
 			snaps.MatchSnapshot(t, typeAnn)
-			assert.Equal(t, errors, []*Error{})
+			assert.Equal(t, parser.errors, []*Error{})
 		})
 	}
 }


### PR DESCRIPTION
This significantly simplifies error reporting in the parser.