### PR TITLE
Remove 'finally'

### DIFF
--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -726,13 +726,12 @@ func (e *AssignExpr) Accept(v Visitor) {
 type TryCatchExpr struct {
 	Try          Block
 	Catch        []*MatchCase // optional
-	Finally      *Block       // optional
 	span         Span
 	inferredType Type
 }
 
-func NewTryCatch(try Block, catch []*MatchCase, finally *Block, span Span) *TryCatchExpr {
-	return &TryCatchExpr{Try: try, Catch: catch, Finally: finally, span: span, inferredType: nil}
+func NewTryCatch(try Block, catch []*MatchCase, span Span) *TryCatchExpr {
+	return &TryCatchExpr{Try: try, Catch: catch, span: span, inferredType: nil}
 }
 func (e *TryCatchExpr) Accept(v Visitor) {
 	if v.EnterExpr(e) {
@@ -748,9 +747,6 @@ func (e *TryCatchExpr) Accept(v Visitor) {
 			if matchCase.Body.Expr != nil {
 				matchCase.Body.Expr.Accept(v)
 			}
-		}
-		if e.Finally != nil {
-			e.Finally.Accept(v)
 		}
 	}
 	v.ExitExpr(e)

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -4855,232 +4855,6 @@
 }
 ---
 
-[TestParseExprNoErrors/TryFinally - 1]
-&ast.TryCatchExpr{
-    Try: ast.Block{
-        Stmts: {
-            &ast.ExprStmt{
-                Expr: &ast.CallExpr{
-                    Callee: &ast.IdentExpr{
-                        Name:      "riskyOperation",
-                        Namespace: 0,
-                        Source:    nil,
-                        span:      ast.Span{
-                            Start:    ast.Location{Line:1, Column:7},
-                            End:      ast.Location{Line:1, Column:21},
-                            SourceID: 0,
-                        },
-                        inferredType: nil,
-                    },
-                    Args: {
-                    },
-                    OptChain: false,
-                    span:     ast.Span{
-                        Start:    ast.Location{Line:1, Column:7},
-                        End:      ast.Location{Line:1, Column:23},
-                        SourceID: 0,
-                    },
-                    inferredType: nil,
-                },
-                span: ast.Span{
-                    Start:    ast.Location{Line:1, Column:7},
-                    End:      ast.Location{Line:1, Column:23},
-                    SourceID: 0,
-                },
-            },
-        },
-        Span: ast.Span{
-            Start:    ast.Location{Line:1, Column:5},
-            End:      ast.Location{Line:1, Column:25},
-            SourceID: 0,
-        },
-    },
-    Catch:   nil,
-    Finally: &ast.Block{
-        Stmts: {
-            &ast.ExprStmt{
-                Expr: &ast.CallExpr{
-                    Callee: &ast.IdentExpr{
-                        Name:      "cleanup",
-                        Namespace: 0,
-                        Source:    nil,
-                        span:      ast.Span{
-                            Start:    ast.Location{Line:1, Column:36},
-                            End:      ast.Location{Line:1, Column:43},
-                            SourceID: 0,
-                        },
-                        inferredType: nil,
-                    },
-                    Args: {
-                    },
-                    OptChain: false,
-                    span:     ast.Span{
-                        Start:    ast.Location{Line:1, Column:36},
-                        End:      ast.Location{Line:1, Column:45},
-                        SourceID: 0,
-                    },
-                    inferredType: nil,
-                },
-                span: ast.Span{
-                    Start:    ast.Location{Line:1, Column:36},
-                    End:      ast.Location{Line:1, Column:45},
-                    SourceID: 0,
-                },
-            },
-        },
-        Span: ast.Span{
-            Start:    ast.Location{Line:1, Column:34},
-            End:      ast.Location{Line:1, Column:47},
-            SourceID: 0,
-        },
-    },
-    span: ast.Span{
-        Start:    ast.Location{Line:1, Column:1},
-        End:      ast.Location{Line:1, Column:47},
-        SourceID: 0,
-    },
-    inferredType: nil,
-}
----
-
-[TestParseExprNoErrors/TryCatchFinally - 1]
-&ast.TryCatchExpr{
-    Try: ast.Block{
-        Stmts: {
-            &ast.ExprStmt{
-                Expr: &ast.CallExpr{
-                    Callee: &ast.IdentExpr{
-                        Name:      "riskyOperation",
-                        Namespace: 0,
-                        Source:    nil,
-                        span:      ast.Span{
-                            Start:    ast.Location{Line:1, Column:7},
-                            End:      ast.Location{Line:1, Column:21},
-                            SourceID: 0,
-                        },
-                        inferredType: nil,
-                    },
-                    Args: {
-                    },
-                    OptChain: false,
-                    span:     ast.Span{
-                        Start:    ast.Location{Line:1, Column:7},
-                        End:      ast.Location{Line:1, Column:23},
-                        SourceID: 0,
-                    },
-                    inferredType: nil,
-                },
-                span: ast.Span{
-                    Start:    ast.Location{Line:1, Column:7},
-                    End:      ast.Location{Line:1, Column:23},
-                    SourceID: 0,
-                },
-            },
-        },
-        Span: ast.Span{
-            Start:    ast.Location{Line:1, Column:5},
-            End:      ast.Location{Line:1, Column:25},
-            SourceID: 0,
-        },
-    },
-    Catch: {
-        &ast.MatchCase{
-            Pattern: &ast.IdentPat{
-                Name:    "error",
-                Default: nil,
-                span:    ast.Span{
-                    Start:    ast.Location{Line:1, Column:34},
-                    End:      ast.Location{Line:1, Column:39},
-                    SourceID: 0,
-                },
-                inferredType: nil,
-            },
-            Guard: nil,
-            Body:  ast.BlockOrExpr{
-                Block: (*ast.Block)(nil),
-                Expr:  &ast.MemberExpr{
-                    Object: &ast.IdentExpr{
-                        Name:      "error",
-                        Namespace: 0,
-                        Source:    nil,
-                        span:      ast.Span{
-                            Start:    ast.Location{Line:1, Column:43},
-                            End:      ast.Location{Line:1, Column:48},
-                            SourceID: 0,
-                        },
-                        inferredType: nil,
-                    },
-                    Prop: &ast.Ident{
-                        Name: "message",
-                        span: ast.Span{
-                            Start:    ast.Location{Line:1, Column:49},
-                            End:      ast.Location{Line:1, Column:56},
-                            SourceID: 0,
-                        },
-                    },
-                    OptChain: false,
-                    span:     ast.Span{
-                        Start:    ast.Location{Line:1, Column:43},
-                        End:      ast.Location{Line:1, Column:56},
-                        SourceID: 0,
-                    },
-                    inferredType: nil,
-                },
-            },
-            span: ast.Span{
-                Start:    ast.Location{Line:1, Column:33},
-                End:      ast.Location{Line:1, Column:56},
-                SourceID: 0,
-            },
-        },
-    },
-    Finally: &ast.Block{
-        Stmts: {
-            &ast.ExprStmt{
-                Expr: &ast.CallExpr{
-                    Callee: &ast.IdentExpr{
-                        Name:      "cleanup",
-                        Namespace: 0,
-                        Source:    nil,
-                        span:      ast.Span{
-                            Start:    ast.Location{Line:1, Column:69},
-                            End:      ast.Location{Line:1, Column:76},
-                            SourceID: 0,
-                        },
-                        inferredType: nil,
-                    },
-                    Args: {
-                    },
-                    OptChain: false,
-                    span:     ast.Span{
-                        Start:    ast.Location{Line:1, Column:69},
-                        End:      ast.Location{Line:1, Column:78},
-                        SourceID: 0,
-                    },
-                    inferredType: nil,
-                },
-                span: ast.Span{
-                    Start:    ast.Location{Line:1, Column:69},
-                    End:      ast.Location{Line:1, Column:78},
-                    SourceID: 0,
-                },
-            },
-        },
-        Span: ast.Span{
-            Start:    ast.Location{Line:1, Column:67},
-            End:      ast.Location{Line:1, Column:80},
-            SourceID: 0,
-        },
-    },
-    span: ast.Span{
-        Start:    ast.Location{Line:1, Column:1},
-        End:      ast.Location{Line:1, Column:80},
-        SourceID: 0,
-    },
-    inferredType: nil,
-}
----
-
 [TestParseExprNoErrors/TryCatch - 1]
 &ast.TryCatchExpr{
     Try: ast.Block{
@@ -5210,8 +4984,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:65},
         SourceID: 0,
@@ -5300,8 +5073,7 @@
                             },
                         },
                     },
