### PR TITLE
Row Poly - Phase 8: Destructuring

### DIFF
--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -713,6 +713,17 @@ func closeTupleType(tupleType *type_system.TupleType, returnVars map[int]*type_s
 	last := tupleType.Elems[len(tupleType.Elems)-1]
 	if rest, ok := last.(*type_system.RestSpreadType); ok {
 		if tv, ok := type_system.Prune(rest.Type).(*type_system.TypeVarType); ok {
+			// Preserve rest variables from explicit destructuring patterns.
+			// For example, in `fn foo([first, ...rest]) { return first }`,
+			// the rest type variable should be kept even though it doesn't
+			// appear in the return type — the user explicitly wrote `...rest`
+			// to accept variadic arguments. Pattern-originated rest bindings
+			// have FromBinding=true (set by inferPattern for IdentPat),
+			// while inferred rest variables from resolveArrayConstraint do
+			// not.
+			if tv.FromBinding {
+				return
+			}
 			if _, found := returnVars[tv.ID]; !found {
 				// Rest var not in return type — remove it
 				tupleType.Elems = tupleType.Elems[:len(tupleType.Elems)-1]

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2309,3 +2309,157 @@ func TestTupleArrayInferenceUnifyErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestDestructuringObjectPatterns(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"ObjectDestructuringWithoutRest": {
+			input: `
+				val foo = fn ({bar, baz}) {
+					return [bar, baz]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>({bar: T0, baz: T1}) -> [T0, T1]",
+			},
+		},
+		"ObjectDestructuringWithRest": {
+			input: `
+				val foo = fn ({bar, ...rest}) {
+					return rest
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>({bar: T0, ...rest: T1}) -> T1",
+			},
+		},
+		"ObjectDestructuringWithRestUnused": {
+			input: `
+				val foo = fn ({bar, ...rest}) {
+					return bar
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>({bar: T0, ...rest: T1}) -> T0",
+			},
+		},
+		"ObjectDestructuringWithoutRestBodyConstraint": {
+			input: `
+				val foo = fn ({x, y}) {
+					return x + y
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn ({x: number, y: number}) -> number",
+			},
+		},
+		"ObjectDestructuringWithTypeAnnotation": {
+			input: `
+				val foo = fn ({bar, ...rest}: {bar: number, baz: string}) {
+					return bar
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn ({bar: number, ...rest}) -> number",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+func TestDestructuringTuplePatterns(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"TupleDestructuringWithoutRest": {
+			input: `
+				val foo = fn ([a, b]) {
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>([a: T0, b: T1]) -> [T0, T1]",
+			},
+		},
+		"TupleDestructuringWithBodyConstraint": {
+			input: `
+				val foo = fn ([a, b]) {
+					return a + b
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn ([a: number, b: number]) -> number",
+			},
+		},
+		"TupleDestructuringWithRest": {
+			input: `
+				val foo = fn ([first, ...rest]) {
+					return rest
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>([first: T0, ...rest: T1]) -> T1",
+			},
+		},
+		"TupleDestructuringWithRestUnused": {
+			input: `
+				val foo = fn ([first, ...rest]) {
+					return first
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>([first: T0, ...rest: T1]) -> T0",
+			},
+		},
+		"TupleDestructuringCalledWithRest": {
+			input: `
+				val foo = fn ([first, ...rest]) {
+					return rest
+				}
+				val r = foo([1, 2, 3])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>([first: T0, ...rest: T1]) -> T1",
+				"r":   "[2, 3]",
+			},
+		},
+		"TupleDestructuringCalledWithoutRest": {
+			input: `
+				val foo = fn ([a, b]) {
+					return a + b
+				}
+				val r = foo([1, 2])
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn ([a: number, b: number]) -> number",
+				"r":   "number",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -964,7 +964,21 @@ func patternStringWithInlineTypesContext(pattern Pat, paramType Type, context st
 						elems = append(elems, e.Key+colon)
 					}
 				case *ObjRestPat:
-					elems = append(elems, e.String())
+					// Find the RestSpreadElem in the ObjectType and use its type
+					// for the inline display of the rest pattern binding.
+					var restType Type
+					for _, objElem := range objType.Elems {
+						if rest, ok := objElem.(*RestSpreadElem); ok {
+							restType = rest.Value
+							break
+						}
+					}
+					if restType != nil {
+						innerStr := patternStringWithInlineTypesContext(e.Pattern, restType, "object")
+						elems = append(elems, "..."+innerStr)
+					} else {
+						elems = append(elems, e.String())
+					}
 				}
 			}
 
@@ -1001,6 +1015,14 @@ func patternStringWithInlineTypesContext(pattern Pat, paramType Type, context st
 			result += "]"
 			return result
 		}
+	case *RestPat:
+		// For rest patterns in tuples like [first, ...rest], the paramType is
+		// a RestSpreadType wrapping the rest binding's type.
+		if rest, ok := paramType.(*RestSpreadType); ok {
+			innerStr := patternStringWithInlineTypesContext(p.Pattern, rest.Type, context)
+			return "..." + innerStr
+		}
+		return pattern.String()
 	case *IdentPat:
 		return p.Name + ": " + paramType.String()
 	}

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -893,7 +893,7 @@ All tests are in `TestRowTypesRowPolymorphism` in `row_types_test.go`.
 
 ---
 
-## Phase 8: Destructuring Patterns on Parameters
+## Phase 8: Destructuring Patterns on Parameters ✅
 
 **Requirements covered:** Section 8f (destructuring patterns — object and
 tuple/array).
@@ -902,130 +902,79 @@ tuple/array).
 types: `RestSpreadElem` for object patterns (row polymorphism), `RestSpreadType`
 for tuple patterns (variadic tuples of the form `[t0, ...R]`).
 
-### Changes — Object Destructuring
+### What was implemented
 
-1. **`internal/checker/infer_func.go`** — `inferFuncParams`:
-   After `inferPattern` creates a closed `ObjectType` from a destructuring
-   pattern, check if the pattern has a rest element and the parameter lacks a
-   type annotation. If so:
-   ```go
-   if hasRestElement && param.TypeAnn == nil {
-       rowTV := c.FreshVar(nil)
-       objType.Elems = append(objType.Elems, NewRestSpreadElem(rowTV))
-       // objType.Open remains false — the explicit properties are fixed
-       // by the pattern, and the parameter itself isn't accessible by name.
-       // The rest binding's type is rowTV.
-   }
-   ```
+Most of the infrastructure was already in place from earlier phases.
+`inferPattern` in `infer_pat.go` already creates `RestSpreadElem` for
+`ObjRestPat` and `RestSpreadType` for `RestPat` inside `TuplePat`, with fresh
+type variables that are shared between the rest spread and the binding. No
+changes to `inferFuncParams` were needed.
 
-2. **Rest binding type:** The rest element's binding should have type `rowTV`
-   (the same row variable). When checking the pattern, the rest binding in the
-   `bindings` map should have its type set to `rowTV`. This connects the rest
-   binding to the row variable so that when `R` is resolved (at a call site),
-   the rest binding's type reflects the remaining properties.
+#### Object destructuring
 
-3. **Without rest element:** The type stays closed with no `RestSpreadElem`.
-   The pattern fully specifies the expected properties.
+`inferPattern` handles the `ObjRestPat` case by creating a `RestSpreadElem`
+whose value is the same fresh type variable used for the rest binding. The
+resulting `ObjectType` has `Open: false` — the explicit properties are fixed by
+the pattern — but includes a `RestSpreadElem` for row polymorphism.
+`closeOpenObjectsInType` already preserves `RestSpreadElem`s on non-open
+objects, so no changes were needed there.
 
-4. **Open vs. closed:** Destructured parameters are always **closed**
-   (`Open: false`) regardless of rest elements. The pattern fully specifies
-   explicit properties, and the parameter itself isn't accessible by name (only
-   the bindings are), so no new explicit properties can be added during
-   inference. The `RestSpreadElem` provides row polymorphism for extra properties
-   passed by callers, while `Open: false` prevents the checker from adding
-   properties during inference.
+#### Tuple destructuring
 
-### Changes — Tuple/Array Destructuring
+`inferPattern` handles `RestPat` inside `TuplePat` by creating a
+`RestSpreadType` element in the `TupleType`. The key change was in
+`closeTupleType`: it previously removed trailing `RestSpreadType` elements
+whose type variable didn't appear in the return type. Pattern-originated rest
+variables (which have `FromBinding=true` on the inner `TypeVarType`) must be
+preserved even when not in the return type, since the user explicitly wrote
+`...rest` to accept variadic arguments.
 
-`inferPattern` already handles `TuplePat` by creating a `TupleType` with a
-fresh type variable for each element position. The changes here address the
-rest element case and the interaction with `inferFuncParams`.
+#### Type display
 
-5. **`internal/checker/infer_func.go`** — `inferFuncParams`, `TuplePat` case:
+`patternStringWithInlineTypesContext` in `types.go` was updated to:
+- **`ObjRestPat` case:** Look up the `RestSpreadElem` in the `ObjectType` and
+  display the rest binding with its type (e.g. `...rest: T1`).
+- **`RestPat` case (new):** Extract the inner type from `RestSpreadType` and
+  display the rest binding with its type (e.g. `...rest: T1`).
 
-   **Without rest element:** `inferPattern` produces a `TupleType` with one
-   element type per position. No changes needed — the parameter type is a
-   fixed-length tuple:
-   ```go
-   // fn foo([a, b]) { ... }
-   // inferPattern returns TupleType{Elems: [t1, t2]}
-   // parameter type: [t1, t2]
-   ```
+### Changes
 
-   **With rest element:** When the `TuplePat` contains a `RestPat`, the
-   parameter should be inferred as a variadic tuple `[t1, t2, ...R]` where
-   each positional element keeps its own type variable and `R` is a fresh
-   rest type variable (requires Phase 13 variadic tuple support):
-   ```go
-   if hasTupleRestElement && param.TypeAnn == nil {
-       restTV := c.FreshVar(nil)
-       // Append a RestSpreadType to the existing tuple elements
-       tupleType.Elems = append(tupleType.Elems,
-           type_system.NewRestSpreadType(nil, restTV))
-       // rest binding's type is restTV
-   }
-   ```
+1. **`internal/checker/infer_func.go`** — `closeTupleType`:
+   Added a check for `tv.FromBinding` to skip removal of rest spread type
+   variables that originated from explicit destructuring patterns.
 
-   This preserves per-position types for the leading elements while allowing
-   callers to pass additional trailing elements. The rest variable `R` enables
-   tuple row polymorphism (Phase 14) — if the parameter is returned, extra
-   elements are preserved in the return type.
+2. **`internal/type_system/types.go`** — `patternStringWithInlineTypesContext`:
+   - `ObjRestPat` case: looks up `RestSpreadElem` in the `ObjectType` and
+     recursively prints the inner pattern with the rest type.
+   - New `RestPat` case: extracts the inner type from `RestSpreadType` and
+     recursively prints the inner pattern.
 
-6. **Rest binding type for tuple patterns:** The rest element's binding should
-   have type `R` (the rest type variable). When `R` is resolved at a call
-   site, the rest binding's type reflects the caller's trailing elements.
+### Tests (in `row_types_test.go`)
 
-7. **Type annotation takes precedence:** If the parameter has a type annotation,
-   use it as-is. Only add a `RestSpreadType` from the rest element when the
-   parameter is unannotated.
+**Object destructuring (`TestDestructuringObjectPatterns`):**
+- `ObjectDestructuringWithoutRest` — `fn ({bar, baz})` infers
+  `fn <T0, T1>({bar: T0, baz: T1}) -> [T0, T1]`.
+- `ObjectDestructuringWithRest` — `fn ({bar, ...rest})` infers
+  `fn <T0, T1>({bar: T0, ...rest: T1}) -> T1`.
+- `ObjectDestructuringWithRestUnused` — rest var preserved even when not in
+  return type: `fn <T0, T1>({bar: T0, ...rest: T1}) -> T0`.
+- `ObjectDestructuringWithoutRestBodyConstraint` — body usage constrains
+  element types: `fn ({x: number, y: number}) -> number`.
+- `ObjectDestructuringWithTypeAnnotation` — type annotation takes precedence.
 
-### Tests — Object Destructuring
-
-- **Destructuring without rest:**
-  `fn foo({bar, baz}) { ... }` — `{bar: t1, baz: t2}` (closed, no rest).
-- **Destructuring with rest:**
-  `fn foo({bar, ...rest}) { ... }` — `{bar: t1, ...R}` (closed, with rest).
-  `rest` has type `R`.
-- **Calling with extra properties:**
-  ```esc
-  fn foo({bar, ...rest}) { return rest }
-  let r = foo({bar: 1, extra: "hi"})
-  ```
-  — `r` includes `{extra: "hi"}`.
-- **Rest without type annotation only:**
-  `fn foo({bar, ...rest}: {bar: number, ...}) { ... }` — if a type annotation
-  is present, use it as-is. Only add a `RestSpreadElem` when the parameter is
-  unannotated.
-
-### Tests — Tuple/Array Destructuring
-
-- **Tuple destructuring without rest:**
-  `fn foo([a, b]) { ... }` — parameter type: `[t1, t2]`.
-- **Tuple destructuring with type constraints from body:**
-  ```esc
-  fn foo([a, b]) { return a + b }
-  ```
-  — element types constrained by usage (e.g. `[number, number]` if `+` requires
-  numbers).
-- **Tuple destructuring with rest:**
-  ```esc
-  fn foo([first, ...rest]) { ... }
-  ```
-  — parameter type: `[t1, ...R]`, `first: t1`, `rest: R`.
-- **Calling tuple-destructured function:**
-  ```esc
-  fn foo([a, b]) { return a + b }
-  val r = foo([1, 2])
-  ```
-  — `r: number`.
-- **Calling with rest — extra elements preserved:**
-  ```esc
-  fn foo([first, ...rest]) { return rest }
-  val r = foo([1, 2, 3])
-  ```
-  — `R = [2, 3]`, `r: [2, 3]`.
-- **Rest with type annotation:**
-  `fn foo([a, ...rest]: [number, ...Array<string>]) { ... }` — use annotation as-is.
+**Tuple destructuring (`TestDestructuringTuplePatterns`):**
+- `TupleDestructuringWithoutRest` — `fn ([a, b])` infers
+  `fn <T0, T1>([a: T0, b: T1]) -> [T0, T1]`.
+- `TupleDestructuringWithBodyConstraint` — body usage constrains element
+  types: `fn ([a: number, b: number]) -> number`.
+- `TupleDestructuringWithRest` — `fn ([first, ...rest])` infers
+  `fn <T0, T1>([first: T0, ...rest: T1]) -> T1`.
+- `TupleDestructuringWithRestUnused` — rest var preserved even when not in
+  return type: `fn <T0, T1>([first: T0, ...rest: T1]) -> T0`.
+- `TupleDestructuringCalledWithRest` — calling `fn ([first, ...rest]) { return rest }`
+  with `[1, 2, 3]` yields `r: [2, 3]`.
+- `TupleDestructuringCalledWithoutRest` — calling `fn ([a, b]) { return a + b }`
+  with `[1, 2]` yields `r: number`.
 
 ---
 
@@ -2094,7 +2043,7 @@ Phase 3 → Phase 13: Variadic Tuple Types ✅
 ### Destructuring (requires both object and tuple row polymorphism)
 
 ```
-Phase 7, Phase 14 → Phase 8: Destructuring
+Phase 7, Phase 14 → Phase 8: Destructuring ✅
 ```
 
 ### Independent branches (can start early)
@@ -2122,7 +2071,7 @@ All phases → Phase 11: Error Reporting
 | 5: Method Calls ✅                | 4          | —                    |
 | 6: Closing ✅                     | 5          | —                    |
 | 7: Row Polymorphism ✅            | 6          | 12                   |
-| 8: Destructuring                  | 7, 14      | —                    |
+| 8: Destructuring ✅               | 7, 14      | —                    |
 | 9: Optional Chaining              | 2          | 3–14                 |
 | 10: Object & Array/Tuple Spread   | 3, 13      | 4–14                 |
 | 11: Error Reporting               | all        | —                    |

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -67,6 +67,14 @@ fn foo(obj) {
   source. Both are also orthogonal to **exactness** (`Exact` field), which
   controls whether an object type can unify with another that has additional
   properties.
+- **`FromBinding`**: A boolean field on `TypeVarType` (`types.go`) that is
+  `true` when the type variable was created from a binding pattern (e.g. an
+  `IdentPat` in a destructuring pattern). `inferPattern` sets this flag for
+  each `IdentPat` it processes. This is used by `closeTupleType` to distinguish
+  pattern-originated rest variables (which should be preserved) from
+  inference-originated rest variables (from `resolveArrayConstraint`, which may
+  be removed when not in the return type). See also `RestSpreadType`,
+  `closeTupleType`, and `TypeVarType`.
 - **Row constraint**: With Option C, row constraints are represented implicitly
   by the `PropertyElem`s and `MethodElem`s within an open `ObjectType`. When a
   property is accessed on a type variable, it is eagerly bound to an open
@@ -933,11 +941,13 @@ fn foo([first, ...rest]) {
 ```
 
 `inferPattern` handles this naturally: `RestPat` inside `TuplePat` creates a
-`RestSpreadType` wrapping the rest binding's fresh type variable. `closeTupleType`
-preserves pattern-originated rest variables (identified by `FromBinding=true` on
-the inner `TypeVarType`) even when the variable doesn't appear in the return
-type — since the user explicitly wrote `...rest`, the function should accept
-variadic arguments.
+`RestSpreadType` wrapping the rest binding's fresh `TypeVarType`. Because the
+inner type variable originates from an `IdentPat`, it has `FromBinding=true`
+(see Definitions). `closeTupleType` checks this flag when deciding whether to
+remove a trailing `RestSpreadType` whose variable doesn't appear in the return
+type: pattern-originated rest variables are preserved (the user explicitly wrote
+`...rest` to accept variadic arguments), while inference-originated rest
+variables from `resolveArrayConstraint` (which lack `FromBinding`) are removed.
 
 This builds on variadic tuple type support (Phase 13). The rest variable `R`
 enables row polymorphism for tuples — if the parameter is returned, callers'

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -886,12 +886,15 @@ fn foo({bar, ...rest}) {
 // RestSpreadElem for R (row polymorphism for extra properties)
 ```
 
-**Mechanism:** `inferPattern` creates a closed `ObjectType` from the pattern. If
-the pattern has a rest element and the parameter lacks a type annotation,
-`inferFuncParams` should add a `RestSpreadElem` with a fresh row variable `R`
-to the pattern-inferred `ObjectType`, but leave `Open` as `false`. The rest
-binding's type is `R`, connecting it to the row variable so that when `R` is
-resolved, the rest binding's type reflects the remaining properties. Without a
+**Mechanism:** `inferPattern` creates a closed `ObjectType` from the pattern.
+When the pattern contains an `ObjRestPat`, `inferPattern` already creates a
+`RestSpreadElem` whose value is the same fresh type variable used for the rest
+binding — no additional work is needed in `inferFuncParams`. The `ObjectType`
+has `Open: false` (explicit properties are fixed by the pattern). The rest
+binding's type is the row variable `R`, connecting it to the `RestSpreadElem`
+so that when `R` is resolved at a call site, the rest binding's type reflects
+the remaining properties. `closeOpenObjectsInType` preserves `RestSpreadElem`s
+on non-open objects, so the row variable persists through closing. Without a
 rest element, the type stays closed with no `RestSpreadElem`.
 
 ##### Tuple/array destructuring
@@ -916,7 +919,7 @@ with at least that many elements.
 
 **With rest element:** When a tuple destructuring pattern includes a rest element
 (`[a, b, ...rest]`), the leading positions get fixed types and the rest binding
-captures the remaining elements. The parameter should be inferred as a variadic
+captures the remaining elements. The parameter is inferred as a variadic
 tuple `[t1, t2, ...R]` where each positional element gets an independent type
 variable and `R` is a rest type variable representing the remaining elements:
 
@@ -929,9 +932,16 @@ fn foo([first, ...rest]) {
 // first: t1, rest: R
 ```
 
-This requires variadic tuple type support (Section 14). The rest variable `R`
+`inferPattern` handles this naturally: `RestPat` inside `TuplePat` creates a
+`RestSpreadType` wrapping the rest binding's fresh type variable. `closeTupleType`
+preserves pattern-originated rest variables (identified by `FromBinding=true` on
+the inner `TypeVarType`) even when the variable doesn't appear in the return
+type — since the user explicitly wrote `...rest`, the function should accept
+variadic arguments.
+
+This builds on variadic tuple type support (Phase 13). The rest variable `R`
 enables row polymorphism for tuples — if the parameter is returned, callers'
-extra elements are preserved (Section 15).
+extra elements are preserved (Phase 14).
 
 **Interaction with Section 13 (tuple/array inference):** If the function body
 also indexes the parameter by name (which isn't possible for tuple-destructured


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type inference for functions with destructuring patterns so trailing rest elements (tuple/object) introduced by explicit bindings are preserved rather than removed.
  * Improved inline type display for rest bindings in destructuring patterns.

* **Tests**
  * Added tests covering object and tuple destructuring with and without rest elements, including unused rest cases and inferred numeric constraints.

* **Documentation**
  * Updated design/requirements notes and implementation plan to reflect rest-pattern behavior and printing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->