### PR TITLE
Simplify code for parsing multi-line expressions

### DIFF
--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -75,7 +75,7 @@ func (p *Parser) varDecl(
 			return nil
 		}
 		p.lexer.consume()
-		init = p.nonDelimitedExpr()
+		init = p.expr()
 		if init == nil {
 			token := p.lexer.peek()
 			p.reportError(token.Span, "Expected an expression")
@@ -150,11 +150,7 @@ func (p *Parser) typeDecl(start ast.Location, export bool, declare bool) ast.Dec
 
 	typeParams := []*ast.TypeParam{}
 
-	// Pushing a MarkerDelim here enables typeAnn to parse type annotations that
-	// span multiple lines.
-	p.markers.Push(MarkerDelim)
 	typeAnn := p.typeAnn()
-	p.markers.Pop()
 
 	if typeAnn == nil {
 		return nil

--- a/internal/parser/jsx.go
+++ b/internal/parser/jsx.go
@@ -111,7 +111,6 @@ func (p *Parser) jsxAttrs() []*ast.JSXAttr {
 			p.lexer.consume() // consume '{'
 			expr := p.expr()
 			if expr == nil {
-				p.reportError(token.Span, "Expected an expression after '{'")
 				return attrs
 			}
 			value = ast.NewJSXExprContainer(expr, token.Span)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -7,25 +7,25 @@ import (
 )
 
 type Parser struct {
-	ctx     context.Context
-	lexer   *Lexer
-	markers Stack[Marker]
-	errors  []*Error
+	ctx      context.Context
+	lexer    *Lexer
+	errors   []*Error
+	exprMode Stack[ExprMode]
 }
 
-type Marker int
+type ExprMode int
 
 const (
-	MarkerExpr Marker = iota
-	MarkerDelim
+	MultiLineExpr = iota
+	SingleLineExpr
 )
 
 func NewParser(ctx context.Context, source Source) *Parser {
 	return &Parser{
-		ctx:     ctx,
-		lexer:   NewLexer(source),
-		markers: Stack[Marker]{},
-		errors:  []*Error{},
+		ctx:      ctx,
+		lexer:    NewLexer(source),
+		errors:   []*Error{},
+		exprMode: Stack[ExprMode]{SingleLineExpr},
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -29,24 +29,8 @@ func NewParser(ctx context.Context, source Source) *Parser {
 	}
 }
 
+// script = stmt* <eof>
 func (p *Parser) ParseScript() (*ast.Script, []*Error) {
-	stmts := []ast.Stmt{}
-
-	token := p.lexer.peek()
-	for {
-		//nolint: exhaustive
-		switch token.Type {
-		case EndOfFile:
-			return &ast.Script{Stmts: stmts}, p.errors
-		case LineComment, BlockComment:
-			p.lexer.consume()
-			token = p.lexer.peek()
-		default:
-			stmt := p.stmt()
-			if stmt != nil {
-				stmts = append(stmts, stmt)
-			}
-			token = p.lexer.peek()
-		}
-	}
+	stmts, _ := p.stmts(EndOfFile)
+	return &ast.Script{Stmts: *stmts}, p.errors
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -50,14 +50,3 @@ func (p *Parser) ParseScript() (*ast.Script, []*Error) {
 		}
 	}
 }
-
-// func (parser *Parser) reportError(span ast.Span, message string) {
-// 	_, _, line, _ := runtime.Caller(1)
-// 	if os.Getenv("DEBUG") == "true" {
-// 		message = fmt.Sprintf("%s:%d", message, line)
-// 	}
-// 	parser.Errors = append(parser.Errors, &Error{
-// 		Span:    span,
-// 		Message: message,
-// 	})
-// }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -14,74 +14,74 @@ func TestParseModuleNoErrors(t *testing.T) {
 	tests := map[string]struct {
 		input string
 	}{
-		// "VarDecls": {
-		// 	input: `
-		// 		val a = 5
-		// 		val b = 10
-		// 		val sum = a + b
-		// 	`,
-		// },
-		// "FuncDecls": {
-		// 	input: `
-		// 		fn add(a, b) {
-		// 			return a + b
-		// 		}
-		// 		fn sub(a, b) {
-		// 			return a - b
-		// 		}
-		// 	`,
-		// },
+		"VarDecls": {
+			input: `
+				val a = 5
+				val b = 10
+				val sum = a + b
+			`,
+		},
+		"FuncDecls": {
+			input: `
+				fn add(a, b) {
+					return a + b
+				}
+				fn sub(a, b) {
+					return a - b
+				}
+			`,
+		},
 		"ExprStmts": {
 			input: `
 				foo()
 				bar()
 			`,
 		},
-		// "SplitExprOnNewline": {
-		// 	input: `
-		// 		var a = x
-		// 		-y
-		// 	`,
-		// },
-		// "MultilineExprInParens": {
-		// 	input: `
-		// 		var a = (x
-		// 		-y)
-		// 	`,
-		// },
-		// "MultilineExprInBrackets": {
-		// 	input: `
-		// 		a[base
-		// 		+offset]
-		// 	`,
-		// },
-		// "SplitExprInNewScope": {
-		// 	input: `
-		// 		val funcs = [
-		// 			fn() {
-		// 				var a = x
-		// 				-y
-		// 			}
-		// 		]
-		// 	`,
-		// },
-		// "IfElse": {
-		// 	input: `
-		// 		val x = if cond {
-		// 			var a = 5
-		// 			-10
-		// 		} else {
-		// 		 	var b = 10
-		// 			-5
-		// 		}
-		// 	`,
-		// },
-		// "MemberAssignment": {
-		// 	input: `
-		// 		p.x = 5
-		// 		p.y = 10
-		// 	`,
-		// },
+		"SplitExprOnNewline": {
+			input: `
+				var a = x
+				-y
+			`,
+		},
+		"MultilineExprInParens": {
+			input: `
+				var a = (x
+				-y)
+			`,
+		},
+		"MultilineExprInBrackets": {
+			input: `
+				a[base
+				+offset]
+			`,
+		},
+		"SplitExprInNewScope": {
+			input: `
+				val funcs = [
+					fn() {
+						var a = x
+						-y
+					}		
+				]
+			`,
+		},
+		"IfElse": {
+			input: `
+				val x = if cond {
+					var a = 5
+					-10
+				} else {
+				 	var b = 10
+					-5
+				}
+			`,
+		},
+		"MemberAssignment": {
+			input: `
+				p.x = 5
+				p.y = 10
+			`,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -14,74 +14,74 @@ func TestParseModuleNoErrors(t *testing.T) {
 	tests := map[string]struct {
 		input string
 	}{
-		"VarDecls": {
-			input: `
-				val a = 5
-				val b = 10
-				val sum = a + b
-			`,
-		},
-		"FuncDecls": {
-			input: `
-				fn add(a, b) {
-					return a + b
-				}
-				fn sub(a, b) {
-					return a - b
-				}
-			`,
-		},
+		// "VarDecls": {
+		// 	input: `
+		// 		val a = 5
+		// 		val b = 10
+		// 		val sum = a + b
+		// 	`,
+		// },
+		// "FuncDecls": {
+		// 	input: `
+		// 		fn add(a, b) {
+		// 			return a + b
+		// 		}
+		// 		fn sub(a, b) {
+		// 			return a - b
+		// 		}
+		// 	`,
+		// },
 		"ExprStmts": {
 			input: `
 				foo()
 				bar()
 			`,
 		},
-		"SplitExprOnNewline": {
-			input: `
-				var a = x
-				-y
-			`,
-		},
-		"MultilineExprInParens": {
-			input: `
-				var a = (x
-				-y)
-			`,
-		},
-		"MultilineExprInBrackets": {
-			input: `
-				a[base
-				+offset]
-			`,
-		},
-		"SplitExprInNewScope": {
-			input: `
-				val funcs = [
-					fn() {
-						var a = x
-						-y
-					}		
-				]
-			`,
-		},
-		"IfElse": {
-			input: `
-				val x = if cond {
-					var a = 5
-					-10
-				} else {
-				 	var b = 10
-					-5
-				}
-			`,
-		},
-		"MemberAssignment": {
-			input: `
-				p.x = 5
-				p.y = 10
-			`,
-		},
+		// "SplitExprOnNewline": {
+		// 	input: `
+		// 		var a = x
+		// 		-y
+		// 	`,
+		// },
+		// "MultilineExprInParens": {
+		// 	input: `
+		// 		var a = (x
+		// 		-y)
+		// 	`,
+		// },
+		// "MultilineExprInBrackets": {
+		// 	input: `
+		// 		a[base
+		// 		+offset]
+		// 	`,
+		// },
+		// "SplitExprInNewScope": {
+		// 	input: `
+		// 		val funcs = [
+		// 			fn() {
+		// 				var a = x
+		// 				-y
+		// 			}
+		// 		]
+		// 	`,
+		// },
+		// "IfElse": {
+		// 	input: `
+		// 		val x = if cond {
+		// 			var a = 5
+		// 			-10
+		// 		} else {
+		// 		 	var b = 10
+		// 			-5
+		// 		}
+		// 	`,
+		// },
+		// "MemberAssignment": {
+		// 	input: `
+		// 		p.x = 5
+		// 		p.y = 10
+		// 	`,
+		// },
 	}
 
 	for name, test := range tests {

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -57,6 +57,7 @@ func (p *Parser) stmts(stopOn TokenType) (*[]ast.Stmt, ast.Location) {
 func (p *Parser) stmt() ast.Stmt {
 	token := p.lexer.peek()
 	p.exprMode.Push(SingleLineExpr)
+	defer p.exprMode.Pop()
 
 	var stmt ast.Stmt
 
@@ -87,6 +88,5 @@ func (p *Parser) stmt() ast.Stmt {
 		}
 	}
 
-	p.exprMode.Pop()
 	return stmt
 }

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -54,7 +54,7 @@ func (p *Parser) stmt() ast.Stmt {
 		stmt = ast.NewDeclStmt(decl, decl.Span())
 	case Return:
 		p.lexer.consume()
-		expr := p.exprInternal()
+		expr := p.exprWithoutErrorCheck()
 		if expr == nil {
 			stmt = ast.NewReturnStmt(nil, token.Span)
 		} else {
@@ -63,9 +63,12 @@ func (p *Parser) stmt() ast.Stmt {
 			)
 		}
 	default:
-		expr := p.exprInternal()
+		expr := p.exprWithoutErrorCheck()
 		// If no tokens have been consumed then we've encountered something we
-		// don't know how to parse.
+		// don't know how to parse.  In this case we consume the next token and
+		// return nil.  The caller will be parsing multiple statements so the
+		// end result will be that we attempt to parse a statement again starting
+		// with the next token.
 		nextToken := p.lexer.peek()
 		if token.Span.End.Line == nextToken.Span.End.Line &&
 			token.Span.End.Column == nextToken.Span.End.Column {

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -77,12 +77,6 @@ loop:
 			break loop
 		}
 
-		// if token.Span.Start.Line != p.lexer.currentLocation.Line {
-		// 	if len(p.markers) == 0 || p.markers.Peek() != MarkerDelim {
-		// 		return typeAnns.Pop()
-		// 	}
-		// }
-
 		p.lexer.consume()
 		skipOp := false
 

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -77,11 +77,11 @@ loop:
 			break loop
 		}
 
-		if token.Span.Start.Line != p.lexer.currentLocation.Line {
-			if len(p.markers) == 0 || p.markers.Peek() != MarkerDelim {
-				return typeAnns.Pop()
-			}
-		}
+		// if token.Span.Start.Line != p.lexer.currentLocation.Line {
+		// 	if len(p.markers) == 0 || p.markers.Peek() != MarkerDelim {
+		// 		return typeAnns.Pop()
+		// 	}
+		// }
 
 		p.lexer.consume()
 		skipOp := false


### PR DESCRIPTION
- replaces `markers` with `exprMode` with aligns better with what's going on
- enums have better names making the code easier to grok
- `exprMode` is only updated around certain calls to `expr()` or `exprWithoutErrorCheck()` instead of including making the approach more targetted