### PR TITLE
Fix more .d.ts parser errors

### DIFF
--- a/internal/dts_parser/__snapshots__/comment_test.snap
+++ b/internal/dts_parser/__snapshots__/comment_test.snap
@@ -593,3 +593,917 @@
     },
 }
 ---
+
+[TestInlineCommentsInConditionalTypes/inline_comment_after_question_mark - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Foo",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:9},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:10},
+                            End:      ast.Location{Line:1, Column:11},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:10},
+                        End:      ast.Location{Line:1, Column:11},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:15},
+                            End:      ast.Location{Line:1, Column:16},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:15},
+                        End:      ast.Location{Line:1, Column:16},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.PrimitiveType{
+                    Kind: 6,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:25},
+                        End:      ast.Location{Line:1, Column:31},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.PrimitiveType{
+                    Kind: 7,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:45},
+                        End:      ast.Location{Line:1, Column:51},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.PrimitiveType{
+                    Kind: 8,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:54},
+                        End:      ast.Location{Line:1, Column:61},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:15},
+                    End:      ast.Location{Line:1, Column:61},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:61},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestInlineCommentsInConditionalTypes/inline_comment_after_colon - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Foo",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:9},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:10},
+                            End:      ast.Location{Line:1, Column:11},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:10},
+                        End:      ast.Location{Line:1, Column:11},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:15},
+                            End:      ast.Location{Line:1, Column:16},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:15},
+                        End:      ast.Location{Line:1, Column:16},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.PrimitiveType{
+                    Kind: 6,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:25},
+                        End:      ast.Location{Line:1, Column:31},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.PrimitiveType{
+                    Kind: 7,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:34},
+                        End:      ast.Location{Line:1, Column:40},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.PrimitiveType{
+                    Kind: 8,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:54},
+                        End:      ast.Location{Line:1, Column:61},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:15},
+                    End:      ast.Location{Line:1, Column:61},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:61},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestInlineCommentsInConditionalTypes/inline_comments_after_both - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Foo",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:9},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:10},
+                            End:      ast.Location{Line:1, Column:11},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:10},
+                        End:      ast.Location{Line:1, Column:11},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:15},
+                            End:      ast.Location{Line:1, Column:16},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:15},
+                        End:      ast.Location{Line:1, Column:16},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.PrimitiveType{
+                    Kind: 6,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:25},
+                        End:      ast.Location{Line:1, Column:31},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.PrimitiveType{
+                    Kind: 7,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:42},
+                        End:      ast.Location{Line:1, Column:48},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.PrimitiveType{
+                    Kind: 8,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:60},
+                        End:      ast.Location{Line:1, Column:67},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:15},
+                    End:      ast.Location{Line:1, Column:67},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:67},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestInlineCommentsInConditionalTypes/line_comment_after_question_mark - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Foo",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:9},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:10},
+                            End:      ast.Location{Line:1, Column:11},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:10},
+                        End:      ast.Location{Line:1, Column:11},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:15},
+                            End:      ast.Location{Line:1, Column:16},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:15},
+                        End:      ast.Location{Line:1, Column:16},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.PrimitiveType{
+                    Kind: 6,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:25},
+                        End:      ast.Location{Line:1, Column:31},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.PrimitiveType{
+                    Kind: 7,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:2, Column:5},
+                        End:      ast.Location{Line:2, Column:11},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.PrimitiveType{
+                    Kind: 8,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:2, Column:14},
+                        End:      ast.Location{Line:2, Column:21},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:15},
+                    End:      ast.Location{Line:2, Column:21},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:2, Column:21},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestInlineCommentsInConditionalTypes/line_comment_after_colon - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Foo",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:9},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:10},
+                            End:      ast.Location{Line:1, Column:11},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:10},
+                        End:      ast.Location{Line:1, Column:11},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:15},
+                            End:      ast.Location{Line:1, Column:16},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:15},
+                        End:      ast.Location{Line:1, Column:16},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.PrimitiveType{
+                    Kind: 6,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:25},
+                        End:      ast.Location{Line:1, Column:31},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.PrimitiveType{
+                    Kind: 7,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:34},
+                        End:      ast.Location{Line:1, Column:40},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.PrimitiveType{
+                    Kind: 8,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:2, Column:5},
+                        End:      ast.Location{Line:2, Column:12},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:15},
+                    End:      ast.Location{Line:2, Column:12},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:2, Column:12},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestInlineCommentsInConditionalTypes/simplified_Awaited_type - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Awaited",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:13},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:14},
+                            End:      ast.Location{Line:1, Column:15},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:14},
+                        End:      ast.Location{Line:1, Column:15},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:19},
+                            End:      ast.Location{Line:1, Column:20},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:19},
+                        End:      ast.Location{Line:1, Column:20},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.UnionType{
+                    Types: {
+                        &dts_parser.PrimitiveType{
+                            Kind: 3,
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:29},
+                                End:      ast.Location{Line:1, Column:33},
+                                SourceID: 0,
+                            },
+                        },
+                        &dts_parser.PrimitiveType{
+                            Kind: 4,
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:36},
+                                End:      ast.Location{Line:1, Column:45},
+                                SourceID: 0,
+                            },
+                        },
+                    },
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:29},
+                        End:      ast.Location{Line:1, Column:45},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:48},
+                            End:      ast.Location{Line:1, Column:49},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:48},
+                        End:      ast.Location{Line:1, Column:49},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.ConditionalType{
+                    CheckType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "T",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:2, Column:5},
+                                End:      ast.Location{Line:2, Column:6},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:2, Column:5},
+                            End:      ast.Location{Line:2, Column:6},
+                            SourceID: 0,
+                        },
+                    },
+                    ExtendsType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "object",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:2, Column:15},
+                                End:      ast.Location{Line:2, Column:21},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:2, Column:15},
+                            End:      ast.Location{Line:2, Column:21},
+                            SourceID: 0,
+                        },
+                    },
+                    TrueType: &dts_parser.PrimitiveType{
+                        Kind: 5,
+                        span: ast.Span{
+                            Start:    ast.Location{Line:2, Column:24},
+                            End:      ast.Location{Line:2, Column:29},
+                            SourceID: 0,
+                        },
+                    },
+                    FalseType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "T",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:3, Column:5},
+                                End:      ast.Location{Line:3, Column:6},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:3, Column:5},
+                            End:      ast.Location{Line:3, Column:6},
+                            SourceID: 0,
+                        },
+                    },
+                    span: ast.Span{
+                        Start:    ast.Location{Line:2, Column:5},
+                        End:      ast.Location{Line:3, Column:6},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:19},
+                    End:      ast.Location{Line:3, Column:6},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:3, Column:6},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestInlineCommentsInConditionalTypes/full_Awaited-like_type - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Awaited",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:13},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:14},
+                            End:      ast.Location{Line:1, Column:15},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:14},
+                        End:      ast.Location{Line:1, Column:15},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:19},
+                            End:      ast.Location{Line:1, Column:20},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:19},
+                        End:      ast.Location{Line:1, Column:20},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.UnionType{
+                    Types: {
+                        &dts_parser.PrimitiveType{
+                            Kind: 3,
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:29},
+                                End:      ast.Location{Line:1, Column:33},
+                                SourceID: 0,
+                            },
+                        },
+                        &dts_parser.PrimitiveType{
+                            Kind: 4,
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:36},
+                                End:      ast.Location{Line:1, Column:45},
+                                SourceID: 0,
+                            },
+                        },
+                    },
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:29},
+                        End:      ast.Location{Line:1, Column:45},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:48},
+                            End:      ast.Location{Line:1, Column:49},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:48},
+                        End:      ast.Location{Line:1, Column:49},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.ConditionalType{
+                    CheckType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "T",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:2, Column:5},
+                                End:      ast.Location{Line:2, Column:6},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:2, Column:5},
+                            End:      ast.Location{Line:2, Column:6},
+                            SourceID: 0,
+                        },
+                    },
+                    ExtendsType: &dts_parser.IntersectionType{
+                        Types: {
+                            &dts_parser.TypeReference{
+                                Name: &dts_parser.Ident{
+                                    Name: "object",
+                                    span: ast.Span{
+                                        Start:    ast.Location{Line:2, Column:15},
+                                        End:      ast.Location{Line:2, Column:21},
+                                        SourceID: 0,
+                                    },
+                                },
+                                TypeArgs: nil,
+                                span:     ast.Span{
+                                    Start:    ast.Location{Line:2, Column:15},
+                                    End:      ast.Location{Line:2, Column:21},
+                                    SourceID: 0,
+                                },
+                            },
+                            &dts_parser.ObjectType{
+                                Members: {
+                                    &dts_parser.MethodSignature{
+                                        Name:       &!%v(DEPTH EXCEEDED),
+                                        TypeParams: nil,
+                                        Params:     {
+                                            &!%v(DEPTH EXCEEDED),
+                                        },
+                                        ReturnType: &!%v(DEPTH EXCEEDED),
+                                        Optional:   false,
+                                        span:       ast.Span{
+                                            Start:    ast.Location{Line:2, Column:26},
+                                            End:      ast.Location{Line:2, Column:57},
+                                            SourceID: 0,
+                                        },
+                                    },
+                                },
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:2, Column:24},
+                                    End:      ast.Location{Line:2, Column:60},
+                                    SourceID: 0,
+                                },
+                            },
+                        },
+                        span: ast.Span{
+                            Start:    ast.Location{Line:2, Column:15},
+                            End:      ast.Location{Line:2, Column:60},
+                            SourceID: 0,
+                        },
+                    },
+                    TrueType: &dts_parser.ConditionalType{
+                        CheckType: &dts_parser.TypeReference{
+                            Name: &dts_parser.Ident{
+                                Name: "F",
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:3, Column:9},
+                                    End:      ast.Location{Line:3, Column:10},
+                                    SourceID: 0,
+                                },
+                            },
+                            TypeArgs: nil,
+                            span:     ast.Span{
+                                Start:    ast.Location{Line:3, Column:9},
+                                End:      ast.Location{Line:3, Column:10},
+                                SourceID: 0,
+                            },
+                        },
+                        ExtendsType: &dts_parser.ParenthesizedType{
+                            Type: &dts_parser.FunctionType{
+                                TypeParams: nil,
+                                Params:     {
+                                    &dts_parser.Param{
+                                        Name: &dts_parser.Ident{
+                                            Name: "value",
+                                            span: ast.Span{
+                                                Start:    ast.Location{Line:3, Column:21},
+                                                End:      ast.Location{Line:3, Column:26},
+                                                SourceID: 0,
+                                            },
+                                        },
+                                        Type: &dts_parser.InferType{
+                                            TypeParam: &!%v(DEPTH EXCEEDED),
+                                            span:      ast.Span{
+                                                Start:    ast.Location{Line:3, Column:28},
+                                                End:      ast.Location{Line:3, Column:35},
+                                                SourceID: 0,
+                                            },
+                                        },
+                                        Optional: false,
+                                        Rest:     false,
+                                        span:     ast.Span{
+                                            Start:    ast.Location{Line:3, Column:21},
+                                            End:      ast.Location{Line:3, Column:35},
+                                            SourceID: 0,
+                                        },
+                                    },
+                                },
+                                ReturnType: &dts_parser.PrimitiveType{
+                                    Kind: 0,
+                                    span: ast.Span{
+                                        Start:    ast.Location{Line:3, Column:40},
+                                        End:      ast.Location{Line:3, Column:43},
+                                        SourceID: 0,
+                                    },
+                                },
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:3, Column:20},
+                                    End:      ast.Location{Line:3, Column:43},
+                                    SourceID: 0,
+                                },
+                            },
+                            span: ast.Span{
+                                Start:    ast.Location{Line:3, Column:19},
+                                End:      ast.Location{Line:3, Column:44},
+                                SourceID: 0,
+                            },
+                        },
+                        TrueType: &dts_parser.TypeReference{
+                            Name: &dts_parser.Ident{
+                                Name: "Awaited",
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:4, Column:13},
+                                    End:      ast.Location{Line:4, Column:20},
+                                    SourceID: 0,
+                                },
+                            },
+                            TypeArgs: {
+                                &dts_parser.TypeReference{
+                                    Name: &dts_parser.Ident{
+                                        Name: "V",
+                                        span: ast.Span{
+                                            Start:    ast.Location{Line:4, Column:21},
+                                            End:      ast.Location{Line:4, Column:22},
+                                            SourceID: 0,
+                                        },
+                                    },
+                                    TypeArgs: nil,
+                                    span:     ast.Span{
+                                        Start:    ast.Location{Line:4, Column:21},
+                                        End:      ast.Location{Line:4, Column:22},
+                                        SourceID: 0,
+                                    },
+                                },
+                            },
+                            span: ast.Span{
+                                Start:    ast.Location{Line:4, Column:13},
+                                End:      ast.Location{Line:4, Column:23},
+                                SourceID: 0,
+                            },
+                        },
+                        FalseType: &dts_parser.PrimitiveType{
+                            Kind: 5,
+                            span: ast.Span{
+                                Start:    ast.Location{Line:5, Column:9},
+                                End:      ast.Location{Line:5, Column:14},
+                                SourceID: 0,
+                            },
+                        },
+                        span: ast.Span{
+                            Start:    ast.Location{Line:3, Column:9},
+                            End:      ast.Location{Line:5, Column:14},
+                            SourceID: 0,
+                        },
+                    },
+                    FalseType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "T",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:6, Column:5},
+                                End:      ast.Location{Line:6, Column:6},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:6, Column:5},
+                            End:      ast.Location{Line:6, Column:6},
+                            SourceID: 0,
+                        },
+                    },
+                    span: ast.Span{
+                        Start:    ast.Location{Line:2, Column:5},
+                        End:      ast.Location{Line:6, Column:6},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:19},
+                    End:      ast.Location{Line:6, Column:6},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:6, Column:7},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---

