### PR TITLE
Fix variadic tuple indexing to return precise element types

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -562,16 +562,12 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 						}
 					}
 					// Check if the tuple has a rest element
-					hasRest := false
 					for _, elem := range t.Elems {
-						if _, isRest := elem.(*type_system.RestSpreadType); isRest {
-							hasRest = true
-							break
+						if rest, isRest := elem.(*type_system.RestSpreadType); isRest {
+							// Index beyond fixed prefix — return the rest's element type
+							restIndex := index - fixedCount
+							return restElemType(rest, restIndex), errors
 						}
-					}
-					if hasRest {
-						// Index beyond fixed prefix — return union of all element types
-						return tupleElemUnion(t), errors
 					}
 					errors = append(errors, &OutOfBoundsError{
 						Index:  index,
@@ -1624,6 +1620,52 @@ func (v *InferTypeReplacer) ExitType(t type_system.Type) type_system.Type {
 
 	// For all other types, return nil to let Accept handle the traversal
 	return nil
+}
+
+// restElemType extracts the element type from a RestSpreadType at the given
+// offset within the rest. For a TupleType, if the index falls within bounds
+// it returns the exact element type; otherwise it returns never. For Array<T>
+// it returns T (the index doesn't matter since all elements have the same
+// type). For unresolved types it returns the type as-is.
+func restElemType(rest *type_system.RestSpreadType, index int) type_system.Type {
+	resolved := type_system.Prune(rest.Type)
+	switch r := resolved.(type) {
+	case *type_system.TupleType:
+		// Count fixed (non-rest) elements and find any nested rest spread.
+		fixedCount := 0
+		var nestedRest *type_system.RestSpreadType
+		for _, elem := range r.Elems {
+			if nr, ok := elem.(*type_system.RestSpreadType); ok {
+				nestedRest = nr
+			} else {
+				fixedCount++
+			}
+		}
+		if index < fixedCount {
+			// Map index to actual position, skipping RestSpreadType
+			pos := 0
+			for _, elem := range r.Elems {
+				if _, ok := elem.(*type_system.RestSpreadType); ok {
+					continue
+				}
+				if pos == index {
+					return elem
+				}
+				pos++
+			}
+		}
+		if nestedRest != nil {
+			return restElemType(nestedRest, index-fixedCount)
+		}
+		return type_system.NewNeverType(nil)
+	case *type_system.TypeRefType:
+		if type_system.QualIdentToString(r.Name) == "Array" && len(r.TypeArgs) == 1 {
+			return r.TypeArgs[0]
+		}
+		return resolved
+	default:
+		return resolved
+	}
 }
 
 // tupleElemUnion computes the union of all element types in a tuple,

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1476,3 +1476,111 @@ func TestVariadicTupleSubtyping(t *testing.T) {
 		require.NotEmpty(t, inferErrors)
 	})
 }
+
+func TestVariadicTupleIndexing(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"IndexWithinFixedPrefix": {
+			// Indexing within the fixed prefix returns the element's type.
+			input: `
+				fn foo<T>(items: [number, string, ...T]) {
+					val a = items[0]
+					val b = items[1]
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T>(items: [number, string, ...T]) -> [number, string]",
+			},
+		},
+		"IndexBeyondFixedPrefix": {
+			// Indexing beyond the fixed prefix returns the union of all
+			// element types (fixed + rest).
+			input: `
+				fn foo(items: [number, ...Array<string>]) {
+					val a = items[0]
+					val b = items[2]
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: [number, ...Array<string>]) -> [number, string]",
+			},
+		},
+		"MethodAccessOnVariadicTuple": {
+			// Method access resolves via Array<union of all element types>.
+			input: `
+				fn foo(items: [number, ...Array<string>]) {
+					return items.length
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: [number, ...Array<string>]) -> number",
+			},
+		},
+		"IndexIntoResolvedTupleRest": {
+			// When the rest resolves to a concrete tuple, indexing beyond
+			// the fixed prefix returns the exact element type at that
+			// offset within the rest tuple.
+			input: `
+				fn foo<T>(items: [number, ...T]) -> T { return items }
+				val r = foo([1, "a", true])
+				val a = r[0]
+				val b = r[1]
+			`,
+			expectedTypes: map[string]string{
+				"a": "\"a\"",
+				"b": "true",
+			},
+		},
+		"IndexIntoConcreteSpreadTuple": {
+			// [number, ...[string, boolean]] — the spread is a concrete
+			// tuple. Indexing should see the flattened view:
+			// index 0 → number, index 1 → string, index 2 → boolean.
+			input: `
+				val items: [number, ...[string, boolean]] = [1, "a", true]
+				val a = items[0]
+				val b = items[1]
+				val c = items[2]
+			`,
+			expectedTypes: map[string]string{
+				"items": "[number, string, boolean]",
+				"a":     "number",
+				"b":     "string",
+				"c":     "boolean",
+			},
+		},
+		"IndexIntoNestedVariadicTuple": {
+			// [number, ...[string, ...Array<boolean>]] — the spread is a
+			// variadic tuple. Index 0 → number, index 1 → string (from the
+			// nested fixed prefix), index 2+ → boolean (from the nested rest).
+			input: `
+				val items: [number, ...[string, ...Array<boolean>]] = [1, "a", true, false]
+				val a = items[0]
+				val b = items[1]
+				val c = items[2]
+				val d = items[3]
+			`,
+			expectedTypes: map[string]string{
+				"a": "number",
+				"b": "string",
+				"c": "boolean",
+				"d": "boolean",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1496,8 +1496,8 @@ func TestVariadicTupleIndexing(t *testing.T) {
 			},
 		},
 		"IndexBeyondFixedPrefix": {
-			// Indexing beyond the fixed prefix returns the union of all
-			// element types (fixed + rest).
+			// Indexing beyond the fixed prefix returns the rest spread's
+			// element type (not a union of all element types).
 			input: `
 				fn foo(items: [number, ...Array<string>]) {
 					val a = items[0]


### PR DESCRIPTION
## Summary
- When indexing beyond the fixed prefix of a variadic tuple (e.g. `items[2]` on `[number, ...Array<string>]`), return the rest spread's element type (`string`) instead of the union of all element types (`number | string`)
- Add `restElemType` helper with recursive resolution through nested variadic tuples (e.g. `[number, ...[string, ...Array<boolean>]]`)
- Add `TestVariadicTupleIndexing` with 6 test cases covering fixed prefix indexing, rest element indexing, method access, resolved tuple rest, concrete spread tuples, and nested variadic tuples

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `IndexWithinFixedPrefix` — literal index within fixed prefix returns exact type
- [x] `IndexBeyondFixedPrefix` — literal index beyond prefix returns rest element type
- [x] `MethodAccessOnVariadicTuple` — `.length` resolves via `Array<union>`
- [x] `IndexIntoResolvedTupleRest` — resolved `...T` where `T = [string, boolean]` returns exact types
- [x] `IndexIntoConcreteSpreadTuple` — `[number, ...[string, boolean]]` indexes through flattened view
- [x] `IndexIntoNestedVariadicTuple` — `[number, ...[string, ...Array<boolean>]]` recurses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for tuple element indexing when using variadic and rest spread elements
  * Enhanced support for accessing elements within complex nested tuple structures with proper type resolution
  * Refined type calculations for out-of-bounds tuple access patterns
  * Added comprehensive test coverage validating type inference across various variadic tuple indexing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->