### PR TITLE
Row Types 9 - Optional Chaining

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1320,8 +1320,12 @@ func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, 
 
 		pType, pErrors := c.getMemberType(ctx, definedElems[0], key)
 		errors = slices.Concat(errors, pErrors)
-		propType := type_system.NewUnionType(nil, pType, type_system.NewUndefinedType(nil))
-		return propType, errors
+		// Only add undefined if the inner result doesn't already contain it
+		// (e.g. from a nested optional chain on a TypeVarType).
+		if !typeContainsUndefined(pType) {
+			pType = type_system.NewUnionType(nil, pType, type_system.NewUndefinedType(nil))
+		}
+		return pType, errors
 	}
 
 	if len(definedElems) > 1 {
@@ -1343,7 +1347,8 @@ func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, 
 		resultType := type_system.NewUnionType(nil, memberTypes...)
 
 		// If there are undefined elements, add undefined to the union
-		if undefinedCount > 0 {
+		// (unless the result already contains it from a nested optional chain).
+		if undefinedCount > 0 && !typeContainsUndefined(resultType) {
 			resultType = type_system.NewUnionType(nil, resultType, type_system.NewUndefinedType(nil))
 		}
 

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -727,6 +727,14 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 				return c.getArrayConstraintPropertyAccess(ctx, t, k.Name, errors)
 			}
 			propTV, openObj := c.newOpenObjectWithProperty(k.Name)
+			if k.OptChain {
+				// Optional chaining: obj?.bar infers obj: {bar: T} | null | undefined.
+				// Use the unwrapped ObjectType (not MutabilityType) since you can't
+				// mutate through optional chaining — the object might be null/undefined.
+				t.Instance = type_system.NewUnionType(nil, openObj.Type, type_system.NewNullType(nil), type_system.NewUndefinedType(nil))
+				// The expression obj?.bar itself may produce undefined
+				return type_system.NewUnionType(nil, propTV, type_system.NewUndefinedType(nil)), errors
+			}
 			t.Instance = openObj
 			return propTV, errors
 		case IndexKey:

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -642,9 +642,13 @@ func closeOpenObjectsInType(t type_system.Type, returnVars map[int]*type_system.
 	case *type_system.MutabilityType:
 		closeOpenObjectsInType(p.Type, returnVars)
 	case *type_system.ObjectType:
-		for _, elem := range p.Elems {
-			if prop, ok := elem.(*type_system.PropertyElem); ok {
-				closeOpenObjectsInType(prop.Value, returnVars)
+		if p.Open {
+			closeObjectType(p, returnVars)
+		} else {
+			for _, elem := range p.Elems {
+				if prop, ok := elem.(*type_system.PropertyElem); ok {
+					closeOpenObjectsInType(prop.Value, returnVars)
+				}
 			}
 		}
 	case *type_system.TypeRefType:

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2916,7 +2916,7 @@ func TestRowTypesOptionalChaining(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined | undefined",
+				"foo": "fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined",
 			},
 		},
 		"AllOptional": {

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2906,7 +2906,7 @@ func TestRowTypesOptionalChaining(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0, T1>(obj: {bar: T0, ...T1} | null | undefined) -> T0 | undefined",
+				"foo": "fn <T0>(obj: {bar: T0} | null | undefined) -> T0 | undefined",
 			},
 		},
 		"NestedOptionalChaining": {
@@ -2916,7 +2916,7 @@ func TestRowTypesOptionalChaining(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined",
+				"foo": "fn <T0>(a: {b: {c: T0} | null | undefined} | null | undefined) -> T0 | undefined",
 			},
 		},
 		"AllOptional": {
@@ -2928,7 +2928,32 @@ func TestRowTypesOptionalChaining(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0, T1, T2>(obj: {bar: T0, ...T1, baz: T2} | null | undefined) -> void",
+				"foo": "fn <T0, T1>(obj: {bar: T0, baz: T1} | null | undefined) -> void",
+			},
+		},
+		"OptionalChainingWithReturn": {
+			// Returning the nullable object preserves the row variable
+			input: `
+				fn foo(obj) {
+					val x = obj?.bar
+					return obj
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(obj: {bar: T0, ...T1} | null | undefined) -> {bar: T0, ...T1} | null | undefined",
+			},
+		},
+		"OptionalChainingRowPolyCall": {
+			// Calling a function that uses ?. with extra properties
+			input: `
+				fn foo(obj) {
+					return obj?.bar
+				}
+				val r = foo({bar: 1, baz: "hello"})
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0>(obj: {bar: T0} | null | undefined) -> T0 | undefined",
+				"r":   "1 | undefined",
 			},
 		},
 	}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -2893,3 +2893,87 @@ func TestTupleSpreadRefined(t *testing.T) {
 		})
 	}
 }
