### PR TITLE
Parse type params in interface methods

### DIFF
--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1047,6 +1047,39 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"red": "Color",
 			},
 		},
+		"GenericMethodInClass": {
+			input: `
+				class Foo {
+					bar<T>(self, value: T) -> T {
+						return value
+					}
+				}
+				declare val foo: Foo
+				val a = foo.bar(5)
+				val b = foo.bar("hello")
+			`,
+			expectedTypes: map[string]string{
+				"Foo": "{new fn () -> mut? Foo throws never}",
+				"foo": "Foo",
+				"a":   "5",
+				"b":   "\"hello\"",
+			},
+		},
+		"GenericMethodInInterface": {
+			input: `
+				interface Foo {
+					bar<T>(value: T) -> T,
+				}
+				declare val foo: Foo
+				val a = foo.bar(5)
+				val b = foo.bar("hello")
+			`,
+			expectedTypes: map[string]string{
+				"foo": "Foo",
+				"a":   "5",
+				"b":   "\"hello\"",
+			},
+		},
 	}
 
 	schema := loadSchema(t)

--- a/internal/interop/integration_test.go
+++ b/internal/interop/integration_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/checker"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
-	"github.com/escalier-lang/escalier/internal/printer"
 )
 
 func TestConvertModule_LibES5(t *testing.T) {
@@ -111,22 +110,16 @@ func TestConvertModule_LibES5(t *testing.T) {
 
 	t.Logf("Infer errors: %d", len(inferErrors))
 	if len(inferErrors) > 0 {
-		// Log first 10 infer errors for debugging
-		maxErrors := 10
-		if len(inferErrors) < maxErrors {
-			maxErrors = len(inferErrors)
-		}
-		t.Logf("First %d infer errors:", maxErrors)
-		for i := 0; i < maxErrors; i++ {
+		for i := 0; i < len(inferErrors); i++ {
 			t.Logf("  %v at %v", inferErrors[i].Message(), inferErrors[i].Span())
-			if e, ok := inferErrors[i].(*checker.UnknownTypeError); ok {
-				node := checker.GetNode(e.TypeRef.Provenance())
-				if node != nil {
-					str, _ := printer.Print(node, printer.DefaultOptions())
-					t.Logf("    node: %s", str)
-					t.Logf("    node: %#v", node)
-				}
-			}
+			// if e, ok := inferErrors[i].(*checker.UnknownTypeError); ok {
+			// 	node := checker.GetNode(e.TypeRef.Provenance())
+			// 	if node != nil {
+			// 		str, _ := printer.Print(node, printer.DefaultOptions())
+			// 		t.Logf("    node: %s", str)
+			// 		t.Logf("    node: %#v", node)
+			// 	}
+			// }
 		}
 	}
 

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -700,6 +700,10 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 	if objKey == nil {
 		return nil
 	}
+
+	// Parse optional type parameters for the method
+	typeParams := p.maybeTypeParams()
+
 	token = p.lexer.peek()
 
 	// nolint: exhaustive
@@ -776,7 +780,7 @@ func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 		}
 
 		fnTypeAnn := ast.NewFuncTypeAnn(
-			nil, // TODO: support type parameters on methods
+			typeParams,
 			params,
 			retType,
 			nil, // TODO: support throws clause


### PR DESCRIPTION
- Parser now calls maybeTypeParams() to parse type parameters before parsing method signatures in object type annotations
- Type checker creates a new scope for function type annotations to properly handle type parameters
- Tests added for generic methods in both classes and interfaces