### PR TITLE
Fix #138

### DIFF
--- a/internal/checker/infer.go
+++ b/internal/checker/infer.go
@@ -1277,7 +1277,7 @@ func (c *Checker) inferFuncSig(
 		params[i] = &FuncParam{
 			Pattern:  patToPat(param.Pattern),
 			Type:     typeAnn,
-			Optional: false, // TODO
+			Optional: param.Optional,
 		}
 	}
 
@@ -1681,7 +1681,10 @@ func (c *Checker) inferPattern(
 					t, elemErrors := inferPatRec(elem.Value)
 					errors = append(errors, elemErrors...)
 					name := NewStrKey(elem.Key.Name)
-					elems = append(elems, NewPropertyElemType(name, t))
+					optional := elem.Default != nil
+					prop := NewPropertyElemType(name, t)
+					prop.Optional = optional
+					elems = append(elems, prop)
 				case *ast.ObjShorthandPat:
 					// We can't infer the type of the shorthand pattern yet, so
 					// we use a fresh type variable.
@@ -1700,7 +1703,10 @@ func (c *Checker) inferPattern(
 						Type:    t,
 						Mutable: false, // TODO
 					}
-					elems = append(elems, NewPropertyElemType(name, t))
+					optional := elem.Default != nil
+					prop := NewPropertyElemType(name, t)
+					prop.Optional = optional
+					elems = append(elems, prop)
 				case *ast.ObjRestPat:
 					t, restErrors := inferPatRec(elem.Pattern)
 					errors = slices.Concat(errors, restErrors)
@@ -1834,7 +1840,7 @@ func (c *Checker) inferFuncTypeAnn(
 		params[i] = &FuncParam{
 			Pattern:  patToPat(param.Pattern),
 			Type:     typeAnn,
-			Optional: false,
+			Optional: param.Optional,
 		}
 	}
 	returnType, returnErrors := c.inferTypeAnn(ctx, funcTypeAnn.Return)

--- a/internal/checker/infer_test.go
+++ b/internal/checker/infer_test.go
@@ -304,6 +304,26 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"add": "fn ({x::number, y::number}) -> number throws never",
 			},
 		},
+		"FuncExprObjectPatternWithInlineTypeAnnAndDefaults": {
+			input: `
+				val add = fn ({x::number = 0, y::number = 0}) {
+					return x + y
+				}
+			`,
+			expectedTypes: map[string]string{
+				"add": "fn ({x?::number, y?::number}) -> number throws never",
+			},
+		},
+		"FuncExprObjectPatternWithInlineTypeAnnAndDefaultsDeep": {
+			input: `
+				val add = fn ({a: {b: {c:: number = 0}}}) {
+					return c
+				}
+			`,
+			expectedTypes: map[string]string{
+				"add": "fn ({a: {b: {c?::number}}}) -> number throws never",
+			},
+		},
 		"FuncExprObjectPatternWithInlineTypeAnnAndRenamining": {
 			input: `
 				val add = fn ({x: a:number, y: b:number}) {


### PR DESCRIPTION
If a function parameter is an object with defaults, those properties will now be marked as optional, e.g.
```ts
// foo.esc
val add = fn ({x::number = 0, y::number = 0}) {
	return x + y
}

// foo.d.ts
declare function add ({x?:number, y?:number}): number;
```