--- a/internal/dts_parser/__snapshots__/decl_test.snap
+++ b/internal/dts_parser/__snapshots__/decl_test.snap
@@ -6878,3 +6878,452 @@
     },
 }
 ---
+
+[TestTypeAliasDeclarations/mapped_type_with_optional - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Partial",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:13},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:14},
+                            End:      ast.Location{Line:1, Column:15},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:14},
+                        End:      ast.Location{Line:1, Column:15},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.MappedType{
+                TypeParam: &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "P",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:22},
+                            End:      ast.Location{Line:1, Column:23},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: &dts_parser.KeyOfType{
+                        Type: &dts_parser.TypeReference{
+                            Name: &dts_parser.Ident{
+                                Name: "T",
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:1, Column:33},
+                                    End:      ast.Location{Line:1, Column:34},
+                                    SourceID: 0,
+                                },
+                            },
+                            TypeArgs: nil,
+                            span:     ast.Span{
+                                Start:    ast.Location{Line:1, Column:33},
+                                End:      ast.Location{Line:1, Column:34},
+                                SourceID: 0,
+                            },
+                        },
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:27},
+                            End:      ast.Location{Line:1, Column:34},
+                            SourceID: 0,
+                        },
+                    },
+                    Default: nil,
+                    span:    ast.Span{
+                        Start:    ast.Location{Line:1, Column:22},
+                        End:      ast.Location{Line:1, Column:34},
+                        SourceID: 0,
+                    },
+                },
+                ValueType: &dts_parser.IndexedAccessType{
+                    ObjectType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "T",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:38},
+                                End:      ast.Location{Line:1, Column:39},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:1, Column:38},
+                            End:      ast.Location{Line:1, Column:39},
+                            SourceID: 0,
+                        },
+                    },
+                    IndexType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "P",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:40},
+                                End:      ast.Location{Line:1, Column:41},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:1, Column:40},
+                            End:      ast.Location{Line:1, Column:41},
+                            SourceID: 0,
+                        },
+                    },
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:38},
+                        End:      ast.Location{Line:1, Column:42},
+                        SourceID: 0,
+                    },
+                },
+                Optional: 1,
+                Readonly: 0,
+                AsClause: nil,
+                span:     ast.Span{
+                    Start:    ast.Location{Line:1, Column:19},
+                    End:      ast.Location{Line:1, Column:44},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:44},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestTypeAliasDeclarations/mapped_type_with_trailing_semicolon - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "Partial",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:13},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:14},
+                            End:      ast.Location{Line:1, Column:15},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: nil,
+                    Default:    nil,
+                    span:       ast.Span{
+                        Start:    ast.Location{Line:1, Column:14},
+                        End:      ast.Location{Line:1, Column:15},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.MappedType{
+                TypeParam: &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "P",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:21},
+                            End:      ast.Location{Line:1, Column:22},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: &dts_parser.KeyOfType{
+                        Type: &dts_parser.TypeReference{
+                            Name: &dts_parser.Ident{
+                                Name: "T",
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:1, Column:32},
+                                    End:      ast.Location{Line:1, Column:33},
+                                    SourceID: 0,
+                                },
+                            },
+                            TypeArgs: nil,
+                            span:     ast.Span{
+                                Start:    ast.Location{Line:1, Column:32},
+                                End:      ast.Location{Line:1, Column:33},
+                                SourceID: 0,
+                            },
+                        },
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:26},
+                            End:      ast.Location{Line:1, Column:33},
+                            SourceID: 0,
+                        },
+                    },
+                    Default: nil,
+                    span:    ast.Span{
+                        Start:    ast.Location{Line:1, Column:21},
+                        End:      ast.Location{Line:1, Column:33},
+                        SourceID: 0,
+                    },
+                },
+                ValueType: &dts_parser.IndexedAccessType{
+                    ObjectType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "T",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:37},
+                                End:      ast.Location{Line:1, Column:38},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:1, Column:37},
+                            End:      ast.Location{Line:1, Column:38},
+                            SourceID: 0,
+                        },
+                    },
+                    IndexType: &dts_parser.TypeReference{
+                        Name: &dts_parser.Ident{
+                            Name: "P",
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:39},
+                                End:      ast.Location{Line:1, Column:40},
+                                SourceID: 0,
+                            },
+                        },
+                        TypeArgs: nil,
+                        span:     ast.Span{
+                            Start:    ast.Location{Line:1, Column:39},
+                            End:      ast.Location{Line:1, Column:40},
+                            SourceID: 0,
+                        },
+                    },
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:37},
+                        End:      ast.Location{Line:1, Column:41},
+                        SourceID: 0,
+                    },
+                },
+                Optional: 1,
+                Readonly: 0,
+                AsClause: nil,
+                span:     ast.Span{
+                    Start:    ast.Location{Line:1, Column:19},
+                    End:      ast.Location{Line:1, Column:43},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:44},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---
+
+[TestTypeAliasDeclarations/ConstructorParameters_type - 1]
+&dts_parser.Module{
+    Statements: {
+        &dts_parser.DeclareTypeAlias{
+            Name: &dts_parser.Ident{
+                Name: "ConstructorParameters",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:6},
+                    End:      ast.Location{Line:1, Column:27},
+                    SourceID: 0,
+                },
+            },
+            TypeParams: {
+                &dts_parser.TypeParam{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:28},
+                            End:      ast.Location{Line:1, Column:29},
+                            SourceID: 0,
+                        },
+                    },
+                    Constraint: &dts_parser.ConstructorType{
+                        Abstract:   true,
+                        TypeParams: nil,
+                        Params:     {
+                            &dts_parser.Param{
+                                Name: &dts_parser.Ident{
+                                    Name: "args",
+                                    span: ast.Span{
+                                        Start:    ast.Location{Line:1, Column:55},
+                                        End:      ast.Location{Line:1, Column:59},
+                                        SourceID: 0,
+                                    },
+                                },
+                                Type: &dts_parser.PrimitiveType{
+                                    Kind: 0,
+                                    span: ast.Span{
+                                        Start:    ast.Location{Line:1, Column:61},
+                                        End:      ast.Location{Line:1, Column:64},
+                                        SourceID: 0,
+                                    },
+                                },
+                                Optional: false,
+                                Rest:     true,
+                                span:     ast.Span{
+                                    Start:    ast.Location{Line:1, Column:52},
+                                    End:      ast.Location{Line:1, Column:64},
+                                    SourceID: 0,
+                                },
+                            },
+                        },
+                        ReturnType: &dts_parser.PrimitiveType{
+                            Kind: 0,
+                            span: ast.Span{
+                                Start:    ast.Location{Line:1, Column:69},
+                                End:      ast.Location{Line:1, Column:72},
+                                SourceID: 0,
+                            },
+                        },
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:38},
+                            End:      ast.Location{Line:1, Column:72},
+                            SourceID: 0,
+                        },
+                    },
+                    Default: nil,
+                    span:    ast.Span{
+                        Start:    ast.Location{Line:1, Column:28},
+                        End:      ast.Location{Line:1, Column:72},
+                        SourceID: 0,
+                    },
+                },
+            },
+            TypeAnn: &dts_parser.ConditionalType{
+                CheckType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "T",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:76},
+                            End:      ast.Location{Line:1, Column:77},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:76},
+                        End:      ast.Location{Line:1, Column:77},
+                        SourceID: 0,
+                    },
+                },
+                ExtendsType: &dts_parser.ConstructorType{
+                    Abstract:   true,
+                    TypeParams: nil,
+                    Params:     {
+                        &dts_parser.Param{
+                            Name: &dts_parser.Ident{
+                                Name: "args",
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:1, Column:103},
+                                    End:      ast.Location{Line:1, Column:107},
+                                    SourceID: 0,
+                                },
+                            },
+                            Type: &dts_parser.InferType{
+                                TypeParam: &dts_parser.TypeParam{
+                                    Name: &dts_parser.Ident{
+                                        Name: "P",
+                                        span: ast.Span{
+                                            Start:    ast.Location{Line:1, Column:115},
+                                            End:      ast.Location{Line:1, Column:116},
+                                            SourceID: 0,
+                                        },
+                                    },
+                                    Constraint: nil,
+                                    Default:    nil,
+                                    span:       ast.Span{
+                                        Start:    ast.Location{Line:1, Column:109},
+                                        End:      ast.Location{Line:1, Column:116},
+                                        SourceID: 0,
+                                    },
+                                },
+                                span: ast.Span{
+                                    Start:    ast.Location{Line:1, Column:109},
+                                    End:      ast.Location{Line:1, Column:116},
+                                    SourceID: 0,
+                                },
+                            },
+                            Optional: false,
+                            Rest:     true,
+                            span:     ast.Span{
+                                Start:    ast.Location{Line:1, Column:100},
+                                End:      ast.Location{Line:1, Column:116},
+                                SourceID: 0,
+                            },
+                        },
+                    },
+                    ReturnType: &dts_parser.PrimitiveType{
+                        Kind: 0,
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:121},
+                            End:      ast.Location{Line:1, Column:124},
+                            SourceID: 0,
+                        },
+                    },
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:86},
+                        End:      ast.Location{Line:1, Column:124},
+                        SourceID: 0,
+                    },
+                },
+                TrueType: &dts_parser.TypeReference{
+                    Name: &dts_parser.Ident{
+                        Name: "P",
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:127},
+                            End:      ast.Location{Line:1, Column:128},
+                            SourceID: 0,
+                        },
+                    },
+                    TypeArgs: nil,
+                    span:     ast.Span{
+                        Start:    ast.Location{Line:1, Column:127},
+                        End:      ast.Location{Line:1, Column:128},
+                        SourceID: 0,
+                    },
+                },
+                FalseType: &dts_parser.PrimitiveType{
+                    Kind: 5,
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:131},
+                        End:      ast.Location{Line:1, Column:136},
+                        SourceID: 0,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:76},
+                    End:      ast.Location{Line:1, Column:136},
+                    SourceID: 0,
+                },
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:136},
+                SourceID: 0,
+            },
+        },
+    },
+}
+---

