### PR TITLE
Update CLI build command to take one or more package dirs as input

### DIFF
--- a/cmd/escalier/fixture_test.go
+++ b/cmd/escalier/fixture_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -79,9 +78,7 @@ func checkFixture(t *testing.T, fixtureDir string) {
 	err = os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	// find all .esc files in the fixture directory and copy them over to the tmpDir
-	// maintaining the directory structure
-
+	// Copy the fixture's lib and bin directories over to the temp directory
 	_, err = os.Stat(filepath.Join(fixtureDir, "lib"))
 	if !os.IsNotExist(err) {
 		err = copyDir(filepath.Join(fixtureDir, "lib"), filepath.Join(tmpDir, "lib"))
@@ -94,53 +91,12 @@ func checkFixture(t *testing.T, fixtureDir string) {
 		require.NoError(t, err)
 	}
 
-	// Find all .esc files in the lib directory
-	var files []string
-	_, err = os.Stat("lib")
-	if !os.IsNotExist(err) {
-		err = filepath.WalkDir("lib", func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-
-			// Check if it's a file and ends with .esc
-			if !d.IsDir() && strings.HasSuffix(d.Name(), ".esc") {
-				files = append(files, path)
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "failed to walk directory:", err)
-			return
-		}
-	}
-
-	_, err = os.Stat("bin")
-	if !os.IsNotExist(err) {
-		err = filepath.WalkDir("bin", func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-
-			// Check if it's a file and ends with .esc
-			if !d.IsDir() && strings.HasSuffix(d.Name(), ".esc") {
-				files = append(files, path)
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "failed to walk directory:", err)
-			return
-		}
-	}
+	// files, err := compiler.FindSourceFiles()
+	// require.NoError(t, err)
 
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
-	build(stdout, stderr, files)
+	build(stdout, stderr, []string{"."})
 	fmt.Println("stderr =", stderr.String())
 
 	if os.Getenv("UPDATE_FIXTURES") == "true" {

--- a/cmd/escalier/main.go
+++ b/cmd/escalier/main.go
@@ -8,8 +8,6 @@ import (
 
 func main() {
 	buildCmd := flag.NewFlagSet("build", flag.ExitOnError)
-	buildOut := buildCmd.String("out", "", "out")
-
 	formatCmd := flag.NewFlagSet("format", flag.ExitOnError)
 
 	if len(os.Args) < 2 {
@@ -24,9 +22,6 @@ func main() {
 			fmt.Println("failed to parse build command")
 			os.Exit(1)
 		}
-		fmt.Println("subcommand 'build'")
-		fmt.Println("  out:", *buildOut)
-		fmt.Println("  tail:", buildCmd.Args())
 		build(os.Stdout, os.Stderr, buildCmd.Args())
 	case "format":
 		err := formatCmd.Parse(os.Args[2:])

--- a/fixtures/basics/async_await/package.json
+++ b/fixtures/basics/async_await/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-async_await",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/comments/package.json
+++ b/fixtures/basics/comments/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-comments",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/destructuring/package.json
+++ b/fixtures/basics/destructuring/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-destructuring",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/do/package.json
+++ b/fixtures/basics/do/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-do",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/enum/package.json
+++ b/fixtures/basics/enum/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-enum",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/exception_handling/package.json
+++ b/fixtures/basics/exception_handling/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-execption_handling",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/generic_enum/package.json
+++ b/fixtures/basics/generic_enum/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-generic_enum",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/literals/package.json
+++ b/fixtures/basics/literals/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-literals",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/logging/package.json
+++ b/fixtures/basics/logging/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-logging",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/objects/package.json
+++ b/fixtures/basics/objects/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-objects",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/objects_with_computed_members/package.json
+++ b/fixtures/basics/objects_with_computed_members/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-objects_with_computed_members",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/objects_with_generic_methods/package.json
+++ b/fixtures/basics/objects_with_generic_methods/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-objects_with_generic_methods",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/objects_with_self/package.json
+++ b/fixtures/basics/objects_with_self/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-objects_with_self",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/operators/package.json
+++ b/fixtures/basics/operators/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-operators",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/pattern_matching/package.json
+++ b/fixtures/basics/pattern_matching/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-pattern_matching",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/symbols/package.json
+++ b/fixtures/basics/symbols/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-symbols",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/basics/template_literal_types/package.json
+++ b/fixtures/basics/template_literal_types/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "basics-template_literal_types",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/classes/class_with_computed_members/package.json
+++ b/fixtures/classes/class_with_computed_members/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "classes-class_with_computed_members",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/classes/class_with_fluent_mutating_methods/package.json
+++ b/fixtures/classes/class_with_fluent_mutating_methods/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "classes-class_with_fluent_mutating_methods",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/classes/class_with_generic_methods/package.json
+++ b/fixtures/classes/class_with_generic_methods/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "classes-class_with_generic_methods",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/classes/class_with_getter_setter/package.json
+++ b/fixtures/classes/class_with_getter_setter/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "classes-class_with_getter_setter",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/classes/class_with_static_members/package.json
+++ b/fixtures/classes/class_with_static_members/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "classes-class_with_static_members",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/classes/generic_class/package.json
+++ b/fixtures/classes/generic_class/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "classes-generic_class",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/errors/incomplete_fn/package.json
+++ b/fixtures/errors/incomplete_fn/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "errors-incomplete_fn",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/errors/not_enough_elements/package.json
+++ b/fixtures/errors/not_enough_elements/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "errors-not_enough_elements",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/extractors/arg_with_init/package.json
+++ b/fixtures/extractors/arg_with_init/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "extractors-arg_with_init",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/extractors/basic/package.json
+++ b/fixtures/extractors/basic/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "extractors-basic",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/extractors/inside_namespaces/package.json
+++ b/fixtures/extractors/inside_namespaces/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "extractors-inside_namespaces",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/extractors/nested/package.json
+++ b/fixtures/extractors/nested/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "extractors-nested",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/extractors/rest_arg/package.json
+++ b/fixtures/extractors/rest_arg/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "extractors-rest_arg",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/extractors/with_defaults/package.json
+++ b/fixtures/extractors/with_defaults/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "extractors-with_defaults",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/functions/destructuring/package.json
+++ b/fixtures/functions/destructuring/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "functions-destructuring",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/functions/func_decl/package.json
+++ b/fixtures/functions/func_decl/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "functions-func_decl",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/functions/func_expr/package.json
+++ b/fixtures/functions/func_expr/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "functions-func_expr",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/functions/generics/package.json
+++ b/fixtures/functions/generics/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "functions-generics",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/functions/generics_with_constraints/package.json
+++ b/fixtures/functions/generics_with_constraints/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "functions-generics_with_constraints",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/functions/rest_params/package.json
+++ b/fixtures/functions/rest_params/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "functions-rest_params",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/namespaces/complex_chain/package.json
+++ b/fixtures/namespaces/complex_chain/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "namespaces-complex_chain",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/namespaces/cross_namespace/package.json
+++ b/fixtures/namespaces/cross_namespace/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "namespaces-cross_namespace",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/namespaces/simple_same_namespace/package.json
+++ b/fixtures/namespaces/simple_same_namespace/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "namespaces-simple_same_namespace",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/namespaces/type_aliases/package.json
+++ b/fixtures/namespaces/type_aliases/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "namespaces-type_aliases",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/packages/bin_and_lib/package.json
+++ b/fixtures/packages/bin_and_lib/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "packages-bin_and_lib",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js",
+    "bin": {
+        "foo": "build/bin/foo.js"
+    }
+}

--- a/fixtures/packages/bin_only/package.json
+++ b/fixtures/packages/bin_only/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "packages-bin",
+    "version": "0.0.1",
+    "type": "module",
+    "bin": {
+        "foo": "build/bin/foo.js"
+    }
+}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -463,7 +463,6 @@ func (c *Checker) unify(ctx Context, t1, t2 Type) []Error {
 						}
 
 						paramType := methodElem.Fn.Params[0].Type
-						fmt.Fprintf(os.Stderr, "Unifying %s with extractor param type %s\n", paramType.String(), t1.String())
 						errors := c.unify(ctx, t1, paramType)
 
 						if tuple, ok := methodElem.Fn.Return.(*TupleType); ok {


### PR DESCRIPTION
This PR also adds package.json files to each fixture.  The package.json is important because not only does it specify the main entry point and bin paths, it also specifies `"type": "module"` which avoids a warning from node about naming ES6 modules using the .js extension.