### PR TITLE
Remove remaining uses of optional.Option

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2,7 +2,6 @@ package checker
 
 import (
 	"github.com/escalier-lang/escalier/internal/type_system"
-	"github.com/moznion/go-optional"
 )
 
 type Checker struct {
@@ -33,7 +32,7 @@ type Context struct {
 func (ctx *Context) WithParentScope() Context {
 	return Context{
 		Filename:   ctx.Filename,
-		Scope:      NewScope(optional.PtrFromNillable(ctx.Scope)),
+		Scope:      NewScope(ctx.Scope),
 		IsAsync:    ctx.IsAsync,
 		IsPatMatch: ctx.IsPatMatch,
 	}

--- a/internal/checker/infer.go
+++ b/internal/checker/infer.go
@@ -1192,10 +1192,10 @@ func (c *Checker) inferTypeAnn(
 				errors = slices.Concat(errors, typeArgErrors)
 			}
 
-			t = NewTypeRefType(typeAnn.Name, optional.Some(*typeAlias), typeArgs...)
+			t = NewTypeRefType(typeAnn.Name, typeAlias, typeArgs...)
 		} else {
 			// TODO: include type args
-			typeRef := NewTypeRefType(typeAnn.Name, optional.None[TypeAlias](), nil)
+			typeRef := NewTypeRefType(typeAnn.Name, nil, nil)
 			typeRef.SetProvenance(&ast.NodeProvenance{
 				Node: typeAnn,
 			})

--- a/internal/checker/infer.go
+++ b/internal/checker/infer.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	. "github.com/escalier-lang/escalier/internal/type_system"
-	"github.com/moznion/go-optional"
 )
 
 func (c *Checker) InferScript(ctx Context, m *ast.Script) (*Scope, []Error) {
@@ -85,7 +84,7 @@ func (c *Checker) InferModule(ctx Context, m *ast.Module) (Namespace, []Error) {
 			errors = slices.Concat(errors, sigErrors)
 
 			namespace.Values[QualifiedIdent(decl.Name.Name)] = &Binding{
-				Source:  optional.Some[ast.BindingSource](decl.Name),
+				Source:  decl.Name,
 				Type:    funcType,
 				Mutable: false,
 			}
@@ -301,7 +300,7 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 	}
 
 	binding := Binding{
-		Source:  optional.Some[ast.BindingSource](decl.Name),
+		Source:  decl.Name,
 		Type:    funcType,
 		Mutable: false,
 	}
@@ -496,7 +495,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (Type, []Error) {
 			// on the identifier itself instead of the binding source.
 			t := Prune(binding.Type).WithProvenance(&ast.NodeProvenance{Node: expr})
 			expr.SetInferredType(t)
-			expr.Source = binding.Source.Unwrap()
+			expr.Source = binding.Source
 			return t, nil
 		} else {
 			t := NewNeverType()
@@ -831,7 +830,7 @@ func (c *Checker) inferFuncSig(
 		Return:     returnType,
 		Throws:     NewNeverType(),
 		TypeParams: []*TypeParam{},
-		Self:       optional.None[Type](),
+		Self:       nil,
 	}
 
 	return t, bindings, errors
@@ -1011,7 +1010,7 @@ func (c *Checker) inferPattern(
 			t = c.FreshVar()
 			// TODO: report an error if the name is already bound
 			bindings[p.Name] = &Binding{
-				Source:  optional.Some[ast.BindingSource](p),
+				Source:  p,
 				Type:    t,
 				Mutable: false, // TODO
 			}
@@ -1042,7 +1041,7 @@ func (c *Checker) inferPattern(
 					name := NewStrKey(elem.Key.Name)
 					// TODO: report an error if the name is already bound
 					bindings[elem.Key.Name] = &Binding{
-						Source:  optional.Some[ast.BindingSource](elem.Key),
+						Source:  elem.Key,
 						Type:    t,
 						Mutable: false, // TODO
 					}
@@ -1168,7 +1167,7 @@ func (c *Checker) inferFuncTypeAnn(
 		Return:     returnType,
 		Throws:     NewNeverType(),
 		TypeParams: []*TypeParam{},
-		Self:       optional.None[Type](),
+		Self:       nil,
 	}
 
 	return &funcType, errors

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -123,7 +123,7 @@ func Prelude() *Scope {
 	}
 	arrayType := NewObjectType([]ObjTypeElem{length})
 	typeParam := NewTypeParam("T")
-	scope.setTypeAlias("Array", TypeAlias{
+	scope.setTypeAlias("Array", &TypeAlias{
 		Type:       arrayType,
 		TypeParams: []*TypeParam{typeParam},
 	})

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Prelude() *Scope {
-	scope := NewScope(optional.None[*Scope]())
+	scope := NewScope(nil)
 
 	binArithType := &FuncType{
 		Params: []*FuncParam{

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -73,20 +73,20 @@ func Prelude() *Scope {
 		Mutable: false,
 	}
 
-	scope.Values["+"] = binArithBinding
-	scope.Values["-"] = binArithBinding
-	scope.Values["*"] = binArithBinding
-	scope.Values["/"] = binArithBinding
+	scope.Values["+"] = &binArithBinding
+	scope.Values["-"] = &binArithBinding
+	scope.Values["*"] = &binArithBinding
+	scope.Values["/"] = &binArithBinding
 
-	scope.Values["=="] = binACompBinding
-	scope.Values["!="] = binACompBinding
-	scope.Values["<"] = binACompBinding
-	scope.Values[">"] = binACompBinding
-	scope.Values["<="] = binACompBinding
-	scope.Values[">="] = binACompBinding
+	scope.Values["=="] = &binACompBinding
+	scope.Values["!="] = &binACompBinding
+	scope.Values["<"] = &binACompBinding
+	scope.Values[">"] = &binACompBinding
+	scope.Values["<="] = &binACompBinding
+	scope.Values[">="] = &binACompBinding
 
-	scope.Values["&&"] = binLogicBinding
-	scope.Values["||"] = binLogicBinding
+	scope.Values["&&"] = &binLogicBinding
+	scope.Values["||"] = &binLogicBinding
 
 	// TODO: uncomment after adding support for calling overloaded functions
 	// scope.Values["-"] = Binding{
@@ -95,7 +95,7 @@ func Prelude() *Scope {
 	// 	Mutable: false,
 	// }
 
-	scope.Values["!"] = unaryLogicBinding
+	scope.Values["!"] = &unaryLogicBinding
 
 	var objElems []ObjTypeElem
 
@@ -109,7 +109,7 @@ func Prelude() *Scope {
 		},
 	})
 
-	scope.Values["console"] = Binding{
+	scope.Values["console"] = &Binding{
 		Source:  optional.None[ast.BindingSource](),
 		Type:    NewObjectType(objElems),
 		Mutable: false,

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -1,9 +1,6 @@
 package checker
 
 import (
-	"github.com/moznion/go-optional"
-
-	"github.com/escalier-lang/escalier/internal/ast"
 	. "github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -18,7 +15,7 @@ func Prelude() *Scope {
 		Return: NewNumType(),
 	}
 	binArithBinding := Binding{
-		Source:  optional.None[ast.BindingSource](),
+		Source:  nil,
 		Type:    binArithType,
 		Mutable: false,
 	}
@@ -31,7 +28,7 @@ func Prelude() *Scope {
 		Return: NewBoolType(),
 	}
 	binACompBinding := Binding{
-		Source:  optional.None[ast.BindingSource](),
+		Source:  nil,
 		Type:    binCompType,
 		Mutable: false,
 	}
@@ -44,7 +41,7 @@ func Prelude() *Scope {
 		Return: NewBoolType(),
 	}
 	binLogicBinding := Binding{
-		Source:  optional.None[ast.BindingSource](),
+		Source:  nil,
 		Type:    binLogicType,
 		Mutable: false,
 	}
@@ -56,7 +53,7 @@ func Prelude() *Scope {
 	// 	Return: NewNumType(),
 	// }
 	// unaryArithBinding := Binding{
-	// 	Source:  optional.None[ast.BindingSource](),
+	// 	Source:  nil,
 	// 	Type:    unaryArithType,
 	// 	Mutable: false,
 	// }
@@ -68,7 +65,7 @@ func Prelude() *Scope {
 		Return: NewBoolType(),
 	}
 	unaryLogicBinding := Binding{
-		Source:  optional.None[ast.BindingSource](),
+		Source:  nil,
 		Type:    unaryLogicType,
 		Mutable: false,
 	}
@@ -90,7 +87,7 @@ func Prelude() *Scope {
 
 	// TODO: uncomment after adding support for calling overloaded functions
 	// scope.Values["-"] = Binding{
-	// 	Source:  optional.None[ast.BindingSource](),
+	// 	Source:  nil,
 	// 	Type:    NewIntersectionType(binArithType, unaryArithType),
 	// 	Mutable: false,
 	// }
@@ -110,7 +107,7 @@ func Prelude() *Scope {
 	})
 
 	scope.Values["console"] = &Binding{
-		Source:  optional.None[ast.BindingSource](),
+		Source:  nil,
 		Type:    NewObjectType(objElems),
 		Mutable: false,
 	}

--- a/internal/checker/scope.go
+++ b/internal/checker/scope.go
@@ -15,12 +15,12 @@ type Binding struct {
 }
 
 type Scope struct {
-	Parent optional.Option[*Scope]
+	Parent *Scope // optional, parent is nil for the root scope
 	Values map[string]Binding
 	Types  map[string]TypeAlias
 }
 
-func NewScope(parent optional.Option[*Scope]) *Scope {
+func NewScope(parent *Scope) *Scope {
 	return &Scope{
 		Parent: parent,
 		Values: map[string]Binding{},
@@ -32,9 +32,10 @@ func (s *Scope) getValue(name string) optional.Option[Binding] {
 	if v, ok := s.Values[name]; ok {
 		return optional.Some(v)
 	}
-	return optional.FlatMap(s.Parent, func(p *Scope) optional.Option[Binding] {
-		return p.getValue(name)
-	}).Or(optional.None[Binding]())
+	if s.Parent != nil {
+		return s.Parent.getValue(name)
+	}
+	return optional.None[Binding]()
 }
 
 func (s *Scope) setValue(name string, binding Binding) {
@@ -48,9 +49,10 @@ func (s *Scope) getTypeAlias(name string) optional.Option[TypeAlias] {
 	if v, ok := s.Types[name]; ok {
 		return optional.Some(v)
 	}
-	return optional.FlatMap(s.Parent, func(p *Scope) optional.Option[TypeAlias] {
-		return p.getTypeAlias(name)
-	}).Or(optional.None[TypeAlias]())
+	if s.Parent != nil {
+		return s.Parent.getTypeAlias(name)
+	}
+	return optional.None[TypeAlias]()
 }
 
 func (s *Scope) setTypeAlias(name string, alias TypeAlias) {

--- a/internal/checker/scope.go
+++ b/internal/checker/scope.go
@@ -17,14 +17,14 @@ type Binding struct {
 type Scope struct {
 	Parent *Scope // optional, parent is nil for the root scope
 	Values map[string]*Binding
-	Types  map[string]TypeAlias
+	Types  map[string]*TypeAlias
 }
 
 func NewScope(parent *Scope) *Scope {
 	return &Scope{
 		Parent: parent,
 		Values: map[string]*Binding{},
-		Types:  map[string]TypeAlias{},
+		Types:  map[string]*TypeAlias{},
 	}
 }
 
@@ -45,17 +45,17 @@ func (s *Scope) setValue(name string, binding *Binding) {
 	s.Values[name] = binding
 }
 
-func (s *Scope) getTypeAlias(name string) optional.Option[TypeAlias] {
+func (s *Scope) getTypeAlias(name string) *TypeAlias {
 	if v, ok := s.Types[name]; ok {
-		return optional.Some(v)
+		return v
 	}
 	if s.Parent != nil {
 		return s.Parent.getTypeAlias(name)
 	}
-	return optional.None[TypeAlias]()
+	return nil
 }
 
-func (s *Scope) setTypeAlias(name string, alias TypeAlias) {
+func (s *Scope) setTypeAlias(name string, alias *TypeAlias) {
 	if _, ok := s.Types[name]; ok {
 		panic("type alias already exists")
 	}

--- a/internal/checker/scope.go
+++ b/internal/checker/scope.go
@@ -1,15 +1,13 @@
 package checker
 
 import (
-	"github.com/moznion/go-optional"
-
 	"github.com/escalier-lang/escalier/internal/ast"
 	. "github.com/escalier-lang/escalier/internal/type_system"
 )
 
 // We want to model both `let x = 5` as well as `fn (x: number) => x`
 type Binding struct {
-	Source  optional.Option[ast.BindingSource]
+	Source  ast.BindingSource // optional
 	Type    Type
 	Mutable bool
 }

--- a/internal/checker/scope.go
+++ b/internal/checker/scope.go
@@ -16,29 +16,29 @@ type Binding struct {
 
 type Scope struct {
 	Parent *Scope // optional, parent is nil for the root scope
-	Values map[string]Binding
+	Values map[string]*Binding
 	Types  map[string]TypeAlias
 }
 
 func NewScope(parent *Scope) *Scope {
 	return &Scope{
 		Parent: parent,
-		Values: map[string]Binding{},
+		Values: map[string]*Binding{},
 		Types:  map[string]TypeAlias{},
 	}
 }
 
-func (s *Scope) getValue(name string) optional.Option[Binding] {
+func (s *Scope) getValue(name string) *Binding {
 	if v, ok := s.Values[name]; ok {
-		return optional.Some(v)
+		return v
 	}
 	if s.Parent != nil {
 		return s.Parent.getValue(name)
 	}
-	return optional.None[Binding]()
+	return nil
 }
 
-func (s *Scope) setValue(name string, binding Binding) {
+func (s *Scope) setValue(name string, binding *Binding) {
 	if _, ok := s.Values[name]; ok {
 		panic("value already exists")
 	}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -170,12 +170,31 @@ func (c *Checker) unify(ctx Context, t1, t2 Type) []Error {
 				// If both type references have no type arguments, we can unify them
 				// directly.
 
-				// If .TypeAlias is nil, use .Name to look up the definition
-				// of the type alias in the current scope.
+				// Most of the time, type references will have their TypeAlias
+				// field set to whatever type alias they refer to when they were
+				// created.  However, certain type references such as those used
+				// for type parameters in generics may not have this field set.
 
-				// TODO: switch to use pointers for TypeAlias instead of optional
-				typeAlias1 := ref1.TypeAlias.Unwrap()
-				typeAlias2 := ref2.TypeAlias.Unwrap()
+				typeAlias1 := ref1.TypeAlias
+				if typeAlias1 == nil {
+					typeAlias1 = ctx.Scope.getTypeAlias(ref1.Name)
+					if typeAlias1 == nil {
+						return []Error{&UnkonwnTypeError{
+							TypeName: ref1.Name,
+							typeRef:  ref1,
+						}}
+					}
+				}
+				typeAlias2 := ref2.TypeAlias
+				if typeAlias2 == nil {
+					typeAlias2 = ctx.Scope.getTypeAlias(ref2.Name)
+					if typeAlias2 == nil {
+						return []Error{&UnkonwnTypeError{
+							TypeName: ref2.Name,
+							typeRef:  ref2,
+						}}
+					}
+				}
 
 				return c.unify(ctx, typeAlias1.Type, typeAlias2.Type)
 			}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -425,18 +425,18 @@ func (c *Checker) unify(ctx Context, t1, t2 Type) []Error {
 
 	retry := false
 	if typeRef, ok := t1.(*TypeRefType); ok {
-		ctx.Scope.getTypeAlias(typeRef.Name).IfSome(func(alias TypeAlias) {
+		if alias := ctx.Scope.getTypeAlias(typeRef.Name); alias != nil {
 			// TODO: apply type args
 			t1 = alias.Type
 			retry = true
-		})
+		}
 	}
 	if typeRef, ok := t2.(*TypeRefType); ok {
-		ctx.Scope.getTypeAlias(typeRef.Name).IfSome(func(alias TypeAlias) {
+		if alias := ctx.Scope.getTypeAlias(typeRef.Name); alias != nil {
 			// TODO: apply type args
 			t2 = alias.Type
 			retry = true
-		})
+		}
 	}
 
 	if retry {

--- a/internal/codegen/ast.go
+++ b/internal/codegen/ast.go
@@ -2,7 +2,6 @@ package codegen
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
-	"github.com/moznion/go-optional"
 )
 
 type Node interface {
@@ -285,12 +284,12 @@ func (e *SetterExpr) Source() ast.Node   { return e.source }
 
 type PropertyExpr struct {
 	Key    ObjKey
-	Value  optional.Option[Expr]
+	Value  Expr
 	source ast.Node
 	span   *Span
 }
 
-func NewPropertyExpr(key ObjKey, value optional.Option[Expr], source ast.Node) *PropertyExpr {
+func NewPropertyExpr(key ObjKey, value Expr, source ast.Node) *PropertyExpr {
 	return &PropertyExpr{Key: key, Value: value, source: source, span: nil}
 }
 func (e *PropertyExpr) Span() *Span        { return e.span }
@@ -415,7 +414,7 @@ const (
 
 type Declarator struct {
 	Pattern Pat
-	TypeAnn optional.Option[TypeAnn]
+	TypeAnn TypeAnn
 	Init    Expr // TODO: make this an optional
 }
 
@@ -439,15 +438,15 @@ func (d *VarDecl) Source() ast.Node   { return d.source }
 type Param struct {
 	Pattern  Pat
 	Optional bool
-	TypeAnn  optional.Option[TypeAnn]
+	TypeAnn  TypeAnn // optional
 }
 
 // TODO: add support for type params
 type FuncDecl struct {
 	Name    *Identifier
 	Params  []*Param
-	Body    optional.Option[[]Stmt]
-	TypeAnn optional.Option[TypeAnn] // return type annotation
+	Body    []Stmt  // optional
+	TypeAnn TypeAnn // optional, return type annotation, required if `declare` is true
 	export  bool
 	declare bool
 	span    *Span
@@ -618,12 +617,12 @@ func (*TupleRestPat) isTuplePatElem() {}
 
 type TupleElemPat struct {
 	Pattern Pat
-	Default optional.Option[Expr]
+	Default Expr // optional
 	source  ast.Node
 	span    *Span
 }
 
-func NewTupleElemPat(pattern Pat, _default optional.Option[Expr], source ast.Node) *TupleElemPat {
+func NewTupleElemPat(pattern Pat, _default Expr, source ast.Node) *TupleElemPat {
 	return &TupleElemPat{Pattern: pattern, Default: _default, source: source, span: nil}
 }
 func (p *TupleElemPat) Span() *Span        { return p.span }

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/escalier-lang/escalier/internal/ast"
-	"github.com/moznion/go-optional"
 )
 
 type Builder struct {
@@ -201,7 +200,7 @@ func (b *Builder) buildPattern(p ast.Pat, target Expr) ([]Expr, []Stmt) {
 			decls := []*Declarator{
 				{
 					Pattern: NewTuplePat(tempVarPats, nil),
-					TypeAnn: optional.None[TypeAnn](),
+					TypeAnn: nil,
 					Init:    call,
 				},
 			}
@@ -255,7 +254,7 @@ func (b *Builder) buildPattern(p ast.Pat, target Expr) ([]Expr, []Stmt) {
 		decls := []*Declarator{
 			{
 				Pattern: pat,
-				TypeAnn: optional.None[TypeAnn](),
+				TypeAnn: nil,
 				Init:    target,
 			},
 		}
@@ -365,8 +364,8 @@ func (b *Builder) buildDecl(decl ast.Decl) []Stmt {
 		fnDecl := &FuncDecl{
 			Name:    buildIdent(d.Name),
 			Params:  params,
-			Body:    optional.Some(slices.Concat(allParamStmts, b.buildStmts(d.Body.Stmts))),
-			TypeAnn: optional.None[TypeAnn](),
+			Body:    slices.Concat(allParamStmts, b.buildStmts(d.Body.Stmts)),
+			TypeAnn: nil,
 			declare: decl.Declare(),
 			export:  decl.Export(),
 			span:    nil,
@@ -483,18 +482,9 @@ func (b *Builder) buildExpr(expr ast.Expr) (Expr, []Stmt) {
 				if elem.Value != nil {
 					valueExpr, valueStmts := b.buildExpr(elem.Value)
 					stmts = slices.Concat(stmts, valueStmts)
-
-					elems[i] = NewPropertyExpr(
-						key,
-						optional.Some(valueExpr),
-						elem,
-					)
+					elems[i] = NewPropertyExpr(key, valueExpr, elem)
 				} else {
-					elems[i] = NewPropertyExpr(
-						key,
-						optional.None[Expr](),
-						elem,
-					)
+					elems[i] = NewPropertyExpr(key, nil, elem)
 				}
 			default:
 				panic(fmt.Sprintf("TODO - buildExpr - ObjectExpr - default case: %#v", elem))
@@ -559,7 +549,7 @@ func (b *Builder) buildParams(inParams []*ast.Param) ([]*Param, []Stmt) {
 			// TODO: handle param defaults
 			Pattern:  paramPat,
 			Optional: p.Optional,
-			TypeAnn:  optional.None[TypeAnn](),
+			TypeAnn:  nil,
 		})
 	}
 	return outParams, outParamStmts

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -7,7 +7,6 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/checker"
 	type_sys "github.com/escalier-lang/escalier/internal/type_system"
-	"github.com/moznion/go-optional"
 )
 
 type BindingVisitor struct {
@@ -58,7 +57,7 @@ func (b *Builder) BuildDefinitions(
 				typeAnn := buildTypeAnn(binding.Type)
 				decls = append(decls, &Declarator{
 					Pattern: NewIdentPat(name, nil, nil),
-					TypeAnn: optional.Some(typeAnn),
+					TypeAnn: typeAnn,
 					Init:    nil,
 				})
 			}
@@ -87,7 +86,7 @@ func (b *Builder) BuildDefinitions(
 				Params: funcTypeToParams(funcType),
 				// TODO: Use the type annotation if there is one and if not
 				// fallback to the inferred return type from the binding.
-				TypeAnn: optional.Some(buildTypeAnn(funcType.Return)),
+				TypeAnn: buildTypeAnn(funcType.Return),
 				Body:    nil,
 				declare: true, // Always true for .d.ts files
 				export:  decl.Export(),
@@ -196,7 +195,7 @@ func buildTypeAnn(t type_sys.Type) TypeAnn {
 			params[i] = &Param{
 				Pattern:  patToPat(param.Pattern),
 				Optional: param.Optional,
-				TypeAnn:  optional.Some(typeAnn),
+				TypeAnn:  typeAnn,
 			}
 		}
 		return NewFuncTypeAnn(
@@ -332,7 +331,7 @@ func funcTypeToParams(fnType *type_sys.FuncType) []*Param {
 		params[i] = &Param{
 			Pattern:  patToPat(param.Pattern),
 			Optional: param.Optional,
-			TypeAnn:  optional.Some(typeAnn),
+			TypeAnn:  typeAnn,
 		}
 	}
 	return params
@@ -345,7 +344,7 @@ func buildFuncTypeAnn(funcType *type_sys.FuncType) FuncTypeAnn {
 		params[i] = &Param{
 			Pattern:  patToPat(param.Pattern),
 			Optional: param.Optional,
-			TypeAnn:  optional.Some(typeAnn),
+			TypeAnn:  typeAnn,
 		}
 	}
 

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -102,21 +102,21 @@ func (b *Builder) BuildDefinitions(
 		case *ast.TypeDecl:
 			typeParams := make([]*TypeParam, len(decl.TypeParams))
 			for i, param := range decl.TypeParams {
-				constraint := optional.None[TypeAnn]()
+				var constraint TypeAnn
 				if param.Constraint != nil {
 					t := param.Constraint.InferredType()
 					if t == nil {
 						// TODO: report an error if there's no inferred type
 					}
-					constraint = optional.Some(buildTypeAnn(t))
+					constraint = buildTypeAnn(t)
 				}
-				default_ := optional.None[TypeAnn]()
+				var default_ TypeAnn
 				if param.Default != nil {
 					t := param.Default.InferredType()
 					if t == nil {
 						// TODO: report an error if there's no inferred type
 					}
-					default_ = optional.Some(buildTypeAnn(t))
+					default_ = buildTypeAnn(t)
 				}
 
 				typeParams[i] = &TypeParam{
@@ -189,7 +189,7 @@ func buildTypeAnn(t type_sys.Type) TypeAnn {
 	case *type_sys.GlobalThisType:
 		panic("TODO: implement GlobalThisType")
 	case *type_sys.FuncType:
-		typeParams := optional.None[[]TypeParam]()
+		var typeParams []*TypeParam
 		params := make([]*Param, len(t.Params))
 		for i, param := range t.Params {
 			typeAnn := buildTypeAnn(param.Type)
@@ -203,7 +203,7 @@ func buildTypeAnn(t type_sys.Type) TypeAnn {
 			typeParams,
 			params,
 			buildTypeAnn(t.Return),
-			optional.None[TypeAnn](),
+			nil,
 			nil,
 		)
 	case *type_sys.ObjectType:
@@ -311,7 +311,7 @@ func buildObjTypeAnnElem(elem type_sys.ObjTypeElem) ObjTypeAnnElem {
 		}
 		return &MappedTypeAnn{
 			TypeParam: typeParam,
-			Name:      optional.None[TypeAnn](),
+			Name:      nil,
 			Value:     buildTypeAnn(elem.Value),
 			Optional:  mapMappedModifier(elem.Optional),
 			ReadOnly:  mapMappedModifier(elem.ReadOnly),
@@ -350,10 +350,10 @@ func buildFuncTypeAnn(funcType *type_sys.FuncType) FuncTypeAnn {
 	}
 
 	return FuncTypeAnn{
-		TypeParams: optional.None[[]TypeParam](),
+		TypeParams: nil,
 		Params:     params,
 		Return:     buildTypeAnn(funcType.Return),
-		Throws:     optional.None[TypeAnn](),
+		Throws:     nil,
 		span:       nil,
 		source:     nil,
 	}

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -170,10 +170,10 @@ func (p *Printer) PrintExpr(expr Expr) {
 				p.printMethod(elem.Name, elem.Params, elem.Body)
 			case *PropertyExpr:
 				p.printObjKey(elem.Key)
-				elem.Value.IfSome(func(value Expr) {
+				if elem.Value != nil {
 					p.print(": ")
-					p.PrintExpr(value)
-				})
+					p.PrintExpr(elem.Value)
+				}
 			case *RestSpreadExpr:
 				p.print("...")
 				p.PrintExpr(elem.Arg)
@@ -323,10 +323,10 @@ func (p *Printer) printPattern(pat Pat) {
 
 func (p *Printer) printParam(param *Param) {
 	p.printPattern(param.Pattern)
-	param.TypeAnn.IfSome(func(ta TypeAnn) {
+	if param.TypeAnn != nil {
 		p.print(": ")
-		p.PrintTypeAnn(ta)
-	})
+		p.PrintTypeAnn(param.TypeAnn)
+	}
 }
 
 func (p *Printer) PrintDecl(decl Decl) {
@@ -353,10 +353,10 @@ func (p *Printer) PrintDecl(decl Decl) {
 				p.print(", ")
 			}
 			p.printPattern(decl.Pattern)
-			decl.TypeAnn.IfSome(func(ta TypeAnn) {
+			if decl.TypeAnn != nil {
 				p.print(": ")
-				p.PrintTypeAnn(ta)
-			})
+				p.PrintTypeAnn(decl.TypeAnn)
+			}
 			if decl.Init != nil {
 				p.print(" = ")
 				p.PrintExpr(decl.Init)
@@ -376,17 +376,17 @@ func (p *Printer) PrintDecl(decl Decl) {
 		}
 		p.print(")")
 
-		d.TypeAnn.IfSome(func(ta TypeAnn) {
+		if d.TypeAnn != nil {
 			p.print(": ")
-			p.PrintTypeAnn(ta)
-		})
+			p.PrintTypeAnn(d.TypeAnn)
+		}
 
-		d.Body.IfSome(func(stmts []Stmt) {
+		if d.Body != nil {
 			p.print(" {")
 
 			p.indent++
 
-			for _, stmt := range stmts {
+			for _, stmt := range d.Body {
 				p.NewLine()
 				p.PrintStmt(stmt)
 			}
@@ -395,11 +395,11 @@ func (p *Printer) PrintDecl(decl Decl) {
 			p.NewLine()
 
 			p.print("}")
-		})
+		}
 
-		d.Body.IfNone(func() {
+		if d.Body == nil {
 			p.print(";")
-		})
+		}
 	case *TypeDecl:
 		p.print("type ")
 		p.print(d.Name.Name)
@@ -484,10 +484,10 @@ func (p *Printer) PrintTypeAnn(ta TypeAnn) {
 						p.print(", ")
 					}
 					p.printPattern(param.Pattern)
-					param.TypeAnn.IfSome(func(ta TypeAnn) {
+					if param.TypeAnn != nil {
 						p.print(": ")
-						p.PrintTypeAnn(ta)
-					})
+						p.PrintTypeAnn(param.TypeAnn)
+					}
 				}
 				p.print(")")
 				p.print(": ")
@@ -501,10 +501,10 @@ func (p *Printer) PrintTypeAnn(ta TypeAnn) {
 						p.print(", ")
 					}
 					p.printPattern(param.Pattern)
-					param.TypeAnn.IfSome(func(ta TypeAnn) {
+					if param.TypeAnn != nil {
 						p.print(": ")
-						p.PrintTypeAnn(ta)
-					})
+						p.PrintTypeAnn(param.TypeAnn)
+					}
 				}
 				p.print(")")
 				p.print(": ")
@@ -518,10 +518,10 @@ func (p *Printer) PrintTypeAnn(ta TypeAnn) {
 						p.print(", ")
 					}
 					p.printPattern(param.Pattern)
-					param.TypeAnn.IfSome(func(ta TypeAnn) {
+					if param.TypeAnn != nil {
 						p.print(": ")
-						p.PrintTypeAnn(ta)
-					})
+						p.PrintTypeAnn(param.TypeAnn)
+					}
 				}
 				p.print(")")
 				// TypeScript doesn't allow setters to have a return type
@@ -579,10 +579,10 @@ func (p *Printer) PrintTypeAnn(ta TypeAnn) {
 				p.print(", ")
 			}
 			p.printPattern(param.Pattern)
-			param.TypeAnn.IfSome(func(ta TypeAnn) {
+			if param.TypeAnn != nil {
 				p.print(": ")
-				p.PrintTypeAnn(ta)
-			})
+				p.PrintTypeAnn(param.TypeAnn)
+			}
 		}
 		p.print(")")
 		p.print(" => ")

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -410,14 +410,14 @@ func (p *Printer) PrintDecl(decl Decl) {
 					p.print(", ")
 				}
 				p.print(param.Name)
-				param.Constraint.IfSome(func(ta TypeAnn) {
+				if param.Constraint != nil {
 					p.print(": ")
-					p.PrintTypeAnn(ta)
-				})
-				param.Default.IfSome(func(t TypeAnn) {
+					p.PrintTypeAnn(param.Constraint)
+				}
+				if param.Default != nil {
 					p.print(" = ")
-					p.PrintTypeAnn(t)
-				})
+					p.PrintTypeAnn(param.Default)
+				}
 			}
 		}
 		p.print(" = ")

--- a/internal/codegen/source_map.go
+++ b/internal/codegen/source_map.go
@@ -216,11 +216,9 @@ func (s *SourceMapGenerator) TraverseDecl(decl Decl) {
 		for _, param := range dk.Params {
 			s.AddSegmentForNode(param.Pattern)
 		}
-		dk.Body.IfSome(func(body []Stmt) {
-			for _, stmt := range body {
-				s.TraverseStmt(stmt)
-			}
-		})
+		for _, stmt := range dk.Body {
+			s.TraverseStmt(stmt)
+		}
 	}
 }
 
@@ -297,9 +295,9 @@ func (s *SourceMapGenerator) TraverseExpr(expr Expr) {
 				}
 			case *PropertyExpr:
 				s.AddSegmentForNode(elem.Key)
-				elem.Value.IfSome(func(value Expr) {
-					s.TraverseExpr(value)
-				})
+				if elem.Value != nil {
+					s.TraverseExpr(elem.Value)
+				}
 			case *RestSpreadExpr:
 				s.AddSegmentForNode(elem)
 				s.TraverseExpr(elem.Arg)

--- a/internal/codegen/type_ann.go
+++ b/internal/codegen/type_ann.go
@@ -2,7 +2,6 @@ package codegen
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
-	"github.com/moznion/go-optional"
 )
 
 //sumtype:decl
@@ -176,7 +175,7 @@ type MappedTypeAnn struct {
 	TypeParam *IndexParamTypeAnn
 	// Name is used to rename keys in the mapped type
 	// It must resolve to a type that can be used as a key
-	Name     optional.Option[TypeAnn]
+	Name     TypeAnn // optional
 	Value    TypeAnn
 	Optional *MappedModifier // TODO: replace with `?`, `!`, or nothing
 	ReadOnly *MappedModifier
@@ -258,24 +257,24 @@ func (t *TypeRefTypeAnn) Source() ast.Node   { return t.source }
 
 type TypeParam struct {
 	Name       string
-	Constraint optional.Option[TypeAnn]
-	Default    optional.Option[TypeAnn]
+	Constraint TypeAnn // optional
+	Default    TypeAnn // optional
 }
 
 type FuncTypeAnn struct {
-	TypeParams optional.Option[[]TypeParam]
+	TypeParams []*TypeParam // optional
 	Params     []*Param
 	Return     TypeAnn
-	Throws     optional.Option[TypeAnn]
+	Throws     TypeAnn // optional
 	span       *Span
 	source     ast.Node
 }
 
 func NewFuncTypeAnn(
-	typeParams optional.Option[[]TypeParam],
+	typeParams []*TypeParam, // optional
 	params []*Param,
 	ret TypeAnn,
-	throws optional.Option[TypeAnn],
+	throws TypeAnn, // optional
 	span *Span,
 ) *FuncTypeAnn {
 	return &FuncTypeAnn{

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -40,7 +40,7 @@ func Compile(source *ast.Source) CompilerOutput {
 	}
 
 	for name, binding := range scope.Values {
-		namespace.Values[checker.QualifiedIdent(name)] = binding
+		namespace.Values[checker.QualifiedIdent(name)] = *binding
 	}
 	for name, typeAlias := range scope.Types {
 		namespace.Types[checker.QualifiedIdent(name)] = typeAlias

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -35,12 +35,12 @@ func Compile(source *ast.Source) CompilerOutput {
 	scope, typeErrors := c.InferScript(inferCtx, inMod)
 
 	namespace := checker.Namespace{
-		Values: make(map[checker.QualifiedIdent]checker.Binding),
-		Types:  make(map[checker.QualifiedIdent]type_system.TypeAlias),
+		Values: make(map[checker.QualifiedIdent]*checker.Binding),
+		Types:  make(map[checker.QualifiedIdent]*type_system.TypeAlias),
 	}
 
 	for name, binding := range scope.Values {
-		namespace.Values[checker.QualifiedIdent(name)] = *binding
+		namespace.Values[checker.QualifiedIdent(name)] = binding
 	}
 	for name, typeAlias := range scope.Types {
 		namespace.Types[checker.QualifiedIdent(name)] = typeAlias

--- a/internal/type_system/pat.go
+++ b/internal/type_system/pat.go
@@ -15,7 +15,7 @@ func (*WildcardPat) isPat()  {}
 
 type IdentPat struct {
 	Name string
-	// Default      optional.Option[Expr]
+	// Default      Expr // optional
 }
 
 func NewIdentPat(name string) *IdentPat {
@@ -37,7 +37,7 @@ func (*ObjRestPat) isObjPatElem()      {}
 type ObjKeyValuePat struct {
 	Key   string
 	Value Pat
-	// Default      optional.Option[Expr]
+	// Default      Expr // optional
 }
 
 func NewObjKeyValuePat(key string, value Pat) *ObjKeyValuePat {
@@ -49,7 +49,7 @@ func (p *ObjKeyValuePat) String() string {
 
 type ObjShorthandPat struct {
 	Key string
-	// Default optional.Option[Expr]
+	// Default Expr // optional
 }
 
 func NewObjShorthandPat(key string) *ObjShorthandPat {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -92,11 +92,11 @@ type TypeAlias struct {
 type TypeRefType struct {
 	Name       string // TODO: Make this a qualified identifier
 	TypeArgs   []Type
-	TypeAlias  optional.Option[TypeAlias] // resolved type alias (definition)
+	TypeAlias  *TypeAlias // optional, resolved type alias (definition)
 	provenance Provenance
 }
 
-func NewTypeRefType(name string, typeAlias optional.Option[TypeAlias], typeArgs ...Type) *TypeRefType {
+func NewTypeRefType(name string, typeAlias *TypeAlias, typeArgs ...Type) *TypeRefType {
 	return &TypeRefType{
 		Name:       name,
 		TypeArgs:   typeArgs,
@@ -472,7 +472,7 @@ type MappedElemType struct {
 	TypeParam *IndexParamType
 	// TODO: rename this so that we can differentiate between this and the
 	// Name() method thats common to all ObjTypeElems.
-	name     optional.Option[Type]
+	name     Type // optional
 	Value    Type
 	Optional *MappedModifier // TODO: replace with `?`, `!`, or nothing
 	ReadOnly *MappedModifier
@@ -518,9 +518,9 @@ func (p *PropertyElemType) Accept(v TypeVisitor) {
 }
 func (m *MappedElemType) Accept(v TypeVisitor) {
 	m.TypeParam.Constraint.Accept(v)
-	m.name.IfSome(func(name Type) {
-		name.Accept(v)
-	})
+	if m.name != nil {
+		m.name.Accept(v)
+	}
 	m.Value.Accept(v)
 }
 func (r *RestSpreadElemType) Accept(v TypeVisitor) {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/moznion/go-optional"
 )
 
 //sumtype:decl
@@ -314,7 +313,7 @@ func NewFuncParam(pattern Pat, t Type) *FuncParam {
 
 type FuncType struct {
 	TypeParams []*TypeParam
-	Self       optional.Option[Type]
+	Self       Type // optional, used for methods only
 	Params     []*FuncParam
 	Return     Type
 	Throws     Type


### PR DESCRIPTION
- make Scope.Parent a pointer instead of optional.Option
- refactor Scope.Values to store *Binding instead of optional.Option[Binding]
- make Scope.Types map store pointers instead of optional.Options
- Make TypeAlias field in TypeRefType a pointer
- get rid of more optional.Options
- remove optional.Option from codegen/type_ann.go
- remove remaining optional.Options