--- a/internal/dts_parser/__snapshots__/func_test.snap
+++ b/internal/dts_parser/__snapshots__/func_test.snap
@@ -1147,6 +1147,7 @@
 
 [TestConstructorTypes/simple_constructor - 1]
 &dts_parser.ConstructorType{
+    Abstract:   false,
     TypeParams: nil,
     Params:     {
     },
@@ -1176,6 +1177,7 @@
 
 [TestConstructorTypes/with_params - 1]
 &dts_parser.ConstructorType{
+    Abstract:   false,
     TypeParams: nil,
     Params:     {
         &dts_parser.Param{
@@ -1255,6 +1257,7 @@
 
 [TestConstructorTypes/with_type_params - 1]
 &dts_parser.ConstructorType{
+    Abstract:   false,
     TypeParams: {
         &dts_parser.TypeParam{
             Name: &dts_parser.Ident{
@@ -1352,6 +1355,7 @@
 
 [TestConstructorTypes/with_optional_param - 1]
 &dts_parser.ConstructorType{
+    Abstract:   false,
     TypeParams: nil,
     Params:     {
         &dts_parser.Param{
@@ -1406,6 +1410,7 @@
 
 [TestConstructorTypes/complex - 1]
 &dts_parser.ConstructorType{
+    Abstract:   false,
     TypeParams: {
         &dts_parser.TypeParam{
             Name: &dts_parser.Ident{
@@ -3331,6 +3336,156 @@
     span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:39},
+        SourceID: 0,
+    },
+}
+---
+
+[TestConstructorTypes/abstract_constructor - 1]
+&dts_parser.ConstructorType{
+    Abstract:   true,
+    TypeParams: nil,
+    Params:     {
+    },
+    ReturnType: &dts_parser.TypeReference{
+        Name: &dts_parser.Ident{
+            Name: "Object",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:20},
+                End:      ast.Location{Line:1, Column:26},
+                SourceID: 0,
+            },
+        },
+        TypeArgs: nil,
+        span:     ast.Span{
+            Start:    ast.Location{Line:1, Column:20},
+            End:      ast.Location{Line:1, Column:26},
+            SourceID: 0,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:26},
+        SourceID: 0,
+    },
+}
+---
+
+[TestConstructorTypes/abstract_with_params - 1]
+&dts_parser.ConstructorType{
+    Abstract:   true,
+    TypeParams: nil,
+    Params:     {
+        &dts_parser.Param{
+            Name: &dts_parser.Ident{
+                Name: "args",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:18},
+                    End:      ast.Location{Line:1, Column:22},
+                    SourceID: 0,
+                },
+            },
+            Type: &dts_parser.PrimitiveType{
+                Kind: 0,
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:24},
+                    End:      ast.Location{Line:1, Column:27},
+                    SourceID: 0,
+                },
+            },
+            Optional: false,
+            Rest:     true,
+            span:     ast.Span{
+                Start:    ast.Location{Line:1, Column:15},
+                End:      ast.Location{Line:1, Column:27},
+                SourceID: 0,
+            },
+        },
+    },
+    ReturnType: &dts_parser.PrimitiveType{
+        Kind: 0,
+        span: ast.Span{
+            Start:    ast.Location{Line:1, Column:32},
+            End:      ast.Location{Line:1, Column:35},
+            SourceID: 0,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:35},
+        SourceID: 0,
+    },
+}
+---
+
+[TestConstructorTypes/abstract_with_type_params - 1]
+&dts_parser.ConstructorType{
+    Abstract:   true,
+    TypeParams: {
+        &dts_parser.TypeParam{
+            Name: &dts_parser.Ident{
+                Name: "T",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:15},
+                    End:      ast.Location{Line:1, Column:16},
+                    SourceID: 0,
+                },
+            },
+            Constraint: nil,
+            Default:    nil,
+            span:       ast.Span{
+                Start:    ast.Location{Line:1, Column:15},
+                End:      ast.Location{Line:1, Column:16},
+                SourceID: 0,
+            },
+        },
+    },
+    Params: {
+        &dts_parser.Param{
+            Name: &dts_parser.Ident{
+                Name: "args",
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:21},
+                    End:      ast.Location{Line:1, Column:25},
+                    SourceID: 0,
+                },
+            },
+            Type: &dts_parser.PrimitiveType{
+                Kind: 0,
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:27},
+                    End:      ast.Location{Line:1, Column:30},
+                    SourceID: 0,
+                },
+            },
+            Optional: false,
+            Rest:     true,
+            span:     ast.Span{
+                Start:    ast.Location{Line:1, Column:18},
+                End:      ast.Location{Line:1, Column:30},
+                SourceID: 0,
+            },
+        },
+    },
+    ReturnType: &dts_parser.TypeReference{
+        Name: &dts_parser.Ident{
+            Name: "T",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:35},
+                End:      ast.Location{Line:1, Column:36},
+                SourceID: 0,
+            },
+        },
+        TypeArgs: nil,
+        span:     ast.Span{
+            Start:    ast.Location{Line:1, Column:35},
+            End:      ast.Location{Line:1, Column:36},
+            SourceID: 0,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:36},
         SourceID: 0,
     },
 }