-                    Finally: (*ast.Block)(nil),
-                    span:    ast.Span{
+                    span: ast.Span{
                         Start:    ast.Location{Line:1, Column:7},
                         End:      ast.Location{Line:1, Column:49},
                         SourceID: 0,
@@ -5355,8 +5127,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:76},
         SourceID: 0,
@@ -5405,9 +5176,8 @@
             SourceID: 0,
         },
     },
-    Catch:   nil,
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    Catch: nil,
+    span:  ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:25},
         SourceID: 0,
@@ -5596,8 +5366,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:93},
         SourceID: 0,
@@ -5788,8 +5557,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:117},
         SourceID: 0,
@@ -5933,8 +5701,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:4, Column:2},
         SourceID: 0,
@@ -5954,9 +5721,8 @@
             SourceID: 0,
         },
     },
-    Catch:   nil,
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    Catch: nil,
+    span:  ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:12},
         SourceID: 0,
@@ -6005,9 +5771,8 @@
             SourceID: 0,
         },
     },
-    Catch:   nil,
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    Catch: nil,
+    span:  ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:20},
         SourceID: 0,
@@ -6027,9 +5792,8 @@
             SourceID: 0,
         },
     },
-    Catch:   nil,
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    Catch: nil,
+    span:  ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:4},
         SourceID: 0,
