### PR TITLE
Drop V2 suffix from all identifiers in the implementation

### DIFF
--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -87,7 +87,7 @@ const DEBUG = false
 // order.
 // TODO: all interface declarations in a namespace to shadow previous ones.
 func (c *Checker) InferModule(ctx Context, m *ast.Module) []Error {
-	depGraph := dep_graph.BuildDepGraphV2(m)
+	depGraph := dep_graph.BuildDepGraph(m)
 
 	// print out all of the dependencies in depGraph for debugging
 	if DEBUG {
@@ -107,7 +107,7 @@ func (c *Checker) InferModule(ctx Context, m *ast.Module) []Error {
 		}
 	}
 
-	return c.InferDepGraphV2(ctx, depGraph)
+	return c.InferDepGraph(ctx, depGraph)
 }
 
 // inferTypeParams infers type parameters from AST type parameters by creating

--- a/internal/checker/infer_module_v2.go
+++ b/internal/checker/infer_module_v2.go
@@ -14,19 +14,19 @@ import (
 // Callers of this function should create a new scope when inferring a module.
 // If it's inferring global declarations then it's okay to omit that step.
 // TODO: Create separate InferModuleDepGraph and InferGlobalDepGraph functions?
-func (c *Checker) InferDepGraphV2(ctx Context, depGraph *dep_graph.DepGraph) []Error {
+func (c *Checker) InferDepGraph(ctx Context, depGraph *dep_graph.DepGraph) []Error {
 	var errors []Error
 	for _, component := range depGraph.Components {
-		declsErrors := c.InferComponentV2(ctx, depGraph, component)
+		declsErrors := c.InferComponent(ctx, depGraph, component)
 		errors = slices.Concat(errors, declsErrors)
 	}
 
 	return errors
 }
 
-// GetNamespaceCtxV2 returns a new Context with its namespace set to the namespace of
+// GetNamespaceCtx returns a new Context with its namespace set to the namespace of
 // the binding with the given key. If the namespace doesn't exist yet, it creates one.
-func GetNamespaceCtxV2(
+func GetNamespaceCtx(
 	ctx Context,
 	depGraph *dep_graph.DepGraph,
 	key dep_graph.BindingKey,
@@ -47,7 +47,7 @@ func GetNamespaceCtxV2(
 	return nsCtx
 }
 
-func (c *Checker) InferComponentV2(
+func (c *Checker) InferComponent(
 	ctx Context,
 	depGraph *dep_graph.DepGraph,
 	component []dep_graph.BindingKey,
@@ -82,7 +82,7 @@ func (c *Checker) InferComponentV2(
 
 	// Infer placeholders
 	for _, key := range component {
-		nsCtx := GetNamespaceCtxV2(ctx, depGraph, key)
+		nsCtx := GetNamespaceCtx(ctx, depGraph, key)
 		decls := depGraph.GetDecls(key)
 
 		for _, decl := range decls {
@@ -531,7 +531,7 @@ func (c *Checker) InferComponentV2(
 	// Infer definitions - Pass 1: FuncDecl, ClassDecl, EnumDecl, TypeDecl, InterfaceDecl
 	// These need to be processed first so their inferred types are available for VarDecl
 	for _, key := range component {
-		nsCtx := GetNamespaceCtxV2(ctx, depGraph, key)
+		nsCtx := GetNamespaceCtx(ctx, depGraph, key)
 		decls := depGraph.GetDecls(key)
 
 		for _, decl := range decls {
@@ -1033,7 +1033,7 @@ func (c *Checker) InferComponentV2(
 	// VarDecl initializers are processed after other declarations so that
 	// function/method return types are already inferred and available.
 	for _, key := range component {
-		nsCtx := GetNamespaceCtxV2(ctx, depGraph, key)
+		nsCtx := GetNamespaceCtx(ctx, depGraph, key)
 		decls := depGraph.GetDecls(key)
 
 		for _, decl := range decls {

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -2188,7 +2188,7 @@ func TestGetDeclCtx(t *testing.T) {
 			depGraph.DeclNamespace.Set(key, test.declNamespace)
 
 			// Call getDeclCtx
-			resultCtx := GetNamespaceCtxV2(rootCtx, depGraph, key)
+			resultCtx := GetNamespaceCtx(rootCtx, depGraph, key)
 
 			// Verify the result context has the expected namespace
 			assert.Equal(t, test.expectedNS, resultCtx.Scope.Namespace)
@@ -2233,7 +2233,7 @@ func TestGetDeclCtxWithNonExistentDeclID(t *testing.T) {
 	key := dep_graph.ValueBindingKey("nonexistent")
 
 	// Call getDeclCtx - should return original context since namespace is empty
-	resultCtx := GetNamespaceCtxV2(rootCtx, depGraph, key)
+	resultCtx := GetNamespaceCtx(rootCtx, depGraph, key)
 
 	// Should return the same context since no namespace mapping exists
 	assert.Equal(t, rootCtx.Scope.Namespace, resultCtx.Scope.Namespace)
@@ -2280,7 +2280,7 @@ func TestGetDeclCtxNestedNamespaceOrder(t *testing.T) {
 	depGraph.DeclNamespace.Set(key, "foo.bar.baz.qux")
 
 	// Call getDeclCtx
-	resultCtx := GetNamespaceCtxV2(rootCtx, depGraph, key)
+	resultCtx := GetNamespaceCtx(rootCtx, depGraph, key)
 
 	// Verify the final context points to the deepest namespace
 	assert.Equal(t, quxNS, resultCtx.Scope.Namespace)
@@ -3030,9 +3030,9 @@ func TestInferDepGraphWithNamespaceDependencies(t *testing.T) {
 
 			depGraph, ctx := test.setup()
 
-			// Run InferDepGraphV2
+			// Run InferDepGraph
 			c := NewChecker()
-			errors := c.InferDepGraphV2(ctx, depGraph)
+			errors := c.InferDepGraph(ctx, depGraph)
 
 			// Verify results
 			test.expected(t, ctx.Scope.Namespace, errors)
@@ -3040,7 +3040,7 @@ func TestInferDepGraphWithNamespaceDependencies(t *testing.T) {
 	}
 }
 
-// newTestDepGraph creates a properly initialized DepGraphV2 for testing
+// newTestDepGraph creates a properly initialized DepGraph for testing
 func newTestDepGraph() *dep_graph.DepGraph {
 	return &dep_graph.DepGraph{
 		Decls:         btree.Map[dep_graph.BindingKey, []ast.Decl]{},

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -15,7 +15,7 @@ import (
 
 type Builder struct {
 	tempId        int
-	depGraphV2    *dep_graph.DepGraph
+	depGraph      *dep_graph.DepGraph
 	hasExtractor  bool
 	isModule      bool
 	inBlockScope  bool
@@ -1268,8 +1268,8 @@ func (b *Builder) buildExpr(expr ast.Expr, parent ast.Expr) (Expr, []Stmt) {
 		return NewUnaryExpr(UnaryOp(expr.Op), argExpr, expr), argStmts
 	case *ast.IdentExpr:
 		var namespaceStr string
-		if b.depGraphV2 != nil {
-			namespaceStr = b.depGraphV2.GetNamespaceString(expr.Namespace)
+		if b.depGraph != nil {
+			namespaceStr = b.depGraph.GetNamespaceString(expr.Namespace)
 		}
 		return NewIdentExpr(expr.Name, namespaceStr, expr), []Stmt{}
 	case *ast.CallExpr:

--- a/internal/codegen/builder_test.go
+++ b/internal/codegen/builder_test.go
@@ -97,11 +97,11 @@ models.utils.validation = {};`,
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Create a mock dependency graph
-			depGraph := dep_graph.NewDepGraphV2(test.namespaces)
+			depGraph := dep_graph.NewDepGraph(test.namespaces)
 
 			// Create a builder and test the method
-			builder := &Builder{tempId: 0, depGraphV2: depGraph}
-			stmts := builder.buildNamespaceStatementsV2(depGraph)
+			builder := &Builder{tempId: 0, depGraph: depGraph}
+			stmts := builder.buildNamespaceStatements(depGraph)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()
@@ -153,7 +153,7 @@ very.deep.nested.namespace.structure = {};`,
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			builder := &Builder{tempId: 0, depGraphV2: nil}
+			builder := &Builder{tempId: 0, depGraph: nil}
 			definedNamespaces := make(map[string]bool)
 			stmts := builder.buildNamespaceHierarchy(test.namespace, definedNamespaces)
 
@@ -172,7 +172,7 @@ very.deep.nested.namespace.structure = {};`,
 }
 
 func TestBuildNamespaceHierarchy_AvoidRedefinition(t *testing.T) {
-	builder := &Builder{tempId: 0, depGraphV2: nil}
+	builder := &Builder{tempId: 0, depGraph: nil}
 	definedNamespaces := make(map[string]bool)
 
 	// First call should generate all statements
@@ -428,7 +428,7 @@ Color.RGB = Color__RGB;`,
 			// Parse the declaration from source string
 			decl := parseDecl(t, test.declSource)
 
-			builder := &Builder{tempId: 0, depGraphV2: nil}
+			builder := &Builder{tempId: 0, depGraph: nil}
 			stmts := builder.buildDeclWithNamespace(decl, test.ns)
 
 			// Use the printer to generate the output
@@ -679,12 +679,12 @@ state.ui.isEnabled = state__ui__isEnabled;`,
 			// Ensure parsing was successful
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			// Build dependency graph using BuildDepGraphV2
-			depGraph := dep_graph.BuildDepGraphV2(module)
+			// Build dependency graph using BuildDepGraph
+			depGraph := dep_graph.BuildDepGraph(module)
 
-			// Create a builder and test BuildTopLevelDeclsV2
-			builder := &Builder{tempId: 0, depGraphV2: depGraph}
-			outModule := builder.BuildTopLevelDeclsV2(depGraph)
+			// Create a builder and test BuildTopLevelDecls
+			builder := &Builder{tempId: 0, depGraph: depGraph}
+			outModule := builder.BuildTopLevelDecls(depGraph)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()
@@ -790,12 +790,12 @@ app.utils.calculate = app__utils__calculate;`,
 			// Ensure parsing was successful
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			// Build dependency graph using BuildDepGraphV2
-			depGraph := dep_graph.BuildDepGraphV2(module)
+			// Build dependency graph using BuildDepGraph
+			depGraph := dep_graph.BuildDepGraph(module)
 
-			// Create a builder and test BuildTopLevelDeclsV2
-			builder := &Builder{tempId: 0, depGraphV2: depGraph}
-			outModule := builder.BuildTopLevelDeclsV2(depGraph)
+			// Create a builder and test BuildTopLevelDecls
+			builder := &Builder{tempId: 0, depGraph: depGraph}
+			outModule := builder.BuildTopLevelDecls(depGraph)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()
@@ -865,12 +865,12 @@ company.project.module.submodule.utils.constant = company__project__module__subm
 			// Ensure parsing was successful
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			// Build dependency graph using BuildDepGraphV2
-			depGraph := dep_graph.BuildDepGraphV2(module)
+			// Build dependency graph using BuildDepGraph
+			depGraph := dep_graph.BuildDepGraph(module)
 
-			// Create a builder and test BuildTopLevelDeclsV2
-			builder := &Builder{tempId: 0, depGraphV2: depGraph}
-			outModule := builder.BuildTopLevelDeclsV2(depGraph)
+			// Create a builder and test BuildTopLevelDecls
+			builder := &Builder{tempId: 0, depGraph: depGraph}
+			outModule := builder.BuildTopLevelDecls(depGraph)
 
 			// Use the printer to generate the output
 			printer := NewPrinter()

--- a/internal/codegen/builder_v2.go
+++ b/internal/codegen/builder_v2.go
@@ -10,18 +10,18 @@ import (
 	type_sys "github.com/escalier-lang/escalier/internal/type_system"
 )
 
-// BuildTopLevelDeclsV2 builds JavaScript code from a V2 dependency graph.
+// BuildTopLevelDecls builds JavaScript code from a V2 dependency graph.
 // This version uses BindingKey instead of DeclID and automatically handles
 // overloaded functions and interface merging.
-func (b *Builder) BuildTopLevelDeclsV2(depGraph *dep_graph.DepGraph) *Module {
+func (b *Builder) BuildTopLevelDecls(depGraph *dep_graph.DepGraph) *Module {
 	// Set up builder state
-	b.depGraphV2 = depGraph // Store V2 dep graph for namespace lookups
+	b.depGraph = depGraph // Store V2 dep graph for namespace lookups
 	b.isModule = true
 
 	var stmts []Stmt
 
 	// Build namespace hierarchy statements
-	nsStmts := b.buildNamespaceStatementsV2(depGraph)
+	nsStmts := b.buildNamespaceStatements(depGraph)
 	stmts = slices.Concat(stmts, nsStmts)
 
 	// Track which declarations we've already processed to avoid duplicates.
@@ -143,9 +143,9 @@ func (b *Builder) BuildTopLevelDeclsV2(depGraph *dep_graph.DepGraph) *Module {
 	}
 }
 
-// buildNamespaceStatementsV2 generates statements to create namespace objects
+// buildNamespaceStatements generates statements to create namespace objects
 // for all namespaces in the V2 dependency graph
-func (b *Builder) buildNamespaceStatementsV2(depGraph *dep_graph.DepGraph) []Stmt {
+func (b *Builder) buildNamespaceStatements(depGraph *dep_graph.DepGraph) []Stmt {
 	// Track which namespace segments have been defined to avoid redefinition
 	definedNamespaces := make(map[string]bool)
 	var stmts []Stmt
@@ -161,9 +161,9 @@ func (b *Builder) buildNamespaceStatementsV2(depGraph *dep_graph.DepGraph) []Stm
 	return stmts
 }
 
-// BuildDefinitionsV2 builds TypeScript .d.ts definitions from a V2 dependency graph.
+// BuildDefinitions builds TypeScript .d.ts definitions from a V2 dependency graph.
 // This version uses BindingKey instead of DeclID.
-func (b *Builder) BuildDefinitionsV2(
+func (b *Builder) BuildDefinitions(
 	depGraph *dep_graph.DepGraph,
 	moduleNS *type_sys.Namespace,
 ) *Module {

--- a/internal/codegen/printer_test.go
+++ b/internal/codegen/printer_test.go
@@ -42,8 +42,8 @@ fn sub(a, b) { return a - b }`,
 	p := parser.NewParser(ctx, source)
 	m1, _ := p.ParseScript()
 	builder := &Builder{
-		tempId:     0,
-		depGraphV2: nil,
+		tempId:   0,
+		depGraph: nil,
 	}
 	m2 := builder.BuildScript(m1)
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -107,7 +107,7 @@ func CompilePackage(sources []*ast.Source) CompilerOutput {
 
 	if len(libSources) > 0 {
 		inMod, parseErrors := parser.ParseLibFiles(ctx, libSources)
-		depGraph := dep_graph.BuildDepGraphV2(inMod)
+		depGraph := dep_graph.BuildDepGraph(inMod)
 
 		c := checker.NewChecker()
 		inferCtx := checker.Context{
@@ -116,15 +116,15 @@ func CompilePackage(sources []*ast.Source) CompilerOutput {
 			IsAsync:    false,
 			IsPatMatch: false,
 		}
-		typeErrors := c.InferDepGraphV2(inferCtx, depGraph)
+		typeErrors := c.InferDepGraph(inferCtx, depGraph)
 
 		// No longer need MergeOverloadedFunctions - overloads are already grouped by BindingKey
 
 		libNS = inferCtx.Scope.Namespace
 
 		builder := &codegen.Builder{}
-		jsMod := builder.BuildTopLevelDeclsV2(depGraph)
-		dtsMod := builder.BuildDefinitionsV2(depGraph, libNS)
+		jsMod := builder.BuildTopLevelDecls(depGraph)
+		dtsMod := builder.BuildDefinitions(depGraph, libNS)
 
 		printer := codegen.NewPrinter()
 		jsOutput := printer.PrintModule(jsMod)

--- a/internal/dep_graph/class_test.go
+++ b/internal/dep_graph/class_test.go
@@ -105,7 +105,7 @@ func TestClassDeclDependencies(t *testing.T) {
 			assert.Empty(t, errors, "Expected no parsing errors")
 
 			// Build the dependency graph
-			depGraph := BuildDepGraphV2(module)
+			depGraph := BuildDepGraph(module)
 
 			// Find the last binding key (which should be our class under test)
 			// We need to iterate through all components to find the last one
@@ -132,7 +132,7 @@ func TestClassDeclDependencies(t *testing.T) {
 			assert.True(t, ok, "Last declaration should be a ClassDecl")
 
 			// Find dependencies
-			deps := FindDeclDependenciesV2(lastKey, depGraph)
+			deps := FindDeclDependencies(lastKey, depGraph)
 
 			// Convert dependency BindingKeys to names
 			var depNames []string

--- a/internal/dep_graph/cycles_test.go
+++ b/internal/dep_graph/cycles_test.go
@@ -50,7 +50,7 @@ func parseMultiFileModule(sources map[string]string) *ast.Module {
 	return module
 }
 
-func TestFindCyclesV2(t *testing.T) {
+func TestFindCycles(t *testing.T) {
 	tests := map[string]struct {
 		input             string
 		expectedCycles    int
@@ -300,8 +300,8 @@ func TestFindCyclesV2(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			module := parseModule(test.input)
-			depGraph := BuildDepGraphV2(module)
-			cycles := depGraph.FindCyclesV2()
+			depGraph := BuildDepGraph(module)
+			cycles := depGraph.FindCycles()
 
 			assert.Equal(t, test.expectedCycles, len(cycles),
 				"Expected %d problematic cycles, got %d. %s",
@@ -375,8 +375,8 @@ func TestFindCyclesV2_EdgeCases(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			module := parseModule(test.input)
-			depGraph := BuildDepGraphV2(module)
-			cycles := depGraph.FindCyclesV2()
+			depGraph := BuildDepGraph(module)
+			cycles := depGraph.FindCycles()
 
 			// Assert expected number of cycles
 			assert.Equal(t, test.expectedCycles, len(cycles),
@@ -591,8 +591,8 @@ func TestFindCyclesV2_NamespacedBindings(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			module := parseMultiFileModule(test.sources)
-			depGraph := BuildDepGraphV2(module)
-			cycles := depGraph.FindCyclesV2()
+			depGraph := BuildDepGraph(module)
+			cycles := depGraph.FindCycles()
 
 			assert.Equal(t, test.expectedCycles, len(cycles),
 				"Expected %d problematic cycles, got %d. %s",
@@ -664,8 +664,8 @@ func TestFindCyclesV2_InterfaceMerging(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			module := parseModule(test.input)
-			depGraph := BuildDepGraphV2(module)
-			cycles := depGraph.FindCyclesV2()
+			depGraph := BuildDepGraph(module)
+			cycles := depGraph.FindCycles()
 
 			assert.Equal(t, test.expectedCycles, len(cycles),
 				"Expected %d problematic cycles, got %d. %s",

--- a/internal/dep_graph/dep_graph_test.go
+++ b/internal/dep_graph/dep_graph_test.go
@@ -134,7 +134,7 @@ func TestBuildDepGraphV2_SimpleBindings(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			// Verify bindings
 			actualKeys := graph.AllBindings()
@@ -345,7 +345,7 @@ func TestBuildDepGraphV2_Dependencies(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -494,7 +494,7 @@ func TestBuildDepGraphV2_Namespaces(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			// Verify bindings
 			actualKeys := graph.AllBindings()
@@ -598,7 +598,7 @@ func TestBuildDepGraphV2_OverloadedFunctions(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			// Verify bindings
 			actualKeys := graph.AllBindings()
@@ -680,7 +680,7 @@ func TestBuildDepGraphV2_InterfaceMerging(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			// Verify bindings
 			actualKeys := graph.AllBindings()
@@ -771,7 +771,7 @@ func TestBuildDepGraphV2_ClassAndEnum(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			actualKeys := graph.AllBindings()
 			assert.ElementsMatch(t, test.expectedKeys, actualKeys,
@@ -882,7 +882,7 @@ func TestBuildDepGraphV2_StronglyConnectedComponents(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			// Count actual cycles (multi-node SCCs or self-referencing single-node SCCs)
 			actualCycles := 0
@@ -1070,7 +1070,7 @@ func TestBuildDepGraphV2_LocalShadowing(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -1192,7 +1192,7 @@ func TestBuildDepGraphV2_DestructuringPatterns(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			// Verify bindings
 			actualKeys := graph.AllBindings()
@@ -1311,7 +1311,7 @@ func TestDepGraphV2_HelperMethods(t *testing.T) {
 		module, errors := parser.ParseLibFiles(ctx, sources)
 		assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-		graph := BuildDepGraphV2(module)
+		graph := BuildDepGraph(module)
 
 		assert.True(t, graph.HasBinding(ValueBindingKey("foo")))
 		assert.True(t, graph.HasBinding(TypeBindingKey("Bar")))
@@ -1342,7 +1342,7 @@ func TestDepGraphV2_HelperMethods(t *testing.T) {
 		module, errors := parser.ParseLibFiles(ctx, sources)
 		assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-		graph := BuildDepGraphV2(module)
+		graph := BuildDepGraph(module)
 
 		assert.Equal(t, "", graph.GetNamespace(ValueBindingKey("root")))
 		assert.Equal(t, "utils", graph.GetNamespace(ValueBindingKey("utils.helper")))
@@ -1422,7 +1422,7 @@ func TestBuildDepGraphV2_TypeOfDependencies(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -1489,7 +1489,7 @@ func TestBuildDepGraphV2_ObjectTypeComputedKeys(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -1593,7 +1593,7 @@ func TestBuildDepGraphV2_InterfaceExtends(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -1668,7 +1668,7 @@ func TestBuildDepGraphV2_ClassExtends(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -1758,7 +1758,7 @@ func TestBuildDepGraphV2_EnumSpread(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -1867,7 +1867,7 @@ func TestBuildDepGraphV2_TypeParameterConstraints(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -1950,7 +1950,7 @@ func TestBuildDepGraphV2_IntraNamespaceDependencies(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -2032,7 +2032,7 @@ func TestBuildDepGraphV2_MemberExpressionChains(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -2099,7 +2099,7 @@ func TestBuildDepGraphV2_TypeShadowing(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)
@@ -2447,7 +2447,7 @@ func TestBuildDepGraphV2_LocalDeclShadowing(t *testing.T) {
 
 			assert.Len(t, errors, 0, "Parser errors: %v", errors)
 
-			graph := BuildDepGraphV2(module)
+			graph := BuildDepGraph(module)
 
 			for key, expectedDeps := range test.expectedDeps {
 				actualDeps := graph.GetDeps(key)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal APIs by standardizing naming conventions across dependency graph construction, type inference, and code generation modules. Removed V2 suffixes from functions, methods, and types to establish a unified, simplified API surface without behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->