### PR TITLE
Row Types - Phase 13: Variadic Tuple Types

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1653,12 +1653,5 @@ func tupleElemUnion(t *type_system.TupleType) type_system.Type {
 			types = append(types, elem)
 		}
 	}
-	switch len(types) {
-	case 0:
-		return type_system.NewNeverType(nil)
-	case 1:
-		return types[0]
-	default:
-		return type_system.NewUnionType(nil, types...)
-	}
+	return type_system.NewUnionType(nil, types...)
 }

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -541,16 +541,44 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 			if indexLit, ok := keyType.(*type_system.LitType); ok {
 				if numLit, ok := indexLit.Lit.(*type_system.NumLit); ok {
 					index := int(numLit.Value)
-					if index < len(t.Elems) {
-						return t.Elems[index], errors
-					} else {
-						errors = append(errors, &OutOfBoundsError{
-							Index:  index,
-							Length: len(t.Elems),
-							span:   indexKey.Span(),
-						})
-						return type_system.NewNeverType(nil), errors
+					// Count only non-RestSpreadType elements for literal indexing
+					fixedCount := 0
+					for _, elem := range t.Elems {
+						if _, isRest := elem.(*type_system.RestSpreadType); !isRest {
+							fixedCount++
+						}
 					}
+					if index < fixedCount {
+						// Map index to actual position, skipping RestSpreadType
+						pos := 0
+						for _, elem := range t.Elems {
+							if _, isRest := elem.(*type_system.RestSpreadType); isRest {
+								continue
+							}
+							if pos == index {
+								return elem, errors
+							}
+							pos++
+						}
+					}
+					// Check if the tuple has a rest element
+					hasRest := false
+					for _, elem := range t.Elems {
+						if _, isRest := elem.(*type_system.RestSpreadType); isRest {
+							hasRest = true
+							break
+						}
+					}
+					if hasRest {
+						// Index beyond fixed prefix — return union of all element types
+						return tupleElemUnion(t), errors
+					}
+					errors = append(errors, &OutOfBoundsError{
+						Index:  index,
+						Length: fixedCount,
+						span:   indexKey.Span(),
+					})
+					return type_system.NewNeverType(nil), errors
 				}
 			}
 			errors = append(errors, &InvalidObjectKeyError{
@@ -561,16 +589,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 		}
 		// If a property (method) is accessed on a tuple, delegate to Array<T>
 		if _, ok := key.(PropertyKey); ok {
-			// Compute the union of the tuple element types
-			var elemUnion type_system.Type
-			switch len(t.Elems) {
-			case 0:
-				elemUnion = type_system.NewNeverType(nil)
-			case 1:
-				elemUnion = t.Elems[0]
-			default:
-				elemUnion = type_system.NewUnionType(nil, t.Elems...)
-			}
+			elemUnion := tupleElemUnion(t)
 			arrayRef := &type_system.TypeRefType{
 				Name:     type_system.NewIdent("Array"),
 				TypeArgs: []type_system.Type{elemUnion},
@@ -1605,4 +1624,41 @@ func (v *InferTypeReplacer) ExitType(t type_system.Type) type_system.Type {
 
 	// For all other types, return nil to let Accept handle the traversal
 	return nil
+}
+
+// tupleElemUnion computes the union of all element types in a tuple,
+// including the inner type of any RestSpreadType elements. For a
+// RestSpreadType whose inner type is an Array<T>, T is included; for a
+// TupleType, its elements are included; otherwise the rest type itself
+// is included.
+func tupleElemUnion(t *type_system.TupleType) type_system.Type {
+	var types []type_system.Type
+	for _, elem := range t.Elems {
+		if rest, ok := elem.(*type_system.RestSpreadType); ok {
+			resolved := type_system.Prune(rest.Type)
+			switch r := resolved.(type) {
+			case *type_system.TupleType:
+				types = append(types, r.Elems...)
+			case *type_system.TypeRefType:
+				// If it's Array<T>, include T
+				if type_system.QualIdentToString(r.Name) == "Array" && len(r.TypeArgs) == 1 {
+					types = append(types, r.TypeArgs[0])
+				} else {
+					types = append(types, resolved)
+				}
+			default:
+				types = append(types, resolved)
+			}
+		} else {
+			types = append(types, elem)
+		}
+	}
+	switch len(types) {
+	case 0:
+		return type_system.NewNeverType(nil)
+	case 1:
+		return types[0]
+	default:
+		return type_system.NewUnionType(nil, types...)
+	}
 }

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -16,6 +16,10 @@ import (
 
 // inferModuleTypesAndErrors parses the input source, runs type inference, and
 // returns the inferred symbol-to-type map along with any inference errors.
+// Parsing must succeed (parse errors cause a test failure via require.Empty).
+// Use this helper for tests that expect successful parsing but want to inspect
+// inference errors. For tests that require both parsing and inference to
+// succeed with no errors, use inferModuleTypes instead.
 func inferModuleTypesAndErrors(t *testing.T, input string) (map[string]string, []Error) {
 	t.Helper()
 
@@ -1349,5 +1353,15 @@ func TestVariadicTupleSubtyping(t *testing.T) {
 			val x: [number, ...Array<string>] = [5]
 		`)
 		assert.Equal(t, "[number, ...Array<string>]", actualTypes["x"])
+	})
+
+	t.Run("IncompatibleElementsRejectAssignment", func(t *testing.T) {
+		t.Parallel()
+		// [1, 2, 3] should NOT conform to [number, ...Array<string>] because
+		// 2 and 3 are numbers, not strings.
+		_, inferErrors := inferModuleTypesAndErrors(t, `
+			val x: [number, ...Array<string>] = [1, 2, 3]
+		`)
+		require.NotEmpty(t, inferErrors)
 	})
 }

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1304,6 +1304,66 @@ func TestVariadicTupleTypes(t *testing.T) {
 	}
 }
 
+func TestVariadicVsFixed(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"VariadicSourceAssignedToShorterTarget": {
+			// Source [number, string, ...T] has 2 mandatory prefix elements.
+			// Target [x] only needs 1. The extra source elements are ignored.
+			input: `
+				fn foo<T>(items: [number, string, ...T]) -> [number, string, ...T] {
+					return items
+				}
+				val [x] = foo([1, "a", true])
+			`,
+			expectedTypes: map[string]string{
+				"x": "number",
+			},
+		},
+		"VariadicSourceRestAbsorbsTargetElements": {
+			// Source [number, ...T] with target [number, string].
+			// Prefix: number↔number. Rest T absorbs [string].
+			input: `
+				fn foo<T>(items: [number, ...T]) -> [number, ...T] {
+					return items
+				}
+				val [a, b] = foo([1, "hello"])
+			`,
+			expectedTypes: map[string]string{
+				"a": "number",
+				"b": "\"hello\"",
+			},
+		},
+		"VariadicSourceRestAbsorbsNothing": {
+			// Source [number, ...T] with target [number].
+			// Prefix: number↔number. Rest absorbs nothing (empty tuple).
+			input: `
+				fn foo<T>(items: [number, ...T]) -> [number, ...T] {
+					return items
+				}
+				val [a] = foo([1])
+			`,
+			expectedTypes: map[string]string{
+				"a": "number",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
 func TestVariadicTupleSubtyping(t *testing.T) {
 	t.Run("VariadicTupleAssignableToArray", func(t *testing.T) {
 		t.Parallel()
@@ -1336,5 +1396,83 @@ func TestVariadicTupleSubtyping(t *testing.T) {
 		require.NotEmpty(t, inferErrors)
 		// Optionally verify the error relates to type incompatibility
 		assert.Contains(t, inferErrors[0].Message(), "cannot be assigned")
+	})
+
+	t.Run("TooFewElementsForVariadicTarget", func(t *testing.T) {
+		t.Parallel()
+		// [] cannot conform to [number, string, ...Array<boolean>] because
+		// the target requires at least 2 elements (the prefix) and the
+		// source provides 0.
+		_, inferErrors := inferModuleTypesAndErrors(t, `
+			val x: [number, string, ...Array<boolean>] = []
+		`)
+		require.NotEmpty(t, inferErrors)
+	})
+
+	t.Run("LeadingRest", func(t *testing.T) {
+		t.Parallel()
+		// [...number[], string] — the rest absorbs leading elements,
+		// the last element must be string.
+		actualTypes := inferModuleTypes(t, `
+			val x: [...Array<number>, string] = [1, 2, "hello"]
+		`)
+		assert.Equal(t, "[...Array<number>, string]", actualTypes["x"])
+	})
+
+	t.Run("LeadingRestZeroAbsorbed", func(t *testing.T) {
+		t.Parallel()
+		// [...number[], string] with only the suffix element present.
+		actualTypes := inferModuleTypes(t, `
+			val x: [...Array<number>, string] = ["hello"]
+		`)
+		assert.Equal(t, "[...Array<number>, string]", actualTypes["x"])
+	})
+
+	t.Run("LeadingRestIncompatibleSuffix", func(t *testing.T) {
+		t.Parallel()
+		// [...number[], string] — the last element must be string, not number.
+		_, inferErrors := inferModuleTypesAndErrors(t, `
+			val x: [...Array<number>, string] = [1, 2, 3]
+		`)
+		require.NotEmpty(t, inferErrors)
+	})
+
+	t.Run("FixedOnBothSidesOfRest", func(t *testing.T) {
+		t.Parallel()
+		// [number, ...boolean[], string] — first must be number, last must
+		// be string, middle elements absorbed by ...boolean[].
+		actualTypes := inferModuleTypes(t, `
+			val x: [number, ...Array<boolean>, string] = [1, true, false, "end"]
+		`)
+		assert.Equal(t, "[number, ...Array<boolean>, string]", actualTypes["x"])
+	})
+
+	t.Run("FixedOnBothSidesRestAbsorbsNothing", func(t *testing.T) {
+		t.Parallel()
+		// [number, ...boolean[], string] with no middle elements — the rest
+		// absorbs nothing.
+		actualTypes := inferModuleTypes(t, `
+			val x: [number, ...Array<boolean>, string] = [1, "end"]
+		`)
+		assert.Equal(t, "[number, ...Array<boolean>, string]", actualTypes["x"])
+	})
+
+	t.Run("FixedOnBothSidesTooFewElements", func(t *testing.T) {
+		t.Parallel()
+		// [number, ...boolean[], string] requires at least 2 elements (the
+		// prefix and suffix). A single-element source doesn't have enough.
+		_, inferErrors := inferModuleTypesAndErrors(t, `
+			val x: [number, ...Array<boolean>, string] = [1]
+		`)
+		require.NotEmpty(t, inferErrors)
+	})
+
+	t.Run("FixedOnBothSidesIncompatibleMiddle", func(t *testing.T) {
+		t.Parallel()
+		// [number, ...boolean[], string] — middle elements must be boolean.
+		_, inferErrors := inferModuleTypesAndErrors(t, `
+			val x: [number, ...Array<boolean>, string] = [1, "not bool", "end"]
+		`)
+		require.NotEmpty(t, inferErrors)
 	})
 }

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1363,5 +1363,7 @@ func TestVariadicTupleSubtyping(t *testing.T) {
 			val x: [number, ...Array<string>] = [1, 2, 3]
 		`)
 		require.NotEmpty(t, inferErrors)
+		// Optionally verify the error relates to type incompatibility
+		assert.Contains(t, inferErrors[0].Message(), "cannot be assigned")
 	})
 }

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -14,6 +14,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// inferModuleTypesAndErrors parses the input source, runs type inference, and
+// returns the inferred symbol-to-type map along with any inference errors.
+func inferModuleTypesAndErrors(t *testing.T, input string) (map[string]string, []Error) {
+	t.Helper()
+
+	source := &ast.Source{
+		ID:       0,
+		Path:     "input.esc",
+		Contents: input,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+
+	if len(errors) > 0 {
+		for i, err := range errors {
+			t.Logf("Parse Error[%d]: %#v", i, err)
+		}
+	}
+	require.Empty(t, errors)
+
+	c := NewChecker()
+	inferCtx := Context{
+		Scope:      Prelude(c),
+		IsAsync:    false,
+		IsPatMatch: false,
+	}
+	inferErrors := c.InferModule(inferCtx, module)
+	scope := inferCtx.Scope.Namespace
+
+	actualTypes := make(map[string]string)
+	for name, binding := range scope.Values {
+		require.NotNil(t, binding)
+		actualTypes[name] = binding.Type.String()
+	}
+	return actualTypes, inferErrors
+}
+
 // inferModuleTypes parses the input source, runs type inference, and returns
 // the inferred symbol-to-type map. Fails the test immediately on parse or
 // inference errors.
@@ -1226,4 +1265,89 @@ func TestRowTypesRowPolymorphism(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVariadicTupleTypes(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"FixedVsVariadic_TrailingRest": {
+			// [number, string, boolean] vs [number, ...R]
+			// → R = [string, boolean]
+			input: `
+				fn foo<T>(items: [number, ...T]) { return items }
+				val r = foo([1, "a", true])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T>(items: [number, ...T]) -> [number, ...T]",
+				"r":   "[number, \"a\", true]",
+			},
+		},
+		"FixedVsVariadic_AllAbsorbed": {
+			// [1, "a", "b"] vs [number, ...Array<string>]
+			input: `
+				val x: [number, ...Array<string>] = [1, "a", "b"]
+			`,
+			expectedTypes: map[string]string{
+				"x": "[number, ...Array<string>]",
+			},
+		},
+		"VariadicVsVariadic_SamePrefix": {
+			// Both have trailing rest with same prefix length
+			input: `
+				fn foo<R1, R2>(a: [number, ...R1], b: [string, ...R2]) {
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <R1, R2>(a: [number, ...R1], b: [string, ...R2]) -> [[number, ...R1], [string, ...R2]]",
+			},
+		},
+		"Generalization_VariadicRest": {
+			// fn foo<T>(items: [number, ...T]) { return items }
+			// → type: fn <T>(items: [number, ...T]) -> [number, ...T]
+			input: `
+				fn foo<T>(items: [number, ...T]) { return items }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T>(items: [number, ...T]) -> [number, ...T]",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+func TestVariadicTupleSubtyping(t *testing.T) {
+	t.Run("VariadicTupleAssignableToArray", func(t *testing.T) {
+		t.Parallel()
+		// [number, ...string[]] should be assignable to Array<number | string>
+		actualTypes := inferModuleTypes(t, `
+			val x: [number, ...Array<string>] = [1, "a", "b"]
+			val y: Array<number | string> = x
+		`)
+		assert.Equal(t, "[number, ...Array<string>]", actualTypes["x"])
+		assert.Equal(t, "Array<number | string>", actualTypes["y"])
+	})
+
+	t.Run("SingleElementConformsToVariadicTuple", func(t *testing.T) {
+		t.Parallel()
+		// [5] should conform to [number, ...Array<string>] because the
+		// prefix `number` matches and ...Array<string> accepts zero elements.
+		actualTypes := inferModuleTypes(t, `
+			val x: [number, ...Array<string>] = [5]
+		`)
+		assert.Equal(t, "[number, ...Array<string>]", actualTypes["x"])
+	})
 }

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -63,31 +63,7 @@ func inferModuleTypesAndErrors(t *testing.T, input string) (map[string]string, [
 func inferModuleTypes(t *testing.T, input string) map[string]string {
 	t.Helper()
 
-	source := &ast.Source{
-		ID:       0,
-		Path:     "input.esc",
-		Contents: input,
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
-
-	if len(errors) > 0 {
-		for i, err := range errors {
-			t.Logf("Parse Error[%d]: %#v", i, err)
-		}
-	}
-	require.Empty(t, errors)
-
-	c := NewChecker()
-	inferCtx := Context{
-		Scope:      Prelude(c),
-		IsAsync:    false,
-		IsPatMatch: false,
-	}
-	inferErrors := c.InferModule(inferCtx, module)
-	scope := inferCtx.Scope.Namespace
+	actualTypes, inferErrors := inferModuleTypesAndErrors(t, input)
 
 	if len(inferErrors) > 0 {
 		for i, err := range inferErrors {
@@ -96,11 +72,6 @@ func inferModuleTypes(t *testing.T, input string) map[string]string {
 	}
 	require.Empty(t, inferErrors)
 
-	actualTypes := make(map[string]string)
-	for name, binding := range scope.Values {
-		require.NotNil(t, binding)
-		actualTypes[name] = binding.Type.String()
-	}
 	return actualTypes
 }
 

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -2472,10 +2472,6 @@ func (c *Checker) unifyVariadicVsFixed(
 // - Unify suffixes pairwise up to the shorter suffix
 // - Collect any extra prefix/suffix elements from the longer side
 // - Unify the rest types, wrapping extras in a tuple with rest if needed
-//
-// NOTE: Like TypeScript, we only support a rest element as the last element
-// of a tuple (i.e. no suffix after rest). Support for both prefix and suffix
-// around a rest element is not planned.
 func (c *Checker) unifyVariadicVsVariadic(
 	ctx Context,
 	prefix1 []type_system.Type, rest1 *type_system.RestSpreadType, suffix1 []type_system.Type,

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -2450,6 +2450,12 @@ func (c *Checker) unifyVariadicVsFixed(
 	}
 
 	// Unify suffix elements pairwise from the end, up to the shorter of the two.
+	// Anchoring the suffix to the end of fixedElems is sound regardless of
+	// whether rest1.Type is concrete or unresolved: the suffix's position at the
+	// end of the source tuple is a structural invariant of the type (e.g. in
+	// [...T, string], the string is always last no matter what T resolves to).
+	// The rest absorbs whatever target elements remain between the prefix and
+	// suffix matches.
 	remaining := fixedElems[prefixLen:]
 	suffixLen := min(len(suffix1), len(remaining))
 	for i := range suffixLen {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -370,92 +370,23 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 	// | TupleType, TupleType -> ...
 	if tuple1, ok := t1.(*type_system.TupleType); ok {
 		if tuple2, ok := t2.(*type_system.TupleType); ok {
-			// TODO: handle spread
-			errors := []Error{}
-
-			// TODO: Don't allow more than one rest element in tuple1
-			restElem2, ok := tuple2.Elems[len(tuple2.Elems)-1].(*type_system.RestSpreadType)
-			if ok {
-				elems2 := tuple2.Elems[:len(tuple2.Elems)-1]
-				elems1 := tuple1.Elems[:len(elems2)]
-
-				for elem1, elem2 := range Zip(elems1, elems2) {
-					unifyErrors := c.Unify(ctx, elem1, elem2)
-					errors = slices.Concat(errors, unifyErrors)
-				}
-				remainingElems := tuple1.Elems[len(elems2):]
-				tuple := type_system.NewTupleType(nil, remainingElems...)
-				unifyErrors := c.Unify(ctx, tuple, restElem2.Type)
-				errors = slices.Concat(errors, unifyErrors)
-				return errors
-			}
-
-			restElem1, ok := tuple1.Elems[len(tuple1.Elems)-1].(*type_system.RestSpreadType)
-			if ok {
-				elems1 := tuple1.Elems[:len(tuple1.Elems)-1]
-				elems2 := tuple2.Elems[:len(elems1)]
-
-				for elem1, elem2 := range Zip(elems1, elems2) {
-					unifyErrors := c.Unify(ctx, elem1, elem2)
-					errors = slices.Concat(errors, unifyErrors)
-				}
-				remainingElems := tuple2.Elems[len(elems1):]
-				tuple := type_system.NewTupleType(nil, remainingElems...)
-				unifyErrors := c.Unify(ctx, restElem1.Type, tuple)
-				errors = slices.Concat(errors, unifyErrors)
-				return errors
-			}
-
-			if len(tuple2.Elems) > len(tuple1.Elems) {
-				// Unify the elements that are present in both tuples
-				for elem1, elem2 := range Zip(tuple1.Elems, tuple2.Elems) {
-					unifyErrors := c.Unify(ctx, elem1, elem2)
-					errors = slices.Concat(errors, unifyErrors)
-				}
-
-				extraElems := tuple2.Elems[len(tuple1.Elems):]
-				first := GetNode(extraElems[0].Provenance())
-				last := GetNode(extraElems[len(extraElems)-1].Provenance())
-
-				// Any remaining elements in tuple2 should be typed as `undefined`
-				// since they are not present in tuple1.
-				for _, elem2 := range extraElems {
-					node := GetNode(elem2.Provenance())
-					undefined := type_system.NewUndefinedType(&ast.NodeProvenance{Node: node})
-					unifyErrors := c.Unify(ctx, elem2, undefined)
-					errors = slices.Concat(errors, unifyErrors)
-				}
-
-				return slices.Concat(errors, []Error{&NotEnoughElementsToUnpackError{
-					span: ast.MergeSpans(first.Span(), last.Span()),
-				}})
-			}
-
-			if len(tuple1.Elems) != len(tuple2.Elems) {
-				return []Error{&CannotUnifyTypesError{
-					T1: tuple1,
-					T2: tuple2,
-				}}
-			}
-
-			for elem1, elem2 := range Zip(tuple1.Elems, tuple2.Elems) {
-				unifyErrors := c.Unify(ctx, elem1, elem2)
-				errors = slices.Concat(errors, unifyErrors)
-			}
-
-			return errors
+			return c.unifyTuples(ctx, tuple1, tuple2)
 		}
 	}
 	// | TupleType, ArrayType -> ...
 	if tuple1, ok := t1.(*type_system.TupleType); ok {
 		if array2, ok := t2.(*type_system.TypeRefType); ok && c.isArrayType(array2) {
-			// A tuple can be unified with an array if all tuple elements
-			// can be unified with the array's element type
 			if len(array2.TypeArgs) == 1 {
 				errors := []Error{}
 				for _, elem := range tuple1.Elems {
-					unifyErrors := c.Unify(ctx, elem, array2.TypeArgs[0])
-					errors = slices.Concat(errors, unifyErrors)
+					if rest, ok := elem.(*type_system.RestSpreadType); ok {
+						// Unify rest type with Array<T>
+						unifyErrors := c.Unify(ctx, rest.Type, array2)
+						errors = slices.Concat(errors, unifyErrors)
+					} else {
+						unifyErrors := c.Unify(ctx, elem, array2.TypeArgs[0])
+						errors = slices.Concat(errors, unifyErrors)
+					}
 				}
 				return errors
 			}
@@ -468,13 +399,17 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 	// | ArrayType, TupleType -> ...
 	if array1, ok := t1.(*type_system.TypeRefType); ok && c.isArrayType(array1) {
 		if tuple2, ok := t2.(*type_system.TupleType); ok {
-			// An array can be unified with a tuple if the array's element type
-			// can be unified with all tuple elements
 			if len(array1.TypeArgs) == 1 {
 				errors := []Error{}
 				for _, elem := range tuple2.Elems {
-					unifyErrors := c.Unify(ctx, array1.TypeArgs[0], elem)
-					errors = slices.Concat(errors, unifyErrors)
+					if rest, ok := elem.(*type_system.RestSpreadType); ok {
+						// Unify Array<T> with rest type
+						unifyErrors := c.Unify(ctx, array1, rest.Type)
+						errors = slices.Concat(errors, unifyErrors)
+					} else {
+						unifyErrors := c.Unify(ctx, array1.TypeArgs[0], elem)
+						errors = slices.Concat(errors, unifyErrors)
+					}
 				}
 				return errors
 			}
@@ -2341,4 +2276,240 @@ func typeContains(haystack type_system.Type, needle type_system.Type) bool {
 		}
 	}
 	return true
+}
+
+// splitTupleAtRest splits a tuple's elements into a prefix of fixed elements,
+// the RestSpreadType (if any), and a suffix of fixed elements after the rest.
+// If no RestSpreadType is found, rest is nil and suffix is empty.
+func splitTupleAtRest(elems []type_system.Type) (prefix []type_system.Type, rest *type_system.RestSpreadType, suffix []type_system.Type) {
+	for i, elem := range elems {
+		if r, ok := elem.(*type_system.RestSpreadType); ok {
+			return elems[:i], r, elems[i+1:]
+		}
+	}
+	return elems, nil, nil
+}
+
+// unifyTuples handles all tuple-vs-tuple unification cases including
+// RestSpreadType at any position.
+func (c *Checker) unifyTuples(ctx Context, tuple1, tuple2 *type_system.TupleType) []Error {
+	prefix1, rest1, suffix1 := splitTupleAtRest(tuple1.Elems)
+	prefix2, rest2, suffix2 := splitTupleAtRest(tuple2.Elems)
+
+	// Case: neither side has a rest spread — plain tuple unification
+	if rest1 == nil && rest2 == nil {
+		return c.unifyFixedTuples(ctx, tuple1, tuple2)
+	}
+
+	// Case: only tuple2 has a rest spread — fixed-vs-variadic
+	if rest1 == nil && rest2 != nil {
+		return c.unifyFixedVsVariadic(ctx, tuple1.Elems, prefix2, rest2, suffix2)
+	}
+
+	// Case: only tuple1 has a rest spread — variadic-vs-fixed (mirror)
+	if rest1 != nil && rest2 == nil {
+		return c.unifyVariadicVsFixed(ctx, prefix1, rest1, suffix1, tuple2.Elems)
+	}
+
+	// Case: both sides have a rest spread — variadic-vs-variadic
+	return c.unifyVariadicVsVariadic(ctx, prefix1, rest1, suffix1, prefix2, rest2, suffix2)
+}
+
+// unifyFixedTuples handles unification of two tuples with no RestSpreadType elements.
+func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.TupleType) []Error {
+	errors := []Error{}
+
+	if len(tuple2.Elems) > len(tuple1.Elems) {
+		// Unify the elements that are present in both tuples
+		for elem1, elem2 := range Zip(tuple1.Elems, tuple2.Elems) {
+			unifyErrors := c.Unify(ctx, elem1, elem2)
+			errors = slices.Concat(errors, unifyErrors)
+		}
+
+		extraElems := tuple2.Elems[len(tuple1.Elems):]
+		first := GetNode(extraElems[0].Provenance())
+		last := GetNode(extraElems[len(extraElems)-1].Provenance())
+
+		// Any remaining elements in tuple2 should be typed as `undefined`
+		// since they are not present in tuple1.
+		for _, elem2 := range extraElems {
+			node := GetNode(elem2.Provenance())
+			undefined := type_system.NewUndefinedType(&ast.NodeProvenance{Node: node})
+			unifyErrors := c.Unify(ctx, elem2, undefined)
+			errors = slices.Concat(errors, unifyErrors)
+		}
+
+		return slices.Concat(errors, []Error{&NotEnoughElementsToUnpackError{
+			span: ast.MergeSpans(first.Span(), last.Span()),
+		}})
+	}
+
+	if len(tuple1.Elems) != len(tuple2.Elems) {
+		return []Error{&CannotUnifyTypesError{
+			T1: tuple1,
+			T2: tuple2,
+		}}
+	}
+
+	for elem1, elem2 := range Zip(tuple1.Elems, tuple2.Elems) {
+		unifyErrors := c.Unify(ctx, elem1, elem2)
+		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	return errors
+}
+
+// unifyFixedVsVariadic handles: fixed tuple vs tuple with rest spread.
+// Example: [A, B, C] vs [D, ...R, E]
+// - prefix2 elements unify with the start of fixedElems
+// - suffix2 elements unify with the end of fixedElems
+// - the rest spread absorbs the middle elements
+func (c *Checker) unifyFixedVsVariadic(
+	ctx Context,
+	fixedElems []type_system.Type,
+	prefix2 []type_system.Type, rest2 *type_system.RestSpreadType, suffix2 []type_system.Type,
+) []Error {
+	requiredCount := len(prefix2) + len(suffix2)
+	if len(fixedElems) < requiredCount {
+		return []Error{&CannotUnifyTypesError{
+			T1: type_system.NewTupleType(nil, fixedElems...),
+			T2: type_system.NewTupleType(nil, append(append(prefix2, rest2), suffix2...)...),
+		}}
+	}
+
+	errors := []Error{}
+
+	// Unify prefix elements pairwise
+	for i, elem2 := range prefix2 {
+		unifyErrors := c.Unify(ctx, fixedElems[i], elem2)
+		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	// Unify suffix elements pairwise (from the end)
+	for i, elem2 := range suffix2 {
+		fixedIdx := len(fixedElems) - len(suffix2) + i
+		unifyErrors := c.Unify(ctx, fixedElems[fixedIdx], elem2)
+		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	// The middle elements are absorbed by the rest spread
+	middleElems := fixedElems[len(prefix2) : len(fixedElems)-len(suffix2)]
+	restTuple := type_system.NewTupleType(nil, middleElems...)
+	unifyErrors := c.Unify(ctx, restTuple, rest2.Type)
+	errors = slices.Concat(errors, unifyErrors)
+
+	return errors
+}
+
+// unifyVariadicVsFixed handles: tuple with rest spread vs fixed tuple.
+// Mirror of unifyFixedVsVariadic.
+func (c *Checker) unifyVariadicVsFixed(
+	ctx Context,
+	prefix1 []type_system.Type, rest1 *type_system.RestSpreadType, suffix1 []type_system.Type,
+	fixedElems []type_system.Type,
+) []Error {
+	requiredCount := len(prefix1) + len(suffix1)
+	if len(fixedElems) < requiredCount {
+		return []Error{&CannotUnifyTypesError{
+			T1: type_system.NewTupleType(nil, append(append(prefix1, rest1), suffix1...)...),
+			T2: type_system.NewTupleType(nil, fixedElems...),
+		}}
+	}
+
+	errors := []Error{}
+
+	// Unify prefix elements pairwise
+	for i, elem1 := range prefix1 {
+		unifyErrors := c.Unify(ctx, elem1, fixedElems[i])
+		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	// Unify suffix elements pairwise (from the end)
+	for i, elem1 := range suffix1 {
+		fixedIdx := len(fixedElems) - len(suffix1) + i
+		unifyErrors := c.Unify(ctx, elem1, fixedElems[fixedIdx])
+		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	// The middle elements are absorbed by the rest spread
+	middleElems := fixedElems[len(prefix1) : len(fixedElems)-len(suffix1)]
+	restTuple := type_system.NewTupleType(nil, middleElems...)
+	unifyErrors := c.Unify(ctx, rest1.Type, restTuple)
+	errors = slices.Concat(errors, unifyErrors)
+
+	return errors
+}
+
+// unifyVariadicVsVariadic handles: tuple with rest vs tuple with rest.
+// Example: [A, ...R1, B] vs [C, ...R2, D]
+// - Unify prefixes pairwise up to the shorter prefix
+// - Unify suffixes pairwise up to the shorter suffix
+// - Collect any extra prefix/suffix elements from the longer side
+// - Unify the rest types, wrapping extras in a tuple with rest if needed
+//
+// NOTE: Like TypeScript, we only support a rest element as the last element
+// of a tuple (i.e. no suffix after rest). Support for both prefix and suffix
+// around a rest element is not planned.
+func (c *Checker) unifyVariadicVsVariadic(
+	ctx Context,
+	prefix1 []type_system.Type, rest1 *type_system.RestSpreadType, suffix1 []type_system.Type,
+	prefix2 []type_system.Type, rest2 *type_system.RestSpreadType, suffix2 []type_system.Type,
+) []Error {
+	errors := []Error{}
+
+	// Unify prefixes pairwise up to the shorter one
+	minPrefix := min(len(prefix1), len(prefix2))
+	for i := 0; i < minPrefix; i++ {
+		unifyErrors := c.Unify(ctx, prefix1[i], prefix2[i])
+		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	// Unify suffixes pairwise up to the shorter one (from the end)
+	minSuffix := min(len(suffix1), len(suffix2))
+	for i := 0; i < minSuffix; i++ {
+		unifyErrors := c.Unify(ctx, suffix1[len(suffix1)-minSuffix+i], suffix2[len(suffix2)-minSuffix+i])
+		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	// Collect extras from the longer prefix/suffix
+	extraPrefix1 := prefix1[minPrefix:]
+	extraPrefix2 := prefix2[minPrefix:]
+	extraSuffix1 := suffix1[:len(suffix1)-minSuffix]
+	extraSuffix2 := suffix2[:len(suffix2)-minSuffix]
+
+	// Build the types for the rest unification.
+	// If one side has extras, the other side's rest absorbs them.
+	// E.g. [A, B, ...R1] vs [A, ...R2] → Unify(R2, [B, ...R1])
+	if len(extraPrefix1) == 0 && len(extraSuffix1) == 0 && len(extraPrefix2) == 0 && len(extraSuffix2) == 0 {
+		// Same number of fixed elements on both sides — unify rests directly
+		unifyErrors := c.Unify(ctx, rest1.Type, rest2.Type)
+		errors = slices.Concat(errors, unifyErrors)
+	} else if len(extraPrefix2) == 0 && len(extraSuffix2) == 0 {
+		// tuple1 has extra fixed elements; rest2 absorbs them
+		// [A, B, C, ...R1] vs [A, ...R2] → R2 = [B, C, ...R1]
+		var wrapped []type_system.Type
+		wrapped = append(wrapped, extraPrefix1...)
+		wrapped = append(wrapped, rest1)
+		wrapped = append(wrapped, extraSuffix1...)
+		wrappedTuple := type_system.NewTupleType(nil, wrapped...)
+		unifyErrors := c.Unify(ctx, wrappedTuple, rest2.Type)
+		errors = slices.Concat(errors, unifyErrors)
+	} else if len(extraPrefix1) == 0 && len(extraSuffix1) == 0 {
+		// tuple2 has extra fixed elements; rest1 absorbs them
+		var wrapped []type_system.Type
+		wrapped = append(wrapped, extraPrefix2...)
+		wrapped = append(wrapped, rest2)
+		wrapped = append(wrapped, extraSuffix2...)
+		wrappedTuple := type_system.NewTupleType(nil, wrapped...)
+		unifyErrors := c.Unify(ctx, rest1.Type, wrappedTuple)
+		errors = slices.Concat(errors, unifyErrors)
+	} else {
+		// Both sides have extras — cannot unify
+		return []Error{&CannotUnifyTypesError{
+			T1: type_system.NewTupleType(nil, append(append(prefix1, rest1), suffix1...)...),
+			T2: type_system.NewTupleType(nil, append(append(prefix2, rest2), suffix2...)...),
+		}}
+	}
+
+	return errors
 }

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -2315,12 +2315,21 @@ func (c *Checker) unifyTuples(ctx Context, tuple1, tuple2 *type_system.TupleType
 	return c.unifyVariadicVsVariadic(ctx, prefix1, rest1, suffix1, prefix2, rest2, suffix2)
 }
 
-// unifyFixedTuples handles unification of two tuples with no RestSpreadType elements.
+// unifyFixedTuples handles unification of two tuples with no RestSpreadType
+// elements. The call convention is Unify(source, target): tuple1 is the value
+// being assigned and tuple2 is the target (pattern or type annotation).
+//
+//   - tuple1 has more elements than tuple2: OK — extras in the value are ignored.
+//   - tuple2 has more elements than tuple1: Error — the target expects more
+//     elements than the value provides (NotEnoughElementsToUnpackError).
+//   - Same length: unify pairwise.
 func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.TupleType) []Error {
 	errors := []Error{}
 
 	if len(tuple2.Elems) > len(tuple1.Elems) {
-		// Unify the elements that are present in both tuples
+		// The target (tuple2) expects more elements than the value (tuple1)
+		// provides. Unify the elements that are present in both tuples, then
+		// report the extra target bindings as unpack errors.
 		for elem1, elem2 := range Zip(tuple1.Elems, tuple2.Elems) {
 			unifyErrors := c.Unify(ctx, elem1, elem2)
 			errors = slices.Concat(errors, unifyErrors)
@@ -2330,8 +2339,8 @@ func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.Tupl
 		first := GetNode(extraElems[0].Provenance())
 		last := GetNode(extraElems[len(extraElems)-1].Provenance())
 
-		// Any remaining elements in tuple2 should be typed as `undefined`
-		// since they are not present in tuple1.
+		// Type the extra target bindings as `undefined` since they have no
+		// corresponding value element.
 		for _, elem2 := range extraElems {
 			node := GetNode(elem2.Provenance())
 			undefined := type_system.NewUndefinedType(&ast.NodeProvenance{Node: node})
@@ -2344,26 +2353,28 @@ func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.Tupl
 		}})
 	}
 
-	if len(tuple1.Elems) != len(tuple2.Elems) {
-		return []Error{&CannotUnifyTypesError{
-			T1: tuple1,
-			T2: tuple2,
-		}}
-	}
-
-	for elem1, elem2 := range Zip(tuple1.Elems, tuple2.Elems) {
-		unifyErrors := c.Unify(ctx, elem1, elem2)
+	// tuple1 has >= tuple2's length. Unify pairwise up to tuple2's length;
+	// any extra elements in tuple1 (the value) are ignored.
+	for i, elem2 := range tuple2.Elems {
+		unifyErrors := c.Unify(ctx, tuple1.Elems[i], elem2)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
 	return errors
 }
 
-// unifyFixedVsVariadic handles: fixed tuple vs tuple with rest spread.
-// Example: [A, B, C] vs [D, ...R, E]
-// - prefix2 elements unify with the start of fixedElems
-// - suffix2 elements unify with the end of fixedElems
-// - the rest spread absorbs the middle elements
+// unifyFixedVsVariadic handles: source is a fixed tuple, target is variadic.
+// The call convention is Unify(source, target): fixedElems is the value being
+// assigned and prefix2/rest2/suffix2 describe the target's structure.
+//
+// The target requires at least len(prefix2)+len(suffix2) elements from the
+// source to fill its mandatory positions. If the source doesn't have enough,
+// that's an error. Any extra source elements beyond the mandatory positions
+// are absorbed by the target's rest spread.
+//
+// Example: [1, "a", "b"] vs [number, ...Array<string>]
+// - prefix: Unify(1, number)
+// - rest absorbs ["a", "b"]: Unify(["a", "b"], Array<string>)
 func (c *Checker) unifyFixedVsVariadic(
 	ctx Context,
 	fixedElems []type_system.Type,
@@ -2371,6 +2382,8 @@ func (c *Checker) unifyFixedVsVariadic(
 ) []Error {
 	requiredCount := len(prefix2) + len(suffix2)
 	if len(fixedElems) < requiredCount {
+		// The source doesn't have enough elements to fill the target's
+		// mandatory prefix and suffix positions.
 		return []Error{&CannotUnifyTypesError{
 			T1: type_system.NewTupleType(nil, fixedElems...),
 			T2: type_system.NewTupleType(nil, append(append(prefix2, rest2), suffix2...)...),
@@ -2401,38 +2414,51 @@ func (c *Checker) unifyFixedVsVariadic(
 	return errors
 }
 
-// unifyVariadicVsFixed handles: tuple with rest spread vs fixed tuple.
-// Mirror of unifyFixedVsVariadic.
+// unifyVariadicVsFixed handles: source is variadic, target is a fixed tuple.
+// The call convention is Unify(source, target): prefix1/rest1/suffix1 describe
+// the source's structure and fixedElems is the target.
+//
+// The target only needs its own positions filled. The source's prefix and
+// suffix are mandatory elements in the source — we unify them pairwise with
+// the target up to the target's length. If the source has more mandatory
+// elements than the target, the extras are ignored (same convention as
+// unifyFixedTuples). The rest spread binds to the remaining target elements
+// between the prefix and suffix matches.
+//
+// Example: [number, ...T] (source) vs [number, string] (target)
+// - prefix: Unify(number, number)
+// - rest absorbs [string]: Unify(T, [string])
 func (c *Checker) unifyVariadicVsFixed(
 	ctx Context,
 	prefix1 []type_system.Type, rest1 *type_system.RestSpreadType, suffix1 []type_system.Type,
 	fixedElems []type_system.Type,
 ) []Error {
-	requiredCount := len(prefix1) + len(suffix1)
-	if len(fixedElems) < requiredCount {
-		return []Error{&CannotUnifyTypesError{
-			T1: type_system.NewTupleType(nil, append(append(prefix1, rest1), suffix1...)...),
-			T2: type_system.NewTupleType(nil, fixedElems...),
-		}}
-	}
-
 	errors := []Error{}
 
-	// Unify prefix elements pairwise
-	for i, elem1 := range prefix1 {
-		unifyErrors := c.Unify(ctx, elem1, fixedElems[i])
+	// Unify prefix elements pairwise, up to the shorter of the two.
+	// If the source prefix is longer, extras are ignored.
+	prefixLen := min(len(prefix1), len(fixedElems))
+	for i := range prefixLen {
+		unifyErrors := c.Unify(ctx, prefix1[i], fixedElems[i])
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
-	// Unify suffix elements pairwise (from the end)
-	for i, elem1 := range suffix1 {
-		fixedIdx := len(fixedElems) - len(suffix1) + i
-		unifyErrors := c.Unify(ctx, elem1, fixedElems[fixedIdx])
+	// If the target was exhausted by the prefix, the rest and suffix are
+	// extra source elements — ignored per the source-extras convention.
+	if len(fixedElems) <= len(prefix1) {
+		return errors
+	}
+
+	// Unify suffix elements pairwise from the end, up to the shorter of the two.
+	remaining := fixedElems[prefixLen:]
+	suffixLen := min(len(suffix1), len(remaining))
+	for i := range suffixLen {
+		unifyErrors := c.Unify(ctx, suffix1[len(suffix1)-suffixLen+i], remaining[len(remaining)-suffixLen+i])
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
-	// The middle elements are absorbed by the rest spread
-	middleElems := fixedElems[len(prefix1) : len(fixedElems)-len(suffix1)]
+	// The middle target elements are absorbed by the source's rest spread
+	middleElems := remaining[:len(remaining)-suffixLen]
 	restTuple := type_system.NewTupleType(nil, middleElems...)
 	unifyErrors := c.Unify(ctx, rest1.Type, restTuple)
 	errors = slices.Concat(errors, unifyErrors)

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -3472,3 +3472,194 @@ nil
     inferredType: nil,
 }
 ---
+
+[TestParseTypeAnnNoErrors/TupleWithRestSpreadArray - 1]
+&ast.TupleTypeAnn{
+    Elems: {
+        &ast.NumberTypeAnn{
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:2},
+                End:      ast.Location{Line:1, Column:8},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+        &ast.RestSpreadTypeAnn{
+            Value: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "Array",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:13},
+                        End:      ast.Location{Line:1, Column:18},
+                        SourceID: 0,
+                    },
+                },
+                TypeArgs: {
+                    &ast.StringTypeAnn{
+                        span: ast.Span{
+                            Start:    ast.Location{Line:1, Column:19},
+                            End:      ast.Location{Line:1, Column:25},
+                            SourceID: 0,
+                        },
+                        inferredType: nil,
+                    },
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:13},
+                    End:      ast.Location{Line:1, Column:26},
+                    SourceID: 0,
+                },
+                inferredType: nil,
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:10},
+                End:      ast.Location{Line:1, Column:26},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:27},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseTypeAnnNoErrors/TupleWithTrailingRestSpread - 1]
+&ast.TupleTypeAnn{
+    Elems: {
+        &ast.NumberTypeAnn{
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:2},
+                End:      ast.Location{Line:1, Column:8},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+        &ast.RestSpreadTypeAnn{
+            Value: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "T",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:13},
+                        End:      ast.Location{Line:1, Column:14},
+                        SourceID: 0,
+                    },
+                },
+                TypeArgs: {
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:13},
+                    End:      ast.Location{Line:1, Column:14},
+                    SourceID: 0,
+                },
+                inferredType: nil,
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:10},
+                End:      ast.Location{Line:1, Column:14},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:15},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseTypeAnnNoErrors/TupleWithLeadingRestSpread - 1]
+&ast.TupleTypeAnn{
+    Elems: {
+        &ast.RestSpreadTypeAnn{
+            Value: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "T",
+                    span: ast.Span{
+                        Start:    ast.Location{Line:1, Column:5},
+                        End:      ast.Location{Line:1, Column:6},
+                        SourceID: 0,
+                    },
+                },
+                TypeArgs: {
+                },
+                span: ast.Span{
+                    Start:    ast.Location{Line:1, Column:5},
+                    End:      ast.Location{Line:1, Column:6},
+                    SourceID: 0,
+                },
+                inferredType: nil,
+            },
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:2},
+                End:      ast.Location{Line:1, Column:6},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+        &ast.StringTypeAnn{
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:8},
+                End:      ast.Location{Line:1, Column:14},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:15},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseTypeAnnErrorHandling/RestSpreadMissingType - 1]
+&ast.TupleTypeAnn{
+    Elems: {
+        &ast.NumberTypeAnn{
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:2},
+                End:      ast.Location{Line:1, Column:8},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+        &ast.ErrorTypeAnn{
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:10},
+                End:      ast.Location{Line:1, Column:13},
+                SourceID: 0,
+            },
+            inferredType: nil,
+        },
+    },
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:14},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---
+
+[TestParseTypeAnnErrorHandling/RestSpreadMissingType - 2]
+[]*parser.Error{
+    &parser.Error{
+        Span: ast.Span{
+            Start:    ast.Location{Line:1, Column:10},
+            End:      ast.Location{Line:1, Column:13},
+            SourceID: 0,
+        },
+        Message: "expected type annotation after '...'",
+    },
+}
+---

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -413,6 +413,15 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 			// Just return the inner type annotation - parentheses are for grouping only
 		case BackTick: // template literal type
 			typeAnn = p.templateLitTypeAnn(token)
+		case DotDotDot: // rest spread type: ...T
+			p.lexer.consume() // consume '...'
+			value := p.typeAnn()
+			if value == nil {
+				p.reportError(token.Span, "expected type annotation after '...'")
+				return nil
+			}
+			span := ast.MergeSpans(token.Span, value.Span())
+			typeAnn = ast.NewRestSpreadTypeAnn(value, span)
 		default:
 			// Return nil without consuming — signals "no type annotation found."
 			// Callers provide their own contextual error messages.

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -418,7 +418,8 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 			value := p.typeAnn()
 			if value == nil {
 				p.reportError(token.Span, "expected type annotation after '...'")
-				return nil
+				typeAnn = ast.NewErrorTypeAnn(token.Span)
+				break
 			}
 			span := ast.MergeSpans(token.Span, value.Span())
 			typeAnn = ast.NewRestSpreadTypeAnn(value, span)

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -170,6 +170,15 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"IntersectionTypeWithTypeOf": {
 			input: "typeof x & U",
 		},
+		"TupleWithTrailingRestSpread": {
+			input: "[number, ...T]",
+		},
+		"TupleWithLeadingRestSpread": {
+			input: "[...T, string]",
+		},
+		"TupleWithRestSpreadArray": {
+			input: "[number, ...Array<string>]",
+		},
 	}
 
 	for name, test := range tests {
@@ -216,6 +225,9 @@ func TestParseTypeAnnErrorHandling(t *testing.T) {
 		},
 		"ConditionalTypeMissingThen": {
 			input: "if A : B { } else { D }",
+		},
+		"RestSpreadMissingType": {
+			input: "[number, ...]",
 		},
 	}
 

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1683,15 +1683,37 @@ func (t *TupleType) Equals(other Type) bool {
 
 func (t *TupleType) String() string {
 	result := "["
-	if len(t.Elems) > 0 {
-		for i, elem := range t.Elems {
-			if i > 0 {
-				result += ", "
-			}
-			result += elem.String()
+	flatElems := collectFlatTupleElems(t.Elems)
+	for i, elem := range flatElems {
+		if i > 0 {
+			result += ", "
 		}
+		result += elem.String()
 	}
 	result += "]"
+	return result
+}
+
+// collectFlatTupleElems collects all displayable elements from a TupleType,
+// flattening any RestSpreadType whose inner type resolves to a TupleType by
+// inlining its elements. RestSpreadTypes that resolve to non-TupleTypes (e.g.
+// unresolved TypeVars or Array types) are kept as-is.
+func collectFlatTupleElems(elems []Type) []Type {
+	var result []Type
+	for _, elem := range elems {
+		rest, ok := elem.(*RestSpreadType)
+		if !ok {
+			result = append(result, elem)
+			continue
+		}
+		resolved := Prune(rest.Type)
+		if tuple, ok := resolved.(*TupleType); ok {
+			// Recursively flatten nested RestSpreadTypes
+			result = append(result, collectFlatTupleElems(tuple.Elems)...)
+		} else {
+			result = append(result, elem)
+		}
+	}
 	return result
 }
 

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1706,7 +1706,7 @@ func collectFlatTupleElems(elems []Type) []Type {
 			result = append(result, elem)
 			continue
 		}
-		resolved := Prune(rest.Type)
+		resolved := resolveTypeVar(rest.Type)
 		if tuple, ok := resolved.(*TupleType); ok {
 			// Recursively flatten nested RestSpreadTypes
 			result = append(result, collectFlatTupleElems(tuple.Elems)...)

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1449,9 +1449,19 @@ deferring the commitment until closing time.
 
 ---
 
-## Phase 13: Variadic Tuple Types
+## Phase 13: Variadic Tuple Types ✅
 
 **Requirements covered:** Section 14 (variadic tuple types).
+
+> **Status (2026-04-08):** Implemented. Tuple-vs-tuple unification with
+> `RestSpreadType` at any position (leading, middle, trailing) is complete.
+> `TupleType.String()` flattens resolved rest types. Tuple-vs-array and
+> array-vs-tuple unification handle `RestSpreadType` elements. `getMemberType`
+> includes rest type element types in the union for method resolution. The
+> parser now supports `...T` in tuple type annotations (previously only in
+> object type annotations). Generalization and instantiation work automatically
+> via the existing visitor pattern. Tests cover fixed-vs-variadic,
+> variadic-vs-variadic, generalization, and array-absorbed rest types.
 
 **Goal:** Support `RestSpreadType` elements inside `TupleType` as variadic
 type parameters, enabling types like `[number, string, ...T]` where `T`
@@ -1581,10 +1591,10 @@ and display.
 
 7. **Type annotation parsing:**
 
-   The parser already handles `[number, string, ...T]` in type annotations
-   since `RestSpreadType` is a valid type and tuple types accept arbitrary
-   type elements. Verify that `...T` where `T` is a type reference parses
-   correctly in a tuple type annotation.
+   **Note:** The original plan assumed the parser already handled `...T` in
+   tuple type annotations, but `DotDotDot` was only handled in
+   `objTypeAnnElem` (for object types). A `DotDotDot` case was added to
+   `primaryTypeAnn` in `type_ann.go` to support `[number, ...T]` syntax.
 
 ### Tests
 
@@ -1974,7 +1984,7 @@ Phase 6 → Phase 12: Tuple/Array Inference
 ### Variadic tuples (after Phase 3, independent)
 
 ```
-Phase 3 → Phase 13: Variadic Tuple Types
+Phase 3 → Phase 13: Variadic Tuple Types ✅
             → Phase 14: Tuple Row Polymorphism (also requires Phase 12)
 ```
 
@@ -1989,7 +1999,7 @@ Phase 7, Phase 14 → Phase 8: Destructuring
 ```
 Phase 2 → Phase 9: Optional Chaining
 Phase 3 → Phase 10: Object Spread
-Phase 3 → Phase 13: Variadic Tuple Types
+Phase 3 → Phase 13: Variadic Tuple Types ✅
 ```
 
 ### Error reporting (after all other phases)
@@ -2014,7 +2024,7 @@ All phases → Phase 11: Error Reporting
 | 10: Object Spread              | 3          | 4–14                 |
 | 11: Error Reporting            | all        | —                    |
 | 12: Tuple/Array Inference      | 6          | 7, 13                |
-| 13: Variadic Tuple Types       | 3          | 4–12                 |
+| 13: Variadic Tuple Types ✅    | 3          | 4–12                 |
 | 14: Tuple Row Polymorphism     | 12, 13     | 7                    |
 
 ---
@@ -2058,12 +2068,12 @@ All phases → Phase 11: Error Reporting
    non-literal usage is observed, and only deferring for the pure literal-index
    case.
 
-7. **Variadic tuple unification (Phase 13):** The existing tuple-vs-tuple
-   unification has a `TODO: handle spread` comment and only partial
-   `RestSpreadType` support. Completing this requires careful handling of
-   positional-vs-rest element alignment. The variadic-vs-variadic case (both
-   sides have `RestSpreadType`) with different prefix lengths is the most
-   complex path.
+7. ~~**Variadic tuple unification (Phase 13):**~~ Resolved. The tuple-vs-tuple
+   unification now uses `splitTupleAtRest` to partition elements into
+   prefix/rest/suffix, then delegates to specialized helpers for each case
+   (fixed-vs-variadic, variadic-vs-fixed, variadic-vs-variadic). The
+   variadic-vs-variadic case handles different prefix/suffix lengths by
+   wrapping extras into a tuple with the shorter side's rest.
 
 8. **Tuple row polymorphism interaction with Phase 8 (Phase 14):** Phase 14
    changes Phase 8's tuple destructuring from collapsing `[a, ...rest]` to
@@ -2077,14 +2087,15 @@ All phases → Phase 11: Error Reporting
 
 | File | Phases | Status |
 |------|--------|--------|
-| `internal/type_system/types.go` | 1, 7, 13 | ✅ (Phase 1) `Open`, `Widenable`, `IsParam`, `Written` fields added; `Accept`/`Copy` updated; (Phase 7) `collectFlatElems` and `ObjectType.String()` flattening of resolved `RestSpreadElem`s; Phase 13: `TupleType.String()` flattening of resolved `RestSpreadType` |
-| `internal/checker/expand_type.go` | 2, 9, 10, 12, 13 | ✅ (Phase 2) `TypeVarType` case in `getMemberType`, open-object handling in `getObjectAccess`, helper functions; Phase 12: modify TypeVarType numeric index branch to defer tuple/array commitment; Phase 13: variadic tuple element type union for method resolution |
-| `internal/checker/unify.go` | 3, 4, 10, 13 | ✅ (Phase 3) `openClosedObjectForParam`, open-vs-open/closed paths; (Phase 4) `unifyPruned` refactor, `widenLiteral`, `flatUnion`, `typeContains`, `unwrapMutability`; Phase 13: complete tuple-vs-tuple `RestSpreadType` unification |
+| `internal/type_system/types.go` | 1, 7, 13 | ✅ (Phase 1) `Open`, `Widenable`, `IsParam`, `Written` fields added; `Accept`/`Copy` updated; (Phase 7) `collectFlatElems` and `ObjectType.String()` flattening of resolved `RestSpreadElem`s; ✅ (Phase 13) `collectFlatTupleElems` and `TupleType.String()` flattening of resolved `RestSpreadType` |
+| `internal/checker/expand_type.go` | 2, 9, 10, 12, 13 | ✅ (Phase 2) `TypeVarType` case in `getMemberType`, open-object handling in `getObjectAccess`, helper functions; Phase 12: modify TypeVarType numeric index branch to defer tuple/array commitment; ✅ (Phase 13) `tupleElemUnion` helper; `getMemberType` TupleType case handles `RestSpreadType` in both numeric index and method access |
+| `internal/checker/unify.go` | 3, 4, 10, 13 | ✅ (Phase 3) `openClosedObjectForParam`, open-vs-open/closed paths; (Phase 4) `unifyPruned` refactor, `widenLiteral`, `flatUnion`, `typeContains`, `unwrapMutability`; ✅ (Phase 13) `splitTupleAtRest`, `unifyTuples`, `unifyFixedTuples`, `unifyFixedVsVariadic`, `unifyVariadicVsFixed`, `unifyVariadicVsVariadic`; tuple-vs-array and array-vs-tuple handle `RestSpreadType` |
+| `internal/parser/type_ann.go` | 13 | ✅ (Phase 13) `DotDotDot` case in `primaryTypeAnn` — enables `...T` in tuple type annotations (e.g. `[number, ...T]`) |
 | `internal/checker/generalize.go` | 2, 6, 7 | ✅ (Phase 2) Mutability resolution in `GeneralizeFuncType`, `Open` preserved in `deepCloneType`; (Phase 7) No changes needed — handles row variables automatically; Phases 13/14: no changes expected (visitor pattern handles `RestSpreadType` in tuples) |
 | `internal/checker/infer_func.go` | 3, 6, 7, 8, 12, 14 | ✅ (Phase 3) `IsParam: true` for unannotated parameters; (Phase 6) `closeOpenParams`, `closeObjectType`; (Phase 7) No changes needed; Phase 12: resolve `ArrayConstraint` during closing; Phase 14: `closeTupleType` for rest variable filtering |
 | `internal/checker/infer_expr.go` | 2, 5, 7, 10, 12 | ✅ (Phase 2) `markPropertyWritten` in assignment handler; (Phase 7) No changes needed; Phase 12: detect index assignment on `ArrayConstraint` |
 | `internal/checker/errors.go` | 11 | Not started |
-| `internal/checker/tests/row_types_test.go` | All | ✅ Tests for Phases 1–7 (PropertyAccess, Errors, KeyOf, IntersectionAccess, PassToTypedFunction, WriteAfterPass, StringLiteralIndex, MethodCallInference, PropertyWidening, Closing, RowPolymorphism) |
+| `internal/checker/tests/row_types_test.go` | All | ✅ Tests for Phases 1–7 (PropertyAccess, Errors, KeyOf, IntersectionAccess, PassToTypedFunction, WriteAfterPass, StringLiteralIndex, MethodCallInference, PropertyWidening, Closing, RowPolymorphism); ✅ Phase 13 (VariadicTupleTypes, VariadicTupleSubtyping) |
 | `internal/checker/widening_test.go` | 4 | ✅ Unit tests for `flatUnion` and `typeContains` helpers |
 
 ---

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -1494,14 +1494,23 @@ is used. This section refines that behavior:
 This deferred approach avoids premature commitment to `Array<T>` when the usage
 pattern actually indicates a tuple.
 
-### 14. Variadic Tuple Types
+### 14. Variadic Tuple Types ✅
+
+> **Status (2026-04-08):** Implemented in Phase 13. Tuple-vs-tuple unification
+> with `RestSpreadType` at any position is complete (`splitTupleAtRest` +
+> specialized helpers in `unify.go`). `TupleType.String()` flattens resolved
+> rest types via `collectFlatTupleElems`. `getMemberType` handles
+> `RestSpreadType` in both numeric index and method access via `tupleElemUnion`.
+> The parser now supports `...T` in tuple type annotations (`primaryTypeAnn` in
+> `type_ann.go`). Generalization and instantiation work automatically via the
+> visitor pattern. Tests: `TestVariadicTupleTypes`, `TestVariadicTupleSubtyping`.
 
 Variadic tuple types extend tuple types with a rest element that captures a
 variable number of trailing elements. This is the tuple analogue of row variables
 (`RestSpreadElem`) in object types — it enables functions to be generic over the
 "tail" of a tuple.
 
-#### 14a. Syntax and representation
+#### 14a. Syntax and representation ✅
 
 A variadic tuple type is written as `[A, B, ...T]` where `A` and `B` are fixed
 positional element types and `T` is a type variable (or concrete type)
@@ -1559,9 +1568,11 @@ TupleType{Elems: [RestSpreadType{Type: Array<number>}, string, RestSpreadType{Ty
 ```
 
 The `RestSpreadType` type already exists and can appear in `TupleType.Elems`.
-The parser already handles `...T` in tuple type annotations.
+The parser handles `...T` in tuple type annotations (support was added to
+`primaryTypeAnn` in Phase 13 — previously `...` was only handled in object type
+annotation elements).
 
-#### 14b. Unification rules
+#### 14b. Unification rules ✅
 
 When unifying tuple types that contain `RestSpreadType` elements:
 
@@ -1595,7 +1606,7 @@ val r = foo([1, "hello", true])
 // T = ["hello", true], r: ["hello", true]
 ```
 
-#### 14c. Interaction with Array methods
+#### 14c. Interaction with Array methods ✅
 
 A variadic tuple like `[number, string, ...T]` supports the same Array methods
 as fixed tuples. The element type union for method resolution includes all
@@ -1606,7 +1617,7 @@ fixed elements plus the rest type's element type:
 - `[number, ...T]` where `T` is unresolved → methods resolve against
   `Array<number | T>`.
 
-#### 14d. Display
+#### 14d. Display ✅
 
 Variadic tuple types display with `...` before the rest type:
 - `[number, string, ...T]` — unresolved rest.
@@ -1797,10 +1808,13 @@ val r = identity([1, "hello"])
     `Array<T>` / `mut Array<T>` (if mutating methods, non-literal indexes, or
     index assignments are present). See Section 13.
 
-11. **Complete variadic tuple type support**: Finish `RestSpreadType` unification
+11. **Complete variadic tuple type support** ✅: Finish `RestSpreadType` unification
     in tuple-vs-tuple, tuple-vs-array, and variadic-vs-variadic paths. Update
     `TupleType.String()` to flatten resolved rest types. Support variadic tuples
     in type annotations, generalization, and instantiation (see Section 14).
+    Implemented in Phase 13: `splitTupleAtRest` + specialized unification helpers
+    in `unify.go`; `collectFlatTupleElems` in `types.go`; `tupleElemUnion` in
+    `expand_type.go`; `DotDotDot` case in `type_ann.go`.
 
 12. **Add tuple row polymorphism**: When an inferred tuple parameter is returned,
     append a `RestSpreadType` with a fresh type variable to capture extra


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rest-spread tuple syntax in type annotations and flattened display of resolved rest spreads.

* **Bug Fixes**
  * Tuple unification, tuple↔array interactions, numeric indexing, and property access correctly handle rest-spread elements anywhere; out-of-prefix indexing now returns the combined element-type union and avoids incorrect never/overflow errors.

* **Tests**
  * Added parsing, inference, and subtyping tests covering variadic tuples, generalization, and error-recovery cases.

* **Documentation**
  * Updated design and requirements to mark variadic tuple support complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->