### PR TITLE
Row Types - Phase 14: Tuple Row Polymorphism

### DIFF
--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -421,6 +421,14 @@ func (c *Checker) findThrowTypes(ctx Context, block *ast.Block) ([]type_system.T
 // don't appear in the return type, resolves mutability, and resolves
 // ArrayConstraints to concrete tuple or array types.
 func (c *Checker) closeOpenParams(funcSigType *type_system.FuncType) {
+	// Resolve ArrayConstraints first so that inferred tuple types (including
+	// rest type variables) are visible when we collect return type vars.
+	// Without this ordering, rest type variables created during resolution
+	// wouldn't appear in returnVars and would always be removed.
+	for _, param := range funcSigType.Params {
+		c.resolveArrayConstraintsInType(param.Type)
+	}
+
 	// Collect unresolved type vars in the return type to determine which
 	// row variables escape. We intentionally do NOT collect from
 	// funcSigType.Throws: GeneralizeFuncType defaults throws-only type vars
@@ -435,7 +443,6 @@ func (c *Checker) closeOpenParams(funcSigType *type_system.FuncType) {
 	collectUnresolvedTypeVars(funcSigType.Return, returnVars, &returnOrder)
 
 	for _, param := range funcSigType.Params {
-		c.resolveArrayConstraintsInType(param.Type)
 		closeOpenObjectsInType(param.Type, returnVars)
 	}
 }
@@ -443,21 +450,31 @@ func (c *Checker) closeOpenParams(funcSigType *type_system.FuncType) {
 // resolveArrayConstraintsInType walks a type tree and resolves any
 // ArrayConstraints on TypeVarTypes to concrete tuple or array types.
 func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
-	// Pruning before the ArrayConstraint check is safe: ArrayConstraints are
-	// only created on parameter TypeVars (IsParam=true), which are always the
-	// representative in their equivalence class (Instance remains nil while
-	// the constraint is active). Prune on a param TypeVar returns itself.
-	t = type_system.Prune(t)
-
+	// Check for ArrayConstraint before pruning: a param TypeVar with an
+	// ArrayConstraint may have had its Instance set during return-type
+	// unification (e.g., `return items` unifies the param TypeVar with the
+	// return TypeVar, setting Instance on one of them). In that case,
+	// Prune() follows Instance and misses the constraint.
 	if tv, ok := t.(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
 		resolved := c.resolveArrayConstraint(tv.ArrayConstraint)
-		tv.Instance = resolved
 		tv.ArrayConstraint = nil
+		// Bind the resolved type to the representative of this TypeVar's
+		// equivalence class. If Instance is set (param was unified with the
+		// return TypeVar), the representative is the other end of the chain;
+		// otherwise the param TypeVar is its own representative.
+		rep := type_system.Prune(tv)
+		if repTV, ok := rep.(*type_system.TypeVarType); ok {
+			repTV.Instance = resolved
+		} else {
+			tv.Instance = resolved
+		}
 		// Recurse into the resolved type to handle nested ArrayConstraints
 		// (e.g. items[0][1] where the element itself is used as a tuple/array).
 		c.resolveArrayConstraintsInType(resolved)
 		return
 	}
+
+	t = type_system.Prune(t)
 
 	// Recurse into type constructors that can appear in inferred parameter types.
 	// We only need to cover shapes produced by inference on unannotated params:
@@ -531,7 +548,8 @@ func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint
 	// Resolve to tuple
 	isMut := constraint.HasIndexAssignment
 	if len(constraint.LiteralIndexes) == 0 {
-		tupleType := type_system.NewTupleType(nil)
+		restTV := c.FreshVar(nil)
+		tupleType := type_system.NewTupleType(nil, type_system.NewRestSpreadType(nil, restTV))
 		if isMut {
 			return &type_system.MutabilityType{
 				Type:       tupleType,
@@ -554,6 +572,12 @@ func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint
 			elems[i] = c.FreshVar(nil) // gap — unresolved type variable
 		}
 	}
+	// Append a rest type variable to capture extra caller-supplied elements.
+	// This is the tuple analogue of the row variable added to open objects.
+	// The rest variable will be removed during closing if it doesn't appear
+	// in the function's return type.
+	restTV := c.FreshVar(nil)
+	elems = append(elems, type_system.NewRestSpreadType(nil, restTV))
 	tupleType := type_system.NewTupleType(nil, elems...)
 	if isMut {
 		return &type_system.MutabilityType{
@@ -615,6 +639,7 @@ func closeOpenObjectsInType(t type_system.Type, returnVars map[int]*type_system.
 		for _, elem := range p.Elems {
 			closeOpenObjectsInType(elem, returnVars)
 		}
+		closeTupleType(p, returnVars)
 	case *type_system.UnionType:
 		for _, opt := range p.Types {
 			closeOpenObjectsInType(opt, returnVars)
@@ -658,4 +683,24 @@ func closeObjectType(objType *type_system.ObjectType, returnVars map[int]*type_s
 		filtered = append(filtered, elem)
 	}
 	objType.Elems = filtered
+}
+
+// closeTupleType removes a trailing RestSpreadType whose type variable doesn't
+// appear in returnVars. This is the tuple analogue of closeObjectType removing
+// RestSpreadElems for objects. If the rest variable appears in the
+// return type, it is kept and GeneralizeFuncType will promote it to a type
+// parameter.
+func closeTupleType(tupleType *type_system.TupleType, returnVars map[int]*type_system.TypeVarType) {
+	if len(tupleType.Elems) == 0 {
+		return
+	}
+	last := tupleType.Elems[len(tupleType.Elems)-1]
+	if rest, ok := last.(*type_system.RestSpreadType); ok {
+		if tv, ok := type_system.Prune(rest.Type).(*type_system.TypeVarType); ok {
+			if _, found := returnVars[tv.ID]; !found {
+				// Rest var not in return type — remove it
+				tupleType.Elems = tupleType.Elems[:len(tupleType.Elems)-1]
+			}
+		}
+	}
 }

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -449,6 +449,15 @@ func (c *Checker) closeOpenParams(funcSigType *type_system.FuncType) {
 
 // resolveArrayConstraintsInType walks a type tree and resolves any
 // ArrayConstraints on TypeVarTypes to concrete tuple or array types.
+//
+// We only need to check for ArrayConstraint on the incoming TypeVar (before
+// pruning), not on its representative. ArrayConstraints are always set on
+// the Prune-representative of a TypeVar because getMemberType prunes before
+// reaching the TypeVarType case where getOrCreateArrayConstraint is called.
+// The representative either IS the incoming TypeVar (the common case, and
+// the pre-prune check catches it), or the incoming TypeVar's representative
+// is a different param TypeVar that will be processed in its own iteration
+// of closeOpenParams's loop over all params.
 func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
 	// Check for ArrayConstraint before pruning: a param TypeVar with an
 	// ArrayConstraint may have had its Instance set during return-type

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1990,6 +1990,103 @@ func TestTupleArrayInferenceFixedBugs(t *testing.T) {
 	}
 }
 
+func TestTupleRowPolymorphism(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"TupleWithReturn_RestPreserved": {
+			// When the tuple parameter is returned, the rest variable is preserved
+			input: `
+				fn foo(items) {
+					val x = items[0]
+					return items
+				}
+				val r = foo([1, "hello", true])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(items: [T0, ...T1]) -> [T0, ...T1]",
+				"r":   "[1, \"hello\", true]",
+			},
+		},
+		"TupleWithoutReturn_RestRemoved": {
+			// When the tuple parameter is not returned, the rest variable is removed
+			input: `
+				fn foo(items) { val x = items[0] }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: [T0]) -> void",
+			},
+		},
+		"DerivedReturn_RestDoesNotEscape": {
+			// Returning an element of the tuple — rest does not escape
+			input: `
+				fn foo(items) { return items[0] }
+				val r = foo([42])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(items: [T0]) -> T0",
+				"r":   "42",
+			},
+		},
+		"MultipleTupleParamsWithReturn": {
+			// Both rest variables appear in return type, both preserved
+			input: `
+				fn foo(a, b) {
+					val x = a[0]
+					val y = b[0]
+					return [a, b]
+				}
+				val r = foo([1, 2], ["a", "b"])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1, T2, T3>(a: [T0, ...T1], b: [T2, ...T3]) -> [[T0, ...T1], [T2, ...T3]]",
+				"r":   "[[1, 2], [\"a\", \"b\"]]",
+			},
+		},
+		"NoExtraElements_RestResolvesToEmptyTuple": {
+			// When caller passes exactly the right number of elements, rest = []
+			input: `
+				fn foo(items) {
+					val x = items[0]
+					return items
+				}
+				val r = foo([42])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(items: [T0, ...T1]) -> [T0, ...T1]",
+				"r":   "[42]",
+			},
+		},
+		"LiteralTypesPreservedThroughRest": {
+			// Literal types are preserved through rest variable
+			input: `
+				fn foo(items) {
+					val x = items[0]
+					return items
+				}
+				val r = foo([1, "hello"])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(items: [T0, ...T1]) -> [T0, ...T1]",
+				"r":   "[1, \"hello\"]",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
 // TestTupleArrayInferenceUnifyErrors verifies that element-type conflicts are
 // properly reported when an array-constrained parameter is bound to an
 // incompatible concrete type.

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1990,6 +1990,111 @@ func TestTupleArrayInferenceFixedBugs(t *testing.T) {
 	}
 }
 
+func TestTupleArrayPassToTypedFunction(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"PassToTupleParam": {
+			// Passing to a function with a tuple parameter infers a tuple
+			input: `
+				fn bar(items: [number, string]) -> number { return items[0] }
+				fn foo(items) { bar(items) }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: [number, string]) -> void",
+			},
+		},
+		"PassToArrayParam": {
+			// Passing to a function with an Array parameter infers Array
+			input: `
+				fn bar(items: Array<number>) -> number { return items[0] }
+				fn foo(items) { bar(items) }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: Array<number>) -> void",
+			},
+		},
+		"PassToMutArrayParam": {
+			// Passing to a function with a mut Array parameter infers mut Array
+			input: `
+				fn bar(items: mut Array<number>) -> void { items[0] = 1 }
+				fn foo(items) { bar(items) }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number>) -> void",
+			},
+		},
+		"IndexThenPassToArrayParam": {
+			// Indexing creates an ArrayConstraint, then passing to Array<T>
+			// forces array resolution
+			input: `
+				fn bar(items: Array<number>) -> number { return items[0] }
+				fn foo(items) {
+					val x = items[0]
+					bar(items)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: Array<number>) -> void",
+			},
+		},
+		"IndexThenPassToTupleParam": {
+			// Indexing creates an ArrayConstraint, then passing to a tuple
+			// binds to the tuple type
+			input: `
+				fn bar(items: [number, string]) -> number { return items[0] }
+				fn foo(items) {
+					val x = items[0]
+					bar(items)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: [number, string]) -> void",
+			},
+		},
+		"PassToMultipleTypedFunctions": {
+			// Passing to two functions with different array/tuple params
+			input: `
+				fn bar(items: Array<number>) -> number { return items[0] }
+				fn baz(items: Array<number>) -> number { return items[0] }
+				fn foo(items) {
+					bar(items)
+					baz(items)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: Array<number>) -> void",
+			},
+		},
+		"IndexThenPassToVariadicTupleParam": {
+			// Indexing and then passing to a variadic tuple parameter
+			input: `
+				fn bar(items: [number, ...Array<string>]) -> number { return items[0] }
+				fn foo(items) {
+					val x = items[0]
+					bar(items)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: [number, ...Array<string>]) -> void",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
 func TestTupleRowPolymorphism(t *testing.T) {
 	tests := map[string]struct {
 		input         string

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -169,6 +169,13 @@ func recordInstanceChain(tv *TypeVarType) {
 // ArrayConstraint tracks numeric indexing patterns on a type variable before
 // committing to tuple vs. array. It is stored on TypeVarType and resolved
 // during closeOpenParams.
+//
+// This deferred approach is used instead of an Open field on TupleType (like
+// ObjectType has) because the tuple-vs-array decision depends on the full set
+// of access patterns: literal indexes produce tuples, while non-literal indexes
+// or mutating methods (.push, .pop) force mut Array<T>, and read-only methods
+// (.map, .filter) without literal indexes force Array<T>. An open TupleType
+// couldn't represent "might actually be an Array or mut Array".
 type ArrayConstraint struct {
 	LiteralIndexes     map[int]Type // index → element type variable
 	HasNonLiteralIndex bool         // true if items[i] used with non-literal number type

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1648,7 +1648,7 @@ and display.
 
 ---
 
-## Phase 14: Tuple Row Polymorphism (Variadic Inference)
+## Phase 14: Tuple Row Polymorphism (Variadic Inference) ✅
 
 **Requirements covered:** Section 15 (tuple row polymorphism).
 
@@ -1959,7 +1959,7 @@ Phase 6 → Phase 12: Tuple/Array Inference ✅
 
 ```
 Phase 3 → Phase 13: Variadic Tuple Types ✅
-            → Phase 14: Tuple Row Polymorphism (also requires Phase 12)
+            → Phase 14: Tuple Row Polymorphism ✅ (also requires Phase 12)
 ```
 
 ### Destructuring (requires both object and tuple row polymorphism)
@@ -1999,7 +1999,7 @@ All phases → Phase 11: Error Reporting
 | 11: Error Reporting            | all        | —                    |
 | 12: Tuple/Array Inference ✅   | 6          | 7, 13                |
 | 13: Variadic Tuple Types ✅    | 3          | 4–12                 |
-| 14: Tuple Row Polymorphism     | 12, 13     | 7                    |
+| 14: Tuple Row Polymorphism ✅  | 12, 13     | 7                    |
 
 ---
 
@@ -2049,11 +2049,14 @@ All phases → Phase 11: Error Reporting
    variadic-vs-variadic case handles different prefix/suffix lengths by
    wrapping extras into a tuple with the shorter side's rest.
 
-8. **Tuple row polymorphism interaction with Phase 8 (Phase 14):** Phase 14
-   changes Phase 8's tuple destructuring from collapsing `[a, ...rest]` to
-   `Array<T>` to using `[t0, ...R]` instead. This means Phase 8's
-   implementation depends on Phase 14 being complete. If Phase 8 needs to
-   ship earlier, the `Array<T>` fallback can be kept as an interim solution.
+8. ~~**Tuple row polymorphism interaction with Phase 8 (Phase 14):**~~ Resolved.
+   Phase 14 is complete. Inferred tuples now include a `RestSpreadType` with a
+   fresh type variable, and `closeTupleType` removes it when it doesn't escape
+   to the return type. Phase 8 can now use `[t0, ...R]` for tuple destructuring
+   with rest patterns. Key implementation detail: `closeOpenParams` was
+   reordered to resolve ArrayConstraints before collecting `returnVars`, so that
+   rest type variables created during resolution are visible in the return type
+   analysis.
 
 ---
 
@@ -2065,11 +2068,11 @@ All phases → Phase 11: Error Reporting
 | `internal/checker/expand_type.go` | 2, 9, 10, 12, 13 | ✅ (Phase 2) `TypeVarType` case in `getMemberType`, open-object handling in `getObjectAccess`, helper functions; ✅ (Phase 12) deferred tuple/array commitment via `ArrayConstraint`; `isArrayMethod`/`isArrayMutatingMethod` for runtime method classification; `getArrayConstraintPropertyAccess`/`getArrayConstraintIndexAccess` for subsequent accesses; ✅ (Phase 13) `tupleElemUnion` helper; `getMemberType` TupleType case handles `RestSpreadType` in both numeric index and method access |
 | `internal/checker/unify.go` | 3, 4, 10, 12, 13 | ✅ (Phase 3) `openClosedObjectForParam`, open-vs-open/closed paths; (Phase 4) `unifyPruned` refactor, `widenLiteral`, `flatUnion`, `typeContains`, `unwrapMutability`; ✅ (Phase 12) `handleArrayConstraintBinding` — updates constraint when TypeVar with `ArrayConstraint` is bound to Array or tuple type; ✅ (Phase 13) `splitTupleAtRest`, `unifyTuples`, `unifyFixedTuples`, `unifyFixedVsVariadic`, `unifyVariadicVsFixed`, `unifyVariadicVsVariadic`; tuple-vs-array and array-vs-tuple handle `RestSpreadType` |
 | `internal/parser/type_ann.go` | 13 | ✅ (Phase 13) `DotDotDot` case in `primaryTypeAnn` — enables `...T` in tuple type annotations (e.g. `[number, ...T]`) |
-| `internal/checker/generalize.go` | 2, 6, 7, 12 | ✅ (Phase 2) Mutability resolution in `GeneralizeFuncType`, `Open` preserved in `deepCloneType`; (Phase 7) No changes needed — handles row variables automatically; ✅ (Phase 12) `deepCloneType` clones `ArrayConstraint`; `collectUnresolvedTypeVars` collects from `ArrayConstraint`; Phases 13/14: no changes expected (visitor pattern handles `RestSpreadType` in tuples) |
-| `internal/checker/infer_func.go` | 3, 6, 7, 8, 12, 14 | ✅ (Phase 3) `IsParam: true` for unannotated parameters; (Phase 6) `closeOpenParams`, `closeObjectType`; (Phase 7) No changes needed; ✅ (Phase 12) `closeOpenParams` now a `Checker` method; `resolveArrayConstraintsInType` and `resolveArrayConstraint` resolve constraints during closing; Phase 14: `closeTupleType` for rest variable filtering |
+| `internal/checker/generalize.go` | 2, 6, 7, 12 | ✅ (Phase 2) Mutability resolution in `GeneralizeFuncType`, `Open` preserved in `deepCloneType`; (Phase 7) No changes needed — handles row variables automatically; ✅ (Phase 12) `deepCloneType` clones `ArrayConstraint`; `collectUnresolvedTypeVars` collects from `ArrayConstraint`; ✅ (Phase 13/14) No changes needed — visitor pattern handles `RestSpreadType` in tuples; `collectUnresolvedTypeVars` already walks `TupleType.Elems` and `RestSpreadType.Type` |
+| `internal/checker/infer_func.go` | 3, 6, 7, 8, 12, 14 | ✅ (Phase 3) `IsParam: true` for unannotated parameters; (Phase 6) `closeOpenParams`, `closeObjectType`; (Phase 7) No changes needed; ✅ (Phase 12) `closeOpenParams` now a `Checker` method; `resolveArrayConstraintsInType` and `resolveArrayConstraint` resolve constraints during closing; ✅ (Phase 14) `closeTupleType` for rest variable filtering; `resolveArrayConstraint` appends `RestSpreadType` with fresh TV to inferred tuples; `resolveArrayConstraintsInType` checks ArrayConstraint before pruning; `closeOpenParams` resolves ArrayConstraints before collecting returnVars |
 | `internal/checker/infer_expr.go` | 2, 5, 7, 10, 12 | ✅ (Phase 2) `markPropertyWritten` in assignment handler; (Phase 7) No changes needed; ✅ (Phase 12) detect index assignment on `ArrayConstraint`, set `HasIndexAssignment` |
 | `internal/checker/errors.go` | 11 | Not started |
-| `internal/checker/tests/row_types_test.go` | All | ✅ Tests for Phases 1–7 (PropertyAccess, Errors, KeyOf, IntersectionAccess, PassToTypedFunction, WriteAfterPass, StringLiteralIndex, MethodCallInference, PropertyWidening, Closing, RowPolymorphism); ✅ Phase 12 (TupleArrayInference, TupleArrayInferenceEdgeCases); ✅ Phase 13 (VariadicTupleTypes, VariadicTupleSubtyping) |
+| `internal/checker/tests/row_types_test.go` | All | ✅ Tests for Phases 1–7 (PropertyAccess, Errors, KeyOf, IntersectionAccess, PassToTypedFunction, WriteAfterPass, StringLiteralIndex, MethodCallInference, PropertyWidening, Closing, RowPolymorphism); ✅ Phase 12 (TupleArrayInference, TupleArrayInferenceEdgeCases); ✅ Phase 13 (VariadicTupleTypes, VariadicTupleSubtyping); ✅ Phase 14 (TupleRowPolymorphism) |
 | `internal/checker/widening_test.go` | 4 | ✅ Unit tests for `flatUnion` and `typeContains` helpers |
 
 ---

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -1649,7 +1649,17 @@ into the parent (same display behavior as `ObjectType.String()` for resolved
 - `[number, ...[string, boolean]]` displays as `[number, string, boolean]`.
 - `[number, ...[]]` displays as `[number]` (empty rest dropped).
 
-### 15. Tuple Row Polymorphism (Variadic Inference)
+### 15. Tuple Row Polymorphism (Variadic Inference) ✅
+
+> **Status (2026-04-09):** Implemented in Phase 14. `resolveArrayConstraint`
+> appends a `RestSpreadType` with a fresh type variable to inferred tuples.
+> `closeTupleType` removes rest variables that don't appear in the return type.
+> `closeOpenParams` was reordered to resolve ArrayConstraints before collecting
+> `returnVars` so that freshly-created rest type variables are visible.
+> Generalization and call-site instantiation required no changes — the existing
+> visitor pattern in `GeneralizeFuncType` and `SubstituteTypeParams` already
+> walks `RestSpreadType` inside `TupleType.Elems`. Tests in
+> `TestTupleRowPolymorphism`.
 
 Tuple row polymorphism enables functions with inferred tuple parameters to
 preserve extra elements through their return types. This is the tuple analogue
@@ -1836,13 +1846,16 @@ val r = identity([1, "hello"])
     in `unify.go`; `collectFlatTupleElems` in `types.go`; `tupleElemUnion` in
     `expand_type.go`; `DotDotDot` case in `type_ann.go`.
 
-12. **Add tuple row polymorphism**: When an inferred tuple parameter is returned,
+12. **Add tuple row polymorphism** ✅: When an inferred tuple parameter is returned,
     append a `RestSpreadType` with a fresh type variable to capture extra
     elements. At closing time, preserve rest variables that appear in the return
     type (promoting to type parameters) and remove those that don't. This is
     the tuple analogue of object row polymorphism (see Section 15).
+    Implemented in Phase 14: `resolveArrayConstraint` appends rest TV;
+    `closeTupleType` filters by `returnVars`; `closeOpenParams` reordered to
+    resolve constraints before collecting return vars.
 
 13. **Add tests**: Cover property access, method calls, array indexing, optional
     chaining, passing to typed functions, widening, closing after inference, row
     polymorphism (return type propagation), object spread, tuple/array inference,
-    variadic tuples, tuple row polymorphism, and error cases.
+    variadic tuples, tuple row polymorphism ✅, and error cases.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tuple/array inference: trailing/rest elements added to inferred tuples when they escape into returns, and removed when they don't, yielding more accurate function signatures and call-site types.

* **Tests**
  * Added tests covering tuple rest polymorphism, variadic inference, and multi-parameter/propagation scenarios.

* **Documentation**
  * Updated design, implementation, and requirements docs to reflect completed tuple row polymorphism behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->