+
+func TestRowTypesOptionalChaining(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"BasicOptionalChaining": {
+			input: `
+				fn foo(obj) {
+					return obj?.bar
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1>(obj: {bar: T0, ...T1} | null | undefined) -> T0 | undefined",
+			},
+		},
+		"NestedOptionalChaining": {
+			input: `
+				fn foo(a) {
+					return a?.b?.c
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined | undefined",
+			},
+		},
+		"AllOptional": {
+			// Second ?. adds baz to the open ObjectType inside the union
+			input: `
+				fn foo(obj) {
+					val x = obj?.bar
+					val y = obj?.baz
+				}
+			`,
+			expectedTypes: map[string]string{
+				"foo": "fn <T0, T1, T2>(obj: {bar: T0, ...T1, baz: T2} | null | undefined) -> void",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actualTypes := inferModuleTypes(t, test.input)
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				require.True(t, exists, "Expected variable %s to be declared", expectedName)
+				assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+			}
+		})
+	}
+}
+
+func TestRowTypesOptionalChainingErrors(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		expectedErrs []string
+	}{
+		"MixOptionalAndNonOptional": {
+			// After obj?.bar, obj is nullable — non-optional .baz should error
+			input: `
+				fn foo(obj) {
+					val x = obj?.bar
+					val y = obj.baz
+				}
+			`,
+			expectedErrs: []string{"Expected an object type"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, inferErrors := inferModuleTypesAndErrors(t, test.input)
+
+			require.Len(t, inferErrors, len(test.expectedErrs), "expected %d errors, got %d", len(test.expectedErrs), len(inferErrors))
+			for i, expectedErr := range test.expectedErrs {
+				if i < len(inferErrors) {
+					assert.Contains(t, inferErrors[i].Message(), expectedErr)
+				}
+			}
+		})
+	}
+}

--- a/internal/checker/utils.go
+++ b/internal/checker/utils.go
@@ -148,6 +148,32 @@ func (c *Checker) getDefinedElems(unionType *type_system.UnionType) []type_syste
 	return definedElems
 }
 
