### PR TITLE
Row Types - Phase 10: Object & Array/Tuple Spread

### DIFF
--- a/fixtures/generators/build/lib/index.d.ts
+++ b/fixtures/generators/build/lib/index.d.ts
@@ -1,9 +1,9 @@
 export declare function count(): Generator<1 | 2 | 3, void, never>;
-export declare function countArray(): [...Array<1 | 2 | 3>];
+export declare function countArray(): Array<1 | 2 | 3>;
 export declare function countWithDone(): Generator<1 | 2, "done", never>;
 export declare function fetchItems(): AsyncGenerator<1 | 2 | 3, void, never>;
 export declare function inner(): Generator<1 | 2, void, never>;
 export declare function mixed(): Generator<1 | "hello", void, never>;
 export declare function outer(): Generator<1 | 2 | 3, void, never>;
-export declare function outerArray(): [...Array<1 | 2 | 3>];
+export declare function outerArray(): Array<1 | 2 | 3>;
 export declare function sumOuter(): number;

--- a/fixtures/iterators/build/lib/index.d.ts
+++ b/fixtures/iterators/build/lib/index.d.ts
@@ -1,5 +1,5 @@
 export declare function charCount(s: string): number;
-export declare function spreadArray(items: Array<number>): [...Array<number>];
-export declare function spreadString(s: string): [...Array<string>];
+export declare function spreadArray(items: Array<number>): Array<number>;
+export declare function spreadString(s: string): Array<string>;
 export declare function sumArray(items: Array<number>): number;
 export declare function sumPairs(pairs: Array<[number, number]>): number;

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -919,7 +919,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		if indexLit, ok := keyType.(*type_system.LitType); ok {
 			if strLit, ok := indexLit.Lit.(*type_system.StrLit); ok {
 				// Search in reverse order for override semantics (same as PropertyKey).
-			// See the PropertyKey branch for the note on MutabilityType and RestSpreadElem.
+				// See the PropertyKey branch for the note on MutabilityType and RestSpreadElem.
 				targetKey := type_system.NewStrKey(strLit.Value)
 				for i := len(objType.Elems) - 1; i >= 0; i-- {
 					switch elem := objType.Elems[i].(type) {
@@ -945,6 +945,9 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						}
 					case *type_system.RestSpreadElem:
 						resolved := type_system.Prune(elem.Value)
+						if mut, ok := resolved.(*type_system.MutabilityType); ok {
+							resolved = mut.Type
+						}
 						if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
 							if propType := getSpreadPropertyType(resolvedObj, strLit.Value); propType != nil {
 								return propType, errors

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -773,6 +773,40 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 	}
 }
 
+// getSpreadPropertyType looks up a property in an ObjectType using JavaScript
+// spread semantics: PropertyElems and MethodElems are copied as-is, GetterElems
+// yield their return type, and SetterElems are skipped (setter-only properties
+// are not readable in a spread). Returns nil if the property is not found.
+func getSpreadPropertyType(objType *type_system.ObjectType, name string) type_system.Type {
+	targetKey := type_system.NewStrKey(name)
+	for i := len(objType.Elems) - 1; i >= 0; i-- {
+		switch elem := objType.Elems[i].(type) {
+		case *type_system.PropertyElem:
+			if elem.Name == targetKey {
+				propType := elem.Value
+				if elem.Optional {
+					propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
+				}
+				return propType
+			}
+		case *type_system.MethodElem:
+			if elem.Name == targetKey {
+				return elem.Fn
+			}
+		case *type_system.GetterElem:
+			if elem.Name == targetKey {
+				return elem.Fn.Return
+			}
+		case *type_system.SetterElem:
+			// Setter-only properties are not readable in a spread — skip.
+			if elem.Name == targetKey {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
 // getObjectAccess handles property and index access on ObjectType
 func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAccessKey, errors []Error) (type_system.Type, []Error) {
 	switch k := key.(type) {
@@ -806,8 +840,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 			case *type_system.RestSpreadElem:
 				resolved := type_system.Prune(elem.Value)
 				if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
-					propType, propErrors := c.getObjectAccess(resolvedObj, key, nil)
-					if len(propErrors) == 0 {
+					if propType := getSpreadPropertyType(resolvedObj, k.Name); propType != nil {
 						return propType, errors
 					}
 				}
@@ -899,9 +932,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					case *type_system.RestSpreadElem:
 						resolved := type_system.Prune(elem.Value)
 						if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
-							indexKey := PropertyKey{Name: strLit.Value}
-							propType, propErrors := c.getObjectAccess(resolvedObj, indexKey, nil)
-							if len(propErrors) == 0 {
+							if propType := getSpreadPropertyType(resolvedObj, strLit.Value); propType != nil {
 								return propType, errors
 							}
 						}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -826,11 +826,7 @@ func getSpreadPropertyType(objType *type_system.ObjectType, name string) type_sy
 				return nil
 			}
 		case *type_system.RestSpreadElem:
-			resolved := type_system.Prune(elem.Value)
-			if mut, ok := resolved.(*type_system.MutabilityType); ok {
-				resolved = type_system.Prune(mut.Type)
-			}
-			if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
+			if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
 				if propType := getSpreadPropertyType(resolvedObj, name); propType != nil {
 					return propType
 				}
@@ -840,7 +836,10 @@ func getSpreadPropertyType(objType *type_system.ObjectType, name string) type_sy
 	return nil
 }
 
-// getObjectAccess handles property and index access on ObjectType
+// getObjectAccess handles property and index access on ObjectType.
+// TODO(#412): differentiate between read and write access so that
+// GetterElem returns the getter's return type for reads and SetterElem
+// returns the setter's parameter type for writes.
 func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAccessKey, errors []Error) (type_system.Type, []Error) {
 	switch k := key.(type) {
 	case PropertyKey:
@@ -871,11 +870,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					return elem.Fn.Params[0].Type, errors
 				}
 			case *type_system.RestSpreadElem:
-				resolved := type_system.Prune(elem.Value)
-				if mut, ok := resolved.(*type_system.MutabilityType); ok {
-					resolved = type_system.Prune(mut.Type)
-				}
-				if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
+				if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
 					if propType := getSpreadPropertyType(resolvedObj, k.Name); propType != nil {
 						return propType, errors
 					}
@@ -966,11 +961,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 							return elem.Fn.Params[0].Type, errors
 						}
 					case *type_system.RestSpreadElem:
-						resolved := type_system.Prune(elem.Value)
-						if mut, ok := resolved.(*type_system.MutabilityType); ok {
-							resolved = type_system.Prune(mut.Type)
-						}
-						if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
+						if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
 							if propType := getSpreadPropertyType(resolvedObj, strLit.Value); propType != nil {
 								return propType, errors
 							}
@@ -1007,6 +998,14 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					if elem.Name == symKey {
 						return elem.Fn, errors
 					}
+				case *type_system.GetterElem:
+					if elem.Name == symKey {
+						return elem.Fn.Return, errors
+					}
+				case *type_system.SetterElem:
+					if elem.Name == symKey {
+						return elem.Fn.Params[0].Type, errors
+					}
 				case *type_system.RestSpreadElem:
 					if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
 						symPropType, symPropErrors := c.getObjectAccess(resolvedObj, key, nil)
@@ -1016,8 +1015,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					}
 				case *type_system.MappedElem:
 					panic("MappedElems should have been expanded before property access")
-				case *type_system.ConstructorElem, *type_system.CallableElem,
-					*type_system.GetterElem, *type_system.SetterElem:
+				case *type_system.ConstructorElem, *type_system.CallableElem:
 					continue
 				default:
 					continue

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -777,10 +777,14 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAccessKey, errors []Error) (type_system.Type, []Error) {
 	switch k := key.(type) {
 	case PropertyKey:
-		for _, elem := range objType.Elems {
-			switch elem := elem.(type) {
+		// Search elements in reverse order so that later elements override
+		// earlier ones. This respects JavaScript spread semantics where
+		// {a: 1, ...{a: 2}} yields a=2 and {...{a: 1}, a: 2} yields a=2.
+		targetKey := type_system.NewStrKey(k.Name)
+		for i := len(objType.Elems) - 1; i >= 0; i-- {
+			switch elem := objType.Elems[i].(type) {
 			case *type_system.PropertyElem:
-				if elem.Name == type_system.NewStrKey(k.Name) {
+				if elem.Name == targetKey {
 					propType := elem.Value
 					if elem.Optional {
 						propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
@@ -788,26 +792,29 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					return propType, errors
 				}
 			case *type_system.MethodElem:
-				if elem.Name == type_system.NewStrKey(k.Name) {
+				if elem.Name == targetKey {
 					return elem.Fn, errors
 				}
 			case *type_system.GetterElem:
-				if elem.Name == type_system.NewStrKey(k.Name) {
+				if elem.Name == targetKey {
 					return elem.Fn.Return, errors
 				}
 			case *type_system.SetterElem:
-				if elem.Name == type_system.NewStrKey(k.Name) {
+				if elem.Name == targetKey {
 					return elem.Fn.Params[0].Type, errors
+				}
+			case *type_system.RestSpreadElem:
+				resolved := type_system.Prune(elem.Value)
+				if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
+					propType, propErrors := c.getObjectAccess(resolvedObj, key, nil)
+					if len(propErrors) == 0 {
+						return propType, errors
+					}
 				}
 			case *type_system.MappedElem:
 				panic("MappedElems should have been expanded before property access")
 			case *type_system.ConstructorElem:
 			case *type_system.CallableElem:
-				continue
-			case *type_system.RestSpreadElem:
-				// The row variable is an unresolved TypeVarType during inference —
-				// there's no concrete ObjectType to query for properties here.
-				// It gets resolved during unification/generalization, not member lookup.
 				continue
 			default:
 				panic(fmt.Sprintf("Unknown object type element: %#v", elem))
@@ -865,10 +872,12 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		}
 		if indexLit, ok := keyType.(*type_system.LitType); ok {
 			if strLit, ok := indexLit.Lit.(*type_system.StrLit); ok {
-				for _, elem := range objType.Elems {
-					switch elem := elem.(type) {
+				// Search in reverse order for override semantics (same as PropertyKey).
+				targetKey := type_system.NewStrKey(strLit.Value)
+				for i := len(objType.Elems) - 1; i >= 0; i-- {
+					switch elem := objType.Elems[i].(type) {
 					case *type_system.PropertyElem:
-						if elem.Name == type_system.NewStrKey(strLit.Value) {
+						if elem.Name == targetKey {
 							propType := elem.Value
 							if elem.Optional {
 								propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
@@ -876,24 +885,30 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 							return propType, errors
 						}
 					case *type_system.MethodElem:
-						if elem.Name == type_system.NewStrKey(strLit.Value) {
+						if elem.Name == targetKey {
 							return elem.Fn, errors
 						}
 					case *type_system.GetterElem:
-						if elem.Name == type_system.NewStrKey(strLit.Value) {
+						if elem.Name == targetKey {
 							return elem.Fn.Return, errors
 						}
 					case *type_system.SetterElem:
-						if elem.Name == type_system.NewStrKey(strLit.Value) {
+						if elem.Name == targetKey {
 							return elem.Fn.Params[0].Type, errors
+						}
+					case *type_system.RestSpreadElem:
+						resolved := type_system.Prune(elem.Value)
+						if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
+							indexKey := PropertyKey{Name: strLit.Value}
+							propType, propErrors := c.getObjectAccess(resolvedObj, indexKey, nil)
+							if len(propErrors) == 0 {
+								return propType, errors
+							}
 						}
 					case *type_system.MappedElem:
 						panic("MappedElems should have been expanded before property access")
 					case *type_system.ConstructorElem:
 					case *type_system.CallableElem:
-						continue
-					case *type_system.RestSpreadElem:
-						// See comment in PropertyKey branch above.
 						continue
 					default:
 						panic(fmt.Sprintf("Unknown object type element: %#v", elem))

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -773,6 +773,29 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 	}
 }
 
+// resolveToObjectType attempts to resolve a type to an *ObjectType. It handles
+// direct ObjectTypes, MutabilityType wrappers, and TypeRefTypes with aliases.
+func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
+	resolved := type_system.Prune(t)
+	if mut, ok := resolved.(*type_system.MutabilityType); ok {
+		resolved = type_system.Prune(mut.Type)
+	}
+	if obj, ok := resolved.(*type_system.ObjectType); ok {
+		return obj
+	}
+	if ref, ok := resolved.(*type_system.TypeRefType); ok {
+		if ref.TypeAlias != nil {
+			aliasType := ref.TypeAlias.Type
+			if len(ref.TypeAlias.TypeParams) > 0 && len(ref.TypeArgs) > 0 {
+				subs := createTypeParamSubstitutions(ref.TypeArgs, ref.TypeAlias.TypeParams)
+				aliasType = SubstituteTypeParams(aliasType, subs)
+			}
+			return resolveToObjectType(aliasType)
+		}
+	}
+	return nil
+}
+
 // getSpreadPropertyType looks up a property in an ObjectType using JavaScript
 // spread semantics: PropertyElems and MethodElems are copied as-is, GetterElems
 // yield their return type, and SetterElems are skipped (setter-only properties
@@ -804,6 +827,9 @@ func getSpreadPropertyType(objType *type_system.ObjectType, name string) type_sy
 			}
 		case *type_system.RestSpreadElem:
 			resolved := type_system.Prune(elem.Value)
+			if mut, ok := resolved.(*type_system.MutabilityType); ok {
+				resolved = type_system.Prune(mut.Type)
+			}
 			if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
 				if propType := getSpreadPropertyType(resolvedObj, name); propType != nil {
 					return propType
@@ -821,12 +847,6 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		// Search elements in reverse order so that later elements override
 		// earlier ones. This respects JavaScript spread semantics where
 		// {a: 1, ...{a: 2}} yields a=2 and {...{a: 1}, a: 2} yields a=2.
-		//
-		// Note on RestSpreadElem and MutabilityType: Prune resolves TypeVarType
-		// chains but does not unwrap MutabilityType. This is fine because
-		// MutabilityType wrappers are resolved away during unification before
-		// getObjectAccess is called — RestSpreadElem.Value is always an
-		// ObjectType or an unresolved TypeVarType at this point.
 		targetKey := type_system.NewStrKey(k.Name)
 		for i := len(objType.Elems) - 1; i >= 0; i-- {
 			switch elem := objType.Elems[i].(type) {
@@ -852,6 +872,9 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				}
 			case *type_system.RestSpreadElem:
 				resolved := type_system.Prune(elem.Value)
+				if mut, ok := resolved.(*type_system.MutabilityType); ok {
+					resolved = type_system.Prune(mut.Type)
+				}
 				if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
 					if propType := getSpreadPropertyType(resolvedObj, k.Name); propType != nil {
 						return propType, errors
@@ -919,7 +942,6 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		if indexLit, ok := keyType.(*type_system.LitType); ok {
 			if strLit, ok := indexLit.Lit.(*type_system.StrLit); ok {
 				// Search in reverse order for override semantics (same as PropertyKey).
-				// See the PropertyKey branch for the note on MutabilityType and RestSpreadElem.
 				targetKey := type_system.NewStrKey(strLit.Value)
 				for i := len(objType.Elems) - 1; i >= 0; i-- {
 					switch elem := objType.Elems[i].(type) {
@@ -946,7 +968,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					case *type_system.RestSpreadElem:
 						resolved := type_system.Prune(elem.Value)
 						if mut, ok := resolved.(*type_system.MutabilityType); ok {
-							resolved = mut.Type
+							resolved = type_system.Prune(mut.Type)
 						}
 						if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
 							if propType := getSpreadPropertyType(resolvedObj, strLit.Value); propType != nil {
@@ -965,15 +987,14 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 			}
 		}
 		// Handle unique symbol keys (e.g. Symbol.iterator).
-		// This branch uses a forward scan and does not handle RestSpreadElem.
-		// This is intentional: symbol-keyed properties (like Symbol.iterator)
-		// come from type declarations and interfaces, not from user-level
-		// object spreads. Users cannot write {[Symbol.iterator]: ...} in
-		// object literals, so spreads never provide symbol-keyed properties.
+		// Search in reverse order for override semantics, and check
+		// RestSpreadElems so that symbol-keyed properties from spread
+		// sources (e.g. spreading an Array which has Symbol.iterator)
+		// are found.
 		if symType, ok := keyType.(*type_system.UniqueSymbolType); ok {
 			symKey := type_system.NewSymKey(symType.Value)
-			for _, elem := range objType.Elems {
-				switch elem := elem.(type) {
+			for i := len(objType.Elems) - 1; i >= 0; i-- {
+				switch elem := objType.Elems[i].(type) {
 				case *type_system.PropertyElem:
 					if elem.Name == symKey {
 						propType := elem.Value
@@ -985,6 +1006,13 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				case *type_system.MethodElem:
 					if elem.Name == symKey {
 						return elem.Fn, errors
+					}
+				case *type_system.RestSpreadElem:
+					if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
+						symPropType, symPropErrors := c.getObjectAccess(resolvedObj, key, nil)
+						if len(symPropErrors) == 0 {
+							return symPropType, errors
+						}
 					}
 				case *type_system.MappedElem:
 					panic("MappedElems should have been expanded before property access")

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -802,6 +802,13 @@ func getSpreadPropertyType(objType *type_system.ObjectType, name string) type_sy
 			if elem.Name == targetKey {
 				return nil
 			}
+		case *type_system.RestSpreadElem:
+			resolved := type_system.Prune(elem.Value)
+			if resolvedObj, ok := resolved.(*type_system.ObjectType); ok {
+				if propType := getSpreadPropertyType(resolvedObj, name); propType != nil {
+					return propType
+				}
+			}
 		}
 	}
 	return nil
@@ -814,6 +821,12 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		// Search elements in reverse order so that later elements override
 		// earlier ones. This respects JavaScript spread semantics where
 		// {a: 1, ...{a: 2}} yields a=2 and {...{a: 1}, a: 2} yields a=2.
+		//
+		// Note on RestSpreadElem and MutabilityType: Prune resolves TypeVarType
+		// chains but does not unwrap MutabilityType. This is fine because
+		// MutabilityType wrappers are resolved away during unification before
+		// getObjectAccess is called — RestSpreadElem.Value is always an
+		// ObjectType or an unresolved TypeVarType at this point.
 		targetKey := type_system.NewStrKey(k.Name)
 		for i := len(objType.Elems) - 1; i >= 0; i-- {
 			switch elem := objType.Elems[i].(type) {
@@ -906,6 +919,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		if indexLit, ok := keyType.(*type_system.LitType); ok {
 			if strLit, ok := indexLit.Lit.(*type_system.StrLit); ok {
 				// Search in reverse order for override semantics (same as PropertyKey).
+			// See the PropertyKey branch for the note on MutabilityType and RestSpreadElem.
 				targetKey := type_system.NewStrKey(strLit.Value)
 				for i := len(objType.Elems) - 1; i >= 0; i-- {
 					switch elem := objType.Elems[i].(type) {
@@ -947,7 +961,12 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				}
 			}
 		}
-		// Handle unique symbol keys (e.g. Symbol.iterator)
+		// Handle unique symbol keys (e.g. Symbol.iterator).
+		// This branch uses a forward scan and does not handle RestSpreadElem.
+		// This is intentional: symbol-keyed properties (like Symbol.iterator)
+		// come from type declarations and interfaces, not from user-level
+		// object spreads. Users cannot write {[Symbol.iterator]: ...} in
+		// object literals, so spreads never provide symbol-keyed properties.
 		if symType, ok := keyType.(*type_system.UniqueSymbolType); ok {
 			symKey := type_system.NewSymKey(symType.Value)
 			for _, elem := range objType.Elems {

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -319,21 +319,13 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			}
 		}
 
-		// If there are multiple Array rest spreads, merge them into a single
-		// Array<T1 | T2 | ...>. Types like [...Array<T1>, ...Array<T2>] are
-		// not valid in Escalier/TypeScript.
-		mergedType := mergeArrayRestSpreads(c, elemTypes)
-		if mergedType != nil {
-			// All elements were array rest spreads — result is Array<T1 | T2 | ...>.
-			exprType = &type_system.MutabilityType{
-				Type:       mergedType,
-				Mutability: type_system.MutabilityUncertain,
-			}
-		} else {
-			exprType = &type_system.MutabilityType{
-				Type:       type_system.NewTupleType(provenance, elemTypes...),
-				Mutability: type_system.MutabilityUncertain,
-			}
+		// Collapse tuples that contain only Array rest spreads into a plain
+		// Array type: [...Array<T>] → Array<T>, and
+		// [...Array<T1>, ...Array<T2>] → Array<T1 | T2>.
+		// Otherwise returns a TupleType.
+		exprType = &type_system.MutabilityType{
+			Type:       collapseArrayRestSpreads(c, elemTypes),
+			Mutability: type_system.MutabilityUncertain,
 		}
 	case *ast.ObjectExpr:
 		// Create a context for the object so that we can add a `Self` type to it
@@ -938,28 +930,26 @@ func (c *Checker) isPropertyReadonly(ctx Context, objType type_system.Type, prop
 	return false
 }
 
-// mergeArrayRestSpreads checks whether all elements are Array rest spreads.
-// If so, it returns a single Array<T1 | T2 | ...> type. Types like
-// [...Array<T1>, ...Array<T2>] are not valid in Escalier/TypeScript.
-// Returns nil if there are fewer than 2 array rest spreads or if there are
-// non-array-rest elements present (those remain as valid tuple types).
-func mergeArrayRestSpreads(c *Checker, elems []type_system.Type) type_system.Type {
-	// Check that all elements are Array rest spreads.
+// collapseArrayRestSpreads builds the result type for a tuple expression.
+// If all elements are Array rest spreads, it collapses them into a single
+// Array<T1 | T2 | ...> (e.g. [...Array<T>] → Array<T>). Otherwise it
+// returns a TupleType with the elements as-is.
+func collapseArrayRestSpreads(c *Checker, elems []type_system.Type) type_system.Type {
 	var unionMembers []type_system.Type
 	for _, elem := range elems {
 		rest, ok := elem.(*type_system.RestSpreadType)
 		if !ok {
-			return nil // has fixed elements — not collapsible
+			return type_system.NewTupleType(nil, elems...)
 		}
 		inner := type_system.Prune(rest.Type)
 		ref, ok := inner.(*type_system.TypeRefType)
 		if !ok || !c.isArrayType(ref) || len(ref.TypeArgs) == 0 {
-			return nil // non-array rest spread — not collapsible
+			return type_system.NewTupleType(nil, elems...)
 		}
 		unionMembers = append(unionMembers, ref.TypeArgs[0])
 	}
-	if len(unionMembers) < 2 {
-		return nil // 0 or 1 array rests — no merge needed
+	if len(unionMembers) == 0 {
+		return type_system.NewTupleType(nil, elems...)
 	}
 	return &type_system.TypeRefType{
 		Name:     type_system.NewIdent("Array"),

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -273,20 +273,45 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				spreadType, spreadErrors := c.inferExpr(ctx, spread.Value)
 				errors = slices.Concat(errors, spreadErrors)
 
-				// Check that the spread operand is iterable
-				elementType := c.GetIterableElementType(ctx, spreadType)
-				if elementType == nil {
-					err := NewGenericError(
-						fmt.Sprintf("Type '%s' is not iterable", spreadType),
-						spread.Span(),
-					)
-					errors = append(errors, err)
-					elementType = type_system.NewAnyType(nil)
+				prunedType := type_system.Prune(spreadType)
+				// Unwrap MutabilityType if present
+				if mut, ok := prunedType.(*type_system.MutabilityType); ok {
+					prunedType = type_system.Prune(mut.Type)
 				}
-				elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, &type_system.TypeRefType{
-					Name:     type_system.NewIdent("Array"),
-					TypeArgs: []type_system.Type{elementType},
-				}))
+				handled := false
+				switch st := prunedType.(type) {
+				case *type_system.TupleType:
+					// Inline tuple elements directly
+					elemTypes = append(elemTypes, st.Elems...)
+					handled = true
+				case *type_system.TypeVarType:
+					// Unannotated parameter - defer iterable constraint to call site
+					elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, st))
+					handled = true
+				case *type_system.TypeRefType:
+					if c.isArrayType(st) {
+						// Array<T> - preserve as RestSpreadType
+						elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, st))
+						handled = true
+					}
+				}
+				if !handled {
+					// Other types (including non-Array TypeRefTypes like Generator) -
+					// extract element type via iterability check
+					elementType := c.GetIterableElementType(ctx, spreadType)
+					if elementType == nil {
+						err := NewGenericError(
+							fmt.Sprintf("Type '%s' is not iterable", spreadType),
+							spread.Span(),
+						)
+						errors = append(errors, err)
+						elementType = type_system.NewAnyType(nil)
+					}
+					elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, &type_system.TypeRefType{
+						Name:     type_system.NewIdent("Array"),
+						TypeArgs: []type_system.Type{elementType},
+					}))
+				}
 			} else {
 				elemType, elemErrors := c.inferExpr(ctx, elem)
 				elemTypes = append(elemTypes, elemType)
@@ -350,6 +375,10 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					types[i] = funcType
 					typeElems[i] = &type_system.SetterElem{Fn: funcType, Name: *key}
 				}
+			case *ast.ObjSpreadExpr:
+				sourceType, spreadErrors := c.inferExpr(ctx, elem.Value)
+				errors = append(errors, spreadErrors...)
+				typeElems[i] = type_system.NewRestSpreadElem(sourceType)
 			}
 		}
 
@@ -433,6 +462,8 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				inferErrors := c.inferFuncBodyWithFuncSigType(
 					objCtx, funcType, paramBindings, setterExpr.Fn.Body, setterExpr.Fn.Async)
 				errors = slices.Concat(errors, inferErrors)
+			case *ast.ObjSpreadExpr:
+				// Already handled in the first loop — nothing to do here.
 			}
 
 			i++

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -285,7 +285,10 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					elemTypes = append(elemTypes, st.Elems...)
 					handled = true
 				case *type_system.TypeVarType:
-					// Unannotated parameter - defer iterable constraint to call site
+					// Unannotated parameter — no upfront iterable constraint is added.
+					// The constraint is enforced structurally at call sites: when the
+					// caller passes a concrete argument, unification resolves the type
+					// variable and validates iterability at that point.
 					elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, st))
 					handled = true
 				case *type_system.TypeRefType:
@@ -331,6 +334,9 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 		// Create a context for the object so that we can add a `Self` type to it
 		objCtx := ctx.WithNewScope()
 
+		// TODO(#413): typeElems may contain nil entries when astKeyToTypeKey
+		// fails (e.g. for unsupported computed key types). These nil entries
+		// cause a panic in bind. Filter them out before creating the ObjectType.
 		typeElems := make([]type_system.ObjTypeElem, len(expr.Elems))
 		types := make([]type_system.Type, len(expr.Elems))
 		paramBindingsSlice := make([]map[string]*type_system.Binding, len(expr.Elems))
@@ -379,6 +385,9 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					types[i] = funcType
 					typeElems[i] = &type_system.SetterElem{Fn: funcType, Name: *key}
 				}
+			// No object-type constraint is enforced on the spread source.
+			// This matches JS/TS semantics where spreading non-objects
+			// (e.g. {...42}) is valid and produces {}.
 			case *ast.ObjSpreadExpr:
 				sourceType, spreadErrors := c.inferExpr(ctx, elem.Value)
 				errors = append(errors, spreadErrors...)
@@ -934,6 +943,11 @@ func (c *Checker) isPropertyReadonly(ctx Context, objType type_system.Type, prop
 // If all elements are Array rest spreads, it collapses them into a single
 // Array<T1 | T2 | ...> (e.g. [...Array<T>] → Array<T>). Otherwise it
 // returns a TupleType with the elements as-is.
+//
+// Note: this function does not Prune elements before checking because it is
+// called during inference before call-site specialization. TypeVarType-based
+// rests (e.g. [...T0]) are still unbound at this point and correctly fall
+// through to the TupleType path.
 func collapseArrayRestSpreads(c *Checker, elems []type_system.Type) type_system.Type {
 	var unionMembers []type_system.Type
 	for _, elem := range elems {

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -319,9 +319,21 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			}
 		}
 
-		exprType = &type_system.MutabilityType{
-			Type:       type_system.NewTupleType(provenance, elemTypes...),
-			Mutability: type_system.MutabilityUncertain,
+		// If there are multiple Array rest spreads, merge them into a single
+		// Array<T1 | T2 | ...>. Types like [...Array<T1>, ...Array<T2>] are
+		// not valid in Escalier/TypeScript.
+		mergedType := mergeArrayRestSpreads(c, elemTypes)
+		if mergedType != nil {
+			// All elements were array rest spreads — result is Array<T1 | T2 | ...>.
+			exprType = &type_system.MutabilityType{
+				Type:       mergedType,
+				Mutability: type_system.MutabilityUncertain,
+			}
+		} else {
+			exprType = &type_system.MutabilityType{
+				Type:       type_system.NewTupleType(provenance, elemTypes...),
+				Mutability: type_system.MutabilityUncertain,
+			}
 		}
 	case *ast.ObjectExpr:
 		// Create a context for the object so that we can add a `Self` type to it
@@ -924,6 +936,35 @@ func (c *Checker) isPropertyReadonly(ctx Context, objType type_system.Type, prop
 	}
 
 	return false
+}
+
+// mergeArrayRestSpreads checks whether all elements are Array rest spreads.
+// If so, it returns a single Array<T1 | T2 | ...> type. Types like
+// [...Array<T1>, ...Array<T2>] are not valid in Escalier/TypeScript.
+// Returns nil if there are fewer than 2 array rest spreads or if there are
+// non-array-rest elements present (those remain as valid tuple types).
+func mergeArrayRestSpreads(c *Checker, elems []type_system.Type) type_system.Type {
+	// Check that all elements are Array rest spreads.
+	var unionMembers []type_system.Type
+	for _, elem := range elems {
+		rest, ok := elem.(*type_system.RestSpreadType)
+		if !ok {
+			return nil // has fixed elements — not collapsible
+		}
+		inner := type_system.Prune(rest.Type)
+		ref, ok := inner.(*type_system.TypeRefType)
+		if !ok || !c.isArrayType(ref) || len(ref.TypeArgs) == 0 {
+			return nil // non-array rest spread — not collapsible
+		}
+		unionMembers = append(unionMembers, ref.TypeArgs[0])
+	}
+	if len(unionMembers) < 2 {
+		return nil // 0 or 1 array rests — no merge needed
+	}
+	return &type_system.TypeRefType{
+		Name:     type_system.NewIdent("Array"),
+		TypeArgs: []type_system.Type{type_system.NewUnionType(nil, unionMembers...)},
+	}
 }
 
 func (c *Checker) inferCallExpr(

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2410,6 +2410,26 @@ func TestDestructuringObjectPatterns(t *testing.T) {
 				"r":   "[1, [2, {z: 3}]]",
 			},
 		},
+		"ChainedDestructuringWithRestAndSpread": {
+			// Both functions destructure with rest — rest from outer
+			// is passed to inner which also has a rest element.
+			// NOTE: r's type [1, 2, ...{z: 3}] contains a spread of a
+			// non-iterable object type. This should be an error — see #411.
+			input: `
+				val foo = fn ({y, ...rest}) {
+					return [y, ...rest]
+				}
+				val bar = fn ({x, ...rest}) {
+					return [x, ...foo(rest)]
+				}
+				val r = bar({x: 1, y: 2, z: 3})
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>({y: T0, ...rest: T1}) -> [T0, ...T1]",
+				"bar": "fn <T0, T1, T2>({x: T0, ...rest: {y: T1, ...T2}}) -> [T0, T1, ...T2]",
+				"r":   "[1, 2, ...{z: 3}]",
+			},
+		},
 		"RestPassedToTypedFunction": {
 			// Rest from destructuring passed to a function with a type annotation.
 			// The rest gets typed as {y: number, z: string} from the process call,

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2715,6 +2715,18 @@ func TestObjectSpread(t *testing.T) {
 				"v": "number",
 			},
 		},
+		"SpreadOfTypeAlias": {
+			// Spread source typed via a type alias.
+			input: `
+				type Point = {x: number, y: number}
+				val p: Point = {x: 1, y: 2}
+				val ext = {...p, z: 3}
+				val v = ext.x
+			`,
+			expectedTypes: map[string]string{
+				"v": "number",
+			},
+		},
 		"SpreadNestedInSpreadSource": {
 			// Nitpick: getSpreadPropertyType should handle nested RestSpreadElems.
 			// val inner = {x: 1}; val outer = {...inner, y: 2}
@@ -2754,6 +2766,18 @@ func TestObjectSpread(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"iter": "fn () -> ArrayIterator<number>",
+			},
+		},
+		"SymbolKeyedGetterAccessViaSpread": {
+			// Spreading an object with a symbol-keyed getter should
+			// make the getter's return type accessible on the result.
+			input: `
+				declare val src: {get [Symbol.iterator]() -> number}
+				val obj = {...src, x: 1}
+				val v = obj[Symbol.iterator]
+			`,
+			expectedTypes: map[string]string{
+				"v": "number",
 			},
 		},
 	}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2365,6 +2365,69 @@ func TestDestructuringObjectPatterns(t *testing.T) {
 				"foo": "fn ({bar: number, ...rest}) -> number",
 			},
 		},
+		"RestPassedToIdentityFunction": {
+			// Rest from destructuring passed to a simple function.
+			input: `
+				fn identity(obj) { return obj }
+				val foo = fn ({x, ...rest}) {
+					return identity(rest)
+				}
+				val r = foo({x: 1, y: 2, z: "hi"})
+			`,
+			expectedTypes: map[string]string{
+				"r": "{y: 2, z: \"hi\"}",
+			},
+		},
+		"TwoFunctionsWithRestCallingEachOther": {
+			// One function destructures and passes rest to another
+			// function that accesses a property on it.
+			input: `
+				fn getY(obj) { return obj.y }
+				val foo = fn ({x, ...rest}) {
+					return [x, getY(rest)]
+				}
+				val r = foo({x: 1, y: 2})
+			`,
+			expectedTypes: map[string]string{
+				"r": "[1, 2]",
+			},
+		},
+		"ChainedDestructuringWithRest": {
+			// Both functions destructure with rest — rest from outer
+			// is passed to inner which also has a rest element.
+			input: `
+				val foo = fn ({y, ...rest}) {
+					return [y, rest]
+				}
+				val bar = fn ({x, ...rest}) {
+					return [x, foo(rest)]
+				}
+				val r = bar({x: 1, y: 2, z: 3})
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>({y: T0, ...rest: T1}) -> [T0, T1]",
+				"bar": "fn <T0, T1, T2>({x: T0, ...rest: {y: T1, ...T2}}) -> [T0, [T1, T2]]",
+				"r":   "[1, [2, {z: 3}]]",
+			},
+		},
+		"RestPassedToTypedFunction": {
+			// Rest from destructuring passed to a function with a type annotation.
+			// The rest gets typed as {y: number, z: string} from the process call,
+			// but x stays generic since nothing constrains it.
+			input: `
+				fn process(obj: {y: number, z: string}) {
+					return obj.y
+				}
+				val foo = fn ({x, ...rest}) {
+					return process(rest)
+				}
+				val r = foo({x: true, y: 42, z: "hi"})
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>({x: T0, ...rest: {y: number, z: string}}) -> number",
+				"r":   "number",
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -2514,6 +2577,30 @@ func TestObjectSpread(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"r": "{x: \"hello\", y: true, extra: 1}",
+			},
+		},
+		"SpreadBeforeExplicitOverride": {
+			// {...obj, x: 1} — explicit x comes after spread, so x:1 wins.
+			input: `
+				fn foo(obj) { return {...obj, x: 1} }
+				val r = foo({x: 99, y: 2})
+				val x = r.x
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(obj: T0) -> {...T0, x: 1}",
+				"x":   "1",
+			},
+		},
+		"SpreadAfterExplicitOverride": {
+			// {x: 1, ...obj} — spread comes after, so obj.x wins.
+			input: `
+				fn foo(obj) { return {x: 1, ...obj} }
+				val r = foo({x: 99, y: 2})
+				val x = r.x
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(obj: T0) -> {x: 1, ...T0}",
+				"x":   "99",
 			},
 		},
 		"SpreadOverrideSemantics": {

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2705,14 +2705,15 @@ func TestTupleSpreadRefined(t *testing.T) {
 			},
 		},
 		"TwoArraySpreads": {
-			// Two array spreads into a tuple — each produces its own RestSpreadType.
+			// Two array spreads collapse to Array<T1 | T2> since
+			// [...Array<T1>, ...Array<T2>] is not a valid type.
 			input: `
 				val a: Array<number> = [1, 2]
 				val b: Array<string> = ["x", "y"]
 				val result = [...a, ...b]
 			`,
 			expectedTypes: map[string]string{
-				"result": "[...Array<number>, ...Array<string>]",
+				"result": "Array<number | string>",
 			},
 		},
 	}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2520,12 +2520,53 @@ func TestObjectSpread(t *testing.T) {
 			input: `
 				val foo = {b: 5, c: 10}
 				val bar = {a: 1, b: 2, ...foo, c: 3}
+				val a = bar.a
+				val b = bar.b
+				val c = bar.c
+			`,
+			expectedTypes: map[string]string{
+				"a": "1",
+				"b": "5",
+				"c": "3",
+			},
+		},
+		"SpreadOverrideSemanticsWithDestructuring": {
+			input: `
+				val foo = {b: 5, c: 10}
+				val bar = {a: 1, b: 2, ...foo, c: 3}
 				val {a, b, c} = bar
 			`,
 			expectedTypes: map[string]string{
 				"a": "1",
 				"b": "5",
 				"c": "3",
+			},
+		},
+		"MultipleSpreadsOverrideSemantics": {
+			// Two spreads with interleaved explicit property — last provider wins.
+			input: `
+				val foo = {b: 5, c: 10}
+				val bar = {c: 20, d: 30}
+				val result = {a: 1, ...foo, c: 3, ...bar}
+				val {a, b, c, d} = result
+			`,
+			expectedTypes: map[string]string{
+				"a": "1",
+				"b": "5",
+				"c": "20",
+				"d": "30",
+			},
+		},
+		"SpreadOfAnnotatedVariable": {
+			// Spread source has an explicit type annotation — ensures
+			// getObjectAccess can look through a non-MutabilityType spread.
+			input: `
+				val base: {x: number, y: string} = {x: 1, y: "hi"}
+				val ext = {...base, z: true}
+				val v = ext.x
+			`,
+			expectedTypes: map[string]string{
+				"v": "number",
 			},
 		},
 	}
@@ -2593,6 +2634,17 @@ func TestTupleSpreadRefined(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"result": "[\"start\", ...Array<number>, \"end\"]",
+			},
+		},
+		"TwoArraySpreads": {
+			// Two array spreads into a tuple — each produces its own RestSpreadType.
+			input: `
+				val a: Array<number> = [1, 2]
+				val b: Array<string> = ["x", "y"]
+				val result = [...a, ...b]
+			`,
+			expectedTypes: map[string]string{
+				"result": "[...Array<number>, ...Array<string>]",
 			},
 		},
 	}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2463,3 +2463,149 @@ func TestDestructuringTuplePatterns(t *testing.T) {
 		})
 	}
 }
+
+func TestObjectSpread(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"BasicSpread": {
+			input: `
+				val r = {...{x: 1}, y: 2}
+			`,
+			expectedTypes: map[string]string{
+				"r": "{x: 1, y: 2}",
+			},
+		},
+		"SpreadWithInferredType": {
+			input: `
+				fn foo(obj) { return {...obj, extra: 1} }
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(obj: T0) -> {...T0, extra: 1}",
+			},
+		},
+		"MultipleSpreads": {
+			input: `
+				fn merge(a, b) { return {...a, ...b} }
+				val r = merge({x: 1}, {y: "hello"})
+			`,
+			expectedTypes: map[string]string{
+				"merge": "fn <T0, T1>(a: T0, b: T1) -> {...T0, ...T1}",
+				"r":     "{x: 1, y: \"hello\"}",
+			},
+		},
+		"PropertyAccessThroughSpread": {
+			input: `
+				val base = {x: 1, y: 2}
+				val extended = {...base, z: 3}
+				val v = extended.x
+			`,
+			expectedTypes: map[string]string{
+				"base":     "{x: 1, y: 2}",
+				"extended": "{x: 1, y: 2, z: 3}",
+				"v":        "1",
+			},
+		},
+		"SpreadCalledWithConcreteArgs": {
+			input: `
+				fn extend(obj) { return {...obj, extra: 1} }
+				val r = extend({x: "hello", y: true})
+			`,
+			expectedTypes: map[string]string{
+				"r": "{x: \"hello\", y: true, extra: 1}",
+			},
+		},
+		"SpreadOverrideSemantics": {
+			input: `
+				val foo = {b: 5, c: 10}
+				val bar = {a: 1, b: 2, ...foo, c: 3}
+				val {a, b, c} = bar
+			`,
+			expectedTypes: map[string]string{
+				"a": "1",
+				"b": "5",
+				"c": "3",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+func TestTupleSpreadRefined(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"SpreadOfTupleIntoTuple": {
+			input: `
+				val tup: [string, boolean] = ["hello", true]
+				val result = [0, ...tup, 4]
+			`,
+			expectedTypes: map[string]string{
+				"result": "[0, string, boolean, 4]",
+			},
+		},
+		"SpreadOfArrayIntoTuple": {
+			input: `
+				val arr: Array<number> = [1, 2, 3]
+				val result = [0, ...arr, 4]
+			`,
+			expectedTypes: map[string]string{
+				"result": "[0, ...Array<number>, 4]",
+			},
+		},
+		"MultipleTupleSpreads": {
+			input: `
+				fn concat(a: [number, string], b: [boolean]) {
+					return [...a, ...b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"concat": "fn (a: [number, string], b: [boolean]) -> [number, string, boolean]",
+			},
+		},
+		"TuplePlusArraySpread": {
+			input: `
+				fn prepend(tup: [number, string], arr: Array<boolean>) {
+					return [...tup, ...arr]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"prepend": "fn (tup: [number, string], arr: Array<boolean>) -> [number, string, ...Array<boolean>]",
+			},
+		},
+		"SpreadWithLiteralElements": {
+			input: `
+				val arr: Array<number> = [1, 2, 3]
+				val result = ["start", ...arr, "end"]
+			`,
+			expectedTypes: map[string]string{
+				"result": "[\"start\", ...Array<number>, \"end\"]",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2608,6 +2608,35 @@ func TestObjectSpread(t *testing.T) {
 				"v": "number",
 			},
 		},
+		"SpreadNestedInSpreadSource": {
+			// Nitpick: getSpreadPropertyType should handle nested RestSpreadElems.
+			// val inner = {x: 1}; val outer = {...inner, y: 2}
+			// val result = {...outer, z: 3}; result.x should find x through
+			// the RestSpreadElem inside outer.
+			input: `
+				val inner = {x: 1}
+				val outer = {...inner, y: 2}
+				val result = {...outer, z: 3}
+				val v = result.x
+			`,
+			expectedTypes: map[string]string{
+				"v": "1",
+			},
+		},
+		"SpreadPropertyAccessViaDestructuring": {
+			// Verifies unification path handles MutabilityType-wrapped spread
+			// sources (object literals produce MutabilityType wrappers).
+			input: `
+				val src = {x: 1, y: 2}
+				val dest = {...src, z: 3}
+				val {x, y, z} = dest
+			`,
+			expectedTypes: map[string]string{
+				"x": "1",
+				"y": "2",
+				"z": "3",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2557,6 +2557,45 @@ func TestObjectSpread(t *testing.T) {
 				"d": "30",
 			},
 		},
+		"SpreadOfObjectWithMethod": {
+			// Methods are copied as function-valued properties.
+			input: `
+				val obj = {x: 1, greet() { return "hello" }}
+				val result = {...obj, y: 2}
+				val g = result.greet
+			`,
+			expectedTypes: map[string]string{
+				"g": "fn () -> \"hello\"",
+			},
+		},
+		"SpreadOfObjectWithGetter": {
+			// Getter's return value becomes a plain property.
+			input: `
+				val obj = {
+					_x: 10,
+					get x(self) { return self._x },
+				}
+				val result = {...obj, y: 2}
+				val v = result.x
+			`,
+			expectedTypes: map[string]string{
+				"v": "10",
+			},
+		},
+		"SpreadOfObjectWithSetterOnly": {
+			// Setter-only properties are omitted from the spread.
+			// The explicit property 'x' in the target is preserved.
+			input: `
+				val obj = {
+					set x(mut self, v: number) { },
+				}
+				val result = {x: "kept", ...obj}
+				val v = result.x
+			`,
+			expectedTypes: map[string]string{
+				"v": "\"kept\"",
+			},
+		},
 		"SpreadOfAnnotatedVariable": {
 			// Spread source has an explicit type annotation — ensures
 			// getObjectAccess can look through a non-MutabilityType spread.

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2637,6 +2637,18 @@ func TestObjectSpread(t *testing.T) {
 				"z": "3",
 			},
 		},
+		"SpreadPreservesSymbolKeys": {
+			// Symbol-keyed properties from a spread source should be
+			// accessible on the result via index access.
+			input: `
+				declare val arr: Array<number>
+				val obj = {...arr, extra: 1}
+				val iter = obj[Symbol.iterator]
+			`,
+			expectedTypes: map[string]string{
+				"iter": "fn () -> ArrayIterator<number>",
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -2714,6 +2726,26 @@ func TestTupleSpreadRefined(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"result": "Array<number | string>",
+			},
+		},
+		"SpreadOfSet": {
+			// Spreading a Set extracts its element type via iterability.
+			input: `
+				declare val s: Set<number>
+				val result = [...s]
+			`,
+			expectedTypes: map[string]string{
+				"result": "Array<number>",
+			},
+		},
+		"SpreadOfMap": {
+			// Spreading a Map yields [K, V] tuples via iterability.
+			input: `
+				declare val m: Map<string, number>
+				val result = [...m]
+			`,
+			expectedTypes: map[string]string{
+				"result": "Array<[string, number]>",
 			},
 		},
 	}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1413,6 +1413,11 @@ func (c *Checker) unifyClosedWithRests(
 	//    in source order and inlining bound RestSpreadElems. Later entries
 	//    overwrite earlier ones, giving JavaScript override semantics.
 	//    Unbound rests (TypeVarType) are collected separately.
+	//
+	//    Note: Prune resolves TypeVarType chains but does not unwrap
+	//    MutabilityType. This is fine because MutabilityType wrappers are
+	//    resolved away during unification before this function is called —
+	//    RestSpreadElem.Value is always an ObjectType or unresolved TypeVarType.
 	effectiveKeys := []type_system.ObjTypeKey{}
 	effectiveValues := map[type_system.ObjTypeKey]type_system.Type{}
 	var unboundRests []*type_system.TypeVarType

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -950,7 +950,6 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 				}
 			}
 
-
 			// Open-vs-open: unify shared properties, merge non-shared,
 			// unify row variables.
 			//
@@ -1033,6 +1032,7 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			} else if hasRests2 && !hasRests1 {
 				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj2, obj1, keys1, namedElems1, true))
 			} else if hasRests1 && hasRests2 {
+				// TODO(#410): implement unification when both sides have RestSpreadElems
 				return []Error{&UnimplementedError{message: "unify types with rest elems on both sides"}}
 			} else {
 				for _, key2 := range keys2 {
@@ -1498,7 +1498,11 @@ func (c *Checker) unifyClosedWithRests(
 		errors = slices.Concat(errors, unifyErrors)
 	} else if len(unboundRests) > 1 && len(remainingElems) > 0 {
 		errors = append(errors, &UnimplementedError{
-			message: "cannot distribute properties across multiple unbound rest elements",
+			message: fmt.Sprintf(
+				"cannot distribute %d properties across %d unbound rest spread elements; consider using a single spread or explicit property definitions",
+				len(remainingElems),
+				len(unboundRests),
+			),
 		})
 	} else if len(unboundRests) == 0 && len(remainingElems) > 0 {
 		// All rests are bound but there are leftover properties — error.

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1416,24 +1416,40 @@ func (c *Checker) unifyClosedWithRests(
 	effectiveKeys := []type_system.ObjTypeKey{}
 	effectiveValues := map[type_system.ObjTypeKey]type_system.Type{}
 	var unboundRests []*type_system.TypeVarType
+	addEffective := func(name type_system.ObjTypeKey, value type_system.Type) {
+		if _, exists := effectiveValues[name]; !exists {
+			effectiveKeys = append(effectiveKeys, name)
+		}
+		effectiveValues[name] = value
+	}
 	for _, elem := range restObj.Elems {
 		switch elem := elem.(type) {
 		case *type_system.PropertyElem:
-			if _, exists := effectiveValues[elem.Name]; !exists {
-				effectiveKeys = append(effectiveKeys, elem.Name)
-			}
-			effectiveValues[elem.Name] = elem.Value
+			addEffective(elem.Name, elem.Value)
+		case *type_system.MethodElem:
+			addEffective(elem.Name, elem.Fn)
+		case *type_system.GetterElem:
+			addEffective(elem.Name, elem.Fn.Return)
+		case *type_system.SetterElem:
+			// Setters on the outer object are kept (direct access).
+			addEffective(elem.Name, elem.Fn.Params[0].Type)
 		case *type_system.RestSpreadElem:
 			pruned := type_system.Prune(elem.Value)
 			if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
 				unboundRests = append(unboundRests, tv)
 			} else if obj, ok := pruned.(*type_system.ObjectType); ok {
+				// Apply spread semantics: methods → fn type, getters → return
+				// type, setter-only → skipped.
 				for _, re := range obj.Elems {
-					if prop, ok := re.(*type_system.PropertyElem); ok {
-						if _, exists := effectiveValues[prop.Name]; !exists {
-							effectiveKeys = append(effectiveKeys, prop.Name)
-						}
-						effectiveValues[prop.Name] = prop.Value
+					switch re := re.(type) {
+					case *type_system.PropertyElem:
+						addEffective(re.Name, re.Value)
+					case *type_system.MethodElem:
+						addEffective(re.Name, re.Fn)
+					case *type_system.GetterElem:
+						addEffective(re.Name, re.Fn.Return)
+					case *type_system.SetterElem:
+						// Setter-only not readable via spread — skip.
 					}
 				}
 			}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1385,11 +1385,41 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 
 // unifyClosedWithRests unifies a closed ObjectType that has RestSpreadElems
 // (restObj) against a closed ObjectType with no rests (targetObj).
-// It distributes targetObj's extra properties across the rests.
 //
-// restObj is the side with RestSpreadElems, targetObj is the concrete side.
-// restKeys/targetKeys and restNamed/targetNamed are their property maps.
-// restTypes are the RestSpreadElem values from restObj.
+// It first expands restObj.Elems in source order — inlining bound
+// RestSpreadElems and applying JavaScript override semantics (later entries
+// win) — to produce a flat effective property map. It then unifies each
+// effective property against the matching target property.
+//
+// Any target properties not covered by the effective map are "remaining".
+// These are distributed to unbound rest elements (TypeVarTypes) as follows:
+//
+//   - One unbound rest: bind it to an ObjectType containing all remaining
+//     properties.
+//     Note the ordering matters for overrides. Both variants have the
+//     same type shape but different element order, which affects which
+//     value wins for shared keys:
+//
+//     // fn <T0>(obj: T0) -> {x: 1, ...T0}
+//     fn foo(obj) {
+//     return {x: 1, ...obj}
+//     }
+//     foo({x: 5, y: 2}).x // 5
+//
+//     // fn <T0>(obj: T0) -> {...T0, x: 1}
+//     fn foo(obj) {
+//     return {...obj, x: 1}
+//     }
+//     foo({x: 5, y: 2}).x // 1.
+//
+//   - Multiple unbound rests with remaining properties: error — the system
+//     cannot determine which rest should receive which properties. In
+//     practice this case is unlikely to be reached because rests originate
+//     from function parameters, which are bound by call-site arguments
+//     before the return type is unified.
+//
+//   - Zero unbound rests with remaining properties: error — all rests are
+//     bound but the target has extra properties not accounted for.
 func (c *Checker) unifyClosedWithRests(
 	ctx Context,
 	restObj, targetObj *type_system.ObjectType,
@@ -1453,6 +1483,14 @@ func (c *Checker) unifyClosedWithRests(
 						addEffective(re.Name, re.Fn.Return)
 					case *type_system.SetterElem:
 						// Setter-only not readable via spread — skip.
+					case *type_system.RestSpreadElem:
+						// Nested rest from chained destructuring (e.g. the T3 in
+						// {y: T2, ...T3}). Collect so remaining target properties
+						// can flow into it.
+						innerPruned := type_system.Prune(re.Value)
+						if tv, ok := innerPruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
+							unboundRests = append(unboundRests, tv)
+						}
 					}
 				}
 			}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1413,11 +1413,6 @@ func (c *Checker) unifyClosedWithRests(
 	//    in source order and inlining bound RestSpreadElems. Later entries
 	//    overwrite earlier ones, giving JavaScript override semantics.
 	//    Unbound rests (TypeVarType) are collected separately.
-	//
-	//    Note: Prune resolves TypeVarType chains but does not unwrap
-	//    MutabilityType. This is fine because MutabilityType wrappers are
-	//    resolved away during unification before this function is called —
-	//    RestSpreadElem.Value is always an ObjectType or unresolved TypeVarType.
 	effectiveKeys := []type_system.ObjTypeKey{}
 	effectiveValues := map[type_system.ObjTypeKey]type_system.Type{}
 	var unboundRests []*type_system.TypeVarType
@@ -1440,6 +1435,9 @@ func (c *Checker) unifyClosedWithRests(
 			addEffective(elem.Name, elem.Fn.Params[0].Type)
 		case *type_system.RestSpreadElem:
 			pruned := type_system.Prune(elem.Value)
+			if mut, ok := pruned.(*type_system.MutabilityType); ok {
+				pruned = type_system.Prune(mut.Type)
+			}
 			if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
 				unboundRests = append(unboundRests, tv)
 			} else if obj, ok := pruned.(*type_system.ObjectType); ok {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -891,8 +891,8 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			keys1 := []type_system.ObjTypeKey{} // original order of keys in obj1
 			keys2 := []type_system.ObjTypeKey{} // original order of keys in obj2
 
-			var restType1 type_system.Type
-			var restType2 type_system.Type
+			var restTypes1 []type_system.Type
+			var restTypes2 []type_system.Type
 
 			for _, elem := range obj1.Elems {
 				switch elem := elem.(type) {
@@ -917,7 +917,7 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 					origElems1[elem.Name] = elem
 					keys1 = append(keys1, elem.Name)
 				case *type_system.RestSpreadElem:
-					restType1 = elem.Value
+					restTypes1 = append(restTypes1, elem.Value)
 				default: // skip other types of elems
 				}
 			}
@@ -945,10 +945,11 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 					origElems2[elem.Name] = elem
 					keys2 = append(keys2, elem.Name)
 				case *type_system.RestSpreadElem:
-					restType2 = elem.Value
+					restTypes2 = append(restTypes2, elem.Value)
 				default: // skip other types of elems
 				}
 			}
+
 
 			// Open-vs-open: unify shared properties, merge non-shared,
 			// unify row variables.
@@ -981,8 +982,8 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 					}
 				}
 				// Unify row variables if both have RestSpreadElems
-				if restType1 != nil && restType2 != nil {
-					unifyErrors := c.Unify(ctx, restType1, restType2)
+				if len(restTypes1) == 1 && len(restTypes2) == 1 {
+					unifyErrors := c.Unify(ctx, restTypes1[0], restTypes2[0])
 					errors = slices.Concat(errors, unifyErrors)
 				}
 				return errors
@@ -1020,87 +1021,19 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 				return errors
 			}
 
-			// Closed-vs-closed (existing path)
-			if restType1 != nil && restType2 != nil {
-				return []Error{&UnimplementedError{message: "unify types with two rest elems"}}
-			} else if restType1 != nil {
-				usedKeys2 := map[type_system.ObjTypeKey]bool{}
-				for _, key1 := range keys1 {
-					value1 := namedElems1[key1]
-					if value2, ok := namedElems2[key1]; ok {
-						unifyErrors := c.Unify(ctx, value1, value2)
-						errors = slices.Concat(errors, unifyErrors)
-						usedKeys2[key1] = true
-					} else {
-						errors = slices.Concat(errors, []Error{&KeyNotFoundError{
-							Object: obj2,
-							Key:    key1,
-							span:   getKeyNotFoundSpan(obj2, value1),
-						}})
-						// Unify the missing property's type with 'undefined' so that it gets
-						// properly resolved and doesn't remain as a type variable.
-						// We intentionally discard the errors since we already
-						// reported the KeyNotFoundError above.
-						undefinedType := type_system.NewUndefinedType(nil)
-						c.Unify(ctx, value1, undefinedType)
-					}
-				}
+			// Closed-vs-closed: handle rest element distribution.
+			//
+			// Multiple RestSpreadElems on one side (from object spread) need
+			// to be distributed against the other side's properties.
+			hasRests1 := len(restTypes1) > 0
+			hasRests2 := len(restTypes2) > 0
 
-				restElems := []type_system.ObjTypeElem{}
-				for _, key := range keys2 {
-					if _, ok := usedKeys2[key]; !ok {
-						restElems = append(restElems, &type_system.PropertyElem{
-							Name:     key,
-							Optional: false, // TODO
-							Readonly: false, // TODO
-							Value:    namedElems2[key],
-						})
-					}
-				}
-
-				objType := type_system.NewObjectType(nil, restElems)
-
-				unifyErrors := c.Unify(ctx, objType, restType1)
-				errors = slices.Concat(errors, unifyErrors)
-			} else if restType2 != nil {
-				usedKeys1 := map[type_system.ObjTypeKey]bool{}
-				for _, key2 := range keys2 {
-					value2 := namedElems2[key2]
-					if value1, ok := namedElems1[key2]; ok {
-						unifyErrors := c.Unify(ctx, value1, value2)
-						errors = slices.Concat(errors, unifyErrors)
-						usedKeys1[key2] = true
-					} else {
-						errors = slices.Concat(errors, []Error{&KeyNotFoundError{
-							Object: obj1,
-							Key:    key2,
-							span:   getKeyNotFoundSpan(obj1, value2),
-						}})
-						// Unify the missing property's type with 'undefined' so that it gets
-						// properly resolved and doesn't remain as a type variable.
-						// We intentionally discard the errors since we already
-						// reported the KeyNotFoundError above.
-						undefinedType := type_system.NewUndefinedType(nil)
-						c.Unify(ctx, value2, undefinedType)
-					}
-				}
-
-				restElems := []type_system.ObjTypeElem{}
-				for _, key := range keys1 {
-					if _, ok := usedKeys1[key]; !ok {
-						restElems = append(restElems, &type_system.PropertyElem{
-							Name:     key,
-							Optional: false, // TODO
-							Readonly: false, // TODO
-							Value:    namedElems1[key],
-						})
-					}
-				}
-
-				objType := type_system.NewObjectType(nil, restElems)
-
-				unifyErrors := c.Unify(ctx, restType2, objType)
-				errors = slices.Concat(errors, unifyErrors)
+			if hasRests1 && !hasRests2 {
+				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj1, obj2, keys1, keys2, namedElems1, namedElems2, restTypes1, false))
+			} else if hasRests2 && !hasRests1 {
+				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj2, obj1, keys2, keys1, namedElems2, namedElems1, restTypes2, true))
+			} else if hasRests1 && hasRests2 {
+				return []Error{&UnimplementedError{message: "unify types with rest elems on both sides"}}
 			} else {
 				for _, key2 := range keys2 {
 					value2 := namedElems2[key2]
@@ -1448,6 +1381,127 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 		T1: t1,
 		T2: t2,
 	}}
+}
+
+// unifyClosedWithRests unifies a closed ObjectType that has RestSpreadElems
+// (restObj) against a closed ObjectType with no rests (targetObj).
+// It distributes targetObj's extra properties across the rests.
+//
+// restObj is the side with RestSpreadElems, targetObj is the concrete side.
+// restKeys/targetKeys and restNamed/targetNamed are their property maps.
+// restTypes are the RestSpreadElem values from restObj.
+func (c *Checker) unifyClosedWithRests(
+	ctx Context,
+	restObj, targetObj *type_system.ObjectType,
+	restKeys, targetKeys []type_system.ObjTypeKey,
+	restNamed, targetNamed map[type_system.ObjTypeKey]type_system.Type,
+	restTypes []type_system.Type,
+	swapped bool,
+) []Error {
+	errors := []Error{}
+
+	// unifyPair preserves the original t1/t2 ordering for Unify calls.
+	// When swapped is false, restObj=t1 and targetObj=t2.
+	// When swapped is true, restObj=t2 and targetObj=t1.
+	unifyPair := func(restVal, targetVal type_system.Type) []Error {
+		if swapped {
+			return c.Unify(ctx, targetVal, restVal)
+		}
+		return c.Unify(ctx, restVal, targetVal)
+	}
+
+	// 1. Unify shared explicit properties.
+	usedTargetKeys := map[type_system.ObjTypeKey]bool{}
+	for _, key := range restKeys {
+		value := restNamed[key]
+		if targetValue, ok := targetNamed[key]; ok {
+			unifyErrors := unifyPair(value, targetValue)
+			errors = slices.Concat(errors, unifyErrors)
+			usedTargetKeys[key] = true
+		} else {
+			errors = slices.Concat(errors, []Error{&KeyNotFoundError{
+				Object: targetObj,
+				Key:    key,
+				span:   getKeyNotFoundSpan(targetObj, value),
+			}})
+			undefinedType := type_system.NewUndefinedType(nil)
+			c.Unify(ctx, value, undefinedType)
+		}
+	}
+
+	// 2. Collect remaining target properties not matched by explicit props.
+	remainingElems := []type_system.ObjTypeElem{}
+	for _, key := range targetKeys {
+		if !usedTargetKeys[key] {
+			remainingElems = append(remainingElems, &type_system.PropertyElem{
+				Name:  key,
+				Value: targetNamed[key],
+			})
+		}
+	}
+
+	// 3. Resolve bound rests — subtract their known properties from remaining.
+	//    Collect unbound rests for later assignment.
+	knownKeys := map[type_system.ObjTypeKey]bool{}
+	var unboundRests []*type_system.TypeVarType
+	for _, rt := range restTypes {
+		pruned := type_system.Prune(rt)
+		if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
+			unboundRests = append(unboundRests, tv)
+		} else if obj, ok := pruned.(*type_system.ObjectType); ok {
+			// Bound rest — unify its properties against the target and track them.
+			for _, elem := range obj.Elems {
+				if prop, ok := elem.(*type_system.PropertyElem); ok {
+					knownKeys[prop.Name] = true
+					if targetValue, ok := targetNamed[prop.Name]; ok {
+						unifyErrors := unifyPair(prop.Value, targetValue)
+						errors = slices.Concat(errors, unifyErrors)
+						usedTargetKeys[prop.Name] = true
+					}
+				}
+			}
+		}
+	}
+
+	// 4. Subtract known keys from remaining.
+	if len(knownKeys) > 0 {
+		filtered := []type_system.ObjTypeElem{}
+		for _, elem := range remainingElems {
+			if prop, ok := elem.(*type_system.PropertyElem); ok {
+				if !knownKeys[prop.Name] {
+					filtered = append(filtered, elem)
+				}
+			} else {
+				filtered = append(filtered, elem)
+			}
+		}
+		remainingElems = filtered
+	}
+
+	// 5. Assign remaining properties to unbound rests.
+	if len(unboundRests) == 1 {
+		objType := type_system.NewObjectType(nil, remainingElems)
+		unifyErrors := unifyPair(unboundRests[0], objType)
+		errors = slices.Concat(errors, unifyErrors)
+	} else if len(unboundRests) > 1 && len(remainingElems) > 0 {
+		errors = append(errors, &UnimplementedError{
+			message: "cannot distribute properties across multiple unbound rest elements",
+		})
+	} else if len(unboundRests) == 0 && len(remainingElems) > 0 {
+		// All rests are bound but there are leftover properties — error.
+		for _, elem := range remainingElems {
+			if prop, ok := elem.(*type_system.PropertyElem); ok {
+				errors = append(errors, &KeyNotFoundError{
+					Object: restObj,
+					Key:    prop.Name,
+					span:   getKeyNotFoundSpan(restObj, prop.Value),
+				})
+			}
+		}
+	}
+	// else: no remaining properties — all rests stay as-is (empty objects if unbound)
+
+	return errors
 }
 
 // unifyFuncTypes unifies two function types

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1470,7 +1470,7 @@ func (c *Checker) unifyClosedWithRests(
 			}
 			if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
 				unboundRests = append(unboundRests, tv)
-			} else if obj, ok := pruned.(*type_system.ObjectType); ok {
+			} else if obj := resolveToObjectType(pruned); obj != nil {
 				// Apply spread semantics: methods → fn type, getters → return
 				// type, setter-only → skipped.
 				for _, re := range obj.Elems {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1029,9 +1029,9 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			hasRests2 := len(restTypes2) > 0
 
 			if hasRests1 && !hasRests2 {
-				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj1, obj2, keys1, keys2, namedElems1, namedElems2, restTypes1, false))
+				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj1, obj2, keys2, namedElems2, false))
 			} else if hasRests2 && !hasRests1 {
-				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj2, obj1, keys2, keys1, namedElems2, namedElems1, restTypes2, true))
+				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj2, obj1, keys1, namedElems1, true))
 			} else if hasRests1 && hasRests2 {
 				return []Error{&UnimplementedError{message: "unify types with rest elems on both sides"}}
 			} else {
@@ -1393,9 +1393,8 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 func (c *Checker) unifyClosedWithRests(
 	ctx Context,
 	restObj, targetObj *type_system.ObjectType,
-	restKeys, targetKeys []type_system.ObjTypeKey,
-	restNamed, targetNamed map[type_system.ObjTypeKey]type_system.Type,
-	restTypes []type_system.Type,
+	targetKeys []type_system.ObjTypeKey,
+	targetNamed map[type_system.ObjTypeKey]type_system.Type,
 	swapped bool,
 ) []Error {
 	errors := []Error{}
@@ -1410,10 +1409,41 @@ func (c *Checker) unifyClosedWithRests(
 		return c.Unify(ctx, restVal, targetVal)
 	}
 
-	// 1. Unify shared explicit properties.
+	// 1. Expand restObj.Elems into a flat effective property map by walking
+	//    in source order and inlining bound RestSpreadElems. Later entries
+	//    overwrite earlier ones, giving JavaScript override semantics.
+	//    Unbound rests (TypeVarType) are collected separately.
+	effectiveKeys := []type_system.ObjTypeKey{}
+	effectiveValues := map[type_system.ObjTypeKey]type_system.Type{}
+	var unboundRests []*type_system.TypeVarType
+	for _, elem := range restObj.Elems {
+		switch elem := elem.(type) {
+		case *type_system.PropertyElem:
+			if _, exists := effectiveValues[elem.Name]; !exists {
+				effectiveKeys = append(effectiveKeys, elem.Name)
+			}
+			effectiveValues[elem.Name] = elem.Value
+		case *type_system.RestSpreadElem:
+			pruned := type_system.Prune(elem.Value)
+			if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
+				unboundRests = append(unboundRests, tv)
+			} else if obj, ok := pruned.(*type_system.ObjectType); ok {
+				for _, re := range obj.Elems {
+					if prop, ok := re.(*type_system.PropertyElem); ok {
+						if _, exists := effectiveValues[prop.Name]; !exists {
+							effectiveKeys = append(effectiveKeys, prop.Name)
+						}
+						effectiveValues[prop.Name] = prop.Value
+					}
+				}
+			}
+		}
+	}
+
+	// 2. Unify effective properties against the target.
 	usedTargetKeys := map[type_system.ObjTypeKey]bool{}
-	for _, key := range restKeys {
-		value := restNamed[key]
+	for _, key := range effectiveKeys {
+		value := effectiveValues[key]
 		if targetValue, ok := targetNamed[key]; ok {
 			unifyErrors := unifyPair(value, targetValue)
 			errors = slices.Concat(errors, unifyErrors)
@@ -1429,7 +1459,7 @@ func (c *Checker) unifyClosedWithRests(
 		}
 	}
 
-	// 2. Collect remaining target properties not matched by explicit props.
+	// 3. Collect remaining target properties not matched by effective props.
 	remainingElems := []type_system.ObjTypeElem{}
 	for _, key := range targetKeys {
 		if !usedTargetKeys[key] {
@@ -1440,45 +1470,7 @@ func (c *Checker) unifyClosedWithRests(
 		}
 	}
 
-	// 3. Resolve bound rests — subtract their known properties from remaining.
-	//    Collect unbound rests for later assignment.
-	knownKeys := map[type_system.ObjTypeKey]bool{}
-	var unboundRests []*type_system.TypeVarType
-	for _, rt := range restTypes {
-		pruned := type_system.Prune(rt)
-		if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
-			unboundRests = append(unboundRests, tv)
-		} else if obj, ok := pruned.(*type_system.ObjectType); ok {
-			// Bound rest — unify its properties against the target and track them.
-			for _, elem := range obj.Elems {
-				if prop, ok := elem.(*type_system.PropertyElem); ok {
-					knownKeys[prop.Name] = true
-					if targetValue, ok := targetNamed[prop.Name]; ok {
-						unifyErrors := unifyPair(prop.Value, targetValue)
-						errors = slices.Concat(errors, unifyErrors)
-						usedTargetKeys[prop.Name] = true
-					}
-				}
-			}
-		}
-	}
-
-	// 4. Subtract known keys from remaining.
-	if len(knownKeys) > 0 {
-		filtered := []type_system.ObjTypeElem{}
-		for _, elem := range remainingElems {
-			if prop, ok := elem.(*type_system.PropertyElem); ok {
-				if !knownKeys[prop.Name] {
-					filtered = append(filtered, elem)
-				}
-			} else {
-				filtered = append(filtered, elem)
-			}
-		}
-		remainingElems = filtered
-	}
-
-	// 5. Assign remaining properties to unbound rests.
+	// 4. Assign remaining properties to unbound rests.
 	if len(unboundRests) == 1 {
 		objType := type_system.NewObjectType(nil, remainingElems)
 		unifyErrors := unifyPair(unboundRests[0], objType)

--- a/internal/checker/utils.go
+++ b/internal/checker/utils.go
@@ -81,6 +81,8 @@ func (c *Checker) astKeyToTypeKey(ctx Context, key ast.ObjKey) (*type_system.Obj
 		// TODO: return the error
 		keyType, _ := c.inferExpr(ctx, key.Expr) // infer the expression for side-effects
 
+		// TODO(#413): handle custom symbols from Symbol() — currently only
+		// well-known symbols (UniqueSymbolType) are supported as computed keys.
 		switch t := type_system.Prune(keyType).(type) {
 		case *type_system.LitType:
 			switch lit := t.Lit.(type) {

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -2099,6 +2099,10 @@ All phases → Phase 11: Error Reporting
 3. ~~**Multiple RestSpreadElems (Phase 10):**~~ Resolved. Property distribution
    across unbound rest elements is inherently ambiguous — the error case for
    ambiguous distributions is kept as designed in `unifyClosedWithRests`.
+   Note: closed-vs-closed unification where **both** sides contain
+   `RestSpreadElem`s still returns `UnimplementedError` — this case does not
+   arise in normal usage (spread expressions unify against concrete types or
+   type variables, not against other spread expressions).
 
 4. **Snapshot tests:** Adding `Open` to `ObjectType` shouldn't change printed
    types (it's an internal flag), but changes to `RestSpreadElem` handling in

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1337,6 +1337,27 @@ sources.
   single `...Array<T>` rest is collapsed to `Array<T>` via
   `collapseArrayRestSpreads`.
 
+### Known limitations
+
+- **Both-sides RestSpreadElems (#410):** Closed-vs-closed ObjectType
+  unification where **both** sides contain `RestSpreadElem`s returns
+  `UnimplementedError`. `unifyClosedWithRests` handles the common case
+  (one side has rests, the other is concrete) but the both-sides case was
+  intentionally deferred. In practice this doesn't arise because spread
+  expressions unify against concrete types or type variables (bound by
+  call-site arguments), not against other spread expressions.
+
+- **Non-iterable RestSpreadType in tuples (#411):** Spreading an object rest
+  element into a tuple (e.g. `[x, ...rest]` where `rest` is an ObjectType)
+  produces a `RestSpreadType` wrapping a non-iterable type. The type checker
+  does not currently validate that `RestSpreadType` inner types are iterable.
+
+- **Custom symbols as computed keys (#413):** `Symbol()` returns the `symbol`
+  primitive type, not a `UniqueSymbolType`, so custom symbols cannot be used
+  as computed keys in object literals. Only well-known symbols (e.g.
+  `Symbol.iterator`) work as computed keys. Additionally, invalid computed
+  keys cause a nil-entry panic in the ObjectType construction.
+
 ---
 
 ## Phase 12: Tuple and Array Inference from Indexing Patterns ✅

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1153,8 +1153,14 @@ sources.
    correctly handles JavaScript override semantics: in `{a: 1, ...{a: 2}}` the
    spread's `a` wins, and in `{...{a: 1}, a: 2}` the explicit `a` wins,
    because in both cases the later element is found first during the reverse
-   scan. Both the `PropertyKey` and `IndexKey` (string-literal) branches use
-   this approach.
+   scan. All three branches (`PropertyKey`, `IndexKey` string-literal, and
+   `IndexKey` unique-symbol) use this approach.
+
+   For `RestSpreadElem` lookups, `getSpreadPropertyType` applies JavaScript
+   spread semantics (methods → fn type, getters → return type, setter-only →
+   skip). For symbol keys, `resolveToObjectType` resolves through
+   `MutabilityType` wrappers and `TypeRefType` aliases (e.g. `Array<T>`) to
+   reach the underlying `ObjectType`.
 
    Note: property addition on open objects (Phase 2) is gated by `Open`, not by
    the presence of `RestSpreadElem`s. These are orthogonal.
@@ -1189,6 +1195,19 @@ sources.
 - **Spread called with concrete args (`TestObjectSpread/SpreadCalledWithConcreteArgs`):**
   `fn extend(obj) { return {...obj, extra: 1} }` called with
   `{x: "hello", y: true}` yields `{x: "hello", y: true, extra: 1}`.
+- **Override ordering (`TestObjectSpread/SpreadBeforeExplicitOverride`,
+  `SpreadAfterExplicitOverride`):** `{...obj, x: 1}` vs `{x: 1, ...obj}` —
+  later element wins for shared keys.
+- **Spread of method/getter/setter (`TestObjectSpread/SpreadOfObjectWithMethod`,
+  `SpreadOfObjectWithGetter`, `SpreadOfObjectWithSetterOnly`):** Methods become
+  function-valued properties, getters yield return types, setter-only skipped.
+- **Symbol keys through spread (`TestObjectSpread/SpreadPreservesSymbolKeys`):**
+  `{...arr, extra: 1}` where `arr: Array<number>` — `obj[Symbol.iterator]`
+  found via spread.
+- **Chained destructuring with rest
+  (`TestDestructuringObjectPatterns/ChainedDestructuringWithRest`):**
+  Two functions that each destructure with rest, passing rest from outer to
+  inner. Nested `RestSpreadElem`s in bound rests are collected as unbound rests.
 
 ### Array/Tuple Spread Changes
 
@@ -1311,6 +1330,12 @@ sources.
   val result = ["start", ...arr, "end"]
   ```
   — `result: ["start", ...Array<number>, "end"]`.
+
+- **Single array spread collapses (`TestTupleSpreadRefined/SpreadOfSet`,
+  `SpreadOfMap`):** `[...Set<number>]` → `Array<number>`,
+  `[...Map<string, number>]` → `Array<[string, number]>`. A tuple with only a
+  single `...Array<T>` rest is collapsed to `Array<T>` via
+  `collapseArrayRestSpreads`.
 
 ---
 

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -882,14 +882,13 @@ All tests are in `TestRowTypesRowPolymorphism` in `row_types_test.go`.
   Calling with exact properties — row variable resolves to empty `ObjectType`,
   which is dropped from display: `r: {x: number}`.
 
-**Not yet implemented (requires Phase 10 — Object Spread):**
+**Multiple row-polymorphic parameters via spread (Phase 10):**
 
-- **Multiple row-polymorphic parameters via spread:**
-  ```esc
+- ```esc
   fn merge(a, b) { return {...a, ...b} }
-  let r = merge({x: 1}, {y: "hi"})
+  val r = merge({x: 1}, {y: "hello"})
   ```
-  — `r: {x: number, y: string}`.
+  — `r: {x: 1, y: "hello"}`. Tested in `TestObjectSpread/MultipleSpreads`.
 
 ---
 
@@ -1066,7 +1065,7 @@ preserved even when not in the return type, since the user explicitly wrote
 
 ---
 
-## Phase 10: Object & Array/Tuple Spread
+## Phase 10: Object & Array/Tuple Spread ✅
 
 **Requirements covered:** Section 12 (object spread, multiple RestSpreadElems),
 Section 16 (array/tuple spread).
@@ -1149,11 +1148,13 @@ sources.
    ```
 
 4. **`internal/checker/expand_type.go`** — `getObjectAccess`:
-   When a property is not found in explicit elements (and the object is **not**
-   open), check each `RestSpreadElem`'s resolved type (via Prune). If it
-   resolves to an `ObjectType`, search its elements recursively. Search in
-   **reverse** order (rightmost rest element first) to respect override
-   semantics. Return the first match found.
+   Search all elements (explicit properties **and** `RestSpreadElem`s) in a
+   single **reverse-order** pass. The first match from the end wins, which
+   correctly handles JavaScript override semantics: in `{a: 1, ...{a: 2}}` the
+   spread's `a` wins, and in `{...{a: 1}, a: 2}` the explicit `a` wins,
+   because in both cases the later element is found first during the reverse
+   scan. Both the `PropertyKey` and `IndexKey` (string-literal) branches use
+   this approach.
 
    Note: property addition on open objects (Phase 2) is gated by `Open`, not by
    the presence of `RestSpreadElem`s. These are orthogonal.
@@ -1168,25 +1169,26 @@ sources.
 
 ### Tests
 
-- **Basic spread:**
-  `let r = {...{x: 1}, y: 2}` — `r: {x: number, y: number}`.
-- **Spread with inferred type:**
-  `fn foo(obj) { return {...obj, extra: 1} }` — return type has
-  `RestSpreadElem` from `obj`.
-- **Multiple spreads:**
+- **Basic spread (`TestObjectSpread/BasicSpread`):**
+  `val r = {...{x: 1}, y: 2}` — `r: {x: 1, y: 2}`.
+- **Spread with inferred type (`TestObjectSpread/SpreadWithInferredType`):**
+  `fn foo(obj) { return {...obj, extra: 1} }` — return type `{...T0, extra: 1}`.
+- **Multiple spreads (`TestObjectSpread/MultipleSpreads`):**
   `fn merge(a, b) { return {...a, ...b} }` — two row variables, two type params.
-- **Override semantics:**
-  `let r = {...{x: 1}, ...{x: "hi"}}` — `r.x` is `string` (rightmost wins).
-- **Explicit property overrides spread:**
-  `let r = {...{x: 1}, x: "hi"}` — `r.x` is `string`.
-- **Spread of TypeVarType:**
-  `fn foo(obj) { let r = {...obj} }` — `RestSpreadElem{Value: typeVar(obj)}`.
-- **Property access through RestSpreadElem:**
+  Calling `merge({x: 1}, {y: "hello"})` yields `{x: 1, y: "hello"}`.
+- **Override semantics (`TestObjectSpread/SpreadOverrideSemantics`):**
+  `val bar = {a: 1, b: 2, ...{b: 5, c: 10}, c: 3}` — `bar.a` is `1`,
+  `bar.b` is `5` (spread overrides earlier explicit), `bar.c` is `3`
+  (later explicit overrides spread).
+- **Property access through RestSpreadElem (`TestObjectSpread/PropertyAccessThroughSpread`):**
   ```esc
-  let base = {x: 1, y: 2}
-  let extended = {...base, z: 3}
-  let v = extended.x  // found via RestSpreadElem
+  val base = {x: 1, y: 2}
+  val extended = {...base, z: 3}
+  val v = extended.x  // found via RestSpreadElem
   ```
+- **Spread called with concrete args (`TestObjectSpread/SpreadCalledWithConcreteArgs`):**
+  `fn extend(obj) { return {...obj, extra: 1} }` called with
+  `{x: "hello", y: true}` yields `{x: "hello", y: true, extra: 1}`.
 
 ### Array/Tuple Spread Changes
 
@@ -2050,7 +2052,7 @@ Phase 7, Phase 14 → Phase 8: Destructuring ✅
 
 ```
 Phase 2 → Phase 9: Optional Chaining
-Phase 3 → Phase 10: Object & Array/Tuple Spread (also requires Phase 13 for tuple spread)
+Phase 3 → Phase 10: Object & Array/Tuple Spread ✅ (also requires Phase 13 for tuple spread)
 Phase 3 → Phase 13: Variadic Tuple Types ✅
 ```
 
@@ -2073,7 +2075,7 @@ All phases → Phase 11: Error Reporting
 | 7: Row Polymorphism ✅            | 6          | 12                   |
 | 8: Destructuring ✅               | 7, 14      | —                    |
 | 9: Optional Chaining              | 2          | 3–14                 |
-| 10: Object & Array/Tuple Spread   | 3, 13      | 4–14                 |
+| 10: Object & Array/Tuple Spread ✅| 3, 13      | 4–14                 |
 | 11: Error Reporting               | all        | —                    |
 | 12: Tuple/Array Inference ✅      | 6          | 7, 13                |
 | 13: Variadic Tuple Types ✅       | 3          | 4–12                 |
@@ -2094,9 +2096,9 @@ All phases → Phase 11: Error Reporting
    inside the union. May be complex — consider deferring if it destabilizes
    earlier phases.
 
-3. **Multiple RestSpreadElems (Phase 10):** Property distribution across
-   unbound rest elements is inherently ambiguous. Keep the error case for
-   ambiguous distributions.
+3. ~~**Multiple RestSpreadElems (Phase 10):**~~ Resolved. Property distribution
+   across unbound rest elements is inherently ambiguous — the error case for
+   ambiguous distributions is kept as designed in `unifyClosedWithRests`.
 
 4. **Snapshot tests:** Adding `Open` to `ObjectType` shouldn't change printed
    types (it's an internal flag), but changes to `RestSpreadElem` handling in

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -1359,10 +1359,14 @@ Tested in `TestObjectSpread/SpreadOverrideSemantics`.
   (`unifyClosedWithRests` in `unify.go`)
 - **Update `getObjectAccess`** to search all elements in reverse order (both
   explicit properties and `RestSpreadElem`s in a single pass) so that later
-  elements override earlier ones. Both the `PropertyKey` and `IndexKey`
-  (string-literal) branches use this approach. Note: adding new properties via
-  `getObjectAccess` is gated by the `Open` field, not by the presence of
-  `RestSpreadElem`s. ✅
+  elements override earlier ones. All three branches (`PropertyKey`, `IndexKey`
+  string-literal, and `IndexKey` unique-symbol) use this approach.
+  `getSpreadPropertyType` applies spread semantics for string-key lookups
+  (methods → fn type, getters → return type, setter-only → skip).
+  `resolveToObjectType` resolves through `MutabilityType` and `TypeRefType`
+  aliases for symbol-key lookups (e.g. finding `Symbol.iterator` on a spread
+  `Array<T>`). Note: adding new properties via `getObjectAccess` is gated by
+  the `Open` field, not by the presence of `RestSpreadElem`s. ✅
 
 ### 13. Tuple and Array Inference from Indexing Patterns
 
@@ -1938,6 +1942,10 @@ val result = [0, ...arr]
     `GetIterableElementType`. The iterable constraint is enforced structurally
     at call sites when unification resolves the type variable — no upfront
     constraint is needed (same deferred approach as `ArrayConstraint`).
+- **Collapse array-only tuples:** `collapseArrayRestSpreads` in `infer_expr.go`
+  collapses tuples that contain only `Array<T>` rest spreads into a plain
+  `Array<T>` (single rest) or `Array<T1 | T2>` (multiple rests). This ensures
+  `[...Set<number>]` produces `Array<number>` rather than `[...Array<number>]`.
 - **Unification:** Tuple-vs-tuple unification with `RestSpreadType` (Phase 13)
   already handles the mechanics. No additional unification changes needed.
 - **Display:** `TupleType.String()` already handles `RestSpreadType` elements

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -1330,6 +1330,13 @@ When both are already bound:
 1. Merge all properties from both rest elements with the explicit properties.
 2. Unify the merged result with the target type.
 
+**Limitation (#410):** The above cases describe unification where one side has
+`RestSpreadElem`s and the other is concrete. When **both** sides of a
+closed-vs-closed unification contain `RestSpreadElem`s, the checker returns
+`UnimplementedError`. This case does not arise in normal usage — spread
+expressions unify against concrete types or type variables (bound by call-site
+arguments), not against other spread expressions.
+
 #### 12d. Property override semantics
 
 In JavaScript/TypeScript, later spreads override earlier ones for shared

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -1246,10 +1246,10 @@ Row polymorphism adds complexity. The following are initially out of scope:
 Note: **multiple row variables** (functions where multiple parameters each have
 their own row variable that appears in the return type) are **in scope** and
 **implemented**. Tested in `TestRowTypesRowPolymorphism/MultipleParamsRowPolymorphism`.
-The spread-based pattern `fn merge(a, b) { return {...a, ...b} }` requires
-Phase 10 (Object Spread).
+The spread-based pattern `fn merge(a, b) { return {...a, ...b} }` is
+**implemented** (Phase 10). Tested in `TestObjectSpread/MultipleSpreads`.
 
-### 12. Object Spread and Multiple RestSpreadElems
+### 12. Object Spread and Multiple RestSpreadElems ✅
 
 Object spread expressions (`{...obj, extra: 1}`) are parsed but not yet handled
 by the checker. Additionally, the unifier currently rejects the case where both
@@ -1344,17 +1344,25 @@ type inference, the rightmost definition of a property wins. When building the
 `ObjectType` from the `ObjectExpr`, properties from later elements shadow
 properties from earlier elements (including from earlier spreads).
 
+**Implemented:** `getObjectAccess` searches all elements (explicit properties
+and `RestSpreadElem`s) in a single reverse-order pass so that later elements
+override earlier ones regardless of whether they are explicit or from a spread.
+Tested in `TestObjectSpread/SpreadOverrideSemantics`.
+
 #### 12e. Implementation notes
 
 - **Add `ObjSpreadExpr` case** to `ObjectExpr` inference in `infer_expr.go`:
   infer the spread source type and add a `RestSpreadElem` to the result's
-  `Elems`.
+  `Elems`. ✅
 - **Update the unifier** to handle the two-rest-elem case instead of returning
-  `UnimplementedError`. Implement the distribution logic from 12c.
-- **Update `getObjectAccess`** to look through `RestSpreadElem`s when searching
-  for a property — if the property isn't found in the explicit elements, check
-  each rest element's type. Note: adding new properties via `getObjectAccess`
-  is gated by the `Open` field, not by the presence of `RestSpreadElem`s.
+  `UnimplementedError`. Implement the distribution logic from 12c. ✅
+  (`unifyClosedWithRests` in `unify.go`)
+- **Update `getObjectAccess`** to search all elements in reverse order (both
+  explicit properties and `RestSpreadElem`s in a single pass) so that later
+  elements override earlier ones. Both the `PropertyKey` and `IndexKey`
+  (string-literal) branches use this approach. Note: adding new properties via
+  `getObjectAccess` is gated by the `Open` field, not by the presence of
+  `RestSpreadElem`s. ✅
 
 ### 13. Tuple and Array Inference from Indexing Patterns
 
@@ -1783,7 +1791,7 @@ val r = identity([1, "hello"])
   rest binding's type — this is now possible thanks to variadic tuple support
   (Phase 13), rather than collapsing to `Array<T>`.
 
-### 16. Array/Tuple Spread
+### 16. Array/Tuple Spread ✅
 
 Array/tuple spread expressions (`[...arr, extra]`) allow spreading an iterable
 into a tuple literal. The checker already handles `ArraySpreadExpr` in


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Object spread now uses a single reverse-order scan so later elements consistently override earlier ones.

* **Improvements**
  * Tuple/array spread inference refined; multiple array spreads can collapse into a single array element type.
  * Spread preserves methods/getters as callables and omits setter-only properties.
  * More robust handling and unification for objects involving rest spreads; some complex both-sides rest cases remain unimplemented.

* **Tests**
  * Added comprehensive tests for object, tuple, and array spread behaviors.

* **Documentation**
  * Updated planning and requirements to reflect implemented spread semantics and examples.

* **Public Types**
  * Updated some TypeScript return types from tuple-spread to standard array forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->