--- a/internal/dts_parser/advanced.go
+++ b/internal/dts_parser/advanced.go
@@ -59,6 +59,9 @@ func (p *DtsParser) parseConditionalType(checkType TypeAnn) TypeAnn {
 		return checkType
 	}
 
+	// Skip any comments after '?'
+	p.skipComments()
+
 	// True and false branches can contain full conditional types
 	trueType := p.parseTypeAnn()
 	if trueType == nil {
@@ -70,6 +73,9 @@ func (p *DtsParser) parseConditionalType(checkType TypeAnn) TypeAnn {
 	if colon == nil {
 		return checkType
 	}
+
+	// Skip any comments after ':'
+	p.skipComments()
 
 	falseType := p.parseTypeAnn()
 	if falseType == nil {
@@ -142,6 +148,9 @@ func (p *DtsParser) parseMappedType() TypeAnn {
 	if start == nil {
 		return nil
 	}
+
+	// Skip comments after opening brace
+	p.skipComments()
 
 	// Parse optional readonly modifier
 	readonlyMod := ReadonlyNone
@@ -246,7 +255,10 @@ func (p *DtsParser) parseMappedType() TypeAnn {
 		return nil
 	}
 
-	// No need to check for semicolon - TypeScript doesn't require it in mapped types
+	// Consume optional semicolon or comma separator
+	if p.peek().Type == Semicolon || p.peek().Type == Comma {
+		p.consume()
+	}
 
 	end := p.expect(CloseBrace)
 	if end == nil {

--- a/internal/dts_parser/ast.go
+++ b/internal/dts_parser/ast.go
@@ -544,8 +544,9 @@ type FunctionType struct {
 
 func (f *FunctionType) Span() ast.Span { return f.span }
 
-// ConstructorType represents new (params) => ReturnType
+// ConstructorType represents new (params) => ReturnType or abstract new (params) => ReturnType
 type ConstructorType struct {
+	Abstract   bool
 	TypeParams []*TypeParam
 	Params     []*Param
 	ReturnType TypeAnn

--- a/internal/dts_parser/compound.go
+++ b/internal/dts_parser/compound.go
@@ -11,6 +11,9 @@ import (
 // parseTypeAnn parses a complete type annotation with unions, intersections, and conditionals
 // Precedence (lowest to highest): conditional > union > intersection > postfix
 func (p *DtsParser) parseTypeAnn() TypeAnn {
+	// Skip any leading comments
+	p.skipComments()
+
 	// Parse union/intersection types first (higher precedence than conditional)
 	left := p.parseUnionType()
 	if left == nil {

--- a/internal/dts_parser/decl_test.go
+++ b/internal/dts_parser/decl_test.go
@@ -140,6 +140,8 @@ func TestTypeAliasDeclarations(t *testing.T) {
 		{"generic type alias", "type Box<T> = { value: T }"},
 		{"conditional type", "type NonNullable<T> = T extends null | undefined ? never : T"},
 		{"mapped type", "type Readonly<T> = { readonly [K in keyof T]: T[K] }"},
+		{"mapped type with optional", "type Partial<T> = { [P in keyof T]?: T[P] }"},
+		{"mapped type with trailing semicolon", `type Partial<T> = {[P in keyof T]?: T[P];};`},
 		{"tuple type", "type Point = [number, number]"},
 		{"function type", "type Callback = (data: string) => void"},
 		{"ambient type alias", "declare type Name = string"},
@@ -151,6 +153,7 @@ func TestTypeAliasDeclarations(t *testing.T) {
 		{"generic type alias with semicolon", "type Box<T> = { value: T };"},
 		{"ambient type alias with semicolon", "declare type Name = string;"},
 		{"ambient generic type alias with semicolon", "declare type Box<T> = { value: T };"},
+		{"ConstructorParameters type", "type ConstructorParameters<T extends abstract new (...args: any) => any> = T extends abstract new (...args: infer P) => any ? P : never"},
 	}
 
 	for _, tt := range tests {

--- a/internal/dts_parser/func.go
+++ b/internal/dts_parser/func.go
@@ -57,9 +57,9 @@ func (p *DtsParser) parseFunctionType() TypeAnn {
 }
 
 // parseConstructorType parses a constructor type: new <T>(params) => ReturnType
-func (p *DtsParser) parseConstructorType() TypeAnn {
-	start := p.expect(New)
-	if start == nil {
+func (p *DtsParser) parseConstructorType(abstract bool, startSpan ast.Span) TypeAnn {
+	newToken := p.expect(New)
+	if newToken == nil {
 		return nil
 	}
 
@@ -95,12 +95,13 @@ func (p *DtsParser) parseConstructorType() TypeAnn {
 
 	endSpan := returnType.Span()
 	span := ast.Span{
-		Start:    start.Span.Start,
+		Start:    startSpan.Start,
 		End:      endSpan.End,
-		SourceID: start.Span.SourceID,
+		SourceID: startSpan.SourceID,
 	}
 
 	return &ConstructorType{
+		Abstract:   abstract,
 		TypeParams: typeParams,
 		Params:     params,
 		ReturnType: returnType,

--- a/internal/dts_parser/func_test.go
+++ b/internal/dts_parser/func_test.go
@@ -95,6 +95,9 @@ func TestConstructorTypes(t *testing.T) {
 		{"with type params", "new <T>(x: T) => MyClass<T>"},
 		{"with optional param", "new (x?: number) => MyClass"},
 		{"complex", "new <T extends Base>(x: T, y?: string) => Derived<T>"},
+		{"abstract constructor", "abstract new () => Object"},
+		{"abstract with params", "abstract new (...args: any) => any"},
+		{"abstract with type params", "abstract new <T>(...args: any) => T"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Added support for abstract new constructor type syntax
- Implemented comment skipping in conditional types and mapped types to handle inline documentation
- Fixed mapped type parsing to accept optional trailing semicolons/commas