+// typeContainsUndefined reports whether t is undefined or is a union that
+// already contains an undefined member. Used to avoid duplicate undefined
+// entries when building result types for optional chaining.
+func typeContainsUndefined(t type_system.Type) bool {
+	if isUndefinedLitType(t) {
+		return true
+	}
+	if u, ok := t.(*type_system.UnionType); ok {
+		for _, elem := range u.Types {
+			if isUndefinedLitType(elem) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isUndefinedLitType(t type_system.Type) bool {
+	if lit, ok := t.(*type_system.LitType); ok {
+		if _, ok := lit.Lit.(*type_system.UndefinedLit); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveQualifiedTypeAlias resolves a qualified type name by traversing namespace hierarchy
 func resolveQualifiedTypeAlias(ctx Context, qualIdent type_system.QualIdent) *type_system.TypeAlias {
 	switch qi := qualIdent.(type) {

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1030,7 +1030,9 @@ preserved even when not in the return type, since the user explicitly wrote
      This triggers the TypeVarType case again, binding `t_b` to
      `{c: t_c, ...R2} | null | undefined`.
    - Result: `a: {b: {c: t_c, ...R2} | null | undefined, ...R} | null | undefined`,
-     expression type `t_c | undefined | undefined`.
+     expression type `t_c | undefined`. (`getUnionAccess` skips adding
+     `| undefined` when the inner result already contains it, via
+     `typeContainsUndefined` in `utils.go`.)
 
 4. **Return type of optional chaining expression:** The expression `obj?.bar`
    has type `propTV | undefined`. The inferred property type itself is just
@@ -1054,7 +1056,7 @@ Tests are in `TestRowTypesOptionalChaining` and
   `fn <T0, T1>(obj: {bar: T0, ...T1} | null | undefined) -> T0 | undefined`.
 - **Nested optional:**
   `fn foo(a) { return a?.b?.c }` →
-  `fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined | undefined`.
+  `fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined`.
 - **All optional:**
   `fn foo(obj) { val x = obj?.bar; val y = obj?.baz }` →
   `fn <T0, T1, T2>(obj: {bar: T0, ...T1, baz: T2} | null | undefined) -> void`

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -977,7 +977,7 @@ preserved even when not in the return type, since the user explicitly wrote
 
 ---
 
-## Phase 9: Optional Chaining
+## Phase 9: Optional Chaining ✅
 
 **Requirements covered:** Section 4 (optional chaining).
 
@@ -986,28 +986,19 @@ preserved even when not in the return type, since the user explicitly wrote
 ### Changes
 
 1. **`internal/checker/expand_type.go`** — `getMemberType`, TypeVarType case:
-   When the key is a `PropertyKey` with `OptChain: true`:
+   When the key is a `PropertyKey` with `OptChain: true`, reuses
+   `newOpenObjectWithProperty` but unwraps the `MutabilityType` — the open
+   `ObjectType` is placed directly into the union because you cannot mutate
+   through optional chaining (the object might be null/undefined):
    ```go
-   propTV := c.FreshVar(nil)
-   propTV.Widenable = true
-   rowTV := c.FreshVar(nil)
-   openObj := NewObjectType(nil, []ObjTypeElem{
-       NewPropertyElem(NewStrKey(k.Name), propTV),
-       NewRestSpreadElem(rowTV),
-   })
-   openObj.Open = true
-   // Wrap the open object in MutabilityUncertain (same as Phase 2's
-   // non-optional path) so writes through optional chaining work.
-   mutObj := NewMutabilityType(nil, openObj, MutabilityUncertain)
-   // Wrap in union with null and undefined
-   typeVar.Instance = NewUnionType(nil, mutObj, NewNullType(nil), NewUndefinedType(nil))
-   // Return propTV | undefined (the ?. expression itself may produce undefined)
-   return NewUnionType(nil, propTV, NewUndefinedType(nil))
+   propTV, openObj := c.newOpenObjectWithProperty(k.Name)
+   if k.OptChain {
+       // Use the unwrapped ObjectType (not MutabilityType) since you can't
+       // mutate through optional chaining.
+       t.Instance = NewUnionType(nil, openObj.Type, NewNullType(nil), NewUndefinedType(nil))
+       return NewUnionType(nil, propTV, NewUndefinedType(nil))
+   }
    ```
-
-   The null/undefined type constructors are `NewNullType(nil)` and
-   `NewUndefinedType(nil)` (confirmed in `types.go` — both return `*LitType`
-   wrapping `NullLit{}` and `UndefinedLit{}` respectively).
 
 2. **Subsequent accesses on the union:** After `obj?.bar`, `typeVar.Instance` is
    `{bar: t1, ...R} | null | undefined`. If the user subsequently accesses
@@ -1015,7 +1006,7 @@ preserved even when not in the return type, since the user explicitly wrote
    `getMemberType` hits the `UnionType` case → `getUnionAccess`.
 
    **How `getUnionAccess` handles this:** `getUnionAccess` (expand_type.go
-   ~line 827) already handles unions containing null/undefined:
+   ~line 1290) already handles unions containing null/undefined:
    - It calls `c.getDefinedElems(unionType)` to filter out null/undefined
      members.
    - If null/undefined are present **without** optional chaining (`?.`), it
@@ -1027,19 +1018,19 @@ preserved even when not in the return type, since the user explicitly wrote
 
    This means:
    - `obj?.baz` on `{bar: t1} | null | undefined` works: accesses the open
-     ObjectType, adds `baz`, returns `t2 | undefined`.
+     ObjectType via `getObjectAccess`, adds `baz`, returns `t2 | undefined`.
    - `obj.baz` (non-optional) on the same union correctly errors — the user
      should use `?.` since the type is nullable. No special handling needed.
 
 3. **Nested optional chaining (`a?.b?.c`):**
    - `a?.b` binds `a` to `{b: t_b, ...R} | null | undefined`, returns
      `t_b | undefined`.
-   - `(t_b | undefined)?.c`: the `?.` operator strips `undefined` from the
-     receiver. The remaining type is `t_b`, which is a `TypeVarType`. This
-     triggers the TypeVarType case again, binding `t_b` to
+   - `(t_b | undefined)?.c`: `getUnionAccess` strips `undefined` via
+     `getDefinedElems`. The remaining type is `t_b`, which is a `TypeVarType`.
+     This triggers the TypeVarType case again, binding `t_b` to
      `{c: t_c, ...R2} | null | undefined`.
    - Result: `a: {b: {c: t_c, ...R2} | null | undefined, ...R} | null | undefined`,
-     expression type `t_c | undefined`.
+     expression type `t_c | undefined | undefined`.
 
 4. **Return type of optional chaining expression:** The expression `obj?.bar`
    has type `propTV | undefined`. The inferred property type itself is just
@@ -1047,21 +1038,31 @@ preserved even when not in the return type, since the user explicitly wrote
    the access expression, not the property. This matches existing optional
    chaining semantics.
 
+5. **No `MutabilityType` wrapper:** Unlike the non-optional path which wraps
+   the open object in `MutabilityUncertain`, the optional chaining path uses
+   the raw `ObjectType`. Since the object might be null/undefined, mutation
+   through `?.` is not meaningful. This means the inferred parameter type
+   prints as `{bar: T0, ...T1} | null | undefined` (no `mut?` prefix).
+
 ### Tests
 
+Tests are in `TestRowTypesOptionalChaining` and
+`TestRowTypesOptionalChainingErrors` in `row_types_test.go`.
+
 - **Basic optional chaining:**
-  `fn foo(obj) { let x = obj?.bar }` — `obj: {bar: t1} | null | undefined`,
-  `x: t1 | undefined`.
+  `fn foo(obj) { return obj?.bar }` →
+  `fn <T0, T1>(obj: {bar: T0, ...T1} | null | undefined) -> T0 | undefined`.
 - **Nested optional:**
-  `fn foo(a) { let x = a?.b?.c }` — nested nullability as described above.
-- **Mix of optional and non-optional:**
-  `fn foo(obj) { let x = obj?.bar; let y = obj.baz }` — error on `obj.baz`
-  because `obj` is `{bar: t1} | null | undefined` and non-optional `.` on a
-  nullable type is an error (`getUnionAccess` reports it).
+  `fn foo(a) { return a?.b?.c }` →
+  `fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined | undefined`.
 - **All optional:**
-  `fn foo(obj) { let x = obj?.bar; let y = obj?.baz }` — `obj` is
-  `{bar: t1, baz: t2} | null | undefined` (second `?.` adds `baz` to the open
-  ObjectType inside the union).
+  `fn foo(obj) { val x = obj?.bar; val y = obj?.baz }` →
+  `fn <T0, T1, T2>(obj: {bar: T0, ...T1, baz: T2} | null | undefined) -> void`
+  (second `?.` adds `baz` to the open ObjectType inside the union).
+- **Mix of optional and non-optional (error):**
+  `fn foo(obj) { val x = obj?.bar; val y = obj.baz }` → error on `obj.baz`
+  because `obj` is nullable and non-optional `.` on a nullable type is flagged
+  by `getUnionAccess`.
 
 ---
 
@@ -2097,7 +2098,7 @@ Phase 7, Phase 14 → Phase 8: Destructuring ✅
 ### Independent branches (can start early)
 
 ```
-Phase 2 → Phase 9: Optional Chaining
+Phase 2 → Phase 9: Optional Chaining ✅
 Phase 3 → Phase 10: Object & Array/Tuple Spread ✅ (also requires Phase 13 for tuple spread)
 Phase 3 → Phase 13: Variadic Tuple Types ✅
 ```
@@ -2120,7 +2121,7 @@ All phases → Phase 11: Error Reporting
 | 6: Closing ✅                     | 5          | —                    |
 | 7: Row Polymorphism ✅            | 6          | 12                   |
 | 8: Destructuring ✅               | 7, 14      | —                    |
-| 9: Optional Chaining              | 2          | 3–14                 |
+| 9: Optional Chaining ✅           | 2          | 3–14                 |
 | 10: Object & Array/Tuple Spread ✅| 3, 13      | 4–14                 |
 | 11: Error Reporting               | all        | —                    |
 | 12: Tuple/Array Inference ✅      | 6          | 7, 13                |

--- a/planning/row_types/implementation_plan.md
+++ b/planning/row_types/implementation_plan.md
@@ -1043,8 +1043,22 @@ preserved even when not in the return type, since the user explicitly wrote
 5. **No `MutabilityType` wrapper:** Unlike the non-optional path which wraps
    the open object in `MutabilityUncertain`, the optional chaining path uses
    the raw `ObjectType`. Since the object might be null/undefined, mutation
-   through `?.` is not meaningful. This means the inferred parameter type
-   prints as `{bar: T0, ...T1} | null | undefined` (no `mut?` prefix).
+   through `?.` is not meaningful.
+
+6. **Closing:** `closeOpenObjectsInType` in `infer_func.go` now closes open
+   `ObjectType`s found inside unions (not just those directly behind a
+   TypeVar → MutabilityType chain). The `ObjectType` case in the switch
+   calls `closeObjectType` when `p.Open` is true, which sets `Open = false`,
+   recurses into property values, and removes `RestSpreadElem`s whose row
+   variables don't appear in the return type. This means the final inferred
+   parameter type is `{bar: T0} | null | undefined` (closed, no rest spread),
+   matching the non-optional equivalent.
+
+7. **Undefined deduplication:** `getUnionAccess` uses `typeContainsUndefined`
+   (in `utils.go`) before adding `| undefined` to the result. This prevents
+   nested optional chains from producing `T | undefined | undefined`: the
+   inner TypeVarType case returns `T | undefined`, and `getUnionAccess` sees
+   undefined is already present and skips adding another.
 
 ### Tests
 
@@ -1053,14 +1067,21 @@ Tests are in `TestRowTypesOptionalChaining` and
 
 - **Basic optional chaining:**
   `fn foo(obj) { return obj?.bar }` →
-  `fn <T0, T1>(obj: {bar: T0, ...T1} | null | undefined) -> T0 | undefined`.
+  `fn <T0>(obj: {bar: T0} | null | undefined) -> T0 | undefined`.
 - **Nested optional:**
   `fn foo(a) { return a?.b?.c }` →
-  `fn <T0, T1, T2>(a: {b: {c: T0, ...T1} | null | undefined, ...T2} | null | undefined) -> T0 | undefined`.
+  `fn <T0>(a: {b: {c: T0} | null | undefined} | null | undefined) -> T0 | undefined`.
 - **All optional:**
   `fn foo(obj) { val x = obj?.bar; val y = obj?.baz }` →
-  `fn <T0, T1, T2>(obj: {bar: T0, ...T1, baz: T2} | null | undefined) -> void`
+  `fn <T0, T1>(obj: {bar: T0, baz: T1} | null | undefined) -> void`
   (second `?.` adds `baz` to the open ObjectType inside the union).
+- **Optional chaining with return (row polymorphism):**
+  `fn foo(obj) { val x = obj?.bar; return obj }` →
+  `fn <T0, T1>(obj: {bar: T0, ...T1} | null | undefined) -> {bar: T0, ...T1} | null | undefined`
+  (row variable preserved because it escapes to the return type).
+- **Optional chaining row poly call:**
+  `fn foo(obj) { return obj?.bar }; val r = foo({bar: 1, baz: "hello"})` →
+  `r: 1 | undefined` (extra properties accepted, closed row variable removed).
 - **Mix of optional and non-optional (error):**
   `fn foo(obj) { val x = obj?.bar; val y = obj.baz }` → error on `obj.baz`
   because `obj` is nullable and non-optional `.` on a nullable type is flagged

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -288,7 +288,10 @@ variable should be bound to `Array<T>` rather than an open `ObjectType`.
 > `ObjectType` is placed directly in the union (no `MutabilityType` wrapper)
 > since mutation through `?.` is not meaningful. Existing `getUnionAccess`
 > handles subsequent accesses on the nullable union, including error reporting
-> for non-optional access on a nullable type.
+> for non-optional access on a nullable type. Open objects inside unions are
+> properly closed by `closeOpenObjectsInType` after body inference, and row
+> polymorphism works correctly (row variables that escape to the return type
+> are preserved).
 
 When optional chaining (`?.`) is used on a value whose type is a type variable,
 the system must:
@@ -332,12 +335,15 @@ fn foo(a) {
 
 ### 5. Open vs. Closed Object Types ✅
 
-> **Status (2026-04-08):** Fully implemented. `closeOpenParams` in
+> **Status (2026-04-11):** Fully implemented. `closeOpenParams` in
 > `infer_func.go` closes all open object types on parameters after
 > `inferFuncBodyWithFuncSigType` completes. `closeObjectType` recursively
 > closes nested open objects. `RestSpreadElem`s whose row variables don't
 > appear in the return type are removed. Row variables that escape to the
 > return type are preserved for Phase 7 (row polymorphism).
+> `closeOpenObjectsInType` also closes open `ObjectType`s found inside
+> unions (e.g. from optional chaining, where the parameter type is
+> `{bar: T} | null | undefined`).
 
 The inferred object type for an unannotated parameter should be **open** during
 inference of the function body — the property set can grow as new usages are

--- a/planning/row_types/requirements.md
+++ b/planning/row_types/requirements.md
@@ -281,7 +281,14 @@ access would fail because `ObjectType` doesn't support numeric indexing (unless
 a numeric index signature is added). If only numeric indexing is used, the type
 variable should be bound to `Array<T>` rather than an open `ObjectType`.
 
-### 4. Optional Chaining
+### 4. Optional Chaining ✅
+
+> **Status (2026-04-11):** Implemented. See Phase 9 in
+> [implementation_plan.md](implementation_plan.md) for details. The open
+> `ObjectType` is placed directly in the union (no `MutabilityType` wrapper)
+> since mutation through `?.` is not meaningful. Existing `getUnionAccess`
+> handles subsequent accesses on the nullable union, including error reporting
+> for non-optional access on a nullable type.
 
 When optional chaining (`?.`) is used on a value whose type is a type variable,
 the system must:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optional-chaining inference so receivers become nullable objects, results include `undefined` only when appropriate, and redundant `undefined` entries are avoided; non-optional access on a nullable receiver now reports the correct error.

* **Tests**
  * Added success and error tests for optional chaining, nested/chained accesses, and interactions with inferred open object properties.

* **Documentation**
  * Updated planning/spec docs to mark optional chaining complete and describe the revised behavior for open object closing and undefined handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->