### PR TITLE
Fully qualify identifiers in generated code

### DIFF
--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -267,13 +267,14 @@ func NewLitExpr(lit Lit) *LiteralExpr {
 
 type IdentExpr struct {
 	Name         string
+	Namespace    string
 	Source       provenance.Provenance
 	span         Span
 	inferredType Type
 }
 
 func NewIdent(name string, span Span) *IdentExpr {
-	return &IdentExpr{Name: name, Source: nil, span: span, inferredType: nil}
+	return &IdentExpr{Name: name, Namespace: "", Source: nil, span: span, inferredType: nil}
 }
 func (e *IdentExpr) Accept(v Visitor) {
 	v.EnterExpr(e)

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -8,6 +8,11 @@ import (
 	"github.com/escalier-lang/escalier/internal/provenance"
 )
 
+// NamespaceID represents a unique identifier for a namespace
+type NamespaceID int
+
+const RootNamespaceID NamespaceID = 0
+
 //sumtype:decl
 type Expr interface {
 	isExpr()
@@ -267,14 +272,18 @@ func NewLitExpr(lit Lit) *LiteralExpr {
 
 type IdentExpr struct {
 	Name         string
-	Namespace    string
+	Namespace    NamespaceID
 	Source       provenance.Provenance
 	span         Span
 	inferredType Type
 }
 
 func NewIdent(name string, span Span) *IdentExpr {
-	return &IdentExpr{Name: name, Namespace: "", Source: nil, span: span, inferredType: nil}
+	return &IdentExpr{Name: name, Namespace: RootNamespaceID, Source: nil, span: span, inferredType: nil}
+}
+
+func NewIdentWithNamespace(name string, namespace NamespaceID, span Span) *IdentExpr {
+	return &IdentExpr{Name: name, Namespace: namespace, Source: nil, span: span, inferredType: nil}
 }
 func (e *IdentExpr) Accept(v Visitor) {
 	v.EnterExpr(e)

--- a/internal/codegen/ast.go
+++ b/internal/codegen/ast.go
@@ -381,13 +381,14 @@ func (e *LitExpr) SetSpan(span *Span) { e.span = span }
 func (e *LitExpr) Source() ast.Node   { return e.source }
 
 type IdentExpr struct {
-	Name   string
-	span   *Span
-	source ast.Node
+	Name      string
+	Namespace string
+	span      *Span
+	source    ast.Node
 }
 
-func NewIdentExpr(name string, source ast.Node) *IdentExpr {
-	return &IdentExpr{Name: name, source: source, span: nil}
+func NewIdentExpr(name string, namespace string, source ast.Node) *IdentExpr {
+	return &IdentExpr{Name: name, Namespace: namespace, source: source, span: nil}
 }
 func (e *IdentExpr) Span() *Span        { return e.span }
 func (e *IdentExpr) SetSpan(span *Span) { e.span = span }

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -191,7 +191,7 @@ func (b *Builder) buildPattern(
 
 			for _, arg := range p.Args {
 				tempId := b.NewTempId()
-				tempVar := NewIdentExpr(tempId, nil)
+				tempVar := NewIdentExpr(tempId, "", nil)
 
 				var init Expr
 				switch arg := arg.(type) {
@@ -208,12 +208,12 @@ func (b *Builder) buildPattern(
 				tempVarPats = append(tempVarPats, tempVarPat)
 				tempVars = append(tempVars, tempVar)
 			}
-			extractor := NewIdentExpr(p.Name, p)
+			extractor := NewIdentExpr(p.Name, "", p)
 			subject := target
-			receiver := NewIdentExpr("undefined", nil)
+			receiver := NewIdentExpr("undefined", "", nil)
 
 			call := NewCallExpr(
-				NewIdentExpr("InvokeCustomMatcherOrThrow", nil),
+				NewIdentExpr("InvokeCustomMatcherOrThrow", "", nil),
 				[]Expr{extractor, subject, receiver},
 				false,
 				nil, // TODO: source
@@ -393,9 +393,9 @@ func (b *Builder) BuildTopLevelDecls(declIDs []dep_graph.DeclID, depGraph *dep_g
 			parts := strings.Split(name, ".")
 			dunderName := strings.Join(parts, "__")
 			assignExpr := NewBinaryExpr(
-				NewIdentExpr(name, nil),
+				NewIdentExpr(name, "", nil),
 				Assign,
-				NewIdentExpr(dunderName, nil),
+				NewIdentExpr(dunderName, "", nil),
 				nil,
 			)
 
@@ -494,7 +494,7 @@ func (b *Builder) buildNamespaceHierarchy(namespace string, definedNamespaces ma
 		} else {
 			// Subsequent levels: foo.bar = {}; foo.bar.baz = {};
 			// Build the left side (foo.bar.baz)
-			var left Expr = NewIdentExpr(parts[0], nil)
+			var left Expr = NewIdentExpr(parts[0], "", nil)
 			for j := 1; j < i; j++ {
 				left = NewMemberExpr(left, NewIdentifier(parts[j], nil), false, nil)
 			}
@@ -612,7 +612,7 @@ func (b *Builder) buildExpr(expr ast.Expr) (Expr, []Stmt) {
 		argExpr, argStmts := b.buildExpr(expr.Arg)
 		return NewUnaryExpr(UnaryOp(expr.Op), argExpr, expr), argStmts
 	case *ast.IdentExpr:
-		return NewIdentExpr(expr.Name, expr), []Stmt{}
+		return NewIdentExpr(expr.Name, expr.Namespace, expr), []Stmt{}
 	case *ast.CallExpr:
 		calleeExpr, calleeStmts := b.buildExpr(expr.Callee)
 		argsExprs, argsStmts := b.buildExprs(expr.Args)
@@ -710,7 +710,7 @@ func (b *Builder) buildExpr(expr ast.Expr) (Expr, []Stmt) {
 func (b *Builder) buildObjKey(key ast.ObjKey) (ObjKey, []Stmt) {
 	switch k := key.(type) {
 	case *ast.IdentExpr:
-		return NewIdentExpr(k.Name, key), []Stmt{}
+		return NewIdentExpr(k.Name, "", key), []Stmt{}
 	case *ast.StrLit:
 		return NewStrLit(k.Value, key), []Stmt{}
 	case *ast.NumLit:
@@ -733,11 +733,11 @@ func (b *Builder) buildParams(inParams []*ast.Param) ([]*Param, []Stmt) {
 
 		switch pat := p.Pattern.(type) {
 		case *ast.RestPat:
-			_, paramStmts := b.buildPattern(pat.Pattern, NewIdentExpr(id, nil), false, ast.ValKind, []string{})
+			_, paramStmts := b.buildPattern(pat.Pattern, NewIdentExpr(id, "", nil), false, ast.ValKind, []string{})
 			outParamStmts = slices.Concat(outParamStmts, paramStmts)
 			paramPat = NewRestPat(paramPat, nil)
 		default:
-			_, paramStmts := b.buildPattern(pat, NewIdentExpr(id, nil), false, ast.ValKind, []string{})
+			_, paramStmts := b.buildPattern(pat, NewIdentExpr(id, "", nil), false, ast.ValKind, []string{})
 			outParamStmts = slices.Concat(outParamStmts, paramStmts)
 		}
 

--- a/internal/codegen/builder_test.go
+++ b/internal/codegen/builder_test.go
@@ -2,7 +2,6 @@ package codegen
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -327,11 +326,7 @@ func TestBuildDeclWithNamespace(t *testing.T) {
 			decl := parseDecl(t, test.declSource)
 
 			builder := &Builder{tempId: 0}
-			var nsParts []string
-			if test.ns != "" {
-				nsParts = strings.Split(test.ns, ".")
-			}
-			stmts := builder.buildDeclWithNamespace(decl, nsParts)
+			stmts := builder.buildDeclWithNamespace(decl, test.ns)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()

--- a/internal/codegen/builder_test.go
+++ b/internal/codegen/builder_test.go
@@ -349,28 +349,44 @@ func TestBuildDeclWithNamespace(t *testing.T) {
 
 func TestBuildDecls(t *testing.T) {
 	tests := map[string]struct {
-		declSources []string
-		namespaces  []string // corresponding namespace for each declaration
-		expected    string
+		sources  []*ast.Source
+		expected string
 	}{
 		"Single_Decl_No_Namespace": {
-			declSources: []string{"val x = 42"},
-			namespaces:  []string{""},
-			expected:    "const x = 42;",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "main.esc",
+					Contents: "val x = 42",
+				},
+			},
+			expected: "const x = 42;",
 		},
 		"Single_Decl_With_Namespace": {
-			declSources: []string{"val x = 42"},
-			namespaces:  []string{"foo"},
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "foo/x.esc",
+					Contents: "val x = 42",
+				},
+			},
 			expected: `const foo = {};
 const foo__x = 42;
 foo.x = foo__x;`,
 		},
 		"Multiple_Decls_Same_Namespace": {
-			declSources: []string{
-				"val x = 42",
-				"fn double(n) { return n * 2 }",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "math/x.esc",
+					Contents: "val x = 42",
+				},
+				{
+					ID:       1,
+					Path:     "math/double.esc",
+					Contents: "fn double(n) { return n * 2 }",
+				},
 			},
-			namespaces: []string{"math", "math"},
 			expected: `const math = {};
 const math__x = 42;
 math.x = math__x;
@@ -381,11 +397,18 @@ function math__double(temp1) {
 math.double = math__double;`,
 		},
 		"Multiple_Decls_Different_Namespaces": {
-			declSources: []string{
-				"val PI = 3.14159",
-				"val message = \"hello\"",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "math/pi.esc",
+					Contents: "val PI = 3.14159",
+				},
+				{
+					ID:       1,
+					Path:     "strings/message.esc",
+					Contents: "val message = \"hello\"",
+				},
 			},
-			namespaces: []string{"math", "strings"},
 			expected: `const math = {};
 const strings = {};
 const math__PI = 3.14159;
@@ -394,44 +417,65 @@ const strings__message = "hello";
 strings.message = strings__message;`,
 		},
 		"Nested_Namespaces": {
-			declSources: []string{
-				"val add = 42",
-				"val PI = 3.14",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "utils/math/add.esc",
+					Contents: "val add = 42",
+				},
+				{
+					ID:       1,
+					Path:     "constants/math/pi.esc",
+					Contents: "val PI = 3.14",
+				},
 			},
-			namespaces: []string{"utils.math", "constants.math"},
 			expected: `const constants = {};
 constants.math = {};
 const utils = {};
 utils.math = {};
-const utils__math__add = 42;
-utils.math.add = utils__math__add;
 const constants__math__PI = 3.14;
-constants.math.PI = constants__math__PI;`,
+constants.math.PI = constants__math__PI;
+const utils__math__add = 42;
+utils.math.add = utils__math__add;`,
 		},
 		"Mixed_Namespace_Levels": {
-			declSources: []string{
-				"val config = {debug: true}",
-				"fn log(msg) { console.log(msg) }",
-				"val VERSION = \"1.0.0\"",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "config.esc",
+					Contents: "val config = {debug: true}",
+				},
+				{
+					ID:       1,
+					Path:     "utils/log.esc",
+					Contents: "fn log(msg) { console.log(msg) }",
+				},
+				{
+					ID:       2,
+					Path:     "constants/app/version.esc",
+					Contents: "val VERSION = \"1.0.0\"",
+				},
 			},
-			namespaces: []string{"", "utils", "constants.app"},
 			expected: `const constants = {};
 constants.app = {};
 const utils = {};
 const config = {debug: true};
+const constants__app__VERSION = "1.0.0";
+constants.app.VERSION = constants__app__VERSION;
 function utils__log(temp1) {
   const msg = temp1;
   console.log(msg);
 }
-utils.log = utils__log;
-const constants__app__VERSION = "1.0.0";
-constants.app.VERSION = constants__app__VERSION;`,
+utils.log = utils__log;`,
 		},
 		"Function_With_Complex_Namespace": {
-			declSources: []string{
-				"fn processData(input) { return input }",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "services/data/processing/process.esc",
+					Contents: "fn processData(input) { return input }",
+				},
 			},
-			namespaces: []string{"services.data.processing"},
 			expected: `const services = {};
 services.data = {};
 services.data.processing = {};
@@ -442,22 +486,36 @@ function services__data__processing__processData(temp1) {
 services.data.processing.processData = services__data__processing__processData;`,
 		},
 		"Variable_Destructuring_With_Namespace": {
-			declSources: []string{
-				"val {x, y} = getPoint()",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "coords/point.esc",
+					Contents: "val {x, y} = getPoint()",
+				},
 			},
-			namespaces: []string{"coords"},
 			expected: `const coords = {};
 const {coords__x, coords__y} = getPoint();
 coords.x = coords__x;
 coords.y = coords__y;`,
 		},
 		"Multiple_Declarations_Overlapping_Namespaces": {
-			declSources: []string{
-				"val user = {name: \"Alice\"}",
-				"fn createUser(name) { return {name} }",
-				"val defaultUser = null",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "models/user/user.esc",
+					Contents: "val user = {name: \"Alice\"}",
+				},
+				{
+					ID:       1,
+					Path:     "models/user/create.esc",
+					Contents: "fn createUser(name) { return {name} }",
+				},
+				{
+					ID:       2,
+					Path:     "models/user/defaults/default.esc",
+					Contents: "val defaultUser = null",
+				},
 			},
-			namespaces: []string{"models.user", "models.user", "models.user.defaults"},
 			expected: `const models = {};
 models.user = {};
 models.user.defaults = {};
@@ -472,22 +530,36 @@ const models__user__defaults__defaultUser = null;
 models.user.defaults.defaultUser = models__user__defaults__defaultUser;`,
 		},
 		"Type_Declaration_Skip": {
-			declSources: []string{
-				"type User = {name: string, age: number}",
-				"val admin = {name: \"admin\", age: 30}",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "types/user.esc",
+					Contents: "type User = {name: string, age: number}",
+				},
+				{
+					ID:       1,
+					Path:     "data/admin.esc",
+					Contents: "val admin = {name: \"admin\", age: 30}",
+				},
 			},
-			namespaces: []string{"types", "data"},
 			expected: `const data = {};
 const types = {};
 const data__admin = {name: "admin", age: 30};
 data.admin = data__admin;`,
 		},
 		"Var_Declaration_With_Namespace": {
-			declSources: []string{
-				"var counter = 0",
-				"var isEnabled = true",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "state/app/counter.esc",
+					Contents: "var counter = 0",
+				},
+				{
+					ID:       1,
+					Path:     "state/ui/enabled.esc",
+					Contents: "var isEnabled = true",
+				},
 			},
-			namespaces: []string{"state.app", "state.ui"},
 			expected: `const state = {};
 state.app = {};
 state.ui = {};
@@ -496,89 +568,32 @@ state.app.counter = state__app__counter;
 let state__ui__isEnabled = true;
 state.ui.isEnabled = state__ui__isEnabled;`,
 		},
-		// 		"Declared_Functions_Skip": {
-		// 			declSources: []string{
-		// 				"declare fn external()",
-		// 				"fn internal() { return 42 }",
-		// 			},
-		// 			namespaces: []string{"api", "utils"},
-		// 			expected: `const utils = {};
-		// function utils__internal() {
-		//   return 42;
-		// }
-		// utils.internal = utils__internal;`,
-		// 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Create a mock dependency graph with test data
-			depGraph := &dep_graph.DepGraph{
-				Decls:         btree.Map[dep_graph.DeclID, ast.Decl]{},
-				Deps:          btree.Map[dep_graph.DeclID, btree.Set[dep_graph.DeclID]]{},
-				ValueBindings: btree.Map[string, dep_graph.DeclID]{},
-				TypeBindings:  btree.Map[string, dep_graph.DeclID]{},
-				DeclNamespace: btree.Map[dep_graph.DeclID, string]{},
-			}
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
 
-			var declIDs []dep_graph.DeclID
+			// Parse the module using ParseLibFiles
+			module, errors := parser.ParseLibFiles(ctx, test.sources)
 
-			// Parse declarations and populate the dependency graph
-			for i, source := range test.declSources {
-				declID := dep_graph.DeclID(i + 1)
-				decl := parseDecl(t, source)
+			// Ensure parsing was successful
+			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-				// Store the declaration
-				depGraph.Decls.Set(declID, decl)
-				depGraph.DeclNamespace.Set(declID, test.namespaces[i])
-				declIDs = append(declIDs, declID)
+			// Build dependency graph using BuildDepGraph
+			depGraph := dep_graph.BuildDepGraph(module)
 
-				// Extract bindings and add them to the dependency graph
-				switch d := decl.(type) {
-				case *ast.VarDecl:
-					bindingNames := ast.FindBindings(d.Pattern)
-					for name := range bindingNames {
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.ValueBindings.Set(qualifiedName, declID)
-					}
-				case *ast.FuncDecl:
-					if d.Name != nil && d.Name.Name != "" {
-						name := d.Name.Name
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.ValueBindings.Set(qualifiedName, declID)
-					}
-				case *ast.TypeDecl:
-					if d.Name != nil && d.Name.Name != "" {
-						name := d.Name.Name
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.TypeBindings.Set(qualifiedName, declID)
-					}
-				}
+			// Get all declaration IDs and sort them for consistent ordering
+			declIDs := depGraph.AllDeclarations()
 
-				// Create empty dependencies for each declaration
-				var deps btree.Set[dep_graph.DeclID]
-				depGraph.Deps.Set(declID, deps)
-			}
-
-			// Create a builder and test BuildDecls
+			// Create a builder and test BuildTopLevelDecls
 			builder := &Builder{tempId: 0}
-			module := builder.BuildTopLevelDecls(declIDs, depGraph)
+			outModule := builder.BuildTopLevelDecls(declIDs, depGraph)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()
-			for i, stmt := range module.Stmts {
+			for i, stmt := range outModule.Stmts {
 				if i > 0 {
 					printer.NewLine()
 				}
@@ -592,154 +607,107 @@ state.ui.isEnabled = state__ui__isEnabled;`,
 
 func TestBuildDecls_WithDependencies(t *testing.T) {
 	tests := map[string]struct {
-		declSources  []string
-		namespaces   []string
-		dependencies map[int][]int // map[declIndex][]dependsOnDeclIndices
-		expected     string
+		sources  []*ast.Source
+		expected string
 	}{
 		"Simple_Dependency_Same_Namespace": {
-			declSources: []string{
-				"val base = 10",
-				"val derived = base * 2",
-			},
-			namespaces: []string{"math", "math"},
-			dependencies: map[int][]int{
-				0: {},  // base has no dependencies
-				1: {0}, // derived depends on base
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "math/base.esc",
+					Contents: "val base = 10",
+				},
+				{
+					ID:       1,
+					Path:     "math/derived.esc",
+					Contents: "val derived = base * 2",
+				},
 			},
 			expected: `const math = {};
 const math__base = 10;
-const math__derived = math__base * 2;
 math.base = math__base;
+const math__derived = math__base * 2;
 math.derived = math__derived;`,
 		},
 		"Cross_Namespace_Dependencies": {
-			declSources: []string{
-				"val PI = 3.14159",
-				"fn circleArea(r) { return PI * r * r }",
-			},
-			namespaces: []string{"constants", "geometry"},
-			dependencies: map[int][]int{
-				0: {},  // PI has no dependencies
-				1: {0}, // circleArea depends on PI
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "constants/pi.esc",
+					Contents: "val PI = 3.14159",
+				},
+				{
+					ID:       1,
+					Path:     "geometry/circle.esc",
+					Contents: "fn circleArea(r) { return constants.PI * r * r }",
+				},
 			},
 			expected: `const constants = {};
 const geometry = {};
 const constants__PI = 3.14159;
+constants.PI = constants__PI;
 function geometry__circleArea(temp1) {
   const r = temp1;
-  return constants__PI * r * r;
+  return constants.PI * r * r;
 }
-constants.PI = constants__PI;
 geometry.circleArea = geometry__circleArea;`,
 		},
 		"Complex_Dependency_Chain": {
-			declSources: []string{
-				"val config = {multiplier: 2}",
-				"val factor = config.multiplier",
-				"fn calculate(x) { return x * factor }",
-			},
-			namespaces: []string{"app", "app.utils", "app.utils"},
-			dependencies: map[int][]int{
-				0: {},  // config has no dependencies
-				1: {0}, // factor depends on config
-				2: {1}, // calculate depends on factor
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "app/config.esc",
+					Contents: "val config = {multiplier: 2}",
+				},
+				{
+					ID:       1,
+					Path:     "app/utils/factor.esc",
+					Contents: "val factor = app.config.multiplier",
+				},
+				{
+					ID:       2,
+					Path:     "app/utils/calculate.esc",
+					Contents: "fn calculate(x) { return x * app.utils.factor }",
+				},
 			},
 			expected: `const app = {};
 app.utils = {};
 const app__config = {multiplier: 2};
-const app__utils__factor = app__config.multiplier;
+app.config = app__config;
+const app__utils__factor = app.config.multiplier;
+app.utils.factor = app__utils__factor;
 function app__utils__calculate(temp1) {
   const x = temp1;
-  return x * app__utils__factor;
+  return x * app.utils.factor;
 }
-app.config = app__config;
-app.utils.factor = app__utils__factor;
 app.utils.calculate = app__utils__calculate;`,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			// TODO: Remove this once variable references are fully qualified
-			t.Skipf("Skipping test %s", name)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
 
-			// Create a mock dependency graph with test data
-			depGraph := &dep_graph.DepGraph{
-				Decls:         btree.Map[dep_graph.DeclID, ast.Decl]{},
-				Deps:          btree.Map[dep_graph.DeclID, btree.Set[dep_graph.DeclID]]{},
-				ValueBindings: btree.Map[string, dep_graph.DeclID]{},
-				TypeBindings:  btree.Map[string, dep_graph.DeclID]{},
-				DeclNamespace: btree.Map[dep_graph.DeclID, string]{},
-			}
+			// Parse the module using ParseLibFiles
+			module, errors := parser.ParseLibFiles(ctx, test.sources)
 
-			var declIDs []dep_graph.DeclID
+			// Ensure parsing was successful
+			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			// Parse declarations and populate the dependency graph
-			for i, source := range test.declSources {
-				declID := dep_graph.DeclID(i + 1)
-				decl := parseDecl(t, source)
+			// Build dependency graph using BuildDepGraph
+			depGraph := dep_graph.BuildDepGraph(module)
 
-				// Store the declaration
-				depGraph.Decls.Set(declID, decl)
-				depGraph.DeclNamespace.Set(declID, test.namespaces[i])
-				declIDs = append(declIDs, declID)
+			// Get all declaration IDs and sort them for consistent ordering
+			declIDs := depGraph.AllDeclarations()
 
-				// Extract bindings and add them to the dependency graph
-				switch d := decl.(type) {
-				case *ast.VarDecl:
-					bindingNames := ast.FindBindings(d.Pattern)
-					for name := range bindingNames {
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.ValueBindings.Set(qualifiedName, declID)
-					}
-				case *ast.FuncDecl:
-					if d.Name != nil && d.Name.Name != "" {
-						name := d.Name.Name
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.ValueBindings.Set(qualifiedName, declID)
-					}
-				case *ast.TypeDecl:
-					if d.Name != nil && d.Name.Name != "" {
-						name := d.Name.Name
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.TypeBindings.Set(qualifiedName, declID)
-					}
-				}
-			}
-
-			// Set up dependencies
-			for declIndex, depIndices := range test.dependencies {
-				declID := dep_graph.DeclID(declIndex + 1)
-				var deps btree.Set[dep_graph.DeclID]
-
-				for _, depIndex := range depIndices {
-					depDeclID := dep_graph.DeclID(depIndex + 1)
-					deps.Insert(depDeclID)
-				}
-
-				depGraph.Deps.Set(declID, deps)
-			}
-
-			// Create a builder and test BuildDecls
+			// Create a builder and test BuildTopLevelDecls
 			builder := &Builder{tempId: 0}
-			module := builder.BuildTopLevelDecls(declIDs, depGraph)
+			outModule := builder.BuildTopLevelDecls(declIDs, depGraph)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()
-			for i, stmt := range module.Stmts {
+			for i, stmt := range outModule.Stmts {
 				if i > 0 {
 					printer.NewLine()
 				}
@@ -753,29 +721,37 @@ app.utils.calculate = app__utils__calculate;`,
 
 func TestBuildDecls_EdgeCases(t *testing.T) {
 	tests := map[string]struct {
-		declSources []string
-		namespaces  []string
-		expected    string
+		sources  []*ast.Source
+		expected string
 	}{
 		"Empty_Declarations": {
-			declSources: []string{},
-			namespaces:  []string{},
-			expected:    "",
+			sources:  []*ast.Source{},
+			expected: "",
 		},
 		"Only_Type_Declarations": {
-			declSources: []string{
-				"type User = {name: string}",
-				"type Config = {debug: boolean}",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "models/user.esc",
+					Contents: "type User = {name: string}",
+				},
+				{
+					ID:       1,
+					Path:     "app/config.esc",
+					Contents: "type Config = {debug: boolean}",
+				},
 			},
-			namespaces: []string{"models", "app"},
 			expected: `const app = {};
 const models = {};`,
 		},
 		"Deep_Namespace_Hierarchy": {
-			declSources: []string{
-				"val constant = \"deep\"",
+			sources: []*ast.Source{
+				{
+					ID:       0,
+					Path:     "company/project/module/submodule/utils/constant.esc",
+					Contents: "val constant = \"deep\"",
+				},
 			},
-			namespaces: []string{"company.project.module.submodule.utils"},
 			expected: `const company = {};
 company.project = {};
 company.project.module = {};
@@ -788,73 +764,28 @@ company.project.module.submodule.utils.constant = company__project__module__subm
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Create a mock dependency graph with test data
-			depGraph := &dep_graph.DepGraph{
-				Decls:         btree.Map[dep_graph.DeclID, ast.Decl]{},
-				Deps:          btree.Map[dep_graph.DeclID, btree.Set[dep_graph.DeclID]]{},
-				ValueBindings: btree.Map[string, dep_graph.DeclID]{},
-				TypeBindings:  btree.Map[string, dep_graph.DeclID]{},
-				DeclNamespace: btree.Map[dep_graph.DeclID, string]{},
-			}
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
 
-			var declIDs []dep_graph.DeclID
+			// Parse the module using ParseLibFiles
+			module, errors := parser.ParseLibFiles(ctx, test.sources)
 
-			// Parse declarations and populate the dependency graph
-			for i, source := range test.declSources {
-				declID := dep_graph.DeclID(i + 1)
-				decl := parseDecl(t, source)
+			// Ensure parsing was successful
+			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-				// Store the declaration
-				depGraph.Decls.Set(declID, decl)
-				depGraph.DeclNamespace.Set(declID, test.namespaces[i])
-				declIDs = append(declIDs, declID)
+			// Build dependency graph using BuildDepGraph
+			depGraph := dep_graph.BuildDepGraph(module)
 
-				// Extract bindings and add them to the dependency graph
-				switch d := decl.(type) {
-				case *ast.VarDecl:
-					bindingNames := ast.FindBindings(d.Pattern)
-					for name := range bindingNames {
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.ValueBindings.Set(qualifiedName, declID)
-					}
-				case *ast.FuncDecl:
-					if d.Name != nil && d.Name.Name != "" {
-						name := d.Name.Name
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.ValueBindings.Set(qualifiedName, declID)
-					}
-				case *ast.TypeDecl:
-					if d.Name != nil && d.Name.Name != "" {
-						name := d.Name.Name
-						// Create fully qualified name if in namespace
-						qualifiedName := name
-						if test.namespaces[i] != "" {
-							qualifiedName = test.namespaces[i] + "." + name
-						}
-						depGraph.TypeBindings.Set(qualifiedName, declID)
-					}
-				}
+			// Get all declaration IDs and sort them for consistent ordering
+			declIDs := depGraph.AllDeclarations()
 
-				// Create empty dependencies for each declaration
-				var deps btree.Set[dep_graph.DeclID]
-				depGraph.Deps.Set(declID, deps)
-			}
-
-			// Create a builder and test BuildDecls
+			// Create a builder and test BuildTopLevelDecls
 			builder := &Builder{tempId: 0}
-			module := builder.BuildTopLevelDecls(declIDs, depGraph)
+			outModule := builder.BuildTopLevelDecls(declIDs, depGraph)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()
-			for i, stmt := range module.Stmts {
+			for i, stmt := range outModule.Stmts {
 				if i > 0 {
 					printer.NewLine()
 				}

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"unicode"
 )
 
@@ -95,6 +96,9 @@ func (p *Printer) PrintExpr(expr Expr) {
 	case *LitExpr:
 		p.PrintLit(e.Lit)
 	case *IdentExpr:
+		if e.Namespace != "" {
+			p.print(strings.ReplaceAll(e.Namespace, ".", "__") + "__")
+		}
 		p.print(e.Name)
 	case *UnaryExpr:
 		p.print(unaryOpMap[e.Op])

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -3,7 +3,6 @@ package codegen
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"unicode"
 )
 
@@ -96,10 +95,7 @@ func (p *Printer) PrintExpr(expr Expr) {
 	case *LitExpr:
 		p.PrintLit(e.Lit)
 	case *IdentExpr:
-		if e.Namespace != "" {
-			p.print(strings.ReplaceAll(e.Namespace, ".", "__") + "__")
-		}
-		p.print(e.Name)
+		p.print(fullyQualifyName(e.Name, e.Namespace))
 	case *UnaryExpr:
 		p.print(unaryOpMap[e.Op])
 		p.PrintExpr(e.Arg)

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -165,6 +165,7 @@ func (v *DependencyVisitor) EnterExpr(expr ast.Expr) bool {
 			qualifiedName := v.CurrentNamespace + "." + e.Name
 			if declID, exists := v.ValueBindings.Get(qualifiedName); exists &&
 				!v.isLocalBinding(e.Name) {
+				e.Namespace = v.CurrentNamespace // Allows us to codegen a fully qualified name
 				v.Dependencies.Insert(declID)
 				return false
 			}

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -23,6 +23,43 @@ type DepBinding struct {
 // DeclID represents a unique identifier for each declaration
 type DeclID int
 
+// NamespaceManager manages namespace IDs and their string representations
+type NamespaceManager struct {
+	namespaces []string // Index is the NamespaceID, value is the namespace string
+	nextID     ast.NamespaceID
+}
+
+func NewNamespaceManager() *NamespaceManager {
+	nm := &NamespaceManager{
+		namespaces: make([]string, 1), // Start with capacity for root namespace
+		nextID:     1,                 // 0 is reserved for root namespace
+	}
+	// Register root namespace at index 0
+	nm.namespaces[0] = ""
+	return nm
+}
+
+func (nm *NamespaceManager) GetNamespaceID(namespace string) ast.NamespaceID {
+	// Check if namespace already exists
+	for i, ns := range nm.namespaces {
+		if ns == namespace {
+			return ast.NamespaceID(i)
+		}
+	}
+	// Create new namespace ID
+	id := nm.nextID
+	nm.nextID++
+	nm.namespaces = append(nm.namespaces, namespace)
+	return id
+}
+
+func (nm *NamespaceManager) GetNamespaceString(id ast.NamespaceID) string {
+	if int(id) < len(nm.namespaces) {
+		return nm.namespaces[id]
+	}
+	return ""
+}
+
 // ModuleBindingVisitor collects all declarations with unique IDs and their bindings
 type ModuleBindingVisitor struct {
 	ast.DefaulVisitor
@@ -123,6 +160,7 @@ type DependencyVisitor struct {
 	Dependencies     btree.Set[DeclID]         // Found dependencies by declaration ID
 	LocalBindings    []set.Set[string]         // Stack of local scopes (still strings for local scope)
 	CurrentNamespace string                    // Current namespace being analyzed
+	NamespaceManager *NamespaceManager         // Manager for namespace IDs
 }
 
 // EnterStmt handles statements that introduce new scopes
@@ -165,7 +203,7 @@ func (v *DependencyVisitor) EnterExpr(expr ast.Expr) bool {
 			qualifiedName := v.CurrentNamespace + "." + e.Name
 			if declID, exists := v.ValueBindings.Get(qualifiedName); exists &&
 				!v.isLocalBinding(e.Name) {
-				e.Namespace = v.CurrentNamespace // Allows us to codegen a fully qualified name
+				e.Namespace = v.NamespaceManager.GetNamespaceID(v.CurrentNamespace) // Allows us to codegen a fully qualified name
 				v.Dependencies.Insert(declID)
 				return false
 			}
@@ -324,6 +362,7 @@ func FindDeclDependencies(
 	valueBindings btree.Map[string, DeclID],
 	typeBindings btree.Map[string, DeclID],
 	currentNamespace string,
+	namespaceManager *NamespaceManager,
 ) btree.Set[DeclID] {
 	var dependencies btree.Set[DeclID]
 	visitor := &DependencyVisitor{
@@ -333,6 +372,7 @@ func FindDeclDependencies(
 		Dependencies:     dependencies,
 		LocalBindings:    make([]set.Set[string], 0),
 		CurrentNamespace: currentNamespace,
+		NamespaceManager: namespaceManager,
 	}
 
 	// Handle different declaration types
@@ -383,6 +423,9 @@ type DepGraph struct {
 
 // BuildDepGraph builds a dependency graph for a module
 func BuildDepGraph(module *ast.Module) *DepGraph {
+	// Create namespace manager
+	namespaceManager := NewNamespaceManager()
+
 	// First, find all decls and bindings in the module
 	decls, valueBindings, typeBindings := FindModuleBindings(module)
 
@@ -409,7 +452,7 @@ func BuildDepGraph(module *ast.Module) *DepGraph {
 		declID := iter.Key()
 		decl := iter.Value()
 		namespace, _ := declNamespace.Get(declID)
-		dependencies := FindDeclDependencies(decl, valueBindings, typeBindings, namespace)
+		dependencies := FindDeclDependencies(decl, valueBindings, typeBindings, namespace, namespaceManager)
 		deps.Set(declID, dependencies)
 	}
 

--- a/internal/dep_graph/dep_graph_test.go
+++ b/internal/dep_graph/dep_graph_test.go
@@ -792,18 +792,18 @@ func TestFindDeclDependencies(t *testing.T) {
 			var typeBindings btree.Map[string, DeclID]
 			for i, binding := range test.validBindings {
 				declID := DeclID(i + 100) // Use arbitrary DeclIDs starting from 100
-				if binding.Kind == DepKindValue {
+				switch binding.Kind {
+				case DepKindValue:
 					valueBindings.Set(binding.Name, declID)
-				} else if binding.Kind == DepKindType {
+				case DepKindType:
 					typeBindings.Set(binding.Name, declID)
 				}
 			}
 
 			// Find dependencies
 			emptyNS2, _ := module.Namespaces.Get("")
-			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, "")
-
-			// Convert dependencies to bindings for comparison
+			namespaceManager := NewNamespaceManager()
+			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, "", namespaceManager) // Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
 			iter := dependencies.Iter()
 			for ok := iter.First(); ok; ok = iter.Next() {
@@ -908,17 +908,17 @@ func TestFindDeclDependencies_EdgeCases(t *testing.T) {
 			var typeBindings btree.Map[string, DeclID]
 			for i, binding := range test.validBindings {
 				declID := DeclID(i + 100) // Use arbitrary DeclIDs starting from 100
-				if binding.Kind == DepKindValue {
+				switch binding.Kind {
+				case DepKindValue:
 					valueBindings.Set(binding.Name, declID)
-				} else if binding.Kind == DepKindType {
+				case DepKindType:
 					typeBindings.Set(binding.Name, declID)
 				}
 			}
 
 			// Find dependencies
-			dependencies := FindDeclDependencies(decl, valueBindings, typeBindings, "")
-
-			// Convert dependencies to bindings for comparison
+			namespaceManager := NewNamespaceManager()
+			dependencies := FindDeclDependencies(decl, valueBindings, typeBindings, "", namespaceManager) // Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
 			iter := dependencies.Iter()
 			for ok := iter.First(); ok; ok = iter.Next() {
@@ -1504,18 +1504,18 @@ func TestFindDeclDependencies_NamespaceResolution(t *testing.T) {
 			var typeBindings btree.Map[string, DeclID]
 			for i, binding := range test.validBindings {
 				declID := DeclID(i + 100) // Use arbitrary DeclIDs starting from 100
-				if binding.Kind == DepKindValue {
+				switch binding.Kind {
+				case DepKindValue:
 					valueBindings.Set(binding.Name, declID)
-				} else if binding.Kind == DepKindType {
+				case DepKindType:
 					typeBindings.Set(binding.Name, declID)
 				}
 			}
 
 			// Find dependencies using the test namespace context
 			emptyNS2, _ := module.Namespaces.Get("")
-			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, test.namespace)
-
-			// Convert dependencies to bindings for comparison
+			namespaceManager := NewNamespaceManager()
+			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, test.namespace, namespaceManager) // Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
 			iter := dependencies.Iter()
 			for ok := iter.First(); ok; ok = iter.Next() {

--- a/internal/dep_graph/dep_graph_test.go
+++ b/internal/dep_graph/dep_graph_test.go
@@ -803,7 +803,9 @@ func TestFindDeclDependencies(t *testing.T) {
 			// Find dependencies
 			emptyNS2, _ := module.Namespaces.Get("")
 			namespaceManager := NewNamespaceManager()
-			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, "", namespaceManager) // Convert dependencies to bindings for comparison
+			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, "", namespaceManager)
+
+			// Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
 			iter := dependencies.Iter()
 			for ok := iter.First(); ok; ok = iter.Next() {
@@ -918,7 +920,9 @@ func TestFindDeclDependencies_EdgeCases(t *testing.T) {
 
 			// Find dependencies
 			namespaceManager := NewNamespaceManager()
-			dependencies := FindDeclDependencies(decl, valueBindings, typeBindings, "", namespaceManager) // Convert dependencies to bindings for comparison
+			dependencies := FindDeclDependencies(decl, valueBindings, typeBindings, "", namespaceManager)
+
+			// Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
 			iter := dependencies.Iter()
 			for ok := iter.First(); ok; ok = iter.Next() {
@@ -1515,7 +1519,9 @@ func TestFindDeclDependencies_NamespaceResolution(t *testing.T) {
 			// Find dependencies using the test namespace context
 			emptyNS2, _ := module.Namespaces.Get("")
 			namespaceManager := NewNamespaceManager()
-			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, test.namespace, namespaceManager) // Convert dependencies to bindings for comparison
+			dependencies := FindDeclDependencies(emptyNS2.Decls[0], valueBindings, typeBindings, test.namespace, namespaceManager)
+
+			// Convert dependencies to bindings for comparison
 			actualDeps := make([]DepBinding, 0)
 			iter := dependencies.Iter()
 			for ok := iter.First(); ok; ok = iter.Next() {

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -7,7 +7,7 @@
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
                     Name:      "a",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:6},
@@ -35,7 +35,7 @@
                 &ast.ExprStmt{
                     Expr: &ast.IdentExpr{
                         Name:      "b",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
@@ -85,7 +85,7 @@
 &ast.IfElseExpr{
     Cond: &ast.IdentExpr{
         Name:      "cond",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
@@ -117,7 +117,7 @@
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
         Name:      "foo",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -129,7 +129,7 @@
     Args: {
         &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -161,7 +161,7 @@
 &ast.TaggedTemplateLitExpr{
     Tag: &ast.IdentExpr{
         Name:      "foo",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -290,7 +290,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -303,7 +303,7 @@
     Right: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
@@ -315,7 +315,7 @@
         Op:    "+",
         Right: &ast.IdentExpr{
             Name:      "c",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
@@ -357,7 +357,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -369,7 +369,7 @@
     Op:    "+",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
@@ -405,7 +405,7 @@
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
@@ -417,7 +417,7 @@
         Op:    "-",
         Right: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -531,7 +531,7 @@
                 Expr: &ast.BinaryExpr{
                     Left: &ast.IdentExpr{
                         Name:      "a",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:12},
@@ -543,7 +543,7 @@
                     Op:    "+",
                     Right: &ast.IdentExpr{
                         Name:      "b",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:16},
@@ -585,7 +585,7 @@
 &ast.IndexExpr{
     Object: &ast.IdentExpr{
         Name:      "foo",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -596,7 +596,7 @@
     },
     Index: &ast.IdentExpr{
         Name:      "bar",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
@@ -619,7 +619,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -632,7 +632,7 @@
     Right: &ast.MemberExpr{
         Object: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -788,7 +788,7 @@
                 Expr: &ast.BinaryExpr{
                     Left: &ast.IdentExpr{
                         Name:      "a",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:12},
@@ -800,7 +800,7 @@
                     Op:    "+",
                     Right: &ast.IdentExpr{
                         Name:      "b",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:16},
@@ -842,7 +842,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -855,7 +855,7 @@
     Right: &ast.MemberExpr{
         Object: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -923,7 +923,7 @@
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
                     Name:      "a",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:6},
@@ -982,7 +982,7 @@
         &ast.MethodExpr{
             Name: &ast.IdentExpr{
                 Name:      "foo",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:3},
@@ -1062,7 +1062,7 @@
         &ast.GetterExpr{
             Name: &ast.IdentExpr{
                 Name:      "bar",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:31},
@@ -1100,7 +1100,7 @@
                             Expr: &ast.MemberExpr{
                                 Object: &ast.IdentExpr{
                                     Name:      "self",
-                                    Namespace: "",
+                                    Namespace: 0,
                                     Source:    nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:50},
@@ -1154,7 +1154,7 @@
         &ast.SetterExpr{
             Name: &ast.IdentExpr{
                 Name:      "bar",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:64},
@@ -1193,7 +1193,7 @@
                                 Left: &ast.MemberExpr{
                                     Object: &ast.IdentExpr{
                                         Name:      "this",
-                                        Namespace: "",
+                                        Namespace: 0,
                                         Source:    nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:1, Column:73},
@@ -1221,7 +1221,7 @@
                                 Op:    "=",
                                 Right: &ast.IdentExpr{
                                     Name:      "x",
-                                    Namespace: "",
+                                    Namespace: 0,
                                     Source:    nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:82},
@@ -1277,7 +1277,7 @@
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
         Name:      "foo",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -1289,7 +1289,7 @@
     Args: {
         &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -1300,7 +1300,7 @@
         },
         &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:8},
@@ -1311,7 +1311,7 @@
         },
         &ast.IdentExpr{
             Name:      "c",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
@@ -1354,7 +1354,7 @@
 &ast.IndexExpr{
     Object: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -1366,7 +1366,7 @@
     Index: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "base",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:3},
@@ -1378,7 +1378,7 @@
         Op:    "+",
         Right: &ast.IdentExpr{
             Name:      "offset",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
@@ -1410,7 +1410,7 @@
         Op:  0,
         Arg: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:2},
@@ -1431,7 +1431,7 @@
         Op:  1,
         Arg: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:7},
@@ -1483,7 +1483,7 @@
 &ast.TaggedTemplateLitExpr{
     Tag: &ast.IdentExpr{
         Name:      "gql",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -1592,7 +1592,7 @@
     Object: &ast.MemberExpr{
         Object: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
@@ -1639,7 +1639,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -1652,7 +1652,7 @@
     Right: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
@@ -1664,7 +1664,7 @@
         Op:    "+",
         Right: &ast.IdentExpr{
             Name:      "c",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
@@ -1712,7 +1712,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -1725,7 +1725,7 @@
     Right: &ast.IndexExpr{
         Object: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -1736,7 +1736,7 @@
         },
         Index: &ast.IdentExpr{
             Name:      "c",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:7},
@@ -1766,7 +1766,7 @@
 &ast.IfElseExpr{
     Cond: &ast.IdentExpr{
         Name:      "cond",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
@@ -1780,7 +1780,7 @@
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
                     Name:      "a",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:11},
@@ -1808,7 +1808,7 @@
                 &ast.ExprStmt{
                     Expr: &ast.IdentExpr{
                         Name:      "b",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:22},
@@ -1912,7 +1912,7 @@
             Exprs: {
                 &ast.IdentExpr{
                     Name:      "c",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:9},
@@ -1943,7 +1943,7 @@
 &ast.IfElseExpr{
     Cond: &ast.IdentExpr{
         Name:      "cond1",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
@@ -1957,7 +1957,7 @@
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
                     Name:      "a",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:12},
@@ -1984,7 +1984,7 @@
         Expr:  &ast.IfElseExpr{
             Cond: &ast.IdentExpr{
                 Name:      "cond2",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:24},
@@ -1998,7 +1998,7 @@
                     &ast.ExprStmt{
                         Expr: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:32},
@@ -2026,7 +2026,7 @@
                         &ast.ExprStmt{
                             Expr: &ast.IdentExpr{
                                 Name:      "c",
-                                Namespace: "",
+                                Namespace: 0,
                                 Source:    nil,
                                 span:      ast.Span{
                                     Start:    ast.Location{Line:1, Column:43},
@@ -2091,7 +2091,7 @@
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
@@ -2103,7 +2103,7 @@
         Op:    "-",
         Right: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -2122,7 +2122,7 @@
     Op:    "+",
     Right: &ast.IdentExpr{
         Name:      "c",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:9},
@@ -2165,7 +2165,7 @@
         Callee: &ast.CallExpr{
             Callee: &ast.IdentExpr{
                 Name:      "foo",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:1},
@@ -2177,7 +2177,7 @@
             Args: {
                 &ast.IdentExpr{
                     Name:      "a",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:5},
@@ -2198,7 +2198,7 @@
         Args: {
             &ast.IdentExpr{
                 Name:      "b",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
@@ -2219,7 +2219,7 @@
     Args: {
         &ast.IdentExpr{
             Name:      "c",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
@@ -2243,7 +2243,7 @@
 &ast.IndexExpr{
     Object: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -2255,7 +2255,7 @@
     Index: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "base",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:4},
@@ -2267,7 +2267,7 @@
         Op:    "+",
         Right: &ast.IdentExpr{
             Name:      "offset",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
@@ -2298,7 +2298,7 @@
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
@@ -2310,7 +2310,7 @@
         Op:    "/",
         Right: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -2329,7 +2329,7 @@
     Op:    "*",
     Right: &ast.IdentExpr{
         Name:      "c",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:9},
@@ -2352,7 +2352,7 @@
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
@@ -2364,7 +2364,7 @@
         Op:    "*",
         Right: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -2384,7 +2384,7 @@
     Right: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
             Name:      "c",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:9},
@@ -2396,7 +2396,7 @@
         Op:    "*",
         Right: &ast.IdentExpr{
             Name:      "d",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:13},
@@ -2444,7 +2444,7 @@
     Exprs: {
         &ast.IdentExpr{
             Name:      "name",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
@@ -2467,7 +2467,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -2480,7 +2480,7 @@
     Right: &ast.MemberExpr{
         Object: &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -2518,7 +2518,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -2531,7 +2531,7 @@
     Right: &ast.CallExpr{
         Callee: &ast.IdentExpr{
             Name:      "foo",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -2543,7 +2543,7 @@
         Args: {
             &ast.IdentExpr{
                 Name:      "b",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:9},
@@ -2601,7 +2601,7 @@
     Exprs: {
         &ast.IdentExpr{
             Name:      "b",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
@@ -2612,7 +2612,7 @@
         },
         &ast.IdentExpr{
             Name:      "d",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
@@ -2635,7 +2635,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -2647,7 +2647,7 @@
     Op:    "+",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
@@ -2669,7 +2669,7 @@
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
         Name:      "foo",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -2681,7 +2681,7 @@
     Args: {
         &ast.IdentExpr{
             Name:      "bar",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
@@ -2725,7 +2725,7 @@
     Object: &ast.IndexExpr{
         Object: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
@@ -2736,7 +2736,7 @@
         },
         Index: &ast.IdentExpr{
             Name:      "i",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:3},
@@ -2755,7 +2755,7 @@
     },
     Index: &ast.IdentExpr{
         Name:      "j",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
@@ -2818,7 +2818,7 @@
                 Expr: &ast.BinaryExpr{
                     Left: &ast.IdentExpr{
                         Name:      "a",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:13},
@@ -2830,7 +2830,7 @@
                     Op:    "+",
                     Right: &ast.IdentExpr{
                         Name:      "b",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
@@ -2907,7 +2907,7 @@
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
                 Name:      "foo",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:15},
@@ -2976,7 +2976,7 @@
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
                 Name:      "baz",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:37},
@@ -2998,7 +2998,7 @@
             Name: &ast.ComputedKey{
                 Expr: &ast.IdentExpr{
                     Name:      "qux",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:43},
@@ -3048,7 +3048,7 @@
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
                 Name:      "foo",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:3},
@@ -3110,7 +3110,7 @@
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
                 Name:      "foo",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:3},
@@ -3146,7 +3146,7 @@
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
                 Name:      "bar",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:10},
@@ -3206,7 +3206,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -3218,7 +3218,7 @@
     Op:    "<=",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
@@ -3240,7 +3240,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -3252,7 +3252,7 @@
     Op:    ">",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
@@ -3274,7 +3274,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -3286,7 +3286,7 @@
     Op:    ">=",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
@@ -3308,7 +3308,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -3320,7 +3320,7 @@
     Op:    "<",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
@@ -3342,7 +3342,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -3354,7 +3354,7 @@
     Op:    "!=",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
@@ -3376,7 +3376,7 @@
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
         Name:      "a",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -3388,7 +3388,7 @@
     Op:    "==",
     Right: &ast.IdentExpr{
         Name:      "b",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
@@ -3410,7 +3410,7 @@
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
         Name:      "foo",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
@@ -3437,7 +3437,7 @@
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
                 Name:      "a",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
@@ -3458,7 +3458,7 @@
         &ast.RestSpreadExpr{
             Value: &ast.IdentExpr{
                 Name:      "b",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
@@ -3479,7 +3479,7 @@
                     &ast.PropertyExpr{
                         Name: &ast.IdentExpr{
                             Name:      "c",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:15},
@@ -3500,7 +3500,7 @@
                     &ast.PropertyExpr{
                         Name: &ast.IdentExpr{
                             Name:      "d",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:18},
@@ -3548,7 +3548,7 @@
         Callee: &ast.MemberExpr{
             Object: &ast.IdentExpr{
                 Name:      "foo",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:1},
@@ -3586,7 +3586,7 @@
     Op:    "/",
     Right: &ast.IdentExpr{
         Name:      "baz",
-        Namespace: "",
+        Namespace: 0,
         Source:    nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:11},

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -6,9 +6,10 @@
         Stmts: {
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
-                    Name:   "a",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "a",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:6},
                         End:      ast.Location{Line:1, Column:7},
                         SourceID: 0,
@@ -33,9 +34,10 @@
             Stmts: {
                 &ast.ExprStmt{
                     Expr: &ast.IdentExpr{
-                        Name:   "b",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "b",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
                             End:      ast.Location{Line:1, Column:18},
                             SourceID: 0,
@@ -82,9 +84,10 @@
 [TestParseExprErrorHandling/IfElseMissingOpeningBraces - 1]
 &ast.IfElseExpr{
     Cond: &ast.IdentExpr{
-        Name:   "cond",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "cond",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
             End:      ast.Location{Line:1, Column:8},
             SourceID: 0,
@@ -113,9 +116,10 @@
 [TestParseExprErrorHandling/IncompleteCall - 1]
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
-        Name:   "foo",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "foo",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
             SourceID: 0,
@@ -124,9 +128,10 @@
     },
     Args: {
         &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -155,9 +160,10 @@
 [TestParseExprErrorHandling/IncompleteTaggedTemplateLiteral - 1]
 &ast.TaggedTemplateLitExpr{
     Tag: &ast.IdentExpr{
-        Name:   "foo",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "foo",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
             SourceID: 0,
@@ -283,9 +289,10 @@
 [TestParseExprErrorHandling/MismatchedParens - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -295,9 +302,10 @@
     Op:    "*",
     Right: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
                 End:      ast.Location{Line:1, Column:7},
                 SourceID: 0,
@@ -306,9 +314,10 @@
         },
         Op:    "+",
         Right: &ast.IdentExpr{
-            Name:   "c",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "c",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:11},
                 SourceID: 0,
@@ -347,9 +356,10 @@
 [TestParseExprErrorHandling/ExtraOperatorsInBinaryExpr - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -358,9 +368,10 @@
     },
     Op:    "+",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
             SourceID: 0,
@@ -393,9 +404,10 @@
 &ast.BinaryExpr{
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
                 SourceID: 0,
@@ -404,9 +416,10 @@
         },
         Op:    "-",
         Right: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -517,9 +530,10 @@
             &ast.ExprStmt{
                 Expr: &ast.BinaryExpr{
                     Left: &ast.IdentExpr{
-                        Name:   "a",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "a",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:12},
                             End:      ast.Location{Line:1, Column:13},
                             SourceID: 0,
@@ -528,9 +542,10 @@
                     },
                     Op:    "+",
                     Right: &ast.IdentExpr{
-                        Name:   "b",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "b",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:16},
                             End:      ast.Location{Line:1, Column:17},
                             SourceID: 0,
@@ -569,9 +584,10 @@
 [TestParseExprErrorHandling/MismatchedBracketsIndex - 1]
 &ast.IndexExpr{
     Object: &ast.IdentExpr{
-        Name:   "foo",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "foo",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
             SourceID: 0,
@@ -579,9 +595,10 @@
         inferredType: nil,
     },
     Index: &ast.IdentExpr{
-        Name:   "bar",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "bar",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:8},
             SourceID: 0,
@@ -601,9 +618,10 @@
 [TestParseExprErrorHandling/IncompleteMember - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -613,9 +631,10 @@
     Op:    "+",
     Right: &ast.MemberExpr{
         Object: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -768,9 +787,10 @@
             &ast.ExprStmt{
                 Expr: &ast.BinaryExpr{
                     Left: &ast.IdentExpr{
-                        Name:   "a",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "a",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:12},
                             End:      ast.Location{Line:1, Column:13},
                             SourceID: 0,
@@ -779,9 +799,10 @@
                     },
                     Op:    "+",
                     Right: &ast.IdentExpr{
-                        Name:   "b",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "b",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:16},
                             End:      ast.Location{Line:1, Column:17},
                             SourceID: 0,
@@ -820,9 +841,10 @@
 [TestParseExprErrorHandling/IncompleteMemberOptChain - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -832,9 +854,10 @@
     Op:    "+",
     Right: &ast.MemberExpr{
         Object: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -899,9 +922,10 @@
         Stmts: {
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
-                    Name:   "a",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "a",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:6},
                         End:      ast.Location{Line:1, Column:7},
                         SourceID: 0,
@@ -957,9 +981,10 @@
     Elems: {
         &ast.MethodExpr{
             Name: &ast.IdentExpr{
-                Name:   "foo",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "foo",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:3},
                     End:      ast.Location{Line:1, Column:6},
                     SourceID: 0,
@@ -1036,9 +1061,10 @@
         },
         &ast.GetterExpr{
             Name: &ast.IdentExpr{
-                Name:   "bar",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "bar",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:31},
                     End:      ast.Location{Line:1, Column:34},
                     SourceID: 0,
@@ -1073,9 +1099,10 @@
                         &ast.ReturnStmt{
                             Expr: &ast.MemberExpr{
                                 Object: &ast.IdentExpr{
-                                    Name:   "self",
-                                    Source: nil,
-                                    span:   ast.Span{
+                                    Name:      "self",
+                                    Namespace: "",
+                                    Source:    nil,
+                                    span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:50},
                                         End:      ast.Location{Line:1, Column:54},
                                         SourceID: 0,
@@ -1126,9 +1153,10 @@
         },
         &ast.SetterExpr{
             Name: &ast.IdentExpr{
-                Name:   "bar",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "bar",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:64},
                     End:      ast.Location{Line:1, Column:67},
                     SourceID: 0,
@@ -1164,9 +1192,10 @@
                             Expr: &ast.BinaryExpr{
                                 Left: &ast.MemberExpr{
                                     Object: &ast.IdentExpr{
-                                        Name:   "this",
-                                        Source: nil,
-                                        span:   ast.Span{
+                                        Name:      "this",
+                                        Namespace: "",
+                                        Source:    nil,
+                                        span:      ast.Span{
                                             Start:    ast.Location{Line:1, Column:73},
                                             End:      ast.Location{Line:1, Column:77},
                                             SourceID: 0,
@@ -1191,9 +1220,10 @@
                                 },
                                 Op:    "=",
                                 Right: &ast.IdentExpr{
-                                    Name:   "x",
-                                    Source: nil,
-                                    span:   ast.Span{
+                                    Name:      "x",
+                                    Namespace: "",
+                                    Source:    nil,
+                                    span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:82},
                                         End:      ast.Location{Line:1, Column:83},
                                         SourceID: 0,
@@ -1246,9 +1276,10 @@
 [TestParseExprNoErrors/Call - 1]
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
-        Name:   "foo",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "foo",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
             SourceID: 0,
@@ -1257,9 +1288,10 @@
     },
     Args: {
         &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -1267,9 +1299,10 @@
             inferredType: nil,
         },
         &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:8},
                 End:      ast.Location{Line:1, Column:9},
                 SourceID: 0,
@@ -1277,9 +1310,10 @@
             inferredType: nil,
         },
         &ast.IdentExpr{
-            Name:   "c",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "c",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
                 End:      ast.Location{Line:1, Column:12},
                 SourceID: 0,
@@ -1319,9 +1353,10 @@
 [TestParseExprNoErrors/Index - 1]
 &ast.IndexExpr{
     Object: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -1330,9 +1365,10 @@
     },
     Index: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "base",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "base",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:3},
                 End:      ast.Location{Line:1, Column:7},
                 SourceID: 0,
@@ -1341,9 +1377,10 @@
         },
         Op:    "+",
         Right: &ast.IdentExpr{
-            Name:   "offset",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "offset",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:16},
                 SourceID: 0,
@@ -1372,9 +1409,10 @@
     Left: &ast.UnaryExpr{
         Op:  0,
         Arg: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:2},
                 End:      ast.Location{Line:1, Column:3},
                 SourceID: 0,
@@ -1392,9 +1430,10 @@
     Right: &ast.UnaryExpr{
         Op:  1,
         Arg: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:7},
                 End:      ast.Location{Line:1, Column:8},
                 SourceID: 0,
@@ -1443,9 +1482,10 @@
 [TestParseExprNoErrors/TaggedTemplateStringLiteral - 1]
 &ast.TaggedTemplateLitExpr{
     Tag: &ast.IdentExpr{
-        Name:   "gql",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "gql",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
             SourceID: 0,
@@ -1551,9 +1591,10 @@
 &ast.MemberExpr{
     Object: &ast.MemberExpr{
         Object: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
                 SourceID: 0,
@@ -1597,9 +1638,10 @@
 [TestParseExprNoErrors/Parens - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -1609,9 +1651,10 @@
     Op:    "*",
     Right: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
                 End:      ast.Location{Line:1, Column:7},
                 SourceID: 0,
@@ -1620,9 +1663,10 @@
         },
         Op:    "+",
         Right: &ast.IdentExpr{
-            Name:   "c",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "c",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:11},
                 SourceID: 0,
@@ -1667,9 +1711,10 @@
 [TestParseExprNoErrors/IndexPrecedence - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -1679,9 +1724,10 @@
     Op:    "+",
     Right: &ast.IndexExpr{
         Object: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -1689,9 +1735,10 @@
             inferredType: nil,
         },
         Index: &ast.IdentExpr{
-            Name:   "c",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "c",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:7},
                 End:      ast.Location{Line:1, Column:8},
                 SourceID: 0,
@@ -1718,9 +1765,10 @@
 [TestParseExprNoErrors/IfElse - 1]
 &ast.IfElseExpr{
     Cond: &ast.IdentExpr{
-        Name:   "cond",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "cond",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
             End:      ast.Location{Line:1, Column:8},
             SourceID: 0,
@@ -1731,9 +1779,10 @@
         Stmts: {
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
-                    Name:   "a",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "a",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:11},
                         End:      ast.Location{Line:1, Column:12},
                         SourceID: 0,
@@ -1758,9 +1807,10 @@
             Stmts: {
                 &ast.ExprStmt{
                     Expr: &ast.IdentExpr{
-                        Name:   "b",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "b",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:22},
                             End:      ast.Location{Line:1, Column:23},
                             SourceID: 0,
@@ -1861,9 +1911,10 @@
             },
             Exprs: {
                 &ast.IdentExpr{
-                    Name:   "c",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "c",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:9},
                         End:      ast.Location{Line:1, Column:10},
                         SourceID: 0,
@@ -1891,9 +1942,10 @@
 [TestParseExprNoErrors/IfElseChaining - 1]
 &ast.IfElseExpr{
     Cond: &ast.IdentExpr{
-        Name:   "cond1",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "cond1",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
             End:      ast.Location{Line:1, Column:9},
             SourceID: 0,
@@ -1904,9 +1956,10 @@
         Stmts: {
             &ast.ExprStmt{
                 Expr: &ast.IdentExpr{
-                    Name:   "a",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "a",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:12},
                         End:      ast.Location{Line:1, Column:13},
                         SourceID: 0,
@@ -1930,9 +1983,10 @@
         Block: (*ast.Block)(nil),
         Expr:  &ast.IfElseExpr{
             Cond: &ast.IdentExpr{
-                Name:   "cond2",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "cond2",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:24},
                     End:      ast.Location{Line:1, Column:29},
                     SourceID: 0,
@@ -1943,9 +1997,10 @@
                 Stmts: {
                     &ast.ExprStmt{
                         Expr: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:32},
                                 End:      ast.Location{Line:1, Column:33},
                                 SourceID: 0,
@@ -1970,9 +2025,10 @@
                     Stmts: {
                         &ast.ExprStmt{
                             Expr: &ast.IdentExpr{
-                                Name:   "c",
-                                Source: nil,
-                                span:   ast.Span{
+                                Name:      "c",
+                                Namespace: "",
+                                Source:    nil,
+                                span:      ast.Span{
                                     Start:    ast.Location{Line:1, Column:43},
                                     End:      ast.Location{Line:1, Column:44},
                                     SourceID: 0,
@@ -2034,9 +2090,10 @@
 &ast.BinaryExpr{
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
                 SourceID: 0,
@@ -2045,9 +2102,10 @@
         },
         Op:    "-",
         Right: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -2063,9 +2121,10 @@
     },
     Op:    "+",
     Right: &ast.IdentExpr{
-        Name:   "c",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "c",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:9},
             End:      ast.Location{Line:1, Column:10},
             SourceID: 0,
@@ -2105,9 +2164,10 @@
     Callee: &ast.CallExpr{
         Callee: &ast.CallExpr{
             Callee: &ast.IdentExpr{
-                Name:   "foo",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "foo",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:1},
                     End:      ast.Location{Line:1, Column:4},
                     SourceID: 0,
@@ -2116,9 +2176,10 @@
             },
             Args: {
                 &ast.IdentExpr{
-                    Name:   "a",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "a",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:5},
                         End:      ast.Location{Line:1, Column:6},
                         SourceID: 0,
@@ -2136,9 +2197,10 @@
         },
         Args: {
             &ast.IdentExpr{
-                Name:   "b",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "b",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
                     End:      ast.Location{Line:1, Column:9},
                     SourceID: 0,
@@ -2156,9 +2218,10 @@
     },
     Args: {
         &ast.IdentExpr{
-            Name:   "c",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "c",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
                 End:      ast.Location{Line:1, Column:12},
                 SourceID: 0,
@@ -2179,9 +2242,10 @@
 [TestParseExprNoErrors/OptChainIndex - 1]
 &ast.IndexExpr{
     Object: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -2190,9 +2254,10 @@
     },
     Index: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "base",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "base",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:4},
                 End:      ast.Location{Line:1, Column:8},
                 SourceID: 0,
@@ -2201,9 +2266,10 @@
         },
         Op:    "+",
         Right: &ast.IdentExpr{
-            Name:   "offset",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "offset",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
                 End:      ast.Location{Line:1, Column:17},
                 SourceID: 0,
@@ -2231,9 +2297,10 @@
 &ast.BinaryExpr{
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
                 SourceID: 0,
@@ -2242,9 +2309,10 @@
         },
         Op:    "/",
         Right: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -2260,9 +2328,10 @@
     },
     Op:    "*",
     Right: &ast.IdentExpr{
-        Name:   "c",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "c",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:9},
             End:      ast.Location{Line:1, Column:10},
             SourceID: 0,
@@ -2282,9 +2351,10 @@
 &ast.BinaryExpr{
     Left: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
                 SourceID: 0,
@@ -2293,9 +2363,10 @@
         },
         Op:    "*",
         Right: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -2312,9 +2383,10 @@
     Op:    "+",
     Right: &ast.BinaryExpr{
         Left: &ast.IdentExpr{
-            Name:   "c",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "c",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:9},
                 End:      ast.Location{Line:1, Column:10},
                 SourceID: 0,
@@ -2323,9 +2395,10 @@
         },
         Op:    "*",
         Right: &ast.IdentExpr{
-            Name:   "d",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "d",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:13},
                 End:      ast.Location{Line:1, Column:14},
                 SourceID: 0,
@@ -2370,9 +2443,10 @@
     },
     Exprs: {
         &ast.IdentExpr{
-            Name:   "name",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "name",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:14},
                 SourceID: 0,
@@ -2392,9 +2466,10 @@
 [TestParseExprNoErrors/MemberPrecedence - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -2404,9 +2479,10 @@
     Op:    "+",
     Right: &ast.MemberExpr{
         Object: &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -2441,9 +2517,10 @@
 [TestParseExprNoErrors/CallPrecedence - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -2453,9 +2530,10 @@
     Op:    "+",
     Right: &ast.CallExpr{
         Callee: &ast.IdentExpr{
-            Name:   "foo",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "foo",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:8},
                 SourceID: 0,
@@ -2464,9 +2542,10 @@
         },
         Args: {
             &ast.IdentExpr{
-                Name:   "b",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "b",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:9},
                     End:      ast.Location{Line:1, Column:10},
                     SourceID: 0,
@@ -2521,9 +2600,10 @@
     },
     Exprs: {
         &ast.IdentExpr{
-            Name:   "b",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "b",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
                 SourceID: 0,
@@ -2531,9 +2611,10 @@
             inferredType: nil,
         },
         &ast.IdentExpr{
-            Name:   "d",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "d",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:11},
                 SourceID: 0,
@@ -2553,9 +2634,10 @@
 [TestParseExprNoErrors/Addition - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -2564,9 +2646,10 @@
     },
     Op:    "+",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:6},
             SourceID: 0,
@@ -2585,9 +2668,10 @@
 [TestParseExprNoErrors/OptChainCall - 1]
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
-        Name:   "foo",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "foo",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
             SourceID: 0,
@@ -2596,9 +2680,10 @@
     },
     Args: {
         &ast.IdentExpr{
-            Name:   "bar",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "bar",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
                 End:      ast.Location{Line:1, Column:9},
                 SourceID: 0,
@@ -2639,9 +2724,10 @@
 &ast.IndexExpr{
     Object: &ast.IndexExpr{
         Object: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
                 SourceID: 0,
@@ -2649,9 +2735,10 @@
             inferredType: nil,
         },
         Index: &ast.IdentExpr{
-            Name:   "i",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "i",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:3},
                 End:      ast.Location{Line:1, Column:4},
                 SourceID: 0,
@@ -2667,9 +2754,10 @@
         inferredType: nil,
     },
     Index: &ast.IdentExpr{
-        Name:   "j",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "j",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
             SourceID: 0,
@@ -2729,9 +2817,10 @@
             &ast.ExprStmt{
                 Expr: &ast.BinaryExpr{
                     Left: &ast.IdentExpr{
-                        Name:   "a",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "a",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:13},
                             End:      ast.Location{Line:1, Column:14},
                             SourceID: 0,
@@ -2740,9 +2829,10 @@
                     },
                     Op:    "+",
                     Right: &ast.IdentExpr{
-                        Name:   "b",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "b",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
                             End:      ast.Location{Line:1, Column:18},
                             SourceID: 0,
@@ -2816,9 +2906,10 @@
         },
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
-                Name:   "foo",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "foo",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:15},
                     End:      ast.Location{Line:1, Column:18},
                     SourceID: 0,
@@ -2884,9 +2975,10 @@
         },
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
-                Name:   "baz",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "baz",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:37},
                     End:      ast.Location{Line:1, Column:40},
                     SourceID: 0,
@@ -2905,9 +2997,10 @@
         &ast.PropertyExpr{
             Name: &ast.ComputedKey{
                 Expr: &ast.IdentExpr{
-                    Name:   "qux",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "qux",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:43},
                         End:      ast.Location{Line:1, Column:46},
                         SourceID: 0,
@@ -2954,9 +3047,10 @@
     Elems: {
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
-                Name:   "foo",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "foo",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:3},
                     End:      ast.Location{Line:1, Column:6},
                     SourceID: 0,
@@ -3015,9 +3109,10 @@
     Elems: {
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
-                Name:   "foo",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "foo",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:3},
                     End:      ast.Location{Line:1, Column:6},
                     SourceID: 0,
@@ -3050,9 +3145,10 @@
         },
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
-                Name:   "bar",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "bar",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:10},
                     End:      ast.Location{Line:1, Column:13},
                     SourceID: 0,
@@ -3109,9 +3205,10 @@
 [TestParseExprNoErrors/LessThanEqual - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -3120,9 +3217,10 @@
     },
     Op:    "<=",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
             SourceID: 0,
@@ -3141,9 +3239,10 @@
 [TestParseExprNoErrors/GreaterThan - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -3152,9 +3251,10 @@
     },
     Op:    ">",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:6},
             SourceID: 0,
@@ -3173,9 +3273,10 @@
 [TestParseExprNoErrors/GreaterThanEqual - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -3184,9 +3285,10 @@
     },
     Op:    ">=",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
             SourceID: 0,
@@ -3205,9 +3307,10 @@
 [TestParseExprNoErrors/LessThan - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -3216,9 +3319,10 @@
     },
     Op:    "<",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:6},
             SourceID: 0,
@@ -3237,9 +3341,10 @@
 [TestParseExprNoErrors/NotEqual - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -3248,9 +3353,10 @@
     },
     Op:    "!=",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
             SourceID: 0,
@@ -3269,9 +3375,10 @@
 [TestParseExprNoErrors/Equal - 1]
 &ast.BinaryExpr{
     Left: &ast.IdentExpr{
-        Name:   "a",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "a",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
             SourceID: 0,
@@ -3280,9 +3387,10 @@
     },
     Op:    "==",
     Right: &ast.IdentExpr{
-        Name:   "b",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "b",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
             SourceID: 0,
@@ -3301,9 +3409,10 @@
 [TestParseExprNoErrors/FuncCall - 1]
 &ast.CallExpr{
     Callee: &ast.IdentExpr{
-        Name:   "foo",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "foo",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
             SourceID: 0,
@@ -3327,9 +3436,10 @@
     Elems: {
         &ast.PropertyExpr{
             Name: &ast.IdentExpr{
-                Name:   "a",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "a",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:3},
                     SourceID: 0,
@@ -3347,9 +3457,10 @@
         },
         &ast.RestSpreadExpr{
             Value: &ast.IdentExpr{
-                Name:   "b",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "b",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
                     End:      ast.Location{Line:1, Column:9},
                     SourceID: 0,
@@ -3367,9 +3478,10 @@
                 Elems: {
                     &ast.PropertyExpr{
                         Name: &ast.IdentExpr{
-                            Name:   "c",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "c",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:15},
                                 End:      ast.Location{Line:1, Column:16},
                                 SourceID: 0,
@@ -3387,9 +3499,10 @@
                     },
                     &ast.PropertyExpr{
                         Name: &ast.IdentExpr{
-                            Name:   "d",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "d",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:18},
                                 End:      ast.Location{Line:1, Column:19},
                                 SourceID: 0,
@@ -3434,9 +3547,10 @@
     Left: &ast.CallExpr{
         Callee: &ast.MemberExpr{
             Object: &ast.IdentExpr{
-                Name:   "foo",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "foo",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:1},
                     End:      ast.Location{Line:1, Column:4},
                     SourceID: 0,
@@ -3471,9 +3585,10 @@
     },
     Op:    "/",
     Right: &ast.IdentExpr{
-        Name:   "baz",
-        Source: nil,
-        span:   ast.Span{
+        Name:      "baz",
+        Namespace: "",
+        Source:    nil,
+        span:      ast.Span{
             Start:    ast.Location{Line:1, Column:11},
             End:      ast.Location{Line:1, Column:14},
             SourceID: 0,

--- a/internal/parser/__snapshots__/jsx_test.snap
+++ b/internal/parser/__snapshots__/jsx_test.snap
@@ -317,7 +317,7 @@
         &ast.JSXExprContainer{
             Expr: &ast.IdentExpr{
                 Name:      "msg",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:14},
@@ -389,7 +389,7 @@
                     &ast.JSXExprContainer{
                         Expr: &ast.IdentExpr{
                             Name:      "foo",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:14},

--- a/internal/parser/__snapshots__/jsx_test.snap
+++ b/internal/parser/__snapshots__/jsx_test.snap
@@ -316,9 +316,10 @@
         },
         &ast.JSXExprContainer{
             Expr: &ast.IdentExpr{
-                Name:   "msg",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "msg",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:14},
                     End:      ast.Location{Line:1, Column:17},
                     SourceID: 0,
@@ -387,9 +388,10 @@
                 Children: {
                     &ast.JSXExprContainer{
                         Expr: &ast.IdentExpr{
-                            Name:   "foo",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "foo",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:14},
                                 End:      ast.Location{Line:1, Column:17},
                                 SourceID: 0,

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -4,7 +4,7 @@
     Expr: &ast.CallExpr{
         Callee: &ast.IdentExpr{
             Name:      "foo",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:5},
@@ -131,7 +131,7 @@
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:13},
@@ -143,7 +143,7 @@
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:17},
@@ -205,7 +205,7 @@
         TypeAnn: nil,
         Init:    &ast.IdentExpr{
             Name:      "x",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:13},
@@ -248,7 +248,7 @@
         Init:    &ast.BinaryExpr{
             Left: &ast.IdentExpr{
                 Name:      "x",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:14},
@@ -260,7 +260,7 @@
             Op:    "-",
             Right: &ast.IdentExpr{
                 Name:      "y",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
@@ -297,7 +297,7 @@
     Expr: &ast.IndexExpr{
         Object: &ast.IdentExpr{
             Name:      "a",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:5},
@@ -309,7 +309,7 @@
         Index: &ast.BinaryExpr{
             Left: &ast.IdentExpr{
                 Name:      "base",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:7},
@@ -321,7 +321,7 @@
             Op:    "+",
             Right: &ast.IdentExpr{
                 Name:      "offset",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
@@ -397,7 +397,7 @@
                                     TypeAnn: nil,
                                     Init:    &ast.IdentExpr{
                                         Name:      "x",
-                                        Namespace: "",
+                                        Namespace: 0,
                                         Source:    nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:15},
@@ -425,7 +425,7 @@
                                     Op:  1,
                                     Arg: &ast.IdentExpr{
                                         Name:      "y",
-                                        Namespace: "",
+                                        Namespace: 0,
                                         Source:    nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:8},
@@ -490,7 +490,7 @@
     Expr: &ast.CallExpr{
         Callee: &ast.IdentExpr{
             Name:      "bar",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:3, Column:5},
@@ -582,7 +582,7 @@
         Init:    &ast.BinaryExpr{
             Left: &ast.IdentExpr{
                 Name:      "a",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:4, Column:15},
@@ -594,7 +594,7 @@
             Op:    "+",
             Right: &ast.IdentExpr{
                 Name:      "b",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:4, Column:19},
@@ -679,7 +679,7 @@
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:6, Column:13},
@@ -691,7 +691,7 @@
                         Op:    "-",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:6, Column:17},
@@ -754,7 +754,7 @@
         Init:    &ast.IfElseExpr{
             Cond: &ast.IdentExpr{
                 Name:      "cond",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:16},
@@ -965,7 +965,7 @@
         Op:  1,
         Arg: &ast.IdentExpr{
             Name:      "y",
-            Namespace: "",
+            Namespace: 0,
             Source:    nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:3, Column:6},
@@ -995,7 +995,7 @@
         Left: &ast.MemberExpr{
             Object: &ast.IdentExpr{
                 Name:      "p",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
@@ -1058,7 +1058,7 @@
         Left: &ast.MemberExpr{
             Object: &ast.IdentExpr{
                 Name:      "p",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:5},

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -3,9 +3,10 @@
 &ast.ExprStmt{
     Expr: &ast.CallExpr{
         Callee: &ast.IdentExpr{
-            Name:   "foo",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "foo",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:5},
                 End:      ast.Location{Line:2, Column:8},
                 SourceID: 0,
@@ -129,9 +130,10 @@
                 &ast.ReturnStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:13},
                                 End:      ast.Location{Line:3, Column:14},
                                 SourceID: 0,
@@ -140,9 +142,10 @@
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:17},
                                 End:      ast.Location{Line:3, Column:18},
                                 SourceID: 0,
@@ -201,9 +204,10 @@
         },
         TypeAnn: nil,
         Init:    &ast.IdentExpr{
-            Name:   "x",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "x",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:13},
                 End:      ast.Location{Line:2, Column:14},
                 SourceID: 0,
@@ -243,9 +247,10 @@
         TypeAnn: nil,
         Init:    &ast.BinaryExpr{
             Left: &ast.IdentExpr{
-                Name:   "x",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "x",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:14},
                     End:      ast.Location{Line:2, Column:15},
                     SourceID: 0,
@@ -254,9 +259,10 @@
             },
             Op:    "-",
             Right: &ast.IdentExpr{
-                Name:   "y",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "y",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:7},
                     SourceID: 0,
@@ -290,9 +296,10 @@
 &ast.ExprStmt{
     Expr: &ast.IndexExpr{
         Object: &ast.IdentExpr{
-            Name:   "a",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "a",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:5},
                 End:      ast.Location{Line:2, Column:6},
                 SourceID: 0,
@@ -301,9 +308,10 @@
         },
         Index: &ast.BinaryExpr{
             Left: &ast.IdentExpr{
-                Name:   "base",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "base",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:7},
                     End:      ast.Location{Line:2, Column:11},
                     SourceID: 0,
@@ -312,9 +320,10 @@
             },
             Op:    "+",
             Right: &ast.IdentExpr{
-                Name:   "offset",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "offset",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:12},
                     SourceID: 0,
@@ -387,9 +396,10 @@
                                     },
                                     TypeAnn: nil,
                                     Init:    &ast.IdentExpr{
-                                        Name:   "x",
-                                        Source: nil,
-                                        span:   ast.Span{
+                                        Name:      "x",
+                                        Namespace: "",
+                                        Source:    nil,
+                                        span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:15},
                                             End:      ast.Location{Line:4, Column:16},
                                             SourceID: 0,
@@ -414,9 +424,10 @@
                                 Expr: &ast.UnaryExpr{
                                     Op:  1,
                                     Arg: &ast.IdentExpr{
-                                        Name:   "y",
-                                        Source: nil,
-                                        span:   ast.Span{
+                                        Name:      "y",
+                                        Namespace: "",
+                                        Source:    nil,
+                                        span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:8},
                                             End:      ast.Location{Line:5, Column:9},
                                             SourceID: 0,
@@ -478,9 +489,10 @@
 &ast.ExprStmt{
     Expr: &ast.CallExpr{
         Callee: &ast.IdentExpr{
-            Name:   "bar",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "bar",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:3, Column:5},
                 End:      ast.Location{Line:3, Column:8},
                 SourceID: 0,
@@ -569,9 +581,10 @@
         TypeAnn: nil,
         Init:    &ast.BinaryExpr{
             Left: &ast.IdentExpr{
-                Name:   "a",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "a",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:4, Column:15},
                     End:      ast.Location{Line:4, Column:16},
                     SourceID: 0,
@@ -580,9 +593,10 @@
             },
             Op:    "+",
             Right: &ast.IdentExpr{
-                Name:   "b",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "b",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:4, Column:19},
                     End:      ast.Location{Line:4, Column:20},
                     SourceID: 0,
@@ -664,9 +678,10 @@
                 &ast.ReturnStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:6, Column:13},
                                 End:      ast.Location{Line:6, Column:14},
                                 SourceID: 0,
@@ -675,9 +690,10 @@
                         },
                         Op:    "-",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:6, Column:17},
                                 End:      ast.Location{Line:6, Column:18},
                                 SourceID: 0,
@@ -737,9 +753,10 @@
         TypeAnn: nil,
         Init:    &ast.IfElseExpr{
             Cond: &ast.IdentExpr{
-                Name:   "cond",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "cond",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:16},
                     End:      ast.Location{Line:2, Column:20},
                     SourceID: 0,
@@ -947,9 +964,10 @@
     Expr: &ast.UnaryExpr{
         Op:  1,
         Arg: &ast.IdentExpr{
-            Name:   "y",
-            Source: nil,
-            span:   ast.Span{
+            Name:      "y",
+            Namespace: "",
+            Source:    nil,
+            span:      ast.Span{
                 Start:    ast.Location{Line:3, Column:6},
                 End:      ast.Location{Line:3, Column:7},
                 SourceID: 0,
@@ -976,9 +994,10 @@
     Expr: &ast.BinaryExpr{
         Left: &ast.MemberExpr{
             Object: &ast.IdentExpr{
-                Name:   "p",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "p",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:6},
                     SourceID: 0,
@@ -1038,9 +1057,10 @@
     Expr: &ast.BinaryExpr{
         Left: &ast.MemberExpr{
             Object: &ast.IdentExpr{
-                Name:   "p",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "p",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:5},
                     End:      ast.Location{Line:3, Column:6},
                     SourceID: 0,

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -354,7 +354,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:12},
@@ -482,7 +482,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
@@ -494,7 +494,7 @@ nil
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
@@ -605,7 +605,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
@@ -617,7 +617,7 @@ nil
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
@@ -1183,7 +1183,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
@@ -1195,7 +1195,7 @@ nil
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:27},
@@ -1293,7 +1293,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
@@ -1305,7 +1305,7 @@ nil
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:27},
@@ -1403,7 +1403,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
@@ -1415,7 +1415,7 @@ nil
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
@@ -1510,7 +1510,7 @@ nil
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
                         Name:      "x",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
@@ -1533,7 +1533,7 @@ nil
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
                         Name:      "y",
-                        Namespace: "",
+                        Namespace: 0,
                         Source:    nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:28},
@@ -1709,7 +1709,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:19},
@@ -1721,7 +1721,7 @@ nil
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
@@ -1879,7 +1879,7 @@ nil
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
                             Name:      "a",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:12},
@@ -1891,7 +1891,7 @@ nil
                         Op:    "+",
                         Right: &ast.IdentExpr{
                             Name:      "b",
-                            Namespace: "",
+                            Namespace: 0,
                             Source:    nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:16},

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -353,9 +353,10 @@ nil
                 &ast.ReturnStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:12},
                                 End:      ast.Location{Line:4, Column:13},
                                 SourceID: 0,
@@ -480,9 +481,10 @@ nil
                 &ast.ExprStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
                                 End:      ast.Location{Line:1, Column:17},
                                 SourceID: 0,
@@ -491,9 +493,10 @@ nil
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
                                 End:      ast.Location{Line:1, Column:21},
                                 SourceID: 0,
@@ -601,9 +604,10 @@ nil
                 &ast.ExprStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
                                 End:      ast.Location{Line:1, Column:17},
                                 SourceID: 0,
@@ -612,9 +616,10 @@ nil
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
                                 End:      ast.Location{Line:1, Column:21},
                                 SourceID: 0,
@@ -1177,9 +1182,10 @@ nil
                 &ast.ExprStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
                                 End:      ast.Location{Line:1, Column:24},
                                 SourceID: 0,
@@ -1188,9 +1194,10 @@ nil
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:27},
                                 End:      ast.Location{Line:1, Column:28},
                                 SourceID: 0,
@@ -1285,9 +1292,10 @@ nil
                 &ast.ReturnStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
                                 End:      ast.Location{Line:1, Column:24},
                                 SourceID: 0,
@@ -1296,9 +1304,10 @@ nil
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:27},
                                 End:      ast.Location{Line:1, Column:28},
                                 SourceID: 0,
@@ -1393,9 +1402,10 @@ nil
                 &ast.ExprStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
                                 End:      ast.Location{Line:1, Column:17},
                                 SourceID: 0,
@@ -1404,9 +1414,10 @@ nil
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
                                 End:      ast.Location{Line:1, Column:21},
                                 SourceID: 0,
@@ -1498,9 +1509,10 @@ nil
             Elems: {
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
-                        Name:   "x",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "x",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
                             End:      ast.Location{Line:1, Column:18},
                             SourceID: 0,
@@ -1520,9 +1532,10 @@ nil
                 },
                 &ast.PropertyTypeAnn{
                     Name: &ast.IdentExpr{
-                        Name:   "y",
-                        Source: nil,
-                        span:   ast.Span{
+                        Name:      "y",
+                        Namespace: "",
+                        Source:    nil,
+                        span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:28},
                             End:      ast.Location{Line:1, Column:29},
                             SourceID: 0,
@@ -1695,9 +1708,10 @@ nil
                 &ast.ExprStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:19},
                                 End:      ast.Location{Line:1, Column:20},
                                 SourceID: 0,
@@ -1706,9 +1720,10 @@ nil
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
                                 End:      ast.Location{Line:1, Column:24},
                                 SourceID: 0,
@@ -1863,9 +1878,10 @@ nil
                 &ast.ReturnStmt{
                     Expr: &ast.BinaryExpr{
                         Left: &ast.IdentExpr{
-                            Name:   "a",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "a",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:12},
                                 End:      ast.Location{Line:4, Column:13},
                                 SourceID: 0,
@@ -1874,9 +1890,10 @@ nil
                         },
                         Op:    "+",
                         Right: &ast.IdentExpr{
-                            Name:   "b",
-                            Source: nil,
-                            span:   ast.Span{
+                            Name:      "b",
+                            Namespace: "",
+                            Source:    nil,
+                            span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:16},
                                 End:      ast.Location{Line:4, Column:17},
                                 SourceID: 0,

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -691,9 +691,10 @@
     Elems: {
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
-                Name:   "a",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "a",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:3},
                     SourceID: 0,
@@ -723,9 +724,10 @@
         },
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
-                Name:   "b",
-                Source: nil,
-                span:   ast.Span{
+                Name:      "b",
+                Namespace: "",
+                Source:    nil,
+                span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
                     End:      ast.Location{Line:1, Column:9},
                     SourceID: 0,
@@ -756,9 +758,10 @@
         &ast.PropertyTypeAnn{
             Name: &ast.ComputedKey{
                 Expr: &ast.IdentExpr{
-                    Name:   "c",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "c",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:16},
                         End:      ast.Location{Line:1, Column:17},
                         SourceID: 0,
@@ -790,9 +793,10 @@
         &ast.PropertyTypeAnn{
             Name: &ast.ComputedKey{
                 Expr: &ast.IdentExpr{
-                    Name:   "d",
-                    Source: nil,
-                    span:   ast.Span{
+                    Name:      "d",
+                    Namespace: "",
+                    Source:    nil,
+                    span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:24},
                         End:      ast.Location{Line:1, Column:25},
                         SourceID: 0,

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -692,7 +692,7 @@
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
                 Name:      "a",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
@@ -725,7 +725,7 @@
         &ast.PropertyTypeAnn{
             Name: &ast.IdentExpr{
                 Name:      "b",
-                Namespace: "",
+                Namespace: 0,
                 Source:    nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
@@ -759,7 +759,7 @@
             Name: &ast.ComputedKey{
                 Expr: &ast.IdentExpr{
                     Name:      "c",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:16},
@@ -794,7 +794,7 @@
             Name: &ast.ComputedKey{
                 Expr: &ast.IdentExpr{
                     Name:      "d",
-                    Namespace: "",
+                    Namespace: 0,
                     Source:    nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:24},


### PR DESCRIPTION
Now that we're flattening namespaces in generated code, all identifiers need to be fully qualified not just those used in declarations.