### PR TITLE
namespace 1

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,6 +1,9 @@
 package ast
 
-import "github.com/escalier-lang/escalier/internal/type_system"
+import (
+	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/tidwall/btree"
+)
 
 type Node interface {
 	Span() Span
@@ -60,7 +63,7 @@ type Namespace struct {
 	Decls []Decl
 }
 type Module struct {
-	Namespaces map[string]*Namespace
+	Namespaces btree.Map[string, *Namespace]
 }
 
 type Script struct {

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -43,8 +43,11 @@ func (i *Ident) Span() Span {
 }
 
 // TODO add support for imports and exports
-type Module struct {
+type Namespace struct {
 	Decls []Decl
+}
+type Module struct {
+	Namespaces map[string]*Namespace
 }
 
 type Script struct {

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -39,7 +39,7 @@ func QualIdentToString(qi QualIdent) string {
 	case *Ident:
 		return q.Name
 	case *Member:
-		left := QualIdentToString(*q.Left)
+		left := QualIdentToString(q.Left)
 		return left + "." + q.Right.Name
 	default:
 		return ""
@@ -47,7 +47,7 @@ func QualIdentToString(qi QualIdent) string {
 }
 
 type Member struct {
-	Left  *QualIdent
+	Left  QualIdent
 	Right *Ident
 }
 

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -33,6 +33,19 @@ type QualIdent interface{ isQualIdent() }
 func (*Ident) isQualIdent()  {}
 func (*Member) isQualIdent() {}
 
+// QualIdentToString converts a QualIdent to its string representation
+func QualIdentToString(qi QualIdent) string {
+	switch q := qi.(type) {
+	case *Ident:
+		return q.Name
+	case *Member:
+		left := QualIdentToString(*q.Left)
+		return left + "." + q.Right.Name
+	default:
+		return ""
+	}
+}
+
 type Member struct {
 	Left  *QualIdent
 	Right *Ident

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -265,13 +265,13 @@ func (t *IntersectionTypeAnn) Accept(v Visitor) {
 }
 
 type TypeRefTypeAnn struct {
-	Name         string
+	Name         QualIdent
 	TypeArgs     []TypeAnn
 	span         Span
 	inferredType Type
 }
 
-func NewRefTypeAnn(name string, typeArgs []TypeAnn, span Span) *TypeRefTypeAnn {
+func NewRefTypeAnn(name QualIdent, typeArgs []TypeAnn, span Span) *TypeRefTypeAnn {
 	return &TypeRefTypeAnn{Name: name, TypeArgs: typeArgs, span: span, inferredType: nil}
 }
 func (t *TypeRefTypeAnn) Accept(v Visitor) {

--- a/internal/checker/infer.go
+++ b/internal/checker/infer.go
@@ -1217,7 +1217,8 @@ func (c *Checker) inferTypeAnn(
 
 	switch typeAnn := typeAnn.(type) {
 	case *ast.TypeRefTypeAnn:
-		typeAlias := ctx.Scope.getTypeAlias(typeAnn.Name)
+		typeName := ast.QualIdentToString(typeAnn.Name)
+		typeAlias := ctx.Scope.getTypeAlias(typeName)
 		if typeAlias != nil {
 			typeArgs := make([]Type, len(typeAnn.TypeArgs))
 			for i, typeArg := range typeAnn.TypeArgs {
@@ -1226,14 +1227,14 @@ func (c *Checker) inferTypeAnn(
 				errors = slices.Concat(errors, typeArgErrors)
 			}
 
-			t = NewTypeRefType(typeAnn.Name, typeAlias, typeArgs...)
+			t = NewTypeRefType(typeName, typeAlias, typeArgs...)
 		} else {
 			// TODO: include type args
-			typeRef := NewTypeRefType(typeAnn.Name, nil, nil)
+			typeRef := NewTypeRefType(typeName, nil, nil)
 			typeRef.SetProvenance(&ast.NodeProvenance{
 				Node: typeAnn,
 			})
-			errors = append(errors, &UnkonwnTypeError{TypeName: typeAnn.Name, typeRef: typeRef})
+			errors = append(errors, &UnkonwnTypeError{TypeName: typeName, typeRef: typeRef})
 		}
 	case *ast.NumberTypeAnn:
 		t = NewNumType()

--- a/internal/checker/infer_test.go
+++ b/internal/checker/infer_test.go
@@ -256,8 +256,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			p := parser.NewParser(ctx, source)
-			module, errors := p.ParseModule()
+			module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
 
 			if len(errors) > 0 {
 				for i, err := range errors {

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -326,7 +326,7 @@ func (b *Builder) BuildScript(mod *ast.Script) *Module {
 
 func (b *Builder) BuildModule(mod *ast.Module) *Module {
 	var stmts []Stmt
-	if ns, ok := mod.Namespaces[""]; ok {
+	if ns, ok := mod.Namespaces.Get(""); ok {
 		// If the module has a default namespace, we build its declarations.
 		for _, d := range ns.Decls {
 			stmts = slices.Concat(stmts, b.buildDecl(d))

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -326,8 +326,13 @@ func (b *Builder) BuildScript(mod *ast.Script) *Module {
 
 func (b *Builder) BuildModule(mod *ast.Module) *Module {
 	var stmts []Stmt
-	for _, d := range mod.Decls {
-		stmts = slices.Concat(stmts, b.buildDecl(d))
+	if ns, ok := mod.Namespaces[""]; ok {
+		// If the module has a default namespace, we build its declarations.
+		for _, d := range ns.Decls {
+			stmts = slices.Concat(stmts, b.buildDecl(d))
+		}
+	} else {
+		panic("TODO - TransformModule - default namespace is missing")
 	}
 	return &Module{
 		Stmts: stmts,

--- a/internal/dep_graph/NAMESPACE.md
+++ b/internal/dep_graph/NAMESPACE.md
@@ -1,0 +1,41 @@
+# Namespaces
+
+Packages in Escalier are composed of multiple files on disk.  Declarations from
+all files form the corresponding module.
+
+Directories within a package define namespaces.  Namespaces can be nested.  The
+following directory structure contains a library named `example` which contains namespaces `Foo`, `Foo.Bar`, and `Baz`:
+
+packages/
+    example/
+        lib/
+            Foo/
+                Bar/
+                    a.esc
+                    b.esc
+                c.esc
+            Baz/
+                d.esc
+            e.esc
+            f.esc
+        package.json
+
+Decls from a.esc appear in the `Foo.Bar` namespace.  Decls from b.esc and c.esc
+appear in the `Foo` namespace.  Decls from d.esc appear in the `Baz` namespace.
+Decls from e.esc and f.esc appear in the root namespace.
+
+Code inside a namespace can refer to symbols from a parent namespace without
+fully qualifying the symbol.  If the symbol is shadowed by a local symbol with
+the same name, you can access the shadowed symbol by qualifying the name.  If the
+shadowed symbol is from the root, it can be accessed using the special namespace
+identifier `$Root`.
+
+Code can refer to symbols in a child namespace by qualifying the identifier using
+the appropriate namespace.
+
+A module consists of all declarations in a package including those in namespaces.
+
+Type checking and codegen should process decls based on strongly connected 
+components.  Strongly connected components can consist of symbols from multiple
+namespaces within the same module.  The current rules regarding cycles between
+decls should be maintained.

--- a/internal/dep_graph/NAMESPACE_SPEC.md
+++ b/internal/dep_graph/NAMESPACE_SPEC.md
@@ -1,0 +1,556 @@
+# Implementation Spec: Namespaces Feature
+
+## Overview
+
+The namespaces feature will extend Escalier's module system to support hierarchical organization of declarations based on directory structure. This will enable better code organization within packages and provide TypeScript-compatible namespace semantics.
+
+## Core Requirements
+
+### 1. Directory-Based Namespace Mapping
+- **Requirement**: Map directory structure to nested namespaces
+- **Behavior**: Each subdirectory within a package's `lib/` creates a namespace
+- **Example**: `lib/Foo/Bar/` creates namespace `Foo.Bar`
+
+### 2. Symbol Resolution Rules
+- **Parent Access**: Child namespaces can access parent namespace symbols without qualification
+- **Child Access**: Parent namespaces must qualify child namespace symbols
+- **Root Access**: Special `$Root` identifier for accessing shadowed root symbols
+
+### 3. Strongly Connected Components
+- **Requirement**: Maintain existing dependency analysis across namespaces
+- **Behavior**: SCCs can span multiple namespaces within the same module
+
+## Key Design Decisions
+
+### Namespace-Qualified Binding Keys
+
+The existing `DepGraph` uses string keys in `ValueBindings` and `TypeBindings` maps. To support namespaces, these keys will be modified to include namespace qualification:
+
+**Examples of namespace-qualified keys:**
+- Variable `x` in `lib/Foo/Bar/a.esc` → key: `"Foo.Bar.x"`
+- Variable `x` in `lib/f.esc` (root) → key: `"x"`
+- Type `Point` in `lib/Baz/types.esc` → key: `"Baz.Point"`
+- Type `Config` in `lib/config.esc` (root) → key: `"Config"`
+
+**Key generation algorithm:**
+```go
+func createQualifiedName(namespace []string, name string) string {
+    if len(namespace) == 0 {
+        return name  // Root namespace, no qualification needed
+    }
+    return strings.Join(namespace, ".") + "." + name
+}
+```
+
+**Symbol resolution with qualified keys:**
+When resolving an unqualified identifier `x` from namespace `["Foo", "Bar"]`, the resolver will:
+1. Try `"Foo.Bar.x"` (current namespace)
+2. Try `"Foo.x"` (parent namespace)  
+3. Try `"x"` (root namespace)
+4. If prefixed with `$Root.`, try `"x"` directly (skip namespace hierarchy)
+
+This approach maintains compatibility with the existing `DepGraph` structure while adding namespace support through key naming conventions.
+
+## Data Structure Changes
+
+### 1. Namespace-Aware AST Extensions
+
+```go
+// internal/ast/namespace.go - New file
+package ast
+
+type NamespaceInfo struct {
+    Path      []string  // e.g., ["Foo", "Bar"]
+    SourceDir string    // Relative path from lib/
+}
+
+// Extend existing Module struct
+type Module struct {
+    Decls      []Decl
+    Namespaces map[string]*NamespaceInfo  // Maps file paths to namespace info
+}
+
+// New namespace-qualified identifier
+type NamespacedIdent struct {
+    Namespace []string  // e.g., ["Foo", "Bar"] 
+    Name      string    // e.g., "myFunction"
+    IsRoot    bool      // true if prefixed with $Root
+    span      Span
+}
+
+func (*NamespacedIdent) isQualIdent() {}
+```
+
+### 2. Enhanced Dependency Graph
+
+```go
+// internal/dep_graph/namespace.go - New file
+package dep_graph
+
+type NamespacedDeclID struct {
+    DeclID    DeclID
+    Namespace []string
+}
+
+type NamespaceDepGraph struct {
+    *DepGraph
+    NamespaceMap map[DeclID][]string  // Maps declarations to their namespaces
+}
+
+// Enhanced dependency graph building to use namespace-qualified keys
+func BuildNamespaceDepGraph(module *ast.Module) *NamespaceDepGraph {
+    // Build value and type bindings with namespace-qualified keys
+    valueBindings := btree.Map[string, DeclID]{}
+    typeBindings := btree.Map[string, DeclID]{}
+    
+    // For each declaration, create namespace-qualified binding keys
+    // e.g., "Foo.Bar.x" for variable x in lib/Foo/Bar/file.esc
+    // e.g., "x" for variable x in lib/file.esc (root namespace)
+    
+    return &NamespaceDepGraph{
+        DepGraph: &DepGraph{
+            Decls:         /* ... */,
+            ValueBindings: valueBindings,  // Keys: "Foo.Bar.x", "Baz.y", "z" (root)
+            TypeBindings:  typeBindings,   // Keys: "Foo.Bar.MyType", "GlobalType" (root)
+            Dependencies:  /* ... */,
+        },
+        NamespaceMap: /* ... */,
+    }
+}
+```
+
+### 3. Checker Namespace Extensions
+
+```go
+// internal/checker/namespace.go - New file
+package checker
+
+type QualifiedIdent string
+
+// Enhanced to support namespaces
+func NewQualifiedIdent(namespace []string, name string) QualifiedIdent {
+    if len(namespace) == 0 {
+        return QualifiedIdent(name)
+    }
+    return QualifiedIdent(strings.Join(namespace, ".") + "." + name)
+}
+
+type NamespaceScope struct {
+    *Scope
+    CurrentNamespace []string
+    ParentNamespaces map[string][]string  // Maps partial namespace paths to full paths
+}
+```
+
+## Implementation Phases
+
+### Phase 1: Parser Extensions
+
+**File**: `internal/parser/namespace_parser.go` (new)
+
+```go
+package parser
+
+func ParseNamespaceFiles(ctx context.Context, sources []*ast.Source) (*ast.Module, []*Error) {
+    allDecls := []ast.Decl{}
+    allErrors := []*Error{}
+    namespaceMap := make(map[string]*ast.NamespaceInfo)
+    
+    for _, source := range sources {
+        if source == nil {
+            continue
+        }
+        
+        // Extract namespace from file path
+        namespaceInfo := extractNamespaceFromPath(source.Path)
+        namespaceMap[source.Path] = namespaceInfo
+        
+        parser := NewParser(ctx, source)
+        parser.currentNamespace = namespaceInfo.Path
+        
+        decls := parser.decls()
+        allDecls = append(allDecls, decls...)
+        allErrors = append(allErrors, parser.errors...)
+    }
+    
+    return &ast.Module{
+        Decls: allDecls,
+        Namespaces: namespaceMap,
+    }, allErrors
+}
+
+func extractNamespaceFromPath(filePath string) *ast.NamespaceInfo {
+    // Extract namespace from file path relative to lib/
+    // e.g., "lib/Foo/Bar/file.esc" -> ["Foo", "Bar"]
+}
+```
+
+**Changes to existing parser**:
+- Add namespace context to parser state
+- Extend identifier parsing to handle `$Root` prefix
+- Add parsing for namespace-qualified identifiers
+
+### Phase 2: Enhanced Symbol Resolution
+
+**File**: `internal/checker/namespace_resolver.go` (new)
+
+```go
+package checker
+
+type NamespaceResolver struct {
+    currentNamespace []string
+    namespaceBindings map[string]map[string]*Binding  // namespace -> name -> binding
+}
+
+func (nr *NamespaceResolver) ResolveSymbol(name string, namespace []string) (*Binding, []string, error) {
+    // 1. Check current namespace
+    // 2. Check parent namespaces (bottom-up)
+    // 3. Check qualified child namespaces
+    // 4. Handle $Root special case
+}
+
+func (nr *NamespaceResolver) BuildNamespaceTree(module *ast.Module) {
+    // Build hierarchical namespace structure from declarations
+}
+```
+
+### Phase 3: Dependency Graph Extensions
+
+**File**: `internal/dep_graph/namespace_deps.go` (new)
+
+```go
+package dep_graph
+
+func BuildNamespaceDepGraph(module *ast.Module) *NamespaceDepGraph {
+    valueBindings := btree.Map[string, DeclID]{}
+    typeBindings := btree.Map[string, DeclID]{}
+    namespaceMap := make(map[DeclID][]string)
+    
+    // Process each declaration and create namespace-qualified binding keys
+    visitor := &ModuleBindingVisitor{
+        DefaulVisitor: ast.DefaulVisitor{},
+        ValueBindings: valueBindings,
+        TypeBindings:  typeBindings,
+        Decls:        btree.Map[DeclID, ast.Decl]{},
+        nextDeclID:   0,
+    }
+    
+    for filePath, namespaceInfo := range module.Namespaces {
+        // Get declarations from this file and assign them to the namespace
+        for _, decl := range getDeclarationsFromFile(module, filePath) {
+            declID := visitor.generateDeclID()
+            visitor.Decls.Set(declID, decl)
+            namespaceMap[declID] = namespaceInfo.Path
+            
+            // Create namespace-qualified binding keys
+            bindings := extractBindingsFromDecl(decl)
+            for _, binding := range bindings {
+                qualifiedName := createQualifiedName(namespaceInfo.Path, binding.Name)
+                if binding.Kind == DepKindValue {
+                    valueBindings.Set(qualifiedName, declID)
+                } else if binding.Kind == DepKindType {
+                    typeBindings.Set(qualifiedName, declID)
+                }
+            }
+        }
+    }
+    
+    // Build dependencies using the namespace-qualified keys
+    dependencies := btree.Map[DeclID, btree.Set[DeclID]]{}
+    for _, decl := range visitor.Decls.Values() {
+        declID := getDeclID(decl, visitor.Decls)
+        deps := FindDeclDependencies(decl, valueBindings, typeBindings)
+        dependencies.Set(declID, deps)
+    }
+    
+    return &NamespaceDepGraph{
+        DepGraph: &DepGraph{
+            Decls:         visitor.Decls,
+            ValueBindings: valueBindings,
+            TypeBindings:  typeBindings,
+            Dependencies:  dependencies,
+        },
+        NamespaceMap: namespaceMap,
+    }
+}
+
+// Helper function to create namespace-qualified names
+func createQualifiedName(namespace []string, name string) string {
+    if len(namespace) == 0 {
+        return name  // Root namespace, no qualification needed
+    }
+    return strings.Join(namespace, ".") + "." + name
+}
+
+func (ndg *NamespaceDepGraph) FindNamespaceDependencies(declID DeclID) []NamespacedDeclID {
+    // Find dependencies considering namespace resolution rules
+    // This needs to handle the namespace-qualified keys in ValueBindings/TypeBindings
+}
+```
+
+### Phase 4: Type Checker Integration
+
+**Changes to** `internal/checker/infer.go`:
+
+```go
+func (c *Checker) InferNamespaceModule(ctx Context, m *ast.Module) (Namespace, []Error) {
+    // Build namespace-aware dependency graph
+    namespaceDepGraph := dep_graph.BuildNamespaceDepGraph(m)
+    
+    // Create namespace-aware context
+    nsCtx := ctx.WithNamespaceScope(m.Namespaces)
+    
+    return c.InferNamespaceDepGraph(nsCtx, namespaceDepGraph)
+}
+
+func (c *Checker) InferNamespaceDepGraph(ctx Context, depGraph *dep_graph.NamespaceDepGraph) (Namespace, []Error) {
+    // Process strongly connected components with namespace awareness
+}
+```
+
+### Phase 5: Code Generation Updates
+
+**Changes to** `internal/codegen/namespace_codegen.go` (new):
+
+```go
+package codegen
+
+func (b *Builder) BuildNamespaceModule(mod *ast.Module) *Module {
+    // Group declarations by namespace
+    namespaceGroups := b.groupByNamespace(mod)
+    
+    // Generate namespace objects/modules
+    stmts := []Stmt{}
+    for namespace, decls := range namespaceGroups {
+        namespaceStmts := b.buildNamespaceBlock(namespace, decls)
+        stmts = append(stmts, namespaceStmts...)
+    }
+    
+    return &Module{Stmts: stmts}
+}
+
+func (b *Builder) buildNamespaceBlock(namespace []string, decls []ast.Decl) []Stmt {
+    // Generate nested namespace structure
+    // Create appropriate export patterns
+}
+```
+
+## File Structure Changes
+
+### New Files to Create:
+
+1. `internal/ast/namespace.go` - Namespace AST extensions
+2. `internal/parser/namespace_parser.go` - Namespace-aware parsing
+3. `internal/checker/namespace_resolver.go` - Symbol resolution logic  
+4. `internal/checker/namespace_scope.go` - Namespace scope management
+5. `internal/dep_graph/namespace_deps.go` - Namespace dependency analysis
+6. `internal/codegen/namespace_codegen.go` - Namespace code generation
+
+### Modified Files:
+
+1. `internal/ast/ast.go` - Add NamespacedIdent to QualIdent interface
+2. `internal/parser/parser.go` - Add namespace context to parser
+3. `internal/parser/expr.go` - Handle namespaced identifiers
+4. `internal/checker/infer.go` - Integrate namespace-aware inference
+5. `internal/checker/scope.go` - Extend scope with namespace support
+6. `internal/compiler/compiler.go` - Use namespace-aware compilation
+7. `cmd/escalier/build.go` - Process directory structure for namespaces
+
+## Testing Strategy
+
+### Unit Tests:
+
+1. **Namespace Extraction**: Test `extractNamespaceFromPath` function
+2. **Symbol Resolution**: Test parent/child namespace access rules
+3. **Dependency Analysis**: Test cross-namespace dependencies
+4. **Code Generation**: Test namespace structure output
+
+### Integration Tests:
+
+Create test fixtures following the example structure:
+```
+fixtures/namespaces/
+  basic/
+    lib/
+      Foo/
+        Bar/
+          a.esc
+          b.esc
+        c.esc
+      Baz/
+        d.esc
+      e.esc
+      f.esc
+    expected_output.js
+    expected_output.d.ts
+```
+
+## Migration Strategy
+
+### Backward Compatibility:
+- Existing single-file modules continue to work unchanged
+- Flat directory structures (no subdirectories) work as before
+- New namespace features are opt-in based on directory structure
+
+### Rollout Plan:
+1. **Phase 1**: Parser and AST extensions (no behavior change)
+2. **Phase 2**: Symbol resolution with namespace support
+3. **Phase 3**: Dependency graph with namespace awareness  
+4. **Phase 4**: Type checker integration
+5. **Phase 5**: Code generation for namespace structures
+
+## Edge Cases and Error Handling
+
+### Error Conditions:
+1. **Conflicting Names**: Same symbol in parent and child namespace
+2. **Circular Namespace References**: Namespace A references B, B references A
+3. **Invalid $Root Usage**: $Root used outside of namespace context
+4. **Missing Namespace**: Reference to non-existent namespace
+
+### Error Messages:
+```go
+// internal/checker/namespace_errors.go (new)
+package checker
+
+type NamespaceError struct {
+    Kind    NamespaceErrorKind
+    Message string
+    Span    ast.Span
+}
+
+type NamespaceErrorKind int
+
+const (
+    NamespaceNotFound NamespaceErrorKind = iota
+    AmbiguousReference
+    InvalidRootReference
+    CircularNamespaceReference
+)
+```
+
+## Performance Considerations
+
+### Optimizations:
+1. **Lazy Namespace Resolution**: Build namespace tree only when needed
+2. **Cached Symbol Lookups**: Cache resolved symbols to avoid repeated traversal
+3. **Incremental Compilation**: Only reprocess changed namespaces
+
+### Memory Usage:
+- Namespace information stored once per module
+- Symbol resolution cache bounded by number of unique symbols
+- Dependency graph size scales linearly with declarations
+
+## Example Implementation Details
+
+### Namespace Path Extraction
+
+```go
+func extractNamespaceFromPath(filePath string) *ast.NamespaceInfo {
+    // Normalize path separators
+    normalizedPath := filepath.ToSlash(filePath)
+    
+    // Find lib/ directory
+    libIndex := strings.Index(normalizedPath, "/lib/")
+    if libIndex == -1 {
+        return &ast.NamespaceInfo{Path: []string{}, SourceDir: ""}
+    }
+    
+    // Get relative path from lib/
+    relativePath := normalizedPath[libIndex+5:] // +5 for "/lib/"
+    
+    // Remove filename to get directory path
+    dirPath := filepath.Dir(relativePath)
+    if dirPath == "." {
+        return &ast.NamespaceInfo{Path: []string{}, SourceDir: ""}
+    }
+    
+    // Split directory path into namespace components
+    namespaceParts := strings.Split(dirPath, "/")
+    
+    return &ast.NamespaceInfo{
+        Path:      namespaceParts,
+        SourceDir: dirPath,
+    }
+}
+```
+
+### Symbol Resolution Algorithm
+
+```go
+func (nr *NamespaceResolver) ResolveSymbol(name string, currentNamespace []string) (*Binding, []string, error) {
+    // Handle $Root prefix
+    if strings.HasPrefix(name, "$Root.") {
+        rootName := strings.TrimPrefix(name, "$Root.")
+        if binding, exists := nr.namespaceBindings[""][rootName]; exists {
+            return binding, []string{}, nil
+        }
+        return nil, nil, fmt.Errorf("symbol %s not found in root namespace", rootName)
+    }
+    
+    // Check if name is already qualified (contains dots)
+    if strings.Contains(name, ".") {
+        return nr.resolveQualifiedSymbol(name)
+    }
+    
+    // Search current namespace and parents (bottom-up)
+    // Try namespace-qualified keys in dependency graph bindings
+    for i := len(currentNamespace); i >= 0; i-- {
+        searchNamespace := currentNamespace[:i]
+        qualifiedName := createQualifiedName(searchNamespace, name)
+        
+        // Check in value bindings (using namespace-qualified keys)
+        if declID, exists := nr.valueBindings.Get(qualifiedName); exists {
+            binding := nr.getBindingFromDeclID(declID)
+            return binding, searchNamespace, nil
+        }
+        
+        // Check in type bindings (using namespace-qualified keys)  
+        if declID, exists := nr.typeBindings.Get(qualifiedName); exists {
+            binding := nr.getBindingFromDeclID(declID)
+            return binding, searchNamespace, nil
+        }
+    }
+    
+    return nil, nil, fmt.Errorf("symbol %s not found", name)
+}
+
+// Enhanced dependency visitor to handle namespace-qualified symbol resolution
+type NamespaceDependencyVisitor struct {
+    ast.DefaulVisitor
+    ValueBindings    btree.Map[string, DeclID] // Keys: "Foo.Bar.x", "y" (root)
+    TypeBindings     btree.Map[string, DeclID] // Keys: "Foo.Bar.MyType", "GlobalType" (root)  
+    Dependencies     btree.Set[DeclID]
+    LocalBindings    []set.Set[string]
+    CurrentNamespace []string // Current namespace context
+}
+
+// When visiting IdentExpr, resolve using namespace-qualified keys
+func (v *NamespaceDependencyVisitor) VisitIdentExpr(expr *ast.IdentExpr) {
+    name := expr.Name.Name
+    
+    // Skip if it's a local binding
+    if v.isLocalBinding(name) {
+        return
+    }
+    
+    // Try to resolve symbol using namespace resolution rules
+    for i := len(v.CurrentNamespace); i >= 0; i-- {
+        searchNamespace := v.CurrentNamespace[:i]
+        qualifiedName := createQualifiedName(searchNamespace, name)
+        
+        if declID, exists := v.ValueBindings.Get(qualifiedName); exists {
+            v.Dependencies.Set(declID, true)
+            return
+        }
+    }
+    
+    // Handle qualified names (e.g., "Foo.Bar.symbol")
+    if strings.Contains(name, ".") {
+        if declID, exists := v.ValueBindings.Get(name); exists {
+            v.Dependencies.Set(declID, true)
+        }
+    }
+}
+```
+
+This implementation spec provides a comprehensive roadmap for implementing the namespaces feature while maintaining compatibility with existing code and following Escalier's current architectural patterns.

--- a/internal/dep_graph/cycles.go
+++ b/internal/dep_graph/cycles.go
@@ -404,7 +404,8 @@ func (v *AllBindingsUsageVisitor) EnterTypeAnn(typeAnn ast.TypeAnn) bool {
 	switch t := typeAnn.(type) {
 	case *ast.TypeRefTypeAnn:
 		// Type references are always outside function bodies (at declaration level)
-		if bindings, exists := v.BindingsByName[t.Name]; exists && !v.isLocalBinding(t.Name) && v.FunctionDepth == 0 {
+		typeName := ast.QualIdentToString(t.Name)
+		if bindings, exists := v.BindingsByName[typeName]; exists && !v.isLocalBinding(typeName) && v.FunctionDepth == 0 {
 			// Only add type bindings for type references
 			for _, binding := range bindings {
 				if binding.Kind == DepKindType {

--- a/internal/dep_graph/cycles_test.go
+++ b/internal/dep_graph/cycles_test.go
@@ -20,8 +20,7 @@ func parseModule(input string) *ast.Module {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	p := parser.NewParser(ctx, source)
-	module, errors := p.ParseModule()
+	module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
 	if len(errors) > 0 {
 		panic(errors[0])
 	}

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -217,8 +217,9 @@ func (v *DependencyVisitor) EnterTypeAnn(typeAnn ast.TypeAnn) bool {
 	switch t := typeAnn.(type) {
 	case *ast.TypeRefTypeAnn:
 		// Check if this type reference is a valid dependency
-		if declID, exists := v.TypeBindings.Get(t.Name); exists &&
-			!v.isLocalBinding(t.Name) {
+		typeName := ast.QualIdentToString(t.Name)
+		if declID, exists := v.TypeBindings.Get(typeName); exists &&
+			!v.isLocalBinding(typeName) {
 			v.Dependencies.Insert(declID)
 		}
 		return true // Continue traversing type arguments

--- a/internal/dep_graph/dep_graph_test.go
+++ b/internal/dep_graph/dep_graph_test.go
@@ -14,24 +14,36 @@ import (
 
 func TestFindModuleBindings(t *testing.T) {
 	tests := map[string]struct {
-		input    string
+		sources  []*ast.Source
 		expected []DepBinding
 	}{
 		"VarDecl_SimpleIdent": {
-			input: `
-				val a = 5
-				var b = 10
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						val a = 5
+						var b = 10
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "a", Kind: DepKindValue},
 				{Name: "b", Kind: DepKindValue},
 			},
 		},
 		"VarDecl_TupleDestructuring": {
-			input: `
-				val [x, y] = [1, 2]
-				var [first, second] = getTuple()
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						val [x, y] = [1, 2]
+						var [first, second] = getTuple()
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "x", Kind: DepKindValue},
 				{Name: "y", Kind: DepKindValue},
@@ -40,10 +52,16 @@ func TestFindModuleBindings(t *testing.T) {
 			},
 		},
 		"VarDecl_ObjectDestructuring": {
-			input: `
-				val {name, age} = person
-				var {x: width, y: height} = dimensions
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						val {name, age} = person
+						var {x: width, y: height} = dimensions
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "name", Kind: DepKindValue},
 				{Name: "age", Kind: DepKindValue},
@@ -52,47 +70,71 @@ func TestFindModuleBindings(t *testing.T) {
 			},
 		},
 		"VarDecl_ObjectShorthand": {
-			input: `
-				val {foo, bar} = obj
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						val {foo, bar} = obj
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "foo", Kind: DepKindValue},
 				{Name: "bar", Kind: DepKindValue},
 			},
 		},
 		"FuncDecl_Simple": {
-			input: `
-				fn add(a, b) {
-					return a + b
-				}
-				fn multiply(x, y) {
-					return x * y
-				}
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						fn add(a, b) {
+							return a + b
+						}
+						fn multiply(x, y) {
+							return x * y
+						}
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "add", Kind: DepKindValue},
 				{Name: "multiply", Kind: DepKindValue},
 			},
 		},
 		"TypeDecl_Simple": {
-			input: `
-				type Point = {x: number, y: number}
-				type Color = "red" | "green" | "blue"
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						type Point = {x: number, y: number}
+						type Color = "red" | "green" | "blue"
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "Point", Kind: DepKindType},
 				{Name: "Color", Kind: DepKindType},
 			},
 		},
 		"Mixed_Declarations": {
-			input: `
-				type User = {name: string, age: number}
-				val defaultUser = {name: "John", age: 30}
-				fn createUser(name, age) {
-					return {name, age}
-				}
-				var [admin, guest] = [createUser("admin", 25), defaultUser]
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						type User = {name: string, age: number}
+						val defaultUser = {name: "John", age: 30}
+						fn createUser(name, age) {
+							return {name, age}
+						}
+						var [admin, guest] = [createUser("admin", 25), defaultUser]
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "User", Kind: DepKindType},
 				{Name: "defaultUser", Kind: DepKindValue},
@@ -102,14 +144,26 @@ func TestFindModuleBindings(t *testing.T) {
 			},
 		},
 		"Empty_Module": {
-			input:    ``,
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "test.esc",
+					Contents: ``,
+				},
+			},
 			expected: []DepBinding{},
 		},
 		"VarDecl_NestedPatterns": {
-			input: `
-				val {user: {name, profile: {email}}} = data
-				val [first, {x, y}] = coordinates
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						val {user: {name, profile: {email}}} = data
+						val [first, {x, y}] = coordinates
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "name", Kind: DepKindValue},
 				{Name: "email", Kind: DepKindValue},
@@ -119,10 +173,16 @@ func TestFindModuleBindings(t *testing.T) {
 			},
 		},
 		"VarDecl_RestPatterns": {
-			input: `
-				val [head, ...tail] = list
-				val {id, ...rest} = object
-			`,
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "test.esc",
+					Contents: `
+						val [head, ...tail] = list
+						val {id, ...rest} = object
+					`,
+				},
+			},
 			expected: []DepBinding{
 				{Name: "head", Kind: DepKindValue},
 				{Name: "tail", Kind: DepKindValue},
@@ -135,16 +195,10 @@ func TestFindModuleBindings(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			source := &ast.Source{
-				ID:       0,
-				Path:     "test.esc",
-				Contents: test.input,
-			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			parser := parser.NewParser(ctx, source)
-			module, errors := parser.ParseModule()
+			module, errors := parser.ParseLibFiles(ctx, test.sources)
 
 			// Ensure parsing was successful
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
@@ -182,21 +236,25 @@ func TestFindModuleBindings_EmptyNames(t *testing.T) {
 		"FuncDecl_NilName": {
 			setupModule: func() *ast.Module {
 				return &ast.Module{
-					Decls: []ast.Decl{
-						&ast.FuncDecl{
-							Name: nil, // Function with nil name
-							FuncSig: ast.FuncSig{
-								TypeParams: []*ast.TypeParam{},
-								Params:     []*ast.Param{},
-								Return:     nil,
-								Throws:     nil,
-							},
-							Body: &ast.Block{
-								Stmts: []ast.Stmt{},
-								Span: ast.Span{
-									Start:    ast.Location{Line: 1, Column: 1},
-									End:      ast.Location{Line: 1, Column: 1},
-									SourceID: 0,
+					Namespaces: map[string]*ast.Namespace{
+						"": {
+							Decls: []ast.Decl{
+								&ast.FuncDecl{
+									Name: nil, // Function with nil name
+									FuncSig: ast.FuncSig{
+										TypeParams: []*ast.TypeParam{},
+										Params:     []*ast.Param{},
+										Return:     nil,
+										Throws:     nil,
+									},
+									Body: &ast.Block{
+										Stmts: []ast.Stmt{},
+										Span: ast.Span{
+											Start:    ast.Location{Line: 1, Column: 1},
+											End:      ast.Location{Line: 1, Column: 1},
+											SourceID: 0,
+										},
+									},
 								},
 							},
 						},
@@ -208,21 +266,25 @@ func TestFindModuleBindings_EmptyNames(t *testing.T) {
 		"FuncDecl_EmptyName": {
 			setupModule: func() *ast.Module {
 				return &ast.Module{
-					Decls: []ast.Decl{
-						&ast.FuncDecl{
-							Name: &ast.Ident{Name: ""}, // Function with empty name
-							FuncSig: ast.FuncSig{
-								TypeParams: []*ast.TypeParam{},
-								Params:     []*ast.Param{},
-								Return:     nil,
-								Throws:     nil,
-							},
-							Body: &ast.Block{
-								Stmts: []ast.Stmt{},
-								Span: ast.Span{
-									Start:    ast.Location{Line: 1, Column: 1},
-									End:      ast.Location{Line: 1, Column: 1},
-									SourceID: 0,
+					Namespaces: map[string]*ast.Namespace{
+						"": {
+							Decls: []ast.Decl{
+								&ast.FuncDecl{
+									Name: &ast.Ident{Name: ""}, // Function with empty name
+									FuncSig: ast.FuncSig{
+										TypeParams: []*ast.TypeParam{},
+										Params:     []*ast.Param{},
+										Return:     nil,
+										Throws:     nil,
+									},
+									Body: &ast.Block{
+										Stmts: []ast.Stmt{},
+										Span: ast.Span{
+											Start:    ast.Location{Line: 1, Column: 1},
+											End:      ast.Location{Line: 1, Column: 1},
+											SourceID: 0,
+										},
+									},
 								},
 							},
 						},
@@ -234,12 +296,16 @@ func TestFindModuleBindings_EmptyNames(t *testing.T) {
 		"TypeDecl_NilName": {
 			setupModule: func() *ast.Module {
 				return &ast.Module{
-					Decls: []ast.Decl{
-						&ast.TypeDecl{
-							Name:       nil, // Type with nil name
-							TypeParams: []*ast.TypeParam{},
-							TypeAnn: &ast.LitTypeAnn{
-								Lit: &ast.StrLit{Value: "test"},
+					Namespaces: map[string]*ast.Namespace{
+						"": {
+							Decls: []ast.Decl{
+								&ast.TypeDecl{
+									Name:       nil, // Type with nil name
+									TypeParams: []*ast.TypeParam{},
+									TypeAnn: &ast.LitTypeAnn{
+										Lit: &ast.StrLit{Value: "test"},
+									},
+								},
 							},
 						},
 					},
@@ -250,12 +316,16 @@ func TestFindModuleBindings_EmptyNames(t *testing.T) {
 		"TypeDecl_EmptyName": {
 			setupModule: func() *ast.Module {
 				return &ast.Module{
-					Decls: []ast.Decl{
-						&ast.TypeDecl{
-							Name:       &ast.Ident{Name: ""}, // Type with empty name
-							TypeParams: []*ast.TypeParam{},
-							TypeAnn: &ast.LitTypeAnn{
-								Lit: &ast.StrLit{Value: "test"},
+					Namespaces: map[string]*ast.Namespace{
+						"": {
+							Decls: []ast.Decl{
+								&ast.TypeDecl{
+									Name:       &ast.Ident{Name: ""}, // Type with empty name
+									TypeParams: []*ast.TypeParam{},
+									TypeAnn: &ast.LitTypeAnn{
+										Lit: &ast.StrLit{Value: "test"},
+									},
+								},
 							},
 						},
 					},
@@ -484,13 +554,12 @@ func TestFindDeclDependencies(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			parser := parser.NewParser(ctx, source)
-			module, errors := parser.ParseModule()
+			module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
 
 			// Ensure parsing was successful
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 			assert.NotNil(t, module, "Module should not be nil")
-			assert.Len(t, module.Decls, 1, "Module should have exactly one declaration")
+			assert.Len(t, module.Namespaces[""].Decls, 1, "Module should have exactly one declaration")
 
 			// Create valid bindings maps (split by kind)
 			var valueBindings btree.Map[string, DeclID]
@@ -505,7 +574,7 @@ func TestFindDeclDependencies(t *testing.T) {
 			}
 
 			// Find dependencies
-			dependencies := FindDeclDependencies(module.Decls[0], valueBindings, typeBindings)
+			dependencies := FindDeclDependencies(module.Namespaces[""].Decls[0], valueBindings, typeBindings)
 
 			// Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
@@ -810,8 +879,7 @@ func TestBuildDepGraph(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			parser := parser.NewParser(ctx, source)
-			module, errors := parser.ParseModule()
+			module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
 
 			// Ensure parsing was successful
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)

--- a/internal/dep_graph/dep_graph_test.go
+++ b/internal/dep_graph/dep_graph_test.go
@@ -363,101 +363,101 @@ func TestFindModuleBindings_EmptyNames(t *testing.T) {
 	}{
 		"FuncDecl_NilName": {
 			setupModule: func() *ast.Module {
-				return &ast.Module{
-					Namespaces: map[string]*ast.Namespace{
-						"": {
-							Decls: []ast.Decl{
-								&ast.FuncDecl{
-									Name: nil, // Function with nil name
-									FuncSig: ast.FuncSig{
-										TypeParams: []*ast.TypeParam{},
-										Params:     []*ast.Param{},
-										Return:     nil,
-										Throws:     nil,
-									},
-									Body: &ast.Block{
-										Stmts: []ast.Stmt{},
-										Span: ast.Span{
-											Start:    ast.Location{Line: 1, Column: 1},
-											End:      ast.Location{Line: 1, Column: 1},
-											SourceID: 0,
-										},
-									},
+				module := &ast.Module{
+					Namespaces: btree.Map[string, *ast.Namespace]{},
+				}
+				module.Namespaces.Set("", &ast.Namespace{
+					Decls: []ast.Decl{
+						&ast.FuncDecl{
+							Name: nil, // Function with nil name
+							FuncSig: ast.FuncSig{
+								TypeParams: []*ast.TypeParam{},
+								Params:     []*ast.Param{},
+								Return:     nil,
+								Throws:     nil,
+							},
+							Body: &ast.Block{
+								Stmts: []ast.Stmt{},
+								Span: ast.Span{
+									Start:    ast.Location{Line: 1, Column: 1},
+									End:      ast.Location{Line: 1, Column: 1},
+									SourceID: 0,
 								},
 							},
 						},
 					},
-				}
+				})
+				return module
 			},
 			expected: []DepBinding{},
 		},
 		"FuncDecl_EmptyName": {
 			setupModule: func() *ast.Module {
-				return &ast.Module{
-					Namespaces: map[string]*ast.Namespace{
-						"": {
-							Decls: []ast.Decl{
-								&ast.FuncDecl{
-									Name: &ast.Ident{Name: ""}, // Function with empty name
-									FuncSig: ast.FuncSig{
-										TypeParams: []*ast.TypeParam{},
-										Params:     []*ast.Param{},
-										Return:     nil,
-										Throws:     nil,
-									},
-									Body: &ast.Block{
-										Stmts: []ast.Stmt{},
-										Span: ast.Span{
-											Start:    ast.Location{Line: 1, Column: 1},
-											End:      ast.Location{Line: 1, Column: 1},
-											SourceID: 0,
-										},
-									},
+				module := &ast.Module{
+					Namespaces: btree.Map[string, *ast.Namespace]{},
+				}
+				module.Namespaces.Set("", &ast.Namespace{
+					Decls: []ast.Decl{
+						&ast.FuncDecl{
+							Name: &ast.Ident{Name: ""}, // Function with empty name
+							FuncSig: ast.FuncSig{
+								TypeParams: []*ast.TypeParam{},
+								Params:     []*ast.Param{},
+								Return:     nil,
+								Throws:     nil,
+							},
+							Body: &ast.Block{
+								Stmts: []ast.Stmt{},
+								Span: ast.Span{
+									Start:    ast.Location{Line: 1, Column: 1},
+									End:      ast.Location{Line: 1, Column: 1},
+									SourceID: 0,
 								},
 							},
 						},
 					},
-				}
+				})
+				return module
 			},
 			expected: []DepBinding{},
 		},
 		"TypeDecl_NilName": {
 			setupModule: func() *ast.Module {
-				return &ast.Module{
-					Namespaces: map[string]*ast.Namespace{
-						"": {
-							Decls: []ast.Decl{
-								&ast.TypeDecl{
-									Name:       nil, // Type with nil name
-									TypeParams: []*ast.TypeParam{},
-									TypeAnn: &ast.LitTypeAnn{
-										Lit: &ast.StrLit{Value: "test"},
-									},
-								},
+				module := &ast.Module{
+					Namespaces: btree.Map[string, *ast.Namespace]{},
+				}
+				module.Namespaces.Set("", &ast.Namespace{
+					Decls: []ast.Decl{
+						&ast.TypeDecl{
+							Name:       nil, // Type with nil name
+							TypeParams: []*ast.TypeParam{},
+							TypeAnn: &ast.LitTypeAnn{
+								Lit: &ast.StrLit{Value: "test"},
 							},
 						},
 					},
-				}
+				})
+				return module
 			},
 			expected: []DepBinding{},
 		},
 		"TypeDecl_EmptyName": {
 			setupModule: func() *ast.Module {
-				return &ast.Module{
-					Namespaces: map[string]*ast.Namespace{
-						"": {
-							Decls: []ast.Decl{
-								&ast.TypeDecl{
-									Name:       &ast.Ident{Name: ""}, // Type with empty name
-									TypeParams: []*ast.TypeParam{},
-									TypeAnn: &ast.LitTypeAnn{
-										Lit: &ast.StrLit{Value: "test"},
-									},
-								},
+				module := &ast.Module{
+					Namespaces: btree.Map[string, *ast.Namespace]{},
+				}
+				module.Namespaces.Set("", &ast.Namespace{
+					Decls: []ast.Decl{
+						&ast.TypeDecl{
+							Name:       &ast.Ident{Name: ""}, // Type with empty name
+							TypeParams: []*ast.TypeParam{},
+							TypeAnn: &ast.LitTypeAnn{
+								Lit: &ast.StrLit{Value: "test"},
 							},
 						},
 					},
-				}
+				})
+				return module
 			},
 			expected: []DepBinding{},
 		},
@@ -782,7 +782,10 @@ func TestFindDeclDependencies(t *testing.T) {
 			// Ensure parsing was successful
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 			assert.NotNil(t, module, "Module should not be nil")
-			assert.Len(t, module.Namespaces[""].Decls, 1, "Module should have exactly one declaration")
+
+			emptyNS, exists := module.Namespaces.Get("")
+			assert.True(t, exists, "Module should have empty namespace")
+			assert.Len(t, emptyNS.Decls, 1, "Module should have exactly one declaration")
 
 			// Create valid bindings maps (split by kind)
 			var valueBindings btree.Map[string, DeclID]
@@ -797,7 +800,8 @@ func TestFindDeclDependencies(t *testing.T) {
 			}
 
 			// Find dependencies
-			dependencies := FindDeclDependencies(module.Namespaces[""].Decls[0], valueBindings, typeBindings)
+			emptyNS2, _ := module.Namespaces.Get("")
+			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, "")
 
 			// Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
@@ -912,7 +916,7 @@ func TestFindDeclDependencies_EdgeCases(t *testing.T) {
 			}
 
 			// Find dependencies
-			dependencies := FindDeclDependencies(decl, valueBindings, typeBindings)
+			dependencies := FindDeclDependencies(decl, valueBindings, typeBindings, "")
 
 			// Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
@@ -1172,147 +1176,147 @@ func TestBuildDepGraph(t *testing.T) {
 				3: {},     // val utils.helper has no dependencies
 			},
 		},
-		// "Multiple_Files_With_Subdirectories": {
-		// 	sources: []*ast.Source{
-		// 		{
-		// 			ID:   0,
-		// 			Path: "main.esc",
-		// 			Contents: `
-		// 				type Config = {name: string, version: string}
-		// 				val config: Config = {name: "app", version: "1.0"}
-		// 				val calculator = math.operations.add(5, 3)
-		// 				val greeting = strings.format("Hello {}", config.name)
-		// 			`,
-		// 		},
-		// 		{
-		// 			ID:   1,
-		// 			Path: "math/operations.esc",
-		// 			Contents: `
-		// 				fn add(a, b) {
-		// 					return a + b
-		// 				}
-		// 				fn multiply(a, b) {
-		// 					return a * b
-		// 				}
-		// 				val PI = 3.14159
-		// 			`,
-		// 		},
-		// 		{
-		// 			ID:   2,
-		// 			Path: "strings/format.esc",
-		// 			Contents: `
-		// 				fn format(template, value) {
-		// 					return template + " " + value
-		// 				}
-		// 				type Template = string
-		// 			`,
-		// 		},
-		// 	},
-		// 	expectedDeclCount: 8,
-		// 	expectedDependencies: map[int][]int{
-		// 		0: {},  // type Config (main.esc) has no dependencies
-		// 		1: {0}, // val config (main.esc) depends on Config (index 0)
-		// 		2: {3}, // val calculator (main.esc) depends on math.operations.add (index 3)
-		// 		3: {6}, // val greeting (main.esc) depends on strings.format (index 6)
-		// 		4: {},  // fn math.operations.add has no dependencies
-		// 		5: {},  // fn math.operations.multiply has no dependencies
-		// 		6: {},  // val math.operations.PI has no dependencies
-		// 		7: {},  // fn strings.format has no dependencies
-		// 		8: {},  // type strings.Template has no dependencies
-		// 	},
-		// },
-		// "Multiple_Files_Cross_Directory_Dependencies": {
-		// 	sources: []*ast.Source{
-		// 		{
-		// 			ID:   0,
-		// 			Path: "index.esc",
-		// 			Contents: `
-		// 				val result = core.engine.process(models.user.defaultUser)
-		// 				type Result = {success: boolean, data: models.User}
-		// 			`,
-		// 		},
-		// 		{
-		// 			ID:   1,
-		// 			Path: "core/engine.esc",
-		// 			Contents: `
-		// 				fn process(user) {
-		// 					return {success: true, data: user}
-		// 				}
-		// 				val engine: Engine = {running: true}
-		// 				type Engine = {running: boolean}
-		// 			`,
-		// 		},
-		// 		{
-		// 			ID:   2,
-		// 			Path: "models/user.esc",
-		// 			Contents: `
-		// 				type User = {id: number, name: string}
-		// 				val defaultUser: User = {id: 0, name: "Guest"}
-		// 				fn createUser(name) {
-		// 					return {id: 1, name: name}
-		// 				}
-		// 			`,
-		// 		},
-		// 	},
-		// 	expectedDeclCount: 8,
-		// 	expectedDependencies: map[int][]int{
-		// 		0: {2, 6}, // val result depends on core.engine.process (index 2) and models.user.defaultUser (index 6)
-		// 		1: {5},    // type Result depends on models.User (index 5)
-		// 		2: {},     // fn core.engine.process has no dependencies
-		// 		3: {4},    // val core.engine.engine depends on core.Engine (index 4)
-		// 		4: {},     // type core.Engine has no dependencies
-		// 		5: {},     // type models.User has no dependencies
-		// 		6: {5},    // val models.user.defaultUser depends on models.User (index 5)
-		// 		7: {},     // fn models.user.createUser has no dependencies
-		// 	},
-		// },
-		// "Multiple_Files_Nested_Subdirectories": {
-		// 	sources: []*ast.Source{
-		// 		{
-		// 			ID:   0,
-		// 			Path: "app.esc",
-		// 			Contents: `
-		// 				val server = core.network.http.createServer(8080)
-		// 				val database = core.storage.db.connect("localhost")
-		// 				type App = {server: core.network.http.Server, db: core.storage.db.Database}
-		// 			`,
-		// 		},
-		// 		{
-		// 			ID:   1,
-		// 			Path: "core/network/http.esc",
-		// 			Contents: `
-		// 				type Server = {port: number, running: boolean}
-		// 				fn createServer(port) {
-		// 					return {port: port, running: false}
-		// 				}
-		// 				val defaultPort = 3000
-		// 			`,
-		// 		},
-		// 		{
-		// 			ID:   2,
-		// 			Path: "core/storage/db.esc",
-		// 			Contents: `
-		// 				type Database = {host: string, connected: boolean}
-		// 				fn connect(host) {
-		// 					return {host: host, connected: true}
-		// 				}
-		// 				val maxConnections = 100
-		// 			`,
-		// 		},
-		// 	},
-		// 	expectedDeclCount: 9,
-		// 	expectedDependencies: map[int][]int{
-		// 		0: {4},    // val server depends on core.network.http.createServer (index 4)
-		// 		1: {7},    // val database depends on core.storage.db.connect (index 7)
-		// 		2: {3, 6}, // type App depends on core.network.http.Server (index 3) and core.storage.db.Database (index 6)
-		// 		3: {},     // type core.network.http.Server has no dependencies
-		// 		4: {},     // fn core.network.http.createServer has no dependencies
-		// 		5: {},     // val core.network.http.defaultPort has no dependencies
-		// 		6: {},     // type core.storage.db.Database has no dependencies
-		// 		7: {},     // fn core.storage.db.connect has no dependencies
-		// 		8: {},     // val core.storage.db.maxConnections has no dependencies
-		// 	},
-		// },
+		"Multiple_Files_With_Subdirectories": {
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "main.esc",
+					Contents: `
+						type Config = {name: string, version: string}
+						val config: Config = {name: "app", version: "1.0"}
+						val calculator = math.add(5, 3)
+						val greeting = strings.format("Hello {}", config.name)
+					`,
+				},
+				{
+					ID:   1,
+					Path: "math/operations.esc",
+					Contents: `
+						fn add(a, b) {
+							return a + b
+						}
+						fn multiply(a, b) {
+							return a * b
+						}
+						val PI = 3.14159
+					`,
+				},
+				{
+					ID:   2,
+					Path: "strings/format.esc",
+					Contents: `
+						fn format(template, value) {
+							return template + " " + value
+						}
+						type Template = string
+					`,
+				},
+			},
+			expectedDeclCount: 9,
+			expectedDependencies: map[int][]int{
+				0: {},     // type Config (main.esc) has no dependencies
+				1: {0},    // val config (main.esc) depends on Config (index 0)
+				2: {4},    // val calculator (main.esc) depends on math.add (index 4)
+				3: {1, 7}, // val greeting (main.esc) depends on strings.format (index 7) and config (index 1)
+				4: {},     // fn math.add has no dependencies
+				5: {},     // fn math.multiply has no dependencies
+				6: {},     // val math.PI has no dependencies
+				7: {},     // fn strings.format has no dependencies
+				8: {},     // type strings.Template has no dependencies
+			},
+		},
+		"Multiple_Files_Cross_Directory_Dependencies": {
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "index.esc",
+					Contents: `
+						val result = core.process(models.defaultUser)
+						type Result = {success: boolean, data: models.User}
+					`,
+				},
+				{
+					ID:   1,
+					Path: "core/engine.esc",
+					Contents: `
+						fn process(user) {
+							return {success: true, data: user}
+						}
+						val engine: Engine = {running: true}
+						type Engine = {running: boolean}
+					`,
+				},
+				{
+					ID:   2,
+					Path: "models/user.esc",
+					Contents: `
+						type User = {id: number, name: string}
+						val defaultUser: User = {id: 0, name: "Guest"}
+						fn createUser(name) {
+							return {id: 1, name: name}
+						}
+					`,
+				},
+			},
+			expectedDeclCount: 8,
+			expectedDependencies: map[int][]int{
+				0: {2, 6}, // val result depends on core.engine.process (index 2) and models.user.defaultUser (index 6)
+				1: {5},    // type Result depends on models.User (index 5)
+				2: {},     // fn core.engine.process has no dependencies
+				3: {4},    // val core.engine.engine depends on core.Engine (index 4)
+				4: {},     // type core.Engine has no dependencies
+				5: {},     // type models.User has no dependencies
+				6: {5},    // val models.defaultUser depends on models.User (index 5)
+				7: {},     // fn models.createUser has no dependencies
+			},
+		},
+		"Multiple_Files_Nested_Subdirectories": {
+			sources: []*ast.Source{
+				{
+					ID:   0,
+					Path: "app.esc",
+					Contents: `
+						val server = core.network.createServer(8080)
+						val database = core.storage.connect("localhost")
+						type App = {server: core.network.Server, db: core.storage.Database}
+					`,
+				},
+				{
+					ID:   1,
+					Path: "core/network/http.esc",
+					Contents: `
+						type Server = {port: number, running: boolean}
+						fn createServer(port) {
+							return {port: port, running: false}
+						}
+						val defaultPort = 3000
+					`,
+				},
+				{
+					ID:   2,
+					Path: "core/storage/db.esc",
+					Contents: `
+						type Database = {host: string, connected: boolean}
+						fn connect(host) {
+							return {host: host, connected: true}
+						}
+						val maxConnections = 100
+					`,
+				},
+			},
+			expectedDeclCount: 9,
+			expectedDependencies: map[int][]int{
+				0: {4},    // val server depends on core.network.http.createServer (index 4)
+				1: {7},    // val database depends on core.storage.db.connect (index 7)
+				2: {3, 6}, // type App depends on core.network.http.Server (index 3) and core.storage.db.Database (index 6)
+				3: {},     // type core.network.http.Server has no dependencies
+				4: {},     // fn core.network.http.createServer has no dependencies
+				5: {},     // val core.network.http.defaultPort has no dependencies
+				6: {},     // type core.storage.db.Database has no dependencies
+				7: {},     // fn core.storage.db.connect has no dependencies
+				8: {},     // val core.storage.db.maxConnections has no dependencies
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/dep_graph/dep_graph_test.go
+++ b/internal/dep_graph/dep_graph_test.go
@@ -678,22 +678,22 @@ func TestFindDeclDependencies(t *testing.T) {
 			},
 			declType: "var",
 		},
-		// "VarDecl_QualifiedTypeAndValueMixed": {
-		// 	declCode: `val config: app.Config = app.createConfig(defaults.host, defaults.port)`,
-		// 	validBindings: []DepBinding{
-		// 		{Name: "app.Config", Kind: DepKindType},
-		// 		{Name: "app.createConfig", Kind: DepKindValue},
-		// 		{Name: "defaults.host", Kind: DepKindValue},
-		// 		{Name: "defaults.port", Kind: DepKindValue},
-		// 	},
-		// 	expectedDeps: []DepBinding{
-		// 		{Name: "app.Config", Kind: DepKindType},
-		// 		{Name: "app.createConfig", Kind: DepKindValue},
-		// 		{Name: "defaults.host", Kind: DepKindValue},
-		// 		{Name: "defaults.port", Kind: DepKindValue},
-		// 	},
-		// 	declType: "var",
-		// },
+		"VarDecl_QualifiedTypeAndValueMixed": {
+			declCode: `val config: app.Config = app.createConfig(defaults.host, defaults.port)`,
+			validBindings: []DepBinding{
+				{Name: "app.Config", Kind: DepKindType},
+				{Name: "app.createConfig", Kind: DepKindValue},
+				{Name: "defaults.host", Kind: DepKindValue},
+				{Name: "defaults.port", Kind: DepKindValue},
+			},
+			expectedDeps: []DepBinding{
+				{Name: "app.Config", Kind: DepKindType},
+				{Name: "app.createConfig", Kind: DepKindValue},
+				{Name: "defaults.host", Kind: DepKindValue},
+				{Name: "defaults.port", Kind: DepKindValue},
+			},
+			declType: "var",
+		},
 		"FuncDecl_QualifiedDependencies": {
 			declCode: `fn processData(input) {
 				val processed = utils.transform(input)
@@ -726,26 +726,26 @@ func TestFindDeclDependencies(t *testing.T) {
 			},
 			declType: "func",
 		},
-		// "TypeDecl_QualifiedTypeDependencies": {
-		// 	declCode:      `type Response = {data: api.Data, meta: core.Meta}`,
-		// 	validBindings: []DepBinding{{Name: "api.Data", Kind: DepKindType}, {Name: "core.Meta", Kind: DepKindType}, {Name: "unused.Type", Kind: DepKindType}},
-		// 	expectedDeps:  []DepBinding{{Name: "api.Data", Kind: DepKindType}, {Name: "core.Meta", Kind: DepKindType}},
-		// 	declType:      "type",
-		// },
-		// "TypeDecl_NestedQualifiedTypes": {
-		// 	declCode:      `type Complex = {nested: {inner: models.User, config: settings.AppConfig}, items: Array<data.Item>}`,
-		// 	validBindings: []DepBinding{
-		// 		{Name: "models.User", Kind: DepKindType},
-		// 		{Name: "settings.AppConfig", Kind: DepKindType},
-		// 		{Name: "data.Item", Kind: DepKindType},
-		// 	},
-		// 	expectedDeps: []DepBinding{
-		// 		{Name: "models.User", Kind: DepKindType},
-		// 		{Name: "settings.AppConfig", Kind: DepKindType},
-		// 		{Name: "data.Item", Kind: DepKindType},
-		// 	},
-		// 	declType: "type",
-		// },
+		"TypeDecl_QualifiedTypeDependencies": {
+			declCode:      `type Response = {data: api.Data, meta: core.Meta}`,
+			validBindings: []DepBinding{{Name: "api.Data", Kind: DepKindType}, {Name: "core.Meta", Kind: DepKindType}, {Name: "unused.Type", Kind: DepKindType}},
+			expectedDeps:  []DepBinding{{Name: "api.Data", Kind: DepKindType}, {Name: "core.Meta", Kind: DepKindType}},
+			declType:      "type",
+		},
+		"TypeDecl_NestedQualifiedTypes": {
+			declCode: `type Complex = {nested: {inner: models.User, config: settings.AppConfig}, items: Array<data.Item>}`,
+			validBindings: []DepBinding{
+				{Name: "models.User", Kind: DepKindType},
+				{Name: "settings.AppConfig", Kind: DepKindType},
+				{Name: "data.Item", Kind: DepKindType},
+			},
+			expectedDeps: []DepBinding{
+				{Name: "models.User", Kind: DepKindType},
+				{Name: "settings.AppConfig", Kind: DepKindType},
+				{Name: "data.Item", Kind: DepKindType},
+			},
+			declType: "type",
+		},
 		"VarDecl_QualifiedNonValidDependency": {
 			declCode:      `val result = unknown.module.func() + 5`,
 			validBindings: []DepBinding{{Name: "known.func", Kind: DepKindValue}, {Name: "other.var", Kind: DepKindValue}},

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -686,7 +686,14 @@ nil
         TypeAnn: &ast.UnionTypeAnn{
             Types: {
                 &ast.TypeRefTypeAnn{
-                    Name:     "Foo",
+                    Name: &ast.Ident{
+                        Name: "Foo",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:2, Column:7},
+                            End:      ast.Location{Line:2, Column:10},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -697,7 +704,14 @@ nil
                     inferredType: nil,
                 },
                 &ast.TypeRefTypeAnn{
-                    Name:     "Bar",
+                    Name: &ast.Ident{
+                        Name: "Bar",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:3, Column:7},
+                            End:      ast.Location{Line:3, Column:10},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -708,7 +722,14 @@ nil
                     inferredType: nil,
                 },
                 &ast.TypeRefTypeAnn{
-                    Name:     "Baz",
+                    Name: &ast.Ident{
+                        Name: "Baz",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:4, Column:7},
+                            End:      ast.Location{Line:4, Column:10},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -1027,7 +1048,14 @@ nil
         TypeAnn: &ast.UnionTypeAnn{
             Types: {
                 &ast.TypeRefTypeAnn{
-                    Name:     "Foo",
+                    Name: &ast.Ident{
+                        Name: "Foo",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:15},
+                            End:      ast.Location{Line:1, Column:18},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -1038,7 +1066,14 @@ nil
                     inferredType: nil,
                 },
                 &ast.TypeRefTypeAnn{
-                    Name:     "Bar",
+                    Name: &ast.Ident{
+                        Name: "Bar",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:3, Column:7},
+                            End:      ast.Location{Line:3, Column:10},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -1049,7 +1084,14 @@ nil
                     inferredType: nil,
                 },
                 &ast.TypeRefTypeAnn{
-                    Name:     "Baz",
+                    Name: &ast.Ident{
+                        Name: "Baz",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:5, Column:7},
+                            End:      ast.Location{Line:5, Column:10},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -497,9 +497,9 @@
 ---
 
 [TestParseTypeAnnNoErrors/IndexedTypeWithDot - 1]
-&ast.IndexTypeAnn{
-    Target: &ast.TypeRefTypeAnn{
-        Name: &ast.Ident{
+&ast.TypeRefTypeAnn{
+    Name: &ast.Member{
+        Left: &ast.Ident{
             Name: "A",
             span: ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
@@ -507,34 +507,20 @@
                 SourceID: 0,
             },
         },
-        TypeArgs: {
-        },
-        span: ast.Span{
-            Start:    ast.Location{Line:1, Column:1},
-            End:      ast.Location{Line:1, Column:2},
-            SourceID: 0,
-        },
-        inferredType: nil,
-    },
-    Index: &ast.LitTypeAnn{
-        Lit: &ast.StrLit{
-            Value: "B",
-            span:  ast.Span{
-                Start:    ast.Location{Line:1, Column:2},
-                End:      ast.Location{Line:1, Column:3},
+        Right: &ast.Ident{
+            Name: "B",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:3},
+                End:      ast.Location{Line:1, Column:4},
                 SourceID: 0,
             },
         },
-        span: ast.Span{
-            Start:    ast.Location{Line:1, Column:2},
-            End:      ast.Location{Line:1, Column:3},
-            SourceID: 0,
-        },
-        inferredType: nil,
+    },
+    TypeArgs: {
     },
     span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
-        End:      ast.Location{Line:1, Column:3},
+        End:      ast.Location{Line:1, Column:4},
         SourceID: 0,
     },
     inferredType: nil,
@@ -940,6 +926,145 @@
     span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:29},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseTypeAnnNoErrors/QualifiedTypeRefWithTypeArgs - 1]
+&ast.TypeRefTypeAnn{
+    Name: &ast.Member{
+        Left: &ast.Ident{
+            Name: "Foo",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:4},
+                SourceID: 0,
+            },
+        },
+        Right: &ast.Ident{
+            Name: "Bar",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:5},
+                End:      ast.Location{Line:1, Column:8},
+                SourceID: 0,
+            },
+        },
+    },
+    TypeArgs: {
+        &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "T",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:9},
+                    End:      ast.Location{Line:1, Column:10},
+                    SourceID: 0,
+                },
+            },
+            TypeArgs: {
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:9},
+                End:      ast.Location{Line:1, Column:10},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+        &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "U",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:12},
+                    End:      ast.Location{Line:1, Column:13},
+                    SourceID: 0,
+                },
+            },
+            TypeArgs: {
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:12},
+                End:      ast.Location{Line:1, Column:13},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:14},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseTypeAnnNoErrors/QualifiedTypeRef - 1]
+&ast.TypeRefTypeAnn{
+    Name: &ast.Member{
+        Left: &ast.Ident{
+            Name: "Foo",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:4},
+                SourceID: 0,
+            },
+        },
+        Right: &ast.Ident{
+            Name: "Bar",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:5},
+                End:      ast.Location{Line:1, Column:8},
+                SourceID: 0,
+            },
+        },
+    },
+    TypeArgs: {
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:8},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseTypeAnnNoErrors/DeepQualifiedTypeRef - 1]
+&ast.TypeRefTypeAnn{
+    Name: &ast.Member{
+        Left: &ast.Member{
+            Left: &ast.Ident{
+                Name: "Foo",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:1},
+                    End:      ast.Location{Line:1, Column:4},
+                    SourceID: 0,
+                },
+            },
+            Right: &ast.Ident{
+                Name: "Bar",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:5},
+                    End:      ast.Location{Line:1, Column:8},
+                    SourceID: 0,
+                },
+            },
+        },
+        Right: &ast.Ident{
+            Name: "Baz",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:9},
+                End:      ast.Location{Line:1, Column:12},
+                SourceID: 0,
+            },
+        },
+    },
+    TypeArgs: {
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:12},
         SourceID: 0,
     },
     inferredType: nil,

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -189,7 +189,14 @@
             },
             Optional: false,
             TypeAnn:  &ast.TypeRefTypeAnn{
-                Name:     "T",
+                Name: &ast.Ident{
+                    Name: "T",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:29},
+                        End:      ast.Location{Line:1, Column:30},
+                        SourceID: 0,
+                    },
+                },
                 TypeArgs: {
                 },
                 span: ast.Span{
@@ -213,7 +220,14 @@
             },
             Optional: false,
             TypeAnn:  &ast.TypeRefTypeAnn{
-                Name:     "U",
+                Name: &ast.Ident{
+                    Name: "U",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:35},
+                        End:      ast.Location{Line:1, Column:36},
+                        SourceID: 0,
+                    },
+                },
                 TypeArgs: {
                 },
                 span: ast.Span{
@@ -249,7 +263,14 @@
         &ast.IntersectionTypeAnn{
             Types: {
                 &ast.TypeRefTypeAnn{
-                    Name:     "A",
+                    Name: &ast.Ident{
+                        Name: "A",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:1},
+                            End:      ast.Location{Line:1, Column:2},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -260,7 +281,14 @@
                     inferredType: nil,
                 },
                 &ast.TypeRefTypeAnn{
-                    Name:     "B",
+                    Name: &ast.Ident{
+                        Name: "B",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:5},
+                            End:      ast.Location{Line:1, Column:6},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -281,7 +309,14 @@
         &ast.IntersectionTypeAnn{
             Types: {
                 &ast.TypeRefTypeAnn{
-                    Name:     "X",
+                    Name: &ast.Ident{
+                        Name: "X",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:9},
+                            End:      ast.Location{Line:1, Column:10},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -292,7 +327,14 @@
                     inferredType: nil,
                 },
                 &ast.TypeRefTypeAnn{
-                    Name:     "Y",
+                    Name: &ast.Ident{
+                        Name: "Y",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:13},
+                            End:      ast.Location{Line:1, Column:14},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -324,7 +366,14 @@
 &ast.IntersectionTypeAnn{
     Types: {
         &ast.TypeRefTypeAnn{
-            Name:     "A",
+            Name: &ast.Ident{
+                Name: "A",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:1},
+                    End:      ast.Location{Line:1, Column:2},
+                    SourceID: 0,
+                },
+            },
             TypeArgs: {
             },
             span: ast.Span{
@@ -335,7 +384,14 @@
             inferredType: nil,
         },
         &ast.TypeRefTypeAnn{
-            Name:     "B",
+            Name: &ast.Ident{
+                Name: "B",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:5},
+                    End:      ast.Location{Line:1, Column:6},
+                    SourceID: 0,
+                },
+            },
             TypeArgs: {
             },
             span: ast.Span{
@@ -346,7 +402,14 @@
             inferredType: nil,
         },
         &ast.TypeRefTypeAnn{
-            Name:     "C",
+            Name: &ast.Ident{
+                Name: "C",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:9},
+                    End:      ast.Location{Line:1, Column:10},
+                    SourceID: 0,
+                },
+            },
             TypeArgs: {
             },
             span: ast.Span{
@@ -370,7 +433,14 @@
 &ast.UnionTypeAnn{
     Types: {
         &ast.TypeRefTypeAnn{
-            Name:     "A",
+            Name: &ast.Ident{
+                Name: "A",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:1},
+                    End:      ast.Location{Line:1, Column:2},
+                    SourceID: 0,
+                },
+            },
             TypeArgs: {
             },
             span: ast.Span{
@@ -381,7 +451,14 @@
             inferredType: nil,
         },
         &ast.TypeRefTypeAnn{
-            Name:     "B",
+            Name: &ast.Ident{
+                Name: "B",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:5},
+                    End:      ast.Location{Line:1, Column:6},
+                    SourceID: 0,
+                },
+            },
             TypeArgs: {
             },
             span: ast.Span{
@@ -392,7 +469,14 @@
             inferredType: nil,
         },
         &ast.TypeRefTypeAnn{
-            Name:     "C",
+            Name: &ast.Ident{
+                Name: "C",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:9},
+                    End:      ast.Location{Line:1, Column:10},
+                    SourceID: 0,
+                },
+            },
             TypeArgs: {
             },
             span: ast.Span{
@@ -415,7 +499,14 @@
 [TestParseTypeAnnNoErrors/IndexedTypeWithDot - 1]
 &ast.IndexTypeAnn{
     Target: &ast.TypeRefTypeAnn{
-        Name:     "A",
+        Name: &ast.Ident{
+            Name: "A",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:2},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -453,7 +544,14 @@
 [TestParseTypeAnnNoErrors/IndexedTypeWithBrackets - 1]
 &ast.IndexTypeAnn{
     Target: &ast.TypeRefTypeAnn{
-        Name:     "A",
+        Name: &ast.Ident{
+            Name: "A",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:2},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -464,7 +562,14 @@
         inferredType: nil,
     },
     Index: &ast.TypeRefTypeAnn{
-        Name:     "B",
+        Name: &ast.Ident{
+            Name: "B",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:3},
+                End:      ast.Location{Line:1, Column:4},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -486,7 +591,14 @@
 [TestParseTypeAnnNoErrors/MutableType - 1]
 &ast.MutableTypeAnn{
     Target: &ast.TypeRefTypeAnn{
-        Name:     "A",
+        Name: &ast.Ident{
+            Name: "A",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:5},
+                End:      ast.Location{Line:1, Column:6},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -508,7 +620,14 @@
 [TestParseTypeAnnNoErrors/ConditionalType - 1]
 &ast.CondTypeAnn{
     Check: &ast.TypeRefTypeAnn{
-        Name:     "A",
+        Name: &ast.Ident{
+            Name: "A",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:4},
+                End:      ast.Location{Line:1, Column:5},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -519,7 +638,14 @@
         inferredType: nil,
     },
     Extends: &ast.TypeRefTypeAnn{
-        Name:     "B",
+        Name: &ast.Ident{
+            Name: "B",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:8},
+                End:      ast.Location{Line:1, Column:9},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -530,7 +656,14 @@
         inferredType: nil,
     },
     Cons: &ast.TypeRefTypeAnn{
-        Name:     "C",
+        Name: &ast.Ident{
+            Name: "C",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:12},
+                End:      ast.Location{Line:1, Column:13},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -541,7 +674,14 @@
         inferredType: nil,
     },
     Alt: &ast.TypeRefTypeAnn{
-        Name:     "D",
+        Name: &ast.Ident{
+            Name: "D",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:23},
+                End:      ast.Location{Line:1, Column:24},
+                SourceID: 0,
+            },
+        },
         TypeArgs: {
         },
         span: ast.Span{
@@ -577,7 +717,14 @@
             Optional: false,
             Readonly: false,
             Value:    &ast.TypeRefTypeAnn{
-                Name:     "A",
+                Name: &ast.Ident{
+                    Name: "A",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:5},
+                        End:      ast.Location{Line:1, Column:6},
+                        SourceID: 0,
+                    },
+                },
                 TypeArgs: {
                 },
                 span: ast.Span{
@@ -602,7 +749,14 @@
             Optional: true,
             Readonly: false,
             Value:    &ast.TypeRefTypeAnn{
-                Name:     "B",
+                Name: &ast.Ident{
+                    Name: "B",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:12},
+                        End:      ast.Location{Line:1, Column:13},
+                        SourceID: 0,
+                    },
+                },
                 TypeArgs: {
                 },
                 span: ast.Span{
@@ -629,7 +783,14 @@
             Optional: false,
             Readonly: false,
             Value:    &ast.TypeRefTypeAnn{
-                Name:     "C",
+                Name: &ast.Ident{
+                    Name: "C",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:20},
+                        End:      ast.Location{Line:1, Column:21},
+                        SourceID: 0,
+                    },
+                },
                 TypeArgs: {
                 },
                 span: ast.Span{
@@ -656,7 +817,14 @@
             Optional: true,
             Readonly: false,
             Value:    &ast.TypeRefTypeAnn{
-                Name:     "D",
+                Name: &ast.Ident{
+                    Name: "D",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:29},
+                        End:      ast.Location{Line:1, Column:30},
+                        SourceID: 0,
+                    },
+                },
                 TypeArgs: {
                 },
                 span: ast.Span{
@@ -684,10 +852,24 @@
             TypeParam: &ast.IndexParamTypeAnn{
                 Name:       "K",
                 Constraint: &ast.TypeRefTypeAnn{
-                    Name:     "Keys",
+                    Name: &ast.Ident{
+                        Name: "Keys",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:21},
+                            End:      ast.Location{Line:1, Column:25},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                         &ast.TypeRefTypeAnn{
-                            Name:     "T",
+                            Name: &ast.Ident{
+                                Name: "T",
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:1, Column:26},
+                                    End:      ast.Location{Line:1, Column:27},
+                                    SourceID: 0,
+                                },
+                            },
                             TypeArgs: {
                             },
                             span: ast.Span{
@@ -709,7 +891,14 @@
             Name:  nil,
             Value: &ast.IndexTypeAnn{
                 Target: &ast.TypeRefTypeAnn{
-                    Name:     "T",
+                    Name: &ast.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:7},
+                            End:      ast.Location{Line:1, Column:8},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{
@@ -720,7 +909,14 @@
                     inferredType: nil,
                 },
                 Index: &ast.TypeRefTypeAnn{
-                    Name:     "K",
+                    Name: &ast.Ident{
+                        Name: "K",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:9},
+                            End:      ast.Location{Line:1, Column:10},
+                            SourceID: 0,
+                        },
+                    },
                     TypeArgs: {
                     },
                     span: ast.Span{

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -139,7 +139,6 @@ func ParseLibFiles(ctx context.Context, sources []*ast.Source) (*ast.Module, []*
 
 		ns, _ := mod.Namespaces.Get(nsName)
 		ns.Decls = append(ns.Decls, decls...)
-		// allDecls = append(allDecls, decls...)
 		allErrors = append(allErrors, parser.errors...)
 	}
 

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -283,10 +283,12 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 				p.lexer.consume() // consume '<'
 				typeArgs := parseDelimSeq(p, GreaterThan, Comma, p.typeAnn)
 				end := p.expect(GreaterThan, AlwaysConsume)
-				return ast.NewRefTypeAnn(token.Value, typeArgs, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
+				ident := ast.NewIdentifier(token.Value, token.Span)
+				return ast.NewRefTypeAnn(ident, typeArgs, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
 			}
 
-			typeAnn = ast.NewRefTypeAnn(token.Value, []ast.TypeAnn{}, token.Span)
+			ident := ast.NewIdentifier(token.Value, token.Span)
+			typeAnn = ast.NewRefTypeAnn(ident, []ast.TypeAnn{}, token.Span)
 		default:
 			p.reportError(token.Span, "expected type annotation")
 			p.lexer.consume()

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -614,10 +614,6 @@ func getQualIdentSpan(qi ast.QualIdent) ast.Span {
 		rightSpan := q.Right.Span()
 		return ast.MergeSpans(leftSpan, rightSpan)
 	default:
-		return ast.Span{
-			Start:    ast.Location{Line: 0, Column: 0},
-			End:      ast.Location{Line: 0, Column: 0},
-			SourceID: 0,
-		}
+		panic("getQualIdentSpan - unknown QualIdent type")
 	}
 }

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -50,6 +50,15 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"IndexedTypeWithDot": {
 			input: "A.B",
 		},
+		"QualifiedTypeRef": {
+			input: "Foo.Bar",
+		},
+		"DeepQualifiedTypeRef": {
+			input: "Foo.Bar.Baz",
+		},
+		"QualifiedTypeRefWithTypeArgs": {
+			input: "Foo.Bar<T, U>",
+		},
 		"MutableType": {
 			input: "mut A",
 		},


### PR DESCRIPTION
- feature spec + initial changes
- Update TestBuildDepGraph to support multiple source files
- handle qualified value bindings in DependencyVisitor
- Update TypeRefTypeAnn to use QualIdent for its Name field
- parse qualified type refs, re-enable commented test cases in TestFindDeclDependencies
- Handle unqualified symbols when used inside the namespaces they were declared in