@@ -6122,8 +5886,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:39},
         SourceID: 0,
@@ -6255,8 +6018,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:51},
         SourceID: 0,
@@ -6436,9 +6198,8 @@
             SourceID: 0,
         },
     },
-    Catch:   nil,
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    Catch: nil,
+    span:  ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:20},
         SourceID: 0,
@@ -6534,8 +6295,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:43},
         SourceID: 0,
@@ -6707,8 +6467,7 @@
             },
         },
     },
-    Finally: (*ast.Block)(nil),
-    span:    ast.Span{
+    span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:45},
         SourceID: 0,

--- a/internal/parser/expect.go
+++ b/internal/parser/expect.go
@@ -44,7 +44,6 @@ var TokenMap = map[TokenType]string{
 	Match:               "match",
 	Try:                 "try",
 	Catch:               "catch",
-	Finally:             "finally",
 	Throw:               "throw",
 	Async:               "async",
 	Await:               "await",

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -865,7 +865,6 @@ func (p *Parser) tryExpr() ast.Expr {
 	tryBlock := p.block()
 
 	var catchCases []*ast.MatchCase
-	var finallyBlock *ast.Block
 
 	token := p.lexer.peek()
 
@@ -905,17 +904,8 @@ func (p *Parser) tryExpr() ast.Expr {
 		token = p.lexer.peek()
 	}
 
-	// Parse finally clause
-	if token.Type == Finally {
-		p.lexer.consume() // consume 'finally'
-		block := p.block()
-		finallyBlock = &block
-	}
-
 	var end ast.Location
-	if finallyBlock != nil {
-		end = finallyBlock.Span.End
-	} else if len(catchCases) > 0 {
+	if len(catchCases) > 0 {
 		// Find the end of the last catch case
 		lastCase := catchCases[len(catchCases)-1]
 		if lastCase.Body.Block != nil {
@@ -931,5 +921,5 @@ func (p *Parser) tryExpr() ast.Expr {
 
 	span := ast.Span{Start: start, End: end, SourceID: p.lexer.source.ID}
 
-	return ast.NewTryCatch(tryBlock, catchCases, finallyBlock, span)
+	return ast.NewTryCatch(tryBlock, catchCases, span)
 }

--- a/internal/parser/expr_test.go
+++ b/internal/parser/expr_test.go
@@ -176,12 +176,6 @@ func TestParseExprNoErrors(t *testing.T) {
 		"TryCatch": {
 			input: "try { riskyOperation() } catch { error => { console.log(error) } }",
 		},
-		"TryFinally": {
-			input: "try { riskyOperation() } finally { cleanup() }",
-		},
-		"TryCatchFinally": {
-			input: "try { riskyOperation() } catch { error => error.message } finally { cleanup() }",
-		},
 		"TryCatchMultipleCases": {
 			input: "try { operation() } catch { NetworkError(msg) => \"Network: \" ++ msg, TimeoutError => \"Timeout\", _ => \"Unknown error\" }",
 		},
@@ -315,12 +309,6 @@ func TestParseExprErrorHandling(t *testing.T) {
 		},
 		"TryCatchIncompleteGuard": {
 			input: "try { operation() } catch { error if => \"failed\" }",
-		},
-		"TryFinallyMissingBlock": {
-			input: "try { operation() } finally",
-		},
-		"TryFinallyMissingOpeningBrace": {
-			input: "try { operation() } finally cleanup()",
 		},
 	}
 

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -43,7 +43,6 @@ var keywords = map[string]TokenType{
 	"match":     Match,
 	"try":       Try,
 	"catch":     Catch,
-	"finally":   Finally,
 	"throw":     Throw,
 	"async":     Async,
 	"await":     Await,
@@ -80,7 +79,7 @@ func (lexer *Lexer) isRegexContext() bool {
 		Equal, EqualEqual, NotEqual, LessThan, LessThanEqual,
 		GreaterThan, GreaterThanEqual, Plus, PlusPlus, Minus, Asterisk,
 		Ampersand, AmpersandAmpersand, Pipe, PipePipe, Bang,
-		Return, If, Else, Match, Try, Catch, Finally, Throw,
+		Return, If, Else, Match, Try, Catch, Throw,
 		Arrow, FatArrow:
 		return true
 	// After these tokens, / is division

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -5,107 +5,90 @@ import "github.com/escalier-lang/escalier/internal/ast"
 type TokenType int
 
 const (
-	Identifier TokenType = iota
-
-	// literals
-	NumLit
-	StrLit
-	RegexLit
-	True
-	False
-	Null
-	Undefined
-
-	// misc
-	Quasi
-	JSXText
-	Underscore
-	LineComment
-	BlockComment
-	Colon
-	Question
-
-	// keywords
-	Fn
-	Get
-	Set
-	Static
-	Var
-	Val
-	Type
-	If
-	Else
-	Match
-	Try
-	Catch
-	Finally
-	Throw
+	Ampersand TokenType = iota
+	AmpersandAmpersand
+	Any
+	Arrow
+	Asterisk
 	Async
 	Await
-	Gen
-	Yield
-	Return
-	Import
-	Export
-	Declare
-
-	// type annotations
-	Number
-	String
-	Boolean
-	Any
-
-	// operators
-	Plus
-	Minus
-	Asterisk
-	Slash
-	SlashGreaterThan
-	Dot
-	Comma
 	BackTick
+	Bang
+	BlockComment
+	Boolean
+	Catch
+	CloseBrace
+	CloseBracket
+	CloseParen
+	Colon
+	Comma
+	Declare
+	Do
+	Dot
+	DotDotDot
+	Else
+	EndOfFile
 	Equal
 	EqualEqual
-	NotEqual
-	LessThan
-	LessThanEqual
+	Export
+	False
+	FatArrow
+	Fn
+	For
+	Gen
+	Get
 	GreaterThan
 	GreaterThanEqual
-	LessThanSlash // Used for JSX
-	DotDotDot
-	Arrow
-	FatArrow
-	Bang
-	Ampersand
-	AmpersandAmpersand
-	Pipe
-	PipePipe
-
-	// optional chaining
-	QuestionOpenParen
-	QuestionDot
-	QuestionOpenBracket
-
-	// grouping
-	OpenParen
-	CloseParen
-	OpenBrace
-	CloseBrace
-	OpenBracket
-	CloseBracket
-
-	Invalid
-	EndOfFile
-
-	Mut
-	For
+	Identifier
+	If
+	Import
 	In
 	Infer
+	Invalid
+	JSXText
+	LessThan
+	LessThanEqual
+	LessThanSlash // Used for JSX
+	LineComment
+	Match
+	Minus
+	Mut
 	Never
-	Unknown
-	Do
+	NotEqual
+	Null
+	Number
+	NumLit
+	OpenBrace
+	OpenBracket
+	OpenParen
+	Pipe
+	PipePipe
+	Plus
 	PlusPlus
+	Quasi
+	Question
+	QuestionDot
+	QuestionOpenBracket
+	QuestionOpenParen
+	RegexLit
+	Return
+	Set
+	Slash
+	SlashGreaterThan
+	Static
+	String
+	StrLit
+	Throw
 	Throws
+	True
+	Try
+	Type
+	Undefined
+	Underscore
+	Unknown
+	Val
+	Var
+	Yield
 )
 
 type Token struct {


### PR DESCRIPTION
Instead of using `finally` for resource cleanup, I'm probably going to go with something based https://fsharpforfunandprofit.com/posts/let-use-do/#use-bindings.  There's a bunch of other functional related stuff I need to implement before I get to that.