### PR TITLE
Use mise to manage tool versions, udpate Go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/escalier-lang/escalier
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/gkampitakis/go-snaps v0.5.11

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
 [tools]
+go = "1.26"
 golangci-lint = "2.9"
 node = "22"
+pnpm = "10.22.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime version to 1.26.0
  * Added pnpm to project tooling configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->