### PR TITLE
Fix #404

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1092,18 +1092,20 @@ func (c *Checker) getArrayConstraintPropertyAccess(ctx Context, t *type_system.T
 		return type_system.NewNumPrimType(nil), errors
 	}
 
-	// Look up the property on the Array type to resolve the method and determine mutability.
-	// We create a temporary Array<ElemTypeVar> to delegate the lookup.
-	// TODO(#404): This immediately resolves the method signature against ElemTypeVar,
-	// which means a second call with a different type (e.g. push(5) then push("hello"))
-	// fails instead of inferring a union. Needs deferred call-site resolution.
+	// Create a fresh elem var for this call site so that multiple calls
+	// with different types don't conflict — they'll be unified into a
+	// union during resolveArrayConstraint.
 	arrayAlias := c.GlobalScope.Namespace.Types["Array"]
 	if arrayAlias == nil {
 		errors = append(errors, &ExpectedObjectError{Type: t, span: ast.Span{}})
 		return type_system.NewNeverType(nil), errors
 	}
 
-	tempArrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, constraint.ElemTypeVar)
+	freshElem := c.FreshVar(nil)
+	freshElem.Widenable = true
+	constraint.MethodElemVars = append(constraint.MethodElemVars, freshElem)
+
+	tempArrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, freshElem)
 	resultType, accessErrors := c.getMemberType(ctx, tempArrayType, PropertyKey{Name: propName})
 	errors = slices.Concat(errors, accessErrors)
 

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -152,9 +152,23 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 			for idx, elemTV := range ac.LiteralIndexes {
 				clonedIndexes[idx] = c.deepCloneType(elemTV, varMapping)
 			}
+			// Clone MethodElemVars without going through deepCloneType: the
+			// fresh elem vars may already be bound (e.g. after push(5) binds
+			// them to number), and deepCloneType would Prune through to the
+			// concrete type, making the cast to *TypeVarType panic.
 			clonedMethodElemVars := make([]*type_system.TypeVarType, len(ac.MethodElemVars))
 			for i, mev := range ac.MethodElemVars {
-				clonedMethodElemVars[i] = c.deepCloneType(mev, varMapping).(*type_system.TypeVarType)
+				if existing, ok := varMapping[mev.ID]; ok {
+					clonedMethodElemVars[i] = existing
+				} else {
+					freshMev := c.FreshVar(nil)
+					freshMev.Widenable = mev.Widenable
+					if mev.Instance != nil {
+						freshMev.Instance = c.deepCloneType(mev.Instance, varMapping)
+					}
+					varMapping[mev.ID] = freshMev
+					clonedMethodElemVars[i] = freshMev
+				}
 			}
 			fresh.ArrayConstraint = &type_system.ArrayConstraint{
 				LiteralIndexes:     clonedIndexes,

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -33,6 +33,9 @@ func collectUnresolvedTypeVars(
 					collectUnresolvedTypeVars(elemTV, vars, order)
 				}
 				collectUnresolvedTypeVars(t.ArrayConstraint.ElemTypeVar, vars, order)
+				for _, mev := range t.ArrayConstraint.MethodElemVars {
+					collectUnresolvedTypeVars(mev, vars, order)
+				}
 			}
 		}
 	case *type_system.FuncType:
@@ -149,6 +152,10 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 			for idx, elemTV := range ac.LiteralIndexes {
 				clonedIndexes[idx] = c.deepCloneType(elemTV, varMapping)
 			}
+			clonedMethodElemVars := make([]*type_system.TypeVarType, len(ac.MethodElemVars))
+			for i, mev := range ac.MethodElemVars {
+				clonedMethodElemVars[i] = c.deepCloneType(mev, varMapping).(*type_system.TypeVarType)
+			}
 			fresh.ArrayConstraint = &type_system.ArrayConstraint{
 				LiteralIndexes:     clonedIndexes,
 				HasNonLiteralIndex: ac.HasNonLiteralIndex,
@@ -156,6 +163,7 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 				HasReadOnlyMethod:  ac.HasReadOnlyMethod,
 				HasIndexAssignment: ac.HasIndexAssignment,
 				ElemTypeVar:        c.deepCloneType(ac.ElemTypeVar, varMapping),
+				MethodElemVars:     clonedMethodElemVars,
 			}
 		}
 		return fresh

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -532,6 +532,13 @@ func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint
 		IsPatMatch: false,
 	}
 
+	// Unify all per-method-call element type vars with ElemTypeVar.
+	// Each freshElem was bound to the argument type during handleFuncCall;
+	// unifying them all with ElemTypeVar accumulates a union.
+	for _, freshElem := range constraint.MethodElemVars {
+		c.Unify(ctx, freshElem, constraint.ElemTypeVar)
+	}
+
 	// Mutating methods, non-literal indexes, or read-only methods without any
 	// literal indexes force resolution to Array<T>. Read-only methods like
 	// .map() operate on the whole collection, so without positional information

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1707,6 +1707,20 @@ func TestTupleArrayInference(t *testing.T) {
 				"foo": "fn (items: mut [number, string]) -> void",
 			},
 		},
