### PR TITLE
Row Types - Phase 12: Tuple/Array Inference

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -698,6 +698,17 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 			case PropertyKey:
 				return c.getArrayConstraintPropertyAccess(ctx, t, k.Name, errors)
 			case IndexKey:
+				// If the index is a string literal, route to property access
+				// instead of numeric index access.
+				keyType := type_system.Prune(k.Type)
+				if mut, ok := keyType.(*type_system.MutabilityType); ok {
+					keyType = mut.Type
+				}
+				if litType, ok := keyType.(*type_system.LitType); ok {
+					if strLit, ok := litType.Lit.(*type_system.StrLit); ok {
+						return c.getArrayConstraintPropertyAccess(ctx, t, strLit.Value, errors)
+					}
+				}
 				return c.getArrayConstraintIndexAccess(ctx, t, k, errors)
 			default:
 				errors = append(errors, &ExpectedObjectError{Type: objType, span: key.Span()})
@@ -1012,23 +1023,40 @@ func markPropertyWritten(prunedType type_system.Type, propName string) bool {
 	return false
 }
 
-// isNumericType returns true if the type represents a numeric type (number primitive).
+// isNumericType returns true if the type represents a numeric type.
+// This includes the number primitive and numeric literal types that are not
+// valid non-negative integer tuple indices (e.g. floats, negatives).
 func isNumericType(t type_system.Type) bool {
 	t = type_system.Prune(t)
 	if numPrim, ok := t.(*type_system.PrimType); ok && numPrim.Prim == type_system.NumPrim {
 		return true
+	}
+	if litType, ok := t.(*type_system.LitType); ok {
+		if _, ok := litType.Lit.(*type_system.NumLit); ok {
+			// If it's a valid non-negative int literal, it's handled by
+			// asNonNegativeIntLiteral, not here. Only treat non-integer
+			// or negative numeric literals as generic numeric types.
+			if _, isIndex := asNonNegativeIntLiteral(t); !isIndex {
+				return true
+			}
+		}
 	}
 	return false
 }
 
 // asNonNegativeIntLiteral extracts a non-negative integer from a numeric literal type.
 // Returns the integer value and true if successful, or 0 and false otherwise.
+// Rejects integers exceeding maxTupleIndex to prevent huge tuple allocations in
+// resolveArrayConstraint.
+// TODO(#402): Make maxTupleIndex configurable via checker options.
+const maxTupleIndex = 20
+
 func asNonNegativeIntLiteral(t type_system.Type) (int, bool) {
 	t = type_system.Prune(t)
 	if litType, ok := t.(*type_system.LitType); ok {
 		if numLit, ok := litType.Lit.(*type_system.NumLit); ok {
 			val := numLit.Value
-			if val >= 0 && val == math.Floor(val) {
+			if val >= 0 && val == math.Floor(val) && int(val) <= maxTupleIndex {
 				return int(val), true
 			}
 		}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"fmt"
+	"math"
 	"slices"
 
 	"maps"
@@ -689,8 +690,29 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 		// Constrained type variables (e.g. `<T: {name: string}>`) should resolve
 		// properties from their constraint first. Currently this only works for
 		// unannotated parameters where Constraint == nil.
+
+		// If this TypeVar already has an ArrayConstraint, handle property access
+		// by looking up the property on the Array type.
+		if t.ArrayConstraint != nil {
+			switch k := key.(type) {
+			case PropertyKey:
+				return c.getArrayConstraintPropertyAccess(ctx, t, k.Name, errors)
+			case IndexKey:
+				return c.getArrayConstraintIndexAccess(ctx, t, k, errors)
+			default:
+				errors = append(errors, &ExpectedObjectError{Type: objType, span: key.Span()})
+				return type_system.NewNeverType(nil), errors
+			}
+		}
+
 		switch k := key.(type) {
 		case PropertyKey:
+			// If this property exists on Array (e.g. .push, .length, .map),
+			// create an ArrayConstraint instead of an open object.
+			if c.isArrayMethod(k.Name) {
+				c.getOrCreateArrayConstraint(t)
+				return c.getArrayConstraintPropertyAccess(ctx, t, k.Name, errors)
+			}
 			propTV, openObj := c.newOpenObjectWithProperty(k.Name)
 			t.Instance = openObj
 			return propTV, errors
@@ -707,26 +729,25 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 					return propTV, errors
 				}
 			}
-			// Numeric index key — bind to Array<T>
-			if numPrim, ok := keyType.(*type_system.PrimType); ok && numPrim.Prim == type_system.NumPrim {
-				elemTV := c.FreshVar(nil)
-				t.Instance = &type_system.TypeRefType{
-					Name:     type_system.NewIdent("Array"),
-					TypeArgs: []type_system.Type{elemTV},
-				}
-				return elemTV, errors
-			}
-			if indexLit, ok := keyType.(*type_system.LitType); ok {
-				if _, ok := indexLit.Lit.(*type_system.NumLit); ok {
+			// Numeric index key — create or update an ArrayConstraint instead of
+			// immediately binding to Array<T>. This defers the tuple-vs-array
+			// decision until closing time.
+			constraint := c.getOrCreateArrayConstraint(t)
+			if litIndex, ok := asNonNegativeIntLiteral(keyType); ok {
+				// Record literal index with a fresh widenable type variable
+				if _, exists := constraint.LiteralIndexes[litIndex]; !exists {
 					elemTV := c.FreshVar(nil)
-					t.Instance = &type_system.TypeRefType{
-						Name:     type_system.NewIdent("Array"),
-						TypeArgs: []type_system.Type{elemTV},
-					}
-					return elemTV, errors
+					elemTV.Widenable = true
+					constraint.LiteralIndexes[litIndex] = elemTV
 				}
+				return constraint.LiteralIndexes[litIndex], errors
 			}
-			// Non-literal string index — defer to later phase
+			if isNumericType(keyType) {
+				// Non-literal numeric type (e.g. number) — must be Array, not tuple
+				constraint.HasNonLiteralIndex = true
+				return constraint.ElemTypeVar, errors
+			}
+			// Non-literal string index — error
 			errors = append(errors, &ExpectedObjectError{Type: objType, span: key.Span()})
 			return type_system.NewNeverType(nil), errors
 		default:
@@ -985,6 +1006,168 @@ func markPropertyWritten(prunedType type_system.Type, propName string) bool {
 			if propElem.Name == type_system.NewStrKey(propName) {
 				propElem.Written = true
 				return true
+			}
+		}
+	}
+	return false
+}
+
+// isNumericType returns true if the type represents a numeric type (number primitive).
+func isNumericType(t type_system.Type) bool {
+	t = type_system.Prune(t)
+	if numPrim, ok := t.(*type_system.PrimType); ok && numPrim.Prim == type_system.NumPrim {
+		return true
+	}
+	return false
+}
+
+// asNonNegativeIntLiteral extracts a non-negative integer from a numeric literal type.
+// Returns the integer value and true if successful, or 0 and false otherwise.
+func asNonNegativeIntLiteral(t type_system.Type) (int, bool) {
+	t = type_system.Prune(t)
+	if litType, ok := t.(*type_system.LitType); ok {
+		if numLit, ok := litType.Lit.(*type_system.NumLit); ok {
+			val := numLit.Value
+			if val >= 0 && val == math.Floor(val) {
+				return int(val), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// getOrCreateArrayConstraint returns the existing ArrayConstraint on a TypeVarType,
+// or creates and attaches a new one with a fresh element type variable.
+func (c *Checker) getOrCreateArrayConstraint(t *type_system.TypeVarType) *type_system.ArrayConstraint {
+	if t.ArrayConstraint != nil {
+		return t.ArrayConstraint
+	}
+	elemTV := c.FreshVar(nil)
+	elemTV.Widenable = true
+	t.ArrayConstraint = &type_system.ArrayConstraint{
+		LiteralIndexes: make(map[int]type_system.Type),
+		ElemTypeVar:    elemTV,
+	}
+	return t.ArrayConstraint
+}
+
+// getArrayConstraintPropertyAccess handles property/method access on a TypeVarType
+// that already has an ArrayConstraint. It looks up the property on the Array type
+// definition to determine if it's a read-only or mutating method.
+func (c *Checker) getArrayConstraintPropertyAccess(ctx Context, t *type_system.TypeVarType, propName string, errors []Error) (type_system.Type, []Error) {
+	constraint := t.ArrayConstraint
+
+	// Special-case .length — always available on both tuples and arrays
+	if propName == "length" {
+		return type_system.NewNumPrimType(nil), errors
+	}
+
+	// Look up the property on the Array type to resolve the method and determine mutability.
+	// We create a temporary Array<ElemTypeVar> to delegate the lookup.
+	arrayAlias := c.GlobalScope.Namespace.Types["Array"]
+	if arrayAlias == nil {
+		errors = append(errors, &ExpectedObjectError{Type: t, span: ast.Span{}})
+		return type_system.NewNeverType(nil), errors
+	}
+
+	// Build a union of all known element types for method resolution.
+	elemType := c.arrayConstraintElemType(constraint)
+
+	tempArrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, elemType)
+	resultType, accessErrors := c.getMemberType(ctx, tempArrayType, PropertyKey{Name: propName})
+	errors = slices.Concat(errors, accessErrors)
+
+	// Check if the resolved method is mutating by inspecting MutSelf on the Array ObjectType.
+	if c.isArrayMutatingMethod(propName) {
+		constraint.HasMutatingMethod = true
+	}
+
+	return resultType, errors
+}
+
+// getArrayConstraintIndexAccess handles numeric index access on a TypeVarType
+// that already has an ArrayConstraint.
+func (c *Checker) getArrayConstraintIndexAccess(_ Context, t *type_system.TypeVarType, k IndexKey, errors []Error) (type_system.Type, []Error) {
+	constraint := t.ArrayConstraint
+	var keyType type_system.Type = k.Type
+	if mut, ok := keyType.(*type_system.MutabilityType); ok && mut.Mutability == type_system.MutabilityUncertain {
+		keyType = mut.Type
+	}
+
+	if litIndex, ok := asNonNegativeIntLiteral(keyType); ok {
+		if _, exists := constraint.LiteralIndexes[litIndex]; !exists {
+			elemTV := c.FreshVar(nil)
+			elemTV.Widenable = true
+			constraint.LiteralIndexes[litIndex] = elemTV
+		}
+		return constraint.LiteralIndexes[litIndex], errors
+	}
+	if isNumericType(keyType) {
+		constraint.HasNonLiteralIndex = true
+		return constraint.ElemTypeVar, errors
+	}
+	errors = append(errors, &ExpectedObjectError{Type: t, span: k.Span()})
+	return type_system.NewNeverType(nil), errors
+}
+
+// arrayConstraintElemType returns a type representing the element type of an ArrayConstraint.
+// If there are literal index type variables, it returns the ElemTypeVar (which will be
+// unified with all literal index types during resolution).
+func (c *Checker) arrayConstraintElemType(constraint *type_system.ArrayConstraint) type_system.Type {
+	return constraint.ElemTypeVar
+}
+
+// isArrayMethod returns true if the given property name exists as a method or
+// property on the Array type (either read-only or mutating).
+func (c *Checker) isArrayMethod(propName string) bool {
+	arrayAlias := c.GlobalScope.Namespace.Types["Array"]
+	if arrayAlias == nil {
+		return false
+	}
+	arrayType := type_system.Prune(arrayAlias.Type)
+	objType, ok := arrayType.(*type_system.ObjectType)
+	if !ok {
+		return false
+	}
+	key := type_system.NewStrKey(propName)
+	for _, elem := range objType.Elems {
+		switch e := elem.(type) {
+		case *type_system.MethodElem:
+			if e.Name == key {
+				return true
+			}
+		case *type_system.PropertyElem:
+			if e.Name == key {
+				return true
+			}
+		case *type_system.GetterElem:
+			if e.Name == key {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isArrayMutatingMethod returns true if the given method name is a mutating method
+// on Array (i.e., it exists on mut Array but not on immutable Array).
+func (c *Checker) isArrayMutatingMethod(methodName string) bool {
+	arrayAlias := c.GlobalScope.Namespace.Types["Array"]
+	if arrayAlias == nil {
+		return false
+	}
+	arrayType := type_system.Prune(arrayAlias.Type)
+	objType, ok := arrayType.(*type_system.ObjectType)
+	if !ok {
+		return false
+	}
+	for _, elem := range objType.Elems {
+		if method, ok := elem.(*type_system.MethodElem); ok {
+			if method.Name == type_system.NewStrKey(methodName) {
+				if method.MutSelf != nil && *method.MutSelf {
+					return true
+				}
+				return false
 			}
 		}
 	}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -718,9 +718,11 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 
 		switch k := key.(type) {
 		case PropertyKey:
-			// If this property exists on Array (e.g. .push, .length, .map),
-			// create an ArrayConstraint instead of an open object.
-			if c.isArrayMethod(k.Name) {
+			// If this property is a method on Array (e.g. .push, .map, .filter),
+			// create an ArrayConstraint instead of an open object. We only check
+			// methods, not properties like .length which are ambiguous (also
+			// exist on strings, etc.).
+			if c.isArrayOnlyMethod(k.Name) {
 				c.getOrCreateArrayConstraint(t)
 				return c.getArrayConstraintPropertyAccess(ctx, t, k.Name, errors)
 			}
@@ -1092,22 +1094,24 @@ func (c *Checker) getArrayConstraintPropertyAccess(ctx Context, t *type_system.T
 
 	// Look up the property on the Array type to resolve the method and determine mutability.
 	// We create a temporary Array<ElemTypeVar> to delegate the lookup.
+	// TODO(#404): This immediately resolves the method signature against ElemTypeVar,
+	// which means a second call with a different type (e.g. push(5) then push("hello"))
+	// fails instead of inferring a union. Needs deferred call-site resolution.
 	arrayAlias := c.GlobalScope.Namespace.Types["Array"]
 	if arrayAlias == nil {
 		errors = append(errors, &ExpectedObjectError{Type: t, span: ast.Span{}})
 		return type_system.NewNeverType(nil), errors
 	}
 
-	// Build a union of all known element types for method resolution.
-	elemType := c.arrayConstraintElemType(constraint)
-
-	tempArrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, elemType)
+	tempArrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, constraint.ElemTypeVar)
 	resultType, accessErrors := c.getMemberType(ctx, tempArrayType, PropertyKey{Name: propName})
 	errors = slices.Concat(errors, accessErrors)
 
-	// Check if the resolved method is mutating by inspecting MutSelf on the Array ObjectType.
+	// Classify the method as mutating or read-only.
 	if c.isArrayMutatingMethod(propName) {
 		constraint.HasMutatingMethod = true
+	} else {
+		constraint.HasReadOnlyMethod = true
 	}
 
 	return resultType, errors
@@ -1138,16 +1142,11 @@ func (c *Checker) getArrayConstraintIndexAccess(_ Context, t *type_system.TypeVa
 	return type_system.NewNeverType(nil), errors
 }
 
-// arrayConstraintElemType returns a type representing the element type of an ArrayConstraint.
-// If there are literal index type variables, it returns the ElemTypeVar (which will be
-// unified with all literal index types during resolution).
-func (c *Checker) arrayConstraintElemType(constraint *type_system.ArrayConstraint) type_system.Type {
-	return constraint.ElemTypeVar
-}
-
-// isArrayMethod returns true if the given property name exists as a method or
-// property on the Array type (either read-only or mutating).
-func (c *Checker) isArrayMethod(propName string) bool {
+// isArrayOnlyMethod returns true if the given name is a method (not a property)
+// on the Array type. This is used to decide whether accessing a property on a
+// fresh TypeVar should create an ArrayConstraint. Only methods qualify because
+// properties like .length are ambiguous (also exist on strings, etc.).
+func (c *Checker) isArrayOnlyMethod(propName string) bool {
 	arrayAlias := c.GlobalScope.Namespace.Types["Array"]
 	if arrayAlias == nil {
 		return false
@@ -1159,19 +1158,8 @@ func (c *Checker) isArrayMethod(propName string) bool {
 	}
 	key := type_system.NewStrKey(propName)
 	for _, elem := range objType.Elems {
-		switch e := elem.(type) {
-		case *type_system.MethodElem:
-			if e.Name == key {
-				return true
-			}
-		case *type_system.PropertyElem:
-			if e.Name == key {
-				return true
-			}
-		case *type_system.GetterElem:
-			if e.Name == key {
-				return true
-			}
+		if method, ok := elem.(*type_system.MethodElem); ok && method.Name == key {
+			return true
 		}
 	}
 	return false

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -25,7 +25,12 @@ func collectUnresolvedTypeVars(
 			*order = append(*order, t.ID)
 			collectUnresolvedTypeVars(t.Constraint, vars, order)
 			collectUnresolvedTypeVars(t.Default, vars, order)
-
+			if t.ArrayConstraint != nil {
+				for _, elemTV := range t.ArrayConstraint.LiteralIndexes {
+					collectUnresolvedTypeVars(elemTV, vars, order)
+				}
+				collectUnresolvedTypeVars(t.ArrayConstraint.ElemTypeVar, vars, order)
+			}
 		}
 	case *type_system.FuncType:
 		for _, tp := range t.TypeParams {
@@ -134,6 +139,20 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 		varMapping[t.ID] = fresh
 		if t.Constraint != nil {
 			fresh.Constraint = c.deepCloneType(t.Constraint, varMapping)
+		}
+		if t.ArrayConstraint != nil {
+			ac := t.ArrayConstraint
+			clonedIndexes := make(map[int]type_system.Type, len(ac.LiteralIndexes))
+			for idx, elemTV := range ac.LiteralIndexes {
+				clonedIndexes[idx] = c.deepCloneType(elemTV, varMapping)
+			}
+			fresh.ArrayConstraint = &type_system.ArrayConstraint{
+				LiteralIndexes:     clonedIndexes,
+				HasNonLiteralIndex: ac.HasNonLiteralIndex,
+				HasMutatingMethod:  ac.HasMutatingMethod,
+				HasIndexAssignment: ac.HasIndexAssignment,
+				ElemTypeVar:        c.deepCloneType(ac.ElemTypeVar, varMapping),
+			}
 		}
 		return fresh
 	case *type_system.FuncType:

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -25,6 +25,9 @@ func collectUnresolvedTypeVars(
 			*order = append(*order, t.ID)
 			collectUnresolvedTypeVars(t.Constraint, vars, order)
 			collectUnresolvedTypeVars(t.Default, vars, order)
+			// Defensive: ArrayConstraints are resolved before generalization
+			// runs, so this branch is unlikely to execute. If it does, we
+			// need to collect the element type vars so they get generalized.
 			if t.ArrayConstraint != nil {
 				for _, elemTV := range t.ArrayConstraint.LiteralIndexes {
 					collectUnresolvedTypeVars(elemTV, vars, order)

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -153,6 +153,7 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 				LiteralIndexes:     clonedIndexes,
 				HasNonLiteralIndex: ac.HasNonLiteralIndex,
 				HasMutatingMethod:  ac.HasMutatingMethod,
+				HasReadOnlyMethod:  ac.HasReadOnlyMethod,
 				HasIndexAssignment: ac.HasIndexAssignment,
 				ElemTypeVar:        c.deepCloneType(ac.ElemTypeVar, varMapping),
 			}

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -89,21 +89,26 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					})
 				} else {
 					pruned := type_system.Prune(objType)
-					// Open object types start without a MutabilityType wrapper —
-					// mark the property as written since we now know mutation occurs.
-					marked := false
-					if litType, ok := indexType.(*type_system.LitType); ok {
-						if strLit, ok := litType.Lit.(*type_system.StrLit); ok {
-							marked = markPropertyWritten(pruned, strLit.Value)
+					// Check if the base has an ArrayConstraint — mark index assignment
+					if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
+						tv.ArrayConstraint.HasIndexAssignment = true
+					} else {
+						// Open object types start without a MutabilityType wrapper —
+						// mark the property as written since we now know mutation occurs.
+						marked := false
+						if litType, ok := indexType.(*type_system.LitType); ok {
+							if strLit, ok := litType.Lit.(*type_system.StrLit); ok {
+								marked = markPropertyWritten(pruned, strLit.Value)
+							}
 						}
-					}
-					if !marked {
-						// Not an open object — check if the object type allows mutation
-						if _, ok := pruned.(*type_system.MutabilityType); !ok {
-							errors = append(errors, &CannotMutateImmutableError{
-								Type: objType,
-								span: expr.Left.Span(),
-							})
+						if !marked {
+							// Not an open object — check if the object type allows mutation
+							if _, ok := pruned.(*type_system.MutabilityType); !ok {
+								errors = append(errors, &CannotMutateImmutableError{
+									Type: objType,
+									span: expr.Left.Span(),
+								})
+							}
 						}
 					}
 				}

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -471,6 +471,14 @@ func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
 			c.resolveArrayConstraintsInType(param.Type)
 		}
 		c.resolveArrayConstraintsInType(p.Return)
+	case *type_system.ObjectType:
+		for _, elem := range p.Elems {
+			if prop, ok := elem.(*type_system.PropertyElem); ok {
+				c.resolveArrayConstraintsInType(prop.Value)
+			}
+		}
+	case *type_system.MutabilityType:
+		c.resolveArrayConstraintsInType(p.Type)
 	}
 }
 
@@ -492,7 +500,7 @@ func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint
 		}
 		arrayAlias := c.GlobalScope.Namespace.Types["Array"]
 		arrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, constraint.ElemTypeVar)
-		if constraint.HasMutatingMethod {
+		if constraint.HasMutatingMethod || constraint.HasIndexAssignment {
 			return &type_system.MutabilityType{
 				Type:       arrayType,
 				Mutability: type_system.MutabilityMutable,

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -492,8 +492,13 @@ func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint
 		IsPatMatch: false,
 	}
 
-	// Mutating methods or non-literal indexes force resolution to Array<T>.
-	if constraint.HasMutatingMethod || constraint.HasNonLiteralIndex {
+	// Mutating methods, non-literal indexes, or read-only methods without any
+	// literal indexes force resolution to Array<T>. Read-only methods like
+	// .map() operate on the whole collection, so without positional information
+	// from literal indexes a tuple would be meaningless.
+	forceArray := constraint.HasMutatingMethod || constraint.HasNonLiteralIndex ||
+		(constraint.HasReadOnlyMethod && len(constraint.LiteralIndexes) == 0)
+	if forceArray {
 		// Unify all literal index type vars with ElemTypeVar
 		for _, elemTV := range constraint.LiteralIndexes {
 			c.Unify(ctx, elemTV, constraint.ElemTypeVar)

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -443,6 +443,10 @@ func (c *Checker) closeOpenParams(funcSigType *type_system.FuncType) {
 // resolveArrayConstraintsInType walks a type tree and resolves any
 // ArrayConstraints on TypeVarTypes to concrete tuple or array types.
 func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
+	// Pruning before the ArrayConstraint check is safe: ArrayConstraints are
+	// only created on parameter TypeVars (IsParam=true), which are always the
+	// representative in their equivalence class (Instance remains nil while
+	// the constraint is active). Prune on a param TypeVar returns itself.
 	t = type_system.Prune(t)
 
 	if tv, ok := t.(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -228,7 +228,7 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 			funcSigType.Return = inferredGenType
 		}
 		funcSigType.Throws = type_system.NewNeverType(nil)
-		closeOpenParams(funcSigType)
+		c.closeOpenParams(funcSigType)
 		return errors
 	}
 
@@ -251,7 +251,7 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 		errors = slices.Concat(errors, unifyReturnErrors, unifyThrowsErrors)
 	}
 
-	closeOpenParams(funcSigType)
+	c.closeOpenParams(funcSigType)
 	return errors
 }
 
@@ -418,8 +418,9 @@ func (c *Checker) findThrowTypes(ctx Context, block *ast.Block) ([]type_system.T
 
 // closeOpenParams closes all open object types on function parameters after
 // body inference is complete. It removes RestSpreadElems whose row variables
-// don't appear in the return type and resolves mutability.
-func closeOpenParams(funcSigType *type_system.FuncType) {
+// don't appear in the return type, resolves mutability, and resolves
+// ArrayConstraints to concrete tuple or array types.
+func (c *Checker) closeOpenParams(funcSigType *type_system.FuncType) {
 	// Collect unresolved type vars in the return type to determine which
 	// row variables escape. We intentionally do NOT collect from
 	// funcSigType.Throws: GeneralizeFuncType defaults throws-only type vars
@@ -434,8 +435,106 @@ func closeOpenParams(funcSigType *type_system.FuncType) {
 	collectUnresolvedTypeVars(funcSigType.Return, returnVars, &returnOrder)
 
 	for _, param := range funcSigType.Params {
+		c.resolveArrayConstraintsInType(param.Type)
 		closeOpenObjectsInType(param.Type, returnVars)
 	}
+}
+
+// resolveArrayConstraintsInType walks a type tree and resolves any
+// ArrayConstraints on TypeVarTypes to concrete tuple or array types.
+func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
+	t = type_system.Prune(t)
+
+	if tv, ok := t.(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
+		resolved := c.resolveArrayConstraint(tv.ArrayConstraint)
+		tv.Instance = resolved
+		tv.ArrayConstraint = nil
+		return
+	}
+
+	// Recurse into type constructors
+	switch p := t.(type) {
+	case *type_system.TypeRefType:
+		for _, arg := range p.TypeArgs {
+			c.resolveArrayConstraintsInType(arg)
+		}
+	case *type_system.TupleType:
+		for _, elem := range p.Elems {
+			c.resolveArrayConstraintsInType(elem)
+		}
+	case *type_system.UnionType:
+		for _, opt := range p.Types {
+			c.resolveArrayConstraintsInType(opt)
+		}
+	case *type_system.FuncType:
+		for _, param := range p.Params {
+			c.resolveArrayConstraintsInType(param.Type)
+		}
+		c.resolveArrayConstraintsInType(p.Return)
+	}
+}
+
+// resolveArrayConstraint resolves an ArrayConstraint to a concrete type.
+// Mutating methods (.push, .pop, etc.) or non-literal indexes force Array<T>.
+// Index assignment (items[0] = v) forces mutability but keeps tuple shape.
+func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint) type_system.Type {
+	ctx := Context{
+		Scope:      c.GlobalScope,
+		IsAsync:    false,
+		IsPatMatch: false,
+	}
+
+	// Mutating methods or non-literal indexes force resolution to Array<T>.
+	if constraint.HasMutatingMethod || constraint.HasNonLiteralIndex {
+		// Unify all literal index type vars with ElemTypeVar
+		for _, elemTV := range constraint.LiteralIndexes {
+			c.Unify(ctx, elemTV, constraint.ElemTypeVar)
+		}
+		arrayAlias := c.GlobalScope.Namespace.Types["Array"]
+		arrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, constraint.ElemTypeVar)
+		if constraint.HasMutatingMethod {
+			return &type_system.MutabilityType{
+				Type:       arrayType,
+				Mutability: type_system.MutabilityMutable,
+			}
+		}
+		return arrayType
+	}
+
+	// Resolve to tuple
+	isMut := constraint.HasIndexAssignment
+	if len(constraint.LiteralIndexes) == 0 {
+		tupleType := type_system.NewTupleType(nil)
+		if isMut {
+			return &type_system.MutabilityType{
+				Type:       tupleType,
+				Mutability: type_system.MutabilityMutable,
+			}
+		}
+		return tupleType
+	}
+	maxIndex := 0
+	for idx := range constraint.LiteralIndexes {
+		if idx > maxIndex {
+			maxIndex = idx
+		}
+	}
+	elems := make([]type_system.Type, maxIndex+1)
+	for i := 0; i <= maxIndex; i++ {
+		if tv, ok := constraint.LiteralIndexes[i]; ok {
+			elems[i] = tv
+		} else {
+			elems[i] = c.FreshVar(nil) // gap — unresolved type variable
+		}
+	}
+	tupleType := type_system.NewTupleType(nil, elems...)
+	if isMut {
+		return &type_system.MutabilityType{
+			Type:       tupleType,
+			Mutability: type_system.MutabilityMutable,
+		}
+	}
+	return tupleType
 }
 
 // closeOpenObjectsInType walks a type tree and closes any open ObjectTypes

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -449,10 +449,20 @@ func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
 		resolved := c.resolveArrayConstraint(tv.ArrayConstraint)
 		tv.Instance = resolved
 		tv.ArrayConstraint = nil
+		// Recurse into the resolved type to handle nested ArrayConstraints
+		// (e.g. items[0][1] where the element itself is used as a tuple/array).
+		c.resolveArrayConstraintsInType(resolved)
 		return
 	}
 
-	// Recurse into type constructors
+	// Recurse into type constructors that can appear in inferred parameter types.
+	// We only need to cover shapes produced by inference on unannotated params:
+	// - IntersectionType, FuncType.Throws, and ObjectType methods/getters/setters
+	//   are omitted because ArrayConstraints are only created on unannotated
+	//   parameter TypeVars during body inference, and those types come from
+	//   annotations or type definitions, not from the inference path.
+	// - ObjectType only checks PropertyElem because open objects created during
+	//   inference (via newOpenObjectWithProperty) only contain PropertyElems.
 	switch p := t.(type) {
 	case *type_system.TypeRefType:
 		for _, arg := range p.TypeArgs {

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -162,13 +162,14 @@ func TestRowTypesPropertyAccess(t *testing.T) {
 			},
 		},
 		"NumericIndex": {
+			// With Phase 12, a single literal index infers a tuple.
 			input: `
 				fn foo(obj) {
 					return obj[0]
 				}
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0>(obj: Array<T0>) -> T0",
+				"foo": "fn <T0>(obj: [T0]) -> T0",
 			},
 		},
 		"StringLiteralIndex": {
@@ -234,13 +235,14 @@ func TestRowTypesPropertyAccess(t *testing.T) {
 			},
 		},
 		"MultipleNumericIndexes": {
+			// With Phase 12, literal indexes infer a tuple, not an array.
 			input: `
 				fn foo(obj) {
 					return [obj[0], obj[1]]
 				}
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0>(obj: Array<T0>) -> [T0, T0]",
+				"foo": "fn <T0, T1>(obj: [T0, T1]) -> [T0, T1]",
 			},
 		},
 		"IdempotentPropertyAccess": {
@@ -1084,21 +1086,23 @@ func TestRowTypesClosing(t *testing.T) {
 			},
 		},
 		"ArrayElementWriteAccess": {
-			// Open object nested inside Array should also be closed
+			// With Phase 12, a single literal index resolves to a tuple.
+			// The nested open object is still closed.
 			input: `
 				fn foo(arr) { arr[0].x = 1 }
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn (arr: Array<mut {x: number}>) -> void",
+				"foo": "fn (arr: [mut {x: number}]) -> void",
 			},
 		},
 		"ArrayElementReadAccess": {
-			// Open object nested inside Array should also be closed
+			// With Phase 12, a single literal index resolves to a tuple.
+			// The nested open object is still closed.
 			input: `
 				fn foo(arr) { return arr[0].bar }
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0>(arr: Array<{bar: T0}>) -> T0",
+				"foo": "fn <T0>(arr: [{bar: T0}]) -> T0",
 			},
 		},
 	}
@@ -1568,6 +1572,197 @@ func TestVariadicTupleIndexing(t *testing.T) {
 				"b": "string",
 				"c": "boolean",
 				"d": "boolean",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+func TestTupleArrayInference(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"TupleFromLiteralIndexes": {
+			input: `
+				fn foo(items) { return [items[0], items[1]] }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(items: [T0, T1]) -> [T0, T1]",
+			},
+		},
+		"TupleWithLength": {
+			input: `
+				fn foo(items) {
+					val a = items[0]
+					val l = items.length
+					return [a, l]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: [T0]) -> [T0, number]",
+			},
+		},
+		"ArrayFromNonLiteralIndex": {
+			input: `
+				fn foo(items, i: number) { return items[i] }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: Array<T0>, i: number) -> T0",
+			},
+		},
+		"MutTupleFromIndexAssignment": {
+			// Index assignment forces mutability but keeps tuple shape.
+			input: `
+				fn foo(items) { items[0] = 42 }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut [number]) -> void",
+			},
+		},
+		"ArrayFromPush": {
+			input: `
+				fn foo(items) { items.push(42) }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number>) -> void",
+			},
+		},
+		"ArrayFromLiteralIndexAndPush": {
+			input: `
+				fn foo(items) {
+					val a = items[0]
+					items.push("hello")
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<string>) -> void",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+func TestTupleArrayInferenceEdgeCases(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"GapIndex": {
+			// Only assigning index 1 creates a 2-tuple with a gap at index 0.
+			input: `
+				fn foo(items) { items[1] = 42 }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: mut [T0, number]) -> void",
+			},
+		},
+		"ObjectLiteralWidening": {
+			// Object literals in index assignment are widened.
+			input: `
+				fn foo(items) { items[0] = {x: 5, y: 10} }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut [{x: number, y: number}]) -> void",
+			},
+		},
+		"ReadAndWriteDifferentIndexes": {
+			// Read index 0 and assign index 1 — mixed read/write, mut tuple.
+			input: `
+				fn foo(items) {
+					val a = items[0]
+					items[1] = "hi"
+					return a
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: mut [T0, string]) -> T0",
+			},
+		},
+		"MultipleWritesSameIndex": {
+			// Writing to the same index twice unifies the value types.
+			input: `
+				fn foo(items) {
+					items[0] = 42
+					items[0] = 99
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut [number]) -> void",
+			},
+		},
+		"SparseIndexes": {
+			// Non-contiguous literal indexes create a tuple with gaps.
+			input: `
+				fn foo(items) { return [items[0], items[3]] }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1, T2, T3>(items: [T0, T1, T2, T3]) -> [T0, T3]",
+			},
+		},
+		"IndexAssignmentAndPush": {
+			// Index assignment + mutating method → mut Array (push forces array).
+			input: `
+				fn foo(items) {
+					items[0] = 42
+					items.push(99)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number>) -> void",
+			},
+		},
+		"SingleIndexReadOnly": {
+			// A single literal index read with no mutation → 1-tuple.
+			input: `
+				fn foo(items) { return items[0] }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: [T0]) -> T0",
+			},
+		},
+		"ReturnTupleElement": {
+			// Reading two elements, returning one — tuple with both type params.
+			input: `
+				fn foo(items) {
+					val a = items[0]
+					val b = items[1]
+					return a
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(items: [T0, T1]) -> T0",
+			},
+		},
+		"WriteOnlyIndex0": {
+			// Writing without reading — mut tuple with widened type.
+			input: `
+				fn foo(items) { items[0] = "hello" }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut [string]) -> void",
 			},
 		},
 	}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1779,3 +1779,119 @@ func TestTupleArrayInferenceEdgeCases(t *testing.T) {
 		})
 	}
 }
+
+// TestTupleArrayInferenceFixedBugs covers regressions for specific bugs that
+// were fixed in the tuple/array inference pipeline.
+func TestTupleArrayInferenceFixedBugs(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		// asNonNegativeIntLiteral rejects indexes above maxTupleIndex (20),
+		// so a huge literal index forces Array<T> via isNumericType.
+		"LargeIndexForcesArray": {
+			input: `
+				fn foo(items) { return items[1001] }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: Array<T0>) -> T0",
+			},
+		},
+		// Non-literal index combined with index assignment should produce
+		// mut Array<T>, not immutable Array<T>.
+		"NonLiteralIndexWithAssignmentIsMutArray": {
+			input: `
+				fn foo(items, i: number) {
+					items[i] = 42
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number>, i: number) -> void",
+			},
+		},
+		// A read-only gap index (no assignment) should produce an immutable
+		// tuple, not a mutable one.
+		"GapIndexReadOnly": {
+			input: `
+				fn foo(items) { return items[1] }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(items: [T0, T1]) -> T1",
+			},
+		},
+		// String literal used as index on an array-constrained param should
+		// route to property access (e.g. items["length"] → number).
+		"StringLiteralIndexRoutesToPropertyAccess": {
+			input: `
+				fn foo(items) {
+					val a = items[0]
+					return items["length"]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: [T0]) -> number",
+			},
+		},
+		// Array constraint resolved inside a function parameter that is a
+		// callback receiving the constrained type via a TypeRefType wrapper
+		// (tests resolveArrayConstraintsInType recursion into nested types).
+		"ArrayConstraintResolvedInCallback": {
+			input: `
+				fn foo(items) {
+					val a = items[0]
+					items.push(a)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: mut Array<T0>) -> void",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+// TestTupleArrayInferenceUnifyErrors verifies that element-type conflicts are
+// properly reported when an array-constrained parameter is bound to an
+// incompatible concrete type.
+func TestTupleArrayInferenceUnifyErrors(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		expectErrors bool
+	}{
+		// Binding an array-constrained param (with number element) to
+		// Array<string> should produce a unification error.
+		"ArrayConstraintBoundToIncompatibleArray": {
+			input: `
+				fn bar(items: Array<string>) { return items[0] }
+				fn foo(items) {
+					items[0] = 42
+					bar(items)
+				}
+			`,
+			expectErrors: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, errors := inferModuleTypesAndErrors(t, test.input)
+			if test.expectErrors {
+				assert.NotEmpty(t, errors, "Expected unification errors but got none")
+			} else {
+				assert.Empty(t, errors, "Expected no errors")
+			}
+		})
+	}
+}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1944,6 +1944,23 @@ func TestTupleArrayInferenceFixedBugs(t *testing.T) {
 				"foo": "fn <T0>(items: [T0]) -> number",
 			},
 		},
+		// Binding an ArrayConstraint to a variadic tuple should unify
+		// literal indexes with the correct element types.
+		"BindToVariadicTuple": {
+			input: `
+				fn bar(x: [number, string, ...Array<boolean>]) { }
+				fn foo(items) {
+					val a = items[0]
+					val b = items[1]
+					val c = items[3]
+					bar(items)
+					return [a, b, c]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: [number, string, ...Array<boolean>]) -> [number, string, boolean]",
+			},
+		},
 		// Array constraint resolved inside a function parameter that is a
 		// callback receiving the constrained type via a TypeRefType wrapper
 		// (tests resolveArrayConstraintsInType recursion into nested types).

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1765,6 +1765,118 @@ func TestTupleArrayInferenceEdgeCases(t *testing.T) {
 				"foo": "fn (items: mut [string]) -> void",
 			},
 		},
+		"ArrayFromMapOnlyGeneric": {
+			// Calling .map() alone (no index access) should infer an array,
+			// not a tuple. The identity callback unifies input and output types.
+			input: `
+				fn foo(items) { return items.map(fn (x) { return x }) }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: Array<T0>) -> Array<T0>",
+			},
+		},
+		"ArrayFromMapOnly": {
+			// Calling .map() alone (no index access) should infer an array,
+			// not a tuple. The identity callback unifies input and output types.
+			input: `
+				fn foo(items) { return items.map(fn (x) { return x * x }) }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: Array<number>) -> Array<number>",
+			},
+		},
+		"PushMultipleSameType": {
+			// Pushing multiple values of the same type works.
+			input: `
+				fn foo(items) {
+					items.push(5)
+					items.push(10)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number>) -> void",
+			},
+		},
+		"LengthOnlyIsNotArray": {
+			// Accessing .length alone should infer an open object, not a tuple
+			// or array — .length is ambiguous (exists on strings, etc.).
+			input: `
+				fn foo(x) { return x.length }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(x: {length: T0}) -> T0",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+func TestTupleArrayInferenceOnProperties(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"PropertyIndexedAsTuple": {
+			// Indexing a property with a literal → tuple on the property.
+			input: `fn foo(obj) { return obj.items[0] }`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(obj: {items: [T0]}) -> T0",
+			},
+		},
+		"PropertyIndexedAsTupleTwoElements": {
+			// Two literal indexes on a property → 2-tuple.
+			input: `fn foo(obj) { return [obj.items[0], obj.items[1]] }`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(obj: {items: [T0, T1]}) -> [T0, T1]",
+			},
+		},
+		"PropertyPushInfersArray": {
+			// Calling .push() on a property → mut Array on the property.
+			input: `fn foo(obj) { obj.items.push(42) }`,
+			expectedTypes: map[string]string{
+				"foo": "fn (obj: {items: mut Array<number>}) -> void",
+			},
+		},
+		"PropertyIndexAssignment": {
+			// Index assignment on a property → mut tuple on the property.
+			input: `fn foo(obj) { obj.items[0] = "hi" }`,
+			expectedTypes: map[string]string{
+				"foo": "fn (obj: {items: mut [string]}) -> void",
+			},
+		},
+		"PropertyMapInfersArray": {
+			// Calling .map() on a property → Array on the property.
+			input: `
+				fn foo(obj) { return obj.items.map(fn (x) { return x }) }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(obj: {items: Array<T0>}) -> Array<T0>",
+			},
+		},
+		"TwoPropertiesDifferentShapes": {
+			// Two properties with different inference: tuple vs mut Array.
+			input: `
+				fn foo(obj) {
+					val a = obj.names[0]
+					obj.scores.push(100)
+					return a
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(obj: {names: [T0], scores: mut Array<number>}) -> T0",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1752,6 +1752,14 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []
 						return errors
 					}
 				}
+				// When a TypeVar with an ArrayConstraint is bound to a concrete
+				// Array or tuple type, update the constraint flags so that
+				// resolution at closing time produces the correct type.
+				if typeVar1.ArrayConstraint != nil {
+					if c.handleArrayConstraintBinding(ctx, typeVar1, t2) {
+						return errors
+					}
+				}
 				// When binding a Widenable TypeVar, widen literals to their
 				// primitive types and recursively widen object/tuple literals
 				// (e.g. "hello" -> string, {x: 1} -> {x: number}).
@@ -1850,6 +1858,47 @@ func occursInType(t1, t2 type_system.Type) bool {
 // converts it to an open object and binds it to the type variable. Returns true if
 // the conversion was performed.
 //
+// handleArrayConstraintBinding handles the case where a TypeVarType with an
+// ArrayConstraint is being bound to a concrete type. If the bound type is an
+// Array, mut Array, or tuple, the constraint is updated accordingly and the
+// function returns true to indicate that binding was handled. Otherwise it
+// returns false and normal binding proceeds.
+func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system.TypeVarType, boundType type_system.Type) bool {
+	constraint := typeVar.ArrayConstraint
+	inner := boundType
+	isMut := false
+	if mut, ok := inner.(*type_system.MutabilityType); ok {
+		isMut = mut.Mutability == type_system.MutabilityMutable
+		inner = mut.Type
+	}
+
+	switch t := inner.(type) {
+	case *type_system.TypeRefType:
+		if type_system.QualIdentToString(t.Name) == "Array" && len(t.TypeArgs) > 0 {
+			// Passed to Array<T> or mut Array<T> — force array resolution
+			constraint.HasNonLiteralIndex = true
+			if isMut {
+				constraint.HasMutatingMethod = true
+			}
+			// Unify the constraint's element type var with the array's element type
+			c.Unify(ctx, constraint.ElemTypeVar, t.TypeArgs[0])
+			for _, elemTV := range constraint.LiteralIndexes {
+				c.Unify(ctx, elemTV, t.TypeArgs[0])
+			}
+			return true
+		}
+	case *type_system.TupleType:
+		// Passed to a tuple type — unify element types pairwise
+		for i, elemType := range t.Elems {
+			if tv, ok := constraint.LiteralIndexes[i]; ok {
+				c.Unify(ctx, tv, elemType)
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // This is needed because when an unannotated parameter (e.g. `fn foo(obj)`) is
 // passed to a function with a typed parameter (e.g. `fn bar(x: {a: number})`),
 // bind() would normally set the type variable's Instance to the closed ObjectType

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1887,7 +1887,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 
 	switch t := inner.(type) {
 	case *type_system.TypeRefType:
-		if type_system.QualIdentToString(t.Name) == "Array" && len(t.TypeArgs) > 0 {
+		if c.isArrayType(t) && len(t.TypeArgs) > 0 {
 			// Passed to Array<T> or mut Array<T> — force array resolution
 			constraint.HasNonLiteralIndex = true
 			if isMut {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1871,10 +1871,6 @@ func occursInType(t1, t2 type_system.Type) bool {
 	return false
 }
 
-// openClosedObjectForParam checks if boundType is a closed ObjectType and, if so,
-// converts it to an open object and binds it to the type variable. Returns true if
-// the conversion was performed.
-//
 // handleArrayConstraintBinding handles the case where a TypeVarType with an
 // ArrayConstraint is being bound to a concrete type. If the bound type is an
 // Array, mut Array, or tuple, the constraint is updated accordingly and the
@@ -1907,10 +1903,16 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 					errs = append(errs, unifyErrs...)
 				}
 			}
+			// Bind the TypeVar to the array type and clear the constraint so
+			// that resolveArrayConstraintsInType won't re-resolve it.
+			typeVar.Instance = boundType
+			typeVar.ArrayConstraint = nil
 			return true, errs
 		}
 	case *type_system.TupleType:
-		// Passed to a tuple type — unify element types pairwise
+		// Passed to a tuple type — unify element types pairwise.
+		// Only unify indexes within the tuple's bounds; any LiteralIndexes
+		// beyond the tuple length are ignored.
 		var errs []Error
 		for i, elemType := range t.Elems {
 			if tv, ok := constraint.LiteralIndexes[i]; ok {
@@ -1919,6 +1921,10 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 				}
 			}
 		}
+		// Bind the TypeVar to the tuple and clear the constraint so that
+		// resolveArrayConstraintsInType won't recreate a different tuple.
+		typeVar.Instance = boundType
+		typeVar.ArrayConstraint = nil
 		return true, errs
 	}
 	return false, nil

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1756,8 +1756,8 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []
 				// Array or tuple type, update the constraint flags so that
 				// resolution at closing time produces the correct type.
 				if typeVar1.ArrayConstraint != nil {
-					if c.handleArrayConstraintBinding(ctx, typeVar1, t2) {
-						return errors
+					if handled, bindErrs := c.handleArrayConstraintBinding(ctx, typeVar1, t2); handled {
+						return append(errors, bindErrs...)
 					}
 				}
 				// When binding a Widenable TypeVar, widen literals to their
@@ -1851,7 +1851,24 @@ func (v *OccursInVisitor) ExitType(t type_system.Type) type_system.Type {
 func occursInType(t1, t2 type_system.Type) bool {
 	visitor := &OccursInVisitor{result: false, t1: t1}
 	t2.Accept(visitor)
-	return visitor.result
+	if visitor.result {
+		return true
+	}
+	// Defensive: Accept doesn't traverse ArrayConstraint children, so check
+	// them explicitly. In practice a TypeVar is unlikely to occur inside its
+	// own ArrayConstraint, but a missed occurs check could cause an infinite
+	// loop during unification.
+	if tv, ok := type_system.Prune(t2).(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
+		if occursInType(t1, tv.ArrayConstraint.ElemTypeVar) {
+			return true
+		}
+		for _, elemTV := range tv.ArrayConstraint.LiteralIndexes {
+			if occursInType(t1, elemTV) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // openClosedObjectForParam checks if boundType is a closed ObjectType and, if so,
@@ -1863,7 +1880,7 @@ func occursInType(t1, t2 type_system.Type) bool {
 // Array, mut Array, or tuple, the constraint is updated accordingly and the
 // function returns true to indicate that binding was handled. Otherwise it
 // returns false and normal binding proceeds.
-func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system.TypeVarType, boundType type_system.Type) bool {
+func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system.TypeVarType, boundType type_system.Type) (bool, []Error) {
 	constraint := typeVar.ArrayConstraint
 	inner := boundType
 	isMut := false
@@ -1881,22 +1898,30 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 				constraint.HasMutatingMethod = true
 			}
 			// Unify the constraint's element type var with the array's element type
-			c.Unify(ctx, constraint.ElemTypeVar, t.TypeArgs[0])
-			for _, elemTV := range constraint.LiteralIndexes {
-				c.Unify(ctx, elemTV, t.TypeArgs[0])
+			var errs []Error
+			if unifyErrs := c.Unify(ctx, constraint.ElemTypeVar, t.TypeArgs[0]); len(unifyErrs) > 0 {
+				errs = append(errs, unifyErrs...)
 			}
-			return true
+			for _, elemTV := range constraint.LiteralIndexes {
+				if unifyErrs := c.Unify(ctx, elemTV, t.TypeArgs[0]); len(unifyErrs) > 0 {
+					errs = append(errs, unifyErrs...)
+				}
+			}
+			return true, errs
 		}
 	case *type_system.TupleType:
 		// Passed to a tuple type — unify element types pairwise
+		var errs []Error
 		for i, elemType := range t.Elems {
 			if tv, ok := constraint.LiteralIndexes[i]; ok {
-				c.Unify(ctx, tv, elemType)
+				if unifyErrs := c.Unify(ctx, tv, elemType); len(unifyErrs) > 0 {
+					errs = append(errs, unifyErrs...)
+				}
 			}
 		}
-		return true
+		return true, errs
 	}
-	return false
+	return false, nil
 }
 
 // This is needed because when an unannotated parameter (e.g. `fn foo(obj)`) is

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1857,7 +1857,10 @@ func occursInType(t1, t2 type_system.Type) bool {
 	// Defensive: Accept doesn't traverse ArrayConstraint children, so check
 	// them explicitly. In practice a TypeVar is unlikely to occur inside its
 	// own ArrayConstraint, but a missed occurs check could cause an infinite
-	// loop during unification.
+	// loop during unification. Note that this check is already recursive:
+	// the occursInType calls below will themselves hit this same block if
+	// ElemTypeVar or a LiteralIndexes entry is a TypeVar with its own
+	// ArrayConstraint, so nested constraints are covered without additional work.
 	if tv, ok := type_system.Prune(t2).(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
 		if occursInType(t1, tv.ArrayConstraint.ElemTypeVar) {
 			return true
@@ -1910,13 +1913,30 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 			return true, errs
 		}
 	case *type_system.TupleType:
-		// Passed to a tuple type — unify element types pairwise.
-		// Only unify indexes within the tuple's bounds; any LiteralIndexes
-		// beyond the tuple length are ignored.
+		// Passed to a tuple type — unify element types pairwise, handling
+		// RestSpreadType for variadic tuples (e.g. [number, string, ...Array<boolean>]).
+		prefix, rest, suffix := splitTupleAtRest(t.Elems)
 		var errs []Error
-		for i, elemType := range t.Elems {
-			if tv, ok := constraint.LiteralIndexes[i]; ok {
-				if unifyErrs := c.Unify(ctx, tv, elemType); len(unifyErrs) > 0 {
+		for idx, tv := range constraint.LiteralIndexes {
+			var targetType type_system.Type
+			if idx < len(prefix) {
+				// Index falls in the fixed prefix
+				targetType = prefix[idx]
+			} else if rest != nil {
+				// Compute where suffix starts in the logical tuple
+				// (unknown length, so suffix indexes can't be mapped from
+				// literal indexes). Indexes beyond the prefix fall into rest.
+				targetType = rest.Type
+				// Extract element type from Array<T> if the rest is an array
+				if ref, ok := type_system.Prune(targetType).(*type_system.TypeRefType); ok && c.isArrayType(ref) && len(ref.TypeArgs) > 0 {
+					targetType = ref.TypeArgs[0]
+				}
+			} else if idx < len(prefix)+len(suffix) {
+				// No rest, index falls in suffix (fixed tuple)
+				targetType = suffix[idx-len(prefix)]
+			}
+			if targetType != nil {
+				if unifyErrs := c.Unify(ctx, tv, targetType); len(unifyErrs) > 0 {
 					errs = append(errs, unifyErrs...)
 				}
 			}

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -166,16 +166,28 @@ func recordInstanceChain(tv *TypeVarType) {
 	}
 }
 
+// ArrayConstraint tracks numeric indexing patterns on a type variable before
+// committing to tuple vs. array. It is stored on TypeVarType and resolved
+// during closeOpenParams.
+type ArrayConstraint struct {
+	LiteralIndexes     map[int]Type // index → element type variable
+	HasNonLiteralIndex bool         // true if items[i] used with non-literal number type
+	HasMutatingMethod  bool         // true if .push(), .pop(), etc. called
+	HasIndexAssignment bool         // true if items[i] = value used
+	ElemTypeVar        Type         // fresh T for Array<T> (union accumulator)
+}
+
 type TypeVarType struct {
-	ID            int
-	Instance      Type
-	Constraint    Type
-	Default       Type
-	FromBinding   bool
-	Widenable     bool // true for type vars whose type is inferred from usage (e.g. property values on open objects)
-	IsParam       bool // true for type vars created for unannotated function parameters
-	InstanceChain []*TypeVarType // populated by Prune when this TypeVar's Instance is another TypeVar (alias chain from bind); stores all TypeVars in the chain before path compression collapses it
-	provenance    Provenance
+	ID              int
+	Instance        Type
+	Constraint      Type
+	Default         Type
+	FromBinding     bool
+	Widenable       bool // true for type vars whose type is inferred from usage (e.g. property values on open objects)
+	IsParam         bool // true for type vars created for unannotated function parameters
+	InstanceChain   []*TypeVarType // populated by Prune when this TypeVar's Instance is another TypeVar (alias chain from bind); stores all TypeVars in the chain before path compression collapses it
+	ArrayConstraint *ArrayConstraint // non-nil when numeric indexing has been observed; resolved during closing
+	provenance      Provenance
 }
 
 func NewTypeVarType(provenance Provenance, id int) *TypeVarType {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -173,6 +173,7 @@ type ArrayConstraint struct {
 	LiteralIndexes     map[int]Type // index → element type variable
 	HasNonLiteralIndex bool         // true if items[i] used with non-literal number type
 	HasMutatingMethod  bool         // true if .push(), .pop(), etc. called
+	HasReadOnlyMethod  bool         // true if .map(), .filter(), etc. called
 	HasIndexAssignment bool         // true if items[i] = value used
 	ElemTypeVar        Type         // fresh T for Array<T> (union accumulator)
 }

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1238,165 +1238,126 @@ rest element case and the interaction with `inferFuncParams`.
 
 ---
 
-## Phase 12: Tuple and Array Inference from Indexing Patterns
+## Phase 12: Tuple and Array Inference from Indexing Patterns ✅
 
 **Requirements covered:** Section 13 (tuple and array inference).
+
+> **Status (2026-04-09):** Implemented. `ArrayConstraint` struct on `TypeVarType`
+> defers tuple-vs-array commitment until closing time. `getMemberType` creates/updates
+> constraints on numeric index access and delegates Array method lookups via
+> `isArrayMethod`/`isArrayMutatingMethod`. `closeOpenParams` (now a `Checker` method)
+> resolves constraints: mutating methods or non-literal indexes → `Array<T>` /
+> `mut Array<T>`; literal-only indexes → tuple; index assignment forces `mut` on
+> tuples (not array — diverges from original plan Section 13d, see note below).
+> `deepCloneType` and `collectUnresolvedTypeVars` handle `ArrayConstraint`.
+> `handleArrayConstraintBinding` in `unify.go` updates constraints when bound to
+> `Array<T>` or tuple types. Tests: `TestTupleArrayInference`,
+> `TestTupleArrayInferenceEdgeCases`.
 
 **Goal:** When a function parameter is indexed numerically, infer whether it
 should be a tuple or an array based on usage patterns. Non-negative integer
 literal indexes with read-only Array methods → tuple. Mutating methods or non-literal
-indexes → `mut Array<T>` or `Array<T>`.
+indexes → `mut Array<T>` or `Array<T>`. Index assignment with literal indexes →
+`mut` tuple (not `mut Array`).
 
 ### Background
 
-Phase 2 currently binds a TypeVarType to `Array<T>` immediately when a numeric
-index is used. This phase refines that behavior to support tuple inference by
+Phase 2 previously bound a TypeVarType to `Array<T>` immediately when a numeric
+index was used. This phase refines that behavior to support tuple inference by
 deferring the commitment until closing time.
 
 ### Changes
 
-1. **New tracking structure — `ArrayConstraint`:**
-   Add a new struct to track numeric indexing patterns on a type variable before
-   committing to tuple vs. array:
+1. **New tracking structure — `ArrayConstraint` (in `internal/type_system/types.go`):**
 
    ```go
-   // In internal/checker or internal/type_system
    type ArrayConstraint struct {
-       LiteralIndexes  map[int]Type  // index → element type variable
-       HasNonLiteralIndex bool       // true if items[i] used with non-literal
-       HasMutatingMethod  bool       // true if .push(), .pop(), etc. called
-       HasIndexAssignment bool       // true if items[i] = value used
-       ElemTypeVar     Type          // fresh T for Array<T> (union accumulator)
+       LiteralIndexes     map[int]Type  // index → element type variable
+       HasNonLiteralIndex bool          // true if items[i] used with non-literal
+       HasMutatingMethod  bool          // true if .push(), .pop(), etc. called
+       HasIndexAssignment bool          // true if items[i] = value used
+       ElemTypeVar        Type          // fresh T for Array<T> (union accumulator)
    }
    ```
 
-   This is stored directly on `TypeVarType` as a new `ArrayConstraint *ArrayConstraint`
-   field (nil when no numeric indexing has been observed). All code that
-   reads or writes the constraint — `getMemberType`, the assignment handler,
-   `closeOpenParams`, `Prune`/alias flows, and `deepCloneType` — uses
-   `typeVar.ArrayConstraint` as the single source of truth.
+   Stored on `TypeVarType` as `ArrayConstraint *ArrayConstraint` (nil when no
+   numeric indexing observed). All code that reads or writes the constraint —
+   `getMemberType`, the assignment handler, `closeOpenParams`, and
+   `deepCloneType` — uses `typeVar.ArrayConstraint` as the single source of
+   truth. Both `ElemTypeVar` and literal index TypeVars are created with
+   `Widenable = true` so that literal values (e.g. `42`) are widened to their
+   primitive types (e.g. `number`) on binding.
 
 2. **`internal/checker/expand_type.go`** — `getMemberType`, TypeVarType case:
 
-   **Modify the numeric IndexKey branch** (currently ~line 522 in Phase 2):
+   The IndexKey branch creates/updates an `ArrayConstraint` instead of
+   immediately binding to `Array<T>`. Literal integer indexes record per-position
+   type variables; non-literal numeric indexes set `HasNonLiteralIndex`.
 
-   Instead of immediately binding to `Array<T>`, create or update an
-   `ArrayConstraint`:
+   The PropertyKey branch first checks `isArrayMethod(propName)` — if the
+   property exists on the Array type definition, an `ArrayConstraint` is created
+   (or the existing one is used) and the access is delegated to
+   `getArrayConstraintPropertyAccess`. This handles the case where `.push()` is
+   called before any numeric index access. If the property is not an Array
+   method, the existing open-object path runs.
 
-   ```go
-   case *type_system.TypeVarType:
-       if indexKey, ok := key.(IndexKey); ok && isNumericType(indexKey.Type) {
-           constraint := getOrCreateArrayConstraint(typeVar)
-           // Check the *type* of the index expression, not its syntax.
-           // items[i] where i has literal type 5 is the same as items[5].
-           if litIndex, ok := asNonNegativeIntLiteral(indexKey.Type); ok {
-               // Record literal index with a fresh type variable
-               if _, exists := constraint.LiteralIndexes[litIndex]; !exists {
-                   constraint.LiteralIndexes[litIndex] = c.FreshVar(nil)
-               }
-               return constraint.LiteralIndexes[litIndex], nil
-           } else {
-               // Non-literal type (e.g. number) — must be Array, not tuple
-               constraint.HasNonLiteralIndex = true
-               return constraint.ElemTypeVar, nil
-           }
-       }
-   ```
+   When a TypeVarType already has an `ArrayConstraint`, all subsequent property
+   and index accesses are routed through `getArrayConstraintPropertyAccess` /
+   `getArrayConstraintIndexAccess`.
 
-   **Modify the property/method access path:** When a property or method is
-   accessed on a TypeVarType that already has an `ArrayConstraint`, classify
-   the access by looking up the property on the actual `Array` and `mut Array`
-   type definitions at runtime (rather than maintaining hardcoded method lists):
+   Method classification uses runtime lookup on the Array type definition via
+   `isArrayMutatingMethod` (checks `MutSelf` on `MethodElem`), keeping the
+   classification in sync with the type system's actual definitions.
 
-   - If the property exists on `Array` (immutable): allow it without changing
-     the constraint. This covers `.length`, `.map()`, `.filter()`, `.slice()`,
-     `.indexOf()`, etc.
-   - If the property exists on `mut Array` but not on `Array`: set
-     `constraint.HasMutatingMethod = true`. This covers `.push()`, `.pop()`,
-     `.sort()`, `.reverse()`, etc.
-   - If the property exists on neither `Array` nor `mut Array`: this is an
-     error — the parameter is used as both an array and an object.
-
-   This lookup-based approach keeps the classification in sync with the type
-   system's actual `Array` / `mut Array` definitions, avoiding brittleness if
-   methods are added or changed.
+   Helper functions added: `isNumericType`, `asNonNegativeIntLiteral`,
+   `getOrCreateArrayConstraint`, `getArrayConstraintPropertyAccess`,
+   `getArrayConstraintIndexAccess`, `arrayConstraintElemType`,
+   `isArrayMethod`, `isArrayMutatingMethod`.
 
 3. **`internal/checker/infer_expr.go`** — Assignment handler:
 
-   When `items[i] = value` is detected and the LHS base has an
-   `ArrayConstraint`, set `constraint.HasIndexAssignment = true` and unify the
-   value type with the constraint's `ElemTypeVar`.
+   When `items[i] = value` is detected and the LHS base (after Prune) is a
+   TypeVarType with an `ArrayConstraint`, sets `constraint.HasIndexAssignment = true`.
+   The value type is unified with the element type via the normal
+   `Unify(rightType, leftType)` call (where `leftType` is the TypeVar from
+   `LiteralIndexes`).
 
-4. **`internal/checker/infer_func.go`** — `closeOpenParams` (or new helper):
+4. **`internal/checker/infer_func.go`** — `closeOpenParams` + resolution:
 
-   At closing time, resolve each `ArrayConstraint` to a concrete type:
+   `closeOpenParams` is now a `Checker` method (was standalone function) to
+   support `Unify` calls during resolution. Before closing open objects, it
+   calls `resolveArrayConstraintsInType` on each parameter.
 
-   ```go
-   func resolveArrayConstraint(constraint *ArrayConstraint) Type {
-       if constraint.HasMutatingMethod || constraint.HasIndexAssignment ||
-          constraint.HasNonLiteralIndex {
-           // Resolve to Array<T> or mut Array<T>
-           arrayType := NewArrayType(constraint.ElemTypeVar)
-           // Unify all literal index type vars with ElemTypeVar
-           for _, elemTV := range constraint.LiteralIndexes {
-               Unify(elemTV, constraint.ElemTypeVar)
-           }
-           if constraint.HasMutatingMethod || constraint.HasIndexAssignment {
-               return NewMutabilityType(nil, arrayType, MutabilityMutable)
-           }
-           return arrayType
-       }
-       // Resolve to tuple
-       if len(constraint.LiteralIndexes) == 0 {
-           return NewTupleType(nil, []Type{})
-       }
-       maxIndex := 0
-       for idx := range constraint.LiteralIndexes {
-           if idx > maxIndex {
-               maxIndex = idx
-           }
-       }
-       elems := make([]Type, maxIndex+1)
-       for i := 0; i <= maxIndex; i++ {
-           if tv, ok := constraint.LiteralIndexes[i]; ok {
-               elems[i] = tv
-           } else {
-               elems[i] = c.FreshVar(nil) // gap — unresolved type variable
-           }
-       }
-       return NewTupleType(nil, elems)
-   }
-   ```
+   `resolveArrayConstraint` resolution rules:
+   - `HasMutatingMethod || HasNonLiteralIndex` → `Array<T>` (or `mut Array<T>`
+     if `HasMutatingMethod`). All literal index TypeVars unified with `ElemTypeVar`.
+   - Otherwise → tuple. `HasIndexAssignment` adds `mut` wrapper to the tuple
+     (diverges from original plan — see note in Section 13d below).
+   - Gaps in literal indexes (e.g. only index 0 and 3 accessed) produce fresh
+     TypeVars for missing positions.
 
-   Bind the TypeVarType's `Instance` to the resolved type.
+5. **`internal/checker/unify.go`** — `handleArrayConstraintBinding`:
 
-5. **Interaction with passing to typed functions:**
+   When a TypeVarType with an `ArrayConstraint` is bound to a concrete type:
+   - Bound to `Array<T>` → forces `HasNonLiteralIndex`, unifies element types.
+   - Bound to `mut Array<T>` → additionally forces `HasMutatingMethod`.
+   - Bound to a tuple type → unifies element types pairwise.
+   Returns `true` if handled (skips normal bind path), `false` otherwise.
 
-   If the parameter is passed to a function expecting `Array<T>`, `mut Array<T>`,
-   or a tuple type, unification should update the `ArrayConstraint` accordingly:
+6. **`internal/checker/generalize.go`**:
 
-   - Passed to `fn(x: Array<T>)` → resolve as `Array<T>` (set
-     `HasNonLiteralIndex = true` to force array).
-   - Passed to `fn(x: mut Array<T>)` → resolve as `mut Array<T>`.
-   - Passed to `fn(x: [number, string])` → resolve as tuple, unify element
-     types pairwise.
+   `deepCloneType` clones `ArrayConstraint` (literal index map, flags, and
+   `ElemTypeVar`) when present on a TypeVarType.
 
-6. **Method call resolution:**
-
-   When a method like `.push(42)` is called on a parameter with an
-   `ArrayConstraint`:
-   - Set `constraint.HasMutatingMethod = true`.
-   - The argument type (`42`, widened to `number`) is unified with
-     `constraint.ElemTypeVar`.
-   - The return type follows from the Array method signature (e.g. `.push()`
-     returns `number` — the new length).
-
-   Read-only method calls like `.map(fn)` need the element type to determine the
-   callback signature. During inference, the element type is the union of all
-   literal index type variables (or `ElemTypeVar` if resolved to array). This
-   may require deferred resolution similar to `resolveCallSites`.
+   `collectUnresolvedTypeVars` collects type vars from `ArrayConstraint`'s
+   `LiteralIndexes` and `ElemTypeVar`.
 
 ### Tests
+
+All tests are in `TestTupleArrayInference` and `TestTupleArrayInferenceEdgeCases`
+in `internal/checker/tests/row_types_test.go`.
+
+**Core tests (`TestTupleArrayInference`):**
 
 - **Tuple inference from literal indexes:**
   ```esc
@@ -1406,9 +1367,9 @@ deferring the commitment until closing time.
 
 - **Tuple with .length:**
   ```esc
-  fn foo(items) { let a = items[0]; let l = items.length }
+  fn foo(items) { val a = items[0]; val l = items.length; return [a, l] }
   ```
-  → `fn <T0>(items: [T0]) -> void`
+  → `fn <T0>(items: [T0]) -> [T0, number]`
 
 - **Array from .push():**
   ```esc
@@ -1418,34 +1379,47 @@ deferring the commitment until closing time.
 
 - **Array from non-literal index:**
   ```esc
-  fn foo(items, i) { let x = items[i] }
+  fn foo(items, i: number) { return items[i] }
   ```
-  → `fn <T0>(items: Array<T0>, i: number) -> void`
+  → `fn <T0>(items: Array<T0>, i: number) -> T0`
 
-- **Array from index assignment:**
+- **Mut tuple from index assignment:**
   ```esc
   fn foo(items) { items[0] = 42 }
   ```
-  → `fn (items: mut Array<number>) -> void`
+  → `fn (items: mut [number]) -> void`
 
 - **Array from mix of literal index + push:**
   ```esc
-  fn foo(items) { let a = items[0]; items.push("hello") }
+  fn foo(items) { val a = items[0]; items.push("hello") }
   ```
   → `fn (items: mut Array<string>) -> void`
   (literal index element type unified with push argument type)
 
-- **Tuple with read-only method (map):**
-  ```esc
-  fn foo(items) { let a = items[0]; items.map(fn(x) { return x }) }
-  ```
-  → `fn <T0>(items: [T0]) -> void`
+**Edge case tests (`TestTupleArrayInferenceEdgeCases`):**
 
-- **Conflict: object property + numeric index (unchanged from Section 9b):**
-  ```esc
-  fn foo(obj) { let x = obj.name; let y = obj[0] }
-  ```
-  → error (object property access conflicts with array/tuple indexing)
+- **Gap index** — only `items[1]` → `fn <T0>(items: mut [T0, number]) -> void`
+  (2-tuple with unresolved T0 at position 0)
+- **Object literal widening** — `items[0] = {x: 5, y: 10}` →
+  `fn (items: mut [{x: number, y: number}]) -> void`
+- **Read/write different indexes** — read `[0]`, write `[1]` →
+  `fn <T0>(items: mut [T0, string]) -> T0`
+- **Multiple writes same index** — `items[0] = 42; items[0] = 99` →
+  `fn (items: mut [number]) -> void`
+- **Sparse indexes** — read `[0]` and `[3]` →
+  `fn <T0, T1, T2, T3>(items: [T0, T1, T2, T3]) -> [T0, T3]`
+- **Index assignment + push** — `items[0] = 42; items.push(99)` →
+  `fn (items: mut Array<number>) -> void` (push forces array)
+- **Single index read-only** — `items[0]` → `fn <T0>(items: [T0]) -> T0`
+- **Return tuple element** — read `[0]` and `[1]`, return `[0]` →
+  `fn <T0, T1>(items: [T0, T1]) -> T0`
+- **Write-only index 0** — `items[0] = "hello"` →
+  `fn (items: mut [string]) -> void`
+
+**Not yet tested:**
+- Conflict: object property + numeric index (e.g. `obj.name` + `obj[0]`)
+- Read-only method (`.map()`) on inferred tuple (currently produces disconnected
+  type variables — may need deferred call-site resolution)
 
 ---
 
@@ -1780,7 +1754,7 @@ fn foo(items) {
 }
 // Phase 12 infers: items has ArrayConstraint with LiteralIndexes {0: t0}
 //   and HasIndexAssignment = true
-// Wait — HasIndexAssignment means it resolves to mut Array, not tuple.
+// HasIndexAssignment + literal-only indexes → resolves to mut [number].
 ```
 
 Better example (read-only with return):
@@ -1978,7 +1952,7 @@ Phase 6 → Phase 7: Row Polymorphism ✅
 ### Tuple/array inference (after Phase 6, parallel with Phase 7)
 
 ```
-Phase 6 → Phase 12: Tuple/Array Inference
+Phase 6 → Phase 12: Tuple/Array Inference ✅
 ```
 
 ### Variadic tuples (after Phase 3, independent)
@@ -2023,7 +1997,7 @@ All phases → Phase 11: Error Reporting
 | 9: Optional Chaining           | 2          | 3–14                 |
 | 10: Object Spread              | 3          | 4–14                 |
 | 11: Error Reporting            | all        | —                    |
-| 12: Tuple/Array Inference      | 6          | 7, 13                |
+| 12: Tuple/Array Inference ✅   | 6          | 7, 13                |
 | 13: Variadic Tuple Types ✅    | 3          | 4–12                 |
 | 14: Tuple Row Polymorphism     | 12, 13     | 7                    |
 
@@ -2087,15 +2061,15 @@ All phases → Phase 11: Error Reporting
 
 | File | Phases | Status |
 |------|--------|--------|
-| `internal/type_system/types.go` | 1, 7, 13 | ✅ (Phase 1) `Open`, `Widenable`, `IsParam`, `Written` fields added; `Accept`/`Copy` updated; (Phase 7) `collectFlatElems` and `ObjectType.String()` flattening of resolved `RestSpreadElem`s; ✅ (Phase 13) `collectFlatTupleElems` and `TupleType.String()` flattening of resolved `RestSpreadType` |
-| `internal/checker/expand_type.go` | 2, 9, 10, 12, 13 | ✅ (Phase 2) `TypeVarType` case in `getMemberType`, open-object handling in `getObjectAccess`, helper functions; Phase 12: modify TypeVarType numeric index branch to defer tuple/array commitment; ✅ (Phase 13) `tupleElemUnion` helper; `getMemberType` TupleType case handles `RestSpreadType` in both numeric index and method access |
-| `internal/checker/unify.go` | 3, 4, 10, 13 | ✅ (Phase 3) `openClosedObjectForParam`, open-vs-open/closed paths; (Phase 4) `unifyPruned` refactor, `widenLiteral`, `flatUnion`, `typeContains`, `unwrapMutability`; ✅ (Phase 13) `splitTupleAtRest`, `unifyTuples`, `unifyFixedTuples`, `unifyFixedVsVariadic`, `unifyVariadicVsFixed`, `unifyVariadicVsVariadic`; tuple-vs-array and array-vs-tuple handle `RestSpreadType` |
+| `internal/type_system/types.go` | 1, 7, 12, 13 | ✅ (Phase 1) `Open`, `Widenable`, `IsParam`, `Written` fields added; `Accept`/`Copy` updated; (Phase 7) `collectFlatElems` and `ObjectType.String()` flattening of resolved `RestSpreadElem`s; ✅ (Phase 12) `ArrayConstraint` struct, `ArrayConstraint` field on `TypeVarType`; ✅ (Phase 13) `collectFlatTupleElems` and `TupleType.String()` flattening of resolved `RestSpreadType` |
+| `internal/checker/expand_type.go` | 2, 9, 10, 12, 13 | ✅ (Phase 2) `TypeVarType` case in `getMemberType`, open-object handling in `getObjectAccess`, helper functions; ✅ (Phase 12) deferred tuple/array commitment via `ArrayConstraint`; `isArrayMethod`/`isArrayMutatingMethod` for runtime method classification; `getArrayConstraintPropertyAccess`/`getArrayConstraintIndexAccess` for subsequent accesses; ✅ (Phase 13) `tupleElemUnion` helper; `getMemberType` TupleType case handles `RestSpreadType` in both numeric index and method access |
+| `internal/checker/unify.go` | 3, 4, 10, 12, 13 | ✅ (Phase 3) `openClosedObjectForParam`, open-vs-open/closed paths; (Phase 4) `unifyPruned` refactor, `widenLiteral`, `flatUnion`, `typeContains`, `unwrapMutability`; ✅ (Phase 12) `handleArrayConstraintBinding` — updates constraint when TypeVar with `ArrayConstraint` is bound to Array or tuple type; ✅ (Phase 13) `splitTupleAtRest`, `unifyTuples`, `unifyFixedTuples`, `unifyFixedVsVariadic`, `unifyVariadicVsFixed`, `unifyVariadicVsVariadic`; tuple-vs-array and array-vs-tuple handle `RestSpreadType` |
 | `internal/parser/type_ann.go` | 13 | ✅ (Phase 13) `DotDotDot` case in `primaryTypeAnn` — enables `...T` in tuple type annotations (e.g. `[number, ...T]`) |
-| `internal/checker/generalize.go` | 2, 6, 7 | ✅ (Phase 2) Mutability resolution in `GeneralizeFuncType`, `Open` preserved in `deepCloneType`; (Phase 7) No changes needed — handles row variables automatically; Phases 13/14: no changes expected (visitor pattern handles `RestSpreadType` in tuples) |
-| `internal/checker/infer_func.go` | 3, 6, 7, 8, 12, 14 | ✅ (Phase 3) `IsParam: true` for unannotated parameters; (Phase 6) `closeOpenParams`, `closeObjectType`; (Phase 7) No changes needed; Phase 12: resolve `ArrayConstraint` during closing; Phase 14: `closeTupleType` for rest variable filtering |
-| `internal/checker/infer_expr.go` | 2, 5, 7, 10, 12 | ✅ (Phase 2) `markPropertyWritten` in assignment handler; (Phase 7) No changes needed; Phase 12: detect index assignment on `ArrayConstraint` |
+| `internal/checker/generalize.go` | 2, 6, 7, 12 | ✅ (Phase 2) Mutability resolution in `GeneralizeFuncType`, `Open` preserved in `deepCloneType`; (Phase 7) No changes needed — handles row variables automatically; ✅ (Phase 12) `deepCloneType` clones `ArrayConstraint`; `collectUnresolvedTypeVars` collects from `ArrayConstraint`; Phases 13/14: no changes expected (visitor pattern handles `RestSpreadType` in tuples) |
+| `internal/checker/infer_func.go` | 3, 6, 7, 8, 12, 14 | ✅ (Phase 3) `IsParam: true` for unannotated parameters; (Phase 6) `closeOpenParams`, `closeObjectType`; (Phase 7) No changes needed; ✅ (Phase 12) `closeOpenParams` now a `Checker` method; `resolveArrayConstraintsInType` and `resolveArrayConstraint` resolve constraints during closing; Phase 14: `closeTupleType` for rest variable filtering |
+| `internal/checker/infer_expr.go` | 2, 5, 7, 10, 12 | ✅ (Phase 2) `markPropertyWritten` in assignment handler; (Phase 7) No changes needed; ✅ (Phase 12) detect index assignment on `ArrayConstraint`, set `HasIndexAssignment` |
 | `internal/checker/errors.go` | 11 | Not started |
-| `internal/checker/tests/row_types_test.go` | All | ✅ Tests for Phases 1–7 (PropertyAccess, Errors, KeyOf, IntersectionAccess, PassToTypedFunction, WriteAfterPass, StringLiteralIndex, MethodCallInference, PropertyWidening, Closing, RowPolymorphism); ✅ Phase 13 (VariadicTupleTypes, VariadicTupleSubtyping) |
+| `internal/checker/tests/row_types_test.go` | All | ✅ Tests for Phases 1–7 (PropertyAccess, Errors, KeyOf, IntersectionAccess, PassToTypedFunction, WriteAfterPass, StringLiteralIndex, MethodCallInference, PropertyWidening, Closing, RowPolymorphism); ✅ Phase 12 (TupleArrayInference, TupleArrayInferenceEdgeCases); ✅ Phase 13 (VariadicTupleTypes, VariadicTupleSubtyping) |
 | `internal/checker/widening_test.go` | 4 | ✅ Unit tests for `flatUnion` and `typeContains` helpers |
 
 ---

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1398,7 +1398,7 @@ in `internal/checker/tests/row_types_test.go`.
 
 **Edge case tests (`TestTupleArrayInferenceEdgeCases`):**
 
-- **Gap index** — only `items[1]` → `fn <T0>(items: mut [T0, number]) -> void`
+- **Gap index** — only `items[1]` → `fn <T0>(items: [T0, number]) -> void`
   (2-tuple with unresolved T0 at position 0)
 - **Object literal widening** — `items[0] = {x: 5, y: 10}` →
   `fn (items: mut [{x: number, y: number}]) -> void`

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -1374,8 +1374,8 @@ fn bar(items) {
     val i = 5
     items[i] = "hello"   // i has literal type 5, so this is items[5]
 }
-// HasIndexAssignment is true → inferred as mut Array, not tuple
-// (but the index itself is treated as a literal index, not a non-literal)
+// HasIndexAssignment is true → inferred as mut [T0, T1, T2, T3, T4, string]
+// (mutable tuple — the index is a literal, so tuple shape is preserved)
 ```
 
 The tuple length is determined by the highest index accessed + 1. If `items[0]`
@@ -1447,49 +1447,69 @@ rule apply.
 **Why:** A non-literal index type means the position being accessed is unknown at
 type-check time, so a tuple would not be meaningful.
 
-#### 13d. Index assignment implies mut Array
+#### 13d. Index assignment implies mutability
 
 If an element is assigned via index notation (`items[i] = value`), the parameter
-should be inferred as `mut Array<T>` regardless of whether the index is a literal
-or a variable:
+must be mutable. When only literal indexes are used (no mutating methods or
+non-literal indexes), the parameter is inferred as a **mutable tuple** rather
+than `mut Array<T>`:
 
 ```esc
 fn foo(items) {
     items[0] = 42
 }
+// inferred: fn foo(items: mut [number]) -> void
+```
+
+If a non-literal index is used for assignment, the parameter is inferred as
+`mut Array<T>` (per Section 13c). If mutating methods are also used, `mut Array<T>`
+takes precedence (per Section 13b):
+
+```esc
+fn foo(items) {
+    items[0] = 42
+    items.push(99)
+}
 // inferred: fn foo(items: mut Array<number>) -> void
 ```
 
-**Why:** Assigning to an index mutates the array. Even though `items[0] = 42`
-uses a literal index, the assignment implies the caller's array will be modified,
-which requires `mut`. A tuple would also be mutated, but tuples are
-value-semantics types in Escalier — they cannot be mutated in place.
+**Why:** Index assignment with a literal index mutates a specific known position.
+A mutable tuple (`mut [T]`) captures this precisely — the length is still fixed
+and each position retains its own type. `mut Array<T>` would lose positional type
+information. Note that mutating methods like `.push()` change the length, which
+is incompatible with tuple semantics, so they still force `mut Array<T>`.
 
 #### 13e. Summary of inference rules
 
 | Usage pattern | Inferred type |
 |---------------|---------------|
 | Only non-negative integer literal indexes + read-only Array methods | Tuple `[t0, t1, ...]` |
+| Literal index assignment only (no mutating methods) | `mut [t0, t1, ...]` |
 | Any non-literal numeric index (read-only) | `Array<T>` |
-| Any index assignment | `mut Array<T>` |
 | Any mutating method (`.push()`, `.pop()`, etc.) | `mut Array<T>` |
 | Mix of literal indexes + mutating methods | `mut Array<T>` |
+| Index assignment + mutating methods | `mut Array<T>` |
 
 #### 13f. Interaction with existing Section 3
 
-Section 3 currently binds a type variable to `Array<T>` whenever a numeric index
-is used. This section refines that behavior:
+Section 3 previously bound a type variable to `Array<T>` whenever a numeric index
+was used. This section refines that behavior:
 
 - **Non-negative integer literal index** (e.g. `obj[0]`): defer commitment —
-  the type variable should not be immediately bound to `Array<T>`. Instead,
-  record the index as a tuple constraint. Final resolution to tuple vs. array
-  happens during closing (Section 5), based on whether any array-only patterns
-  were observed. Other numeric literals (negative, fractional) are treated as
-  non-literal access.
-- **Non-literal numeric index** (e.g. `obj[i]`): bind to `Array<T>` immediately,
-  as before.
-- **Mutating method call**: bind to `mut Array<T>` (or upgrade an existing
-  constraint to `mut Array<T>`).
+  the type variable is not immediately bound to `Array<T>`. Instead, an
+  `ArrayConstraint` is created on the `TypeVarType` to record the index as a
+  tuple constraint. Final resolution to tuple vs. array happens during closing
+  (Section 5), based on whether any array-only patterns were observed. Other
+  numeric literals (negative, fractional) are treated as non-literal access.
+- **Non-literal numeric index** (e.g. `obj[i]`): records `HasNonLiteralIndex`
+  on the `ArrayConstraint`, which forces resolution to `Array<T>` at closing
+  time.
+- **Mutating method call**: records `HasMutatingMethod` on the `ArrayConstraint`,
+  which forces resolution to `mut Array<T>` at closing time.
+- **Array method on fresh TypeVar**: When a property like `.push()` or `.length`
+  is accessed on a TypeVarType that doesn't yet have an `ArrayConstraint`, the
+  system checks whether the property exists on the Array type definition. If so,
+  an `ArrayConstraint` is created instead of an open object.
 
 This deferred approach avoids premature commitment to `Array<T>` when the usage
 pattern actually indicates a tuple.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred tuple-vs-array inference for numeric indexing: literal numeric reads produce tuples; non-literal or mutating patterns yield arrays. `.length` and array-method calls consistently create/update deferred array constraints.
* **Bug Fixes**
  * Improved mutability/index-assignment handling: literal-index writes infer mutable tuples when appropriate; non-literal indexes or mutating methods force mutable arrays. String-literal indices route to property access.
* **Tests**
  * Expanded coverage for tuples vs arrays, sparse/non-contiguous indexes, read/write interactions, push/mutation, large-index and regression cases.
* **Documentation**
  * Updated design, requirements, and implementation notes to reflect deferred array-constraint resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->