+		"PushThenPassToCallback": {
+			// Push calls bind MethodElemVars, then passing to a callback triggers
+			// deepCloneType on the ArrayConstraint during resolveCallSites.
+			input: `
+				fn foo(cb, items) {
+					items.push(5)
+					items.push("hello")
+					cb(items)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(cb: fn (arg0: mut Array<number | string>) -> T0, items: mut Array<number | string>) -> void",
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -1789,6 +1803,18 @@ func TestTupleArrayInferenceEdgeCases(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"foo": "fn (items: mut Array<number>) -> void",
+			},
+		},
+		"IndexAssignmentAndPushDifferentTypes": {
+			// Index assignment + push with different types → mut Array with union.
+			input: `
+				fn foo(items) {
+					items[0] = 5
+					items.push("hello")
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<string | number>) -> void",
 			},
 		},
 		"SingleIndexReadOnly": {

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1650,6 +1650,63 @@ func TestTupleArrayInference(t *testing.T) {
 				"foo": "fn (items: mut Array<string>) -> void",
 			},
 		},
+		"MultiplePushDifferentTypes": {
+			input: `
+				fn foo(items) {
+					items.push(5)
+					items.push("hello")
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number | string>) -> void",
+			},
+		},
+		"MultiplePushSameType": {
+			input: `
+				fn foo(items) {
+					items.push(5)
+					items.push(10)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number>) -> void",
+			},
+		},
+		"PushAndUnshiftDifferentTypes": {
+			input: `
+				fn foo(items) {
+					items.push(5)
+					items.unshift("hello")
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number | string>) -> void",
+			},
+		},
+		"MultiplePushWithLiteralIndex": {
+			input: `
+				fn foo(items) {
+					val a = items[0]
+					items.push(5)
+					items.push("hello")
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut Array<number | string>) -> void",
+			},
+		},
+		"IndexAssignmentDifferentTypes": {
+			// Literal index assignments with different types produce a tuple, not an array.
+			input: `
+				fn foo(items) {
+					items[0] = 5
+					items[1] = "hello"
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn (items: mut [number, string]) -> void",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -177,12 +177,13 @@ func recordInstanceChain(tv *TypeVarType) {
 // (.map, .filter) without literal indexes force Array<T>. An open TupleType
 // couldn't represent "might actually be an Array or mut Array".
 type ArrayConstraint struct {
-	LiteralIndexes     map[int]Type // index → element type variable
-	HasNonLiteralIndex bool         // true if items[i] used with non-literal number type
-	HasMutatingMethod  bool         // true if .push(), .pop(), etc. called
-	HasReadOnlyMethod  bool         // true if .map(), .filter(), etc. called
-	HasIndexAssignment bool         // true if items[i] = value used
-	ElemTypeVar        Type         // fresh T for Array<T> (union accumulator)
+	LiteralIndexes     map[int]Type   // index → element type variable
+	HasNonLiteralIndex bool           // true if items[i] used with non-literal number type
+	HasMutatingMethod  bool           // true if .push(), .pop(), etc. called
+	HasReadOnlyMethod  bool           // true if .map(), .filter(), etc. called
+	HasIndexAssignment bool           // true if items[i] = value used
+	ElemTypeVar        Type           // fresh T for Array<T> (union accumulator)
+	MethodElemVars     []*TypeVarType // per-call fresh elem vars from method calls (e.g. .push(), .unshift())
 }
 
 type TypeVarType struct {

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1430,6 +1430,13 @@ deferring the commitment until closing time.
    and index accesses are routed through `getArrayConstraintPropertyAccess` /
    `getArrayConstraintIndexAccess`.
 
+   `getArrayConstraintPropertyAccess` creates a **fresh element type variable**
+   for each method call and appends it to `constraint.MethodElemVars`. This
+   allows multiple calls with different argument types (e.g. `push(5)` then
+   `push("hello")`) to each bind their own fresh var independently, deferring
+   union accumulation to `resolveArrayConstraint`. Without this, the second
+   call would fail trying to unify against the already-bound `ElemTypeVar`.
+
    Method classification uses runtime lookup on the Array type definition via
    `isArrayMutatingMethod` (checks `MutSelf` on `MethodElem`), keeping the
    classification in sync with the type system's actual definitions.
@@ -1454,6 +1461,9 @@ deferring the commitment until closing time.
    calls `resolveArrayConstraintsInType` on each parameter.
 
    `resolveArrayConstraint` resolution rules:
+   - First, all `MethodElemVars` (fresh type vars from per-call-site method
+     resolution) are unified with `ElemTypeVar`, accumulating a union of all
+     argument types across method calls.
    - `HasMutatingMethod || HasNonLiteralIndex` → `Array<T>` (or `mut Array<T>`
      if `HasMutatingMethod`). All literal index TypeVars unified with `ElemTypeVar`.
    - Otherwise → tuple. `HasIndexAssignment` adds `mut` wrapper to the tuple
@@ -1540,6 +1550,19 @@ in `internal/checker/tests/row_types_test.go`.
   `fn <T0, T1>(items: [T0, T1]) -> T0`
 - **Write-only index 0** — `items[0] = "hello"` →
   `fn (items: mut [string]) -> void`
+
+- **Multiple push with different types** — `push(5)` then `push("hello")` →
+  `fn (items: mut Array<number | string>) -> void`
+  (each method call gets a fresh elem var; unified into union during resolution)
+- **Multiple push with same type** — `push(5)` then `push(10)` →
+  `fn (items: mut Array<number>) -> void`
+- **Push + unshift with different types** — `push(5)` then `unshift("hello")` →
+  `fn (items: mut Array<number | string>) -> void`
+- **Multiple push + literal index** — read `[0]`, `push(5)`, `push("hello")` →
+  `fn (items: mut Array<number | string>) -> void`
+- **Index assignment with different types** — `items[0] = 5; items[1] = "hello"` →
+  `fn (items: mut [number, string]) -> void`
+  (literal indexes produce a tuple, not an array)
 
 **Not yet tested:**
 - Conflict: object property + numeric index (e.g. `obj.name` + `obj[0]`)
@@ -2170,12 +2193,12 @@ All phases → Phase 11: Error Reporting
 
 | File | Phases | Status |
 |------|--------|--------|
-| `internal/type_system/types.go` | 1, 7, 12, 13 | ✅ (Phase 1) `Open`, `Widenable`, `IsParam`, `Written` fields added; `Accept`/`Copy` updated; (Phase 7) `collectFlatElems` and `ObjectType.String()` flattening of resolved `RestSpreadElem`s; ✅ (Phase 12) `ArrayConstraint` struct, `ArrayConstraint` field on `TypeVarType`; ✅ (Phase 13) `collectFlatTupleElems` and `TupleType.String()` flattening of resolved `RestSpreadType` |
-| `internal/checker/expand_type.go` | 2, 9, 10, 12, 13 | ✅ (Phase 2) `TypeVarType` case in `getMemberType`, open-object handling in `getObjectAccess`, helper functions; ✅ (Phase 12) deferred tuple/array commitment via `ArrayConstraint`; `isArrayMethod`/`isArrayMutatingMethod` for runtime method classification; `getArrayConstraintPropertyAccess`/`getArrayConstraintIndexAccess` for subsequent accesses; ✅ (Phase 13) `tupleElemUnion` helper; `getMemberType` TupleType case handles `RestSpreadType` in both numeric index and method access |
+| `internal/type_system/types.go` | 1, 7, 12, 13 | ✅ (Phase 1) `Open`, `Widenable`, `IsParam`, `Written` fields added; `Accept`/`Copy` updated; (Phase 7) `collectFlatElems` and `ObjectType.String()` flattening of resolved `RestSpreadElem`s; ✅ (Phase 12) `ArrayConstraint` struct with `MethodElemVars` field for per-call-site deferred resolution, `ArrayConstraint` field on `TypeVarType`; ✅ (Phase 13) `collectFlatTupleElems` and `TupleType.String()` flattening of resolved `RestSpreadType` |
+| `internal/checker/expand_type.go` | 2, 9, 10, 12, 13 | ✅ (Phase 2) `TypeVarType` case in `getMemberType`, open-object handling in `getObjectAccess`, helper functions; ✅ (Phase 12) deferred tuple/array commitment via `ArrayConstraint`; `isArrayMethod`/`isArrayMutatingMethod` for runtime method classification; `getArrayConstraintPropertyAccess` uses fresh elem var per method call for deferred union resolution; `getArrayConstraintIndexAccess` for subsequent accesses; ✅ (Phase 13) `tupleElemUnion` helper; `getMemberType` TupleType case handles `RestSpreadType` in both numeric index and method access |
 | `internal/checker/unify.go` | 3, 4, 10, 12, 13 | ✅ (Phase 3) `openClosedObjectForParam`, open-vs-open/closed paths; (Phase 4) `unifyPruned` refactor, `widenLiteral`, `flatUnion`, `typeContains`, `unwrapMutability`; ✅ (Phase 12) `handleArrayConstraintBinding` — updates constraint when TypeVar with `ArrayConstraint` is bound to Array or tuple type; ✅ (Phase 13) `splitTupleAtRest`, `unifyTuples`, `unifyFixedTuples`, `unifyFixedVsVariadic`, `unifyVariadicVsFixed`, `unifyVariadicVsVariadic`; tuple-vs-array and array-vs-tuple handle `RestSpreadType` |
 | `internal/parser/type_ann.go` | 13 | ✅ (Phase 13) `DotDotDot` case in `primaryTypeAnn` — enables `...T` in tuple type annotations (e.g. `[number, ...T]`) |
-| `internal/checker/generalize.go` | 2, 6, 7, 12 | ✅ (Phase 2) Mutability resolution in `GeneralizeFuncType`, `Open` preserved in `deepCloneType`; (Phase 7) No changes needed — handles row variables automatically; ✅ (Phase 12) `deepCloneType` clones `ArrayConstraint`; `collectUnresolvedTypeVars` collects from `ArrayConstraint`; ✅ (Phase 13/14) No changes needed — visitor pattern handles `RestSpreadType` in tuples; `collectUnresolvedTypeVars` already walks `TupleType.Elems` and `RestSpreadType.Type` |
-| `internal/checker/infer_func.go` | 3, 6, 7, 8, 12, 14 | ✅ (Phase 3) `IsParam: true` for unannotated parameters; (Phase 6) `closeOpenParams`, `closeObjectType`; (Phase 7) No changes needed; ✅ (Phase 12) `closeOpenParams` now a `Checker` method; `resolveArrayConstraintsInType` and `resolveArrayConstraint` resolve constraints during closing; ✅ (Phase 14) `closeTupleType` for rest variable filtering; `resolveArrayConstraint` appends `RestSpreadType` with fresh TV to inferred tuples; `resolveArrayConstraintsInType` checks ArrayConstraint before pruning; `closeOpenParams` resolves ArrayConstraints before collecting returnVars |
+| `internal/checker/generalize.go` | 2, 6, 7, 12 | ✅ (Phase 2) Mutability resolution in `GeneralizeFuncType`, `Open` preserved in `deepCloneType`; (Phase 7) No changes needed — handles row variables automatically; ✅ (Phase 12) `deepCloneType` clones `ArrayConstraint` including `MethodElemVars`; `collectUnresolvedTypeVars` collects from `ArrayConstraint` including `MethodElemVars`; ✅ (Phase 13/14) No changes needed — visitor pattern handles `RestSpreadType` in tuples; `collectUnresolvedTypeVars` already walks `TupleType.Elems` and `RestSpreadType.Type` |
+| `internal/checker/infer_func.go` | 3, 6, 7, 8, 12, 14 | ✅ (Phase 3) `IsParam: true` for unannotated parameters; (Phase 6) `closeOpenParams`, `closeObjectType`; (Phase 7) No changes needed; ✅ (Phase 12) `closeOpenParams` now a `Checker` method; `resolveArrayConstraintsInType` and `resolveArrayConstraint` resolve constraints during closing; `resolveArrayConstraint` unifies `MethodElemVars` with `ElemTypeVar` before resolution to accumulate union types from multiple method calls; ✅ (Phase 14) `closeTupleType` for rest variable filtering; `resolveArrayConstraint` appends `RestSpreadType` with fresh TV to inferred tuples; `resolveArrayConstraintsInType` checks ArrayConstraint before pruning; `closeOpenParams` resolves ArrayConstraints before collecting returnVars |
 | `internal/checker/infer_expr.go` | 2, 5, 7, 10, 12 | ✅ (Phase 2) `markPropertyWritten` in assignment handler; (Phase 7) No changes needed; ✅ (Phase 12) detect index assignment on `ArrayConstraint`, set `HasIndexAssignment` |
 | `internal/checker/errors.go` | 11 | Not started |
 | `internal/checker/tests/row_types_test.go` | All | ✅ Tests for Phases 1–7 (PropertyAccess, Errors, KeyOf, IntersectionAccess, PassToTypedFunction, WriteAfterPass, StringLiteralIndex, MethodCallInference, PropertyWidening, Closing, RowPolymorphism); ✅ Phase 12 (TupleArrayInference, TupleArrayInferenceEdgeCases); ✅ Phase 13 (VariadicTupleTypes, VariadicTupleSubtyping); ✅ Phase 14 (TupleRowPolymorphism) |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array/tuple inference so multiple mutating calls (e.g., repeated push/unshift) with differing element types correctly widen the inferred element type (e.g., Array<number | string>) or resolve to a tuple when index assignments imply fixed positions.
  * Inference now accumulates information across calls so callback parameter types reflect the widened array element type.

* **Tests**
  * Added comprehensive cases covering mixed push/unshift, literal index reads/writes, tuple vs array outcomes, and callback interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->