### PR TITLE
Fix #411

### DIFF
--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -142,6 +142,7 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 			return fresh
 		}
 		fresh := c.FreshVar(nil)
+		fresh.IsObjectRest = t.IsObjectRest
 		varMapping[t.ID] = fresh
 		if t.Constraint != nil {
 			fresh.Constraint = c.deepCloneType(t.Constraint, varMapping)

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -285,11 +285,22 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					elemTypes = append(elemTypes, st.Elems...)
 					handled = true
 				case *type_system.TypeVarType:
-					// Unannotated parameter — no upfront iterable constraint is added.
-					// The constraint is enforced structurally at call sites: when the
-					// caller passes a concrete argument, unification resolves the type
-					// variable and validates iterability at that point.
-					elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, st))
+					// If the type variable originated from an object rest pattern
+					// (e.g. {a, ...rest}), it must be an object and is not iterable.
+					if st.IsObjectRest {
+						err := NewGenericError(
+							"Object rest type is not iterable",
+							spread.Span(),
+						)
+						errors = append(errors, err)
+						elementType := type_system.NewAnyType(nil)
+						elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, &type_system.TypeRefType{
+							Name:     type_system.NewIdent("Array"),
+							TypeArgs: []type_system.Type{elementType},
+						}))
+					} else {
+						elemTypes = append(elemTypes, type_system.NewRestSpreadType(nil, st))
+					}
 					handled = true
 				case *type_system.TypeRefType:
 					if c.isArrayType(st) {

--- a/internal/checker/infer_pat.go
+++ b/internal/checker/infer_pat.go
@@ -96,6 +96,12 @@ func (c *Checker) inferPattern(
 				case *ast.ObjRestPat:
 					t, restErrors := inferPatRec(elem.Pattern)
 					errors = slices.Concat(errors, restErrors)
+					// Mark the type variable as originating from an object rest
+					// pattern so that spreading it into a tuple can be flagged
+					// as an error (objects are not iterable).
+					if tvar, ok := t.(*type_system.TypeVarType); ok {
+						tvar.IsObjectRest = true
+					}
 					elems = append(elems, type_system.NewRestSpreadElem(t))
 				}
 			}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -354,6 +354,19 @@ func TestRowTypesErrors(t *testing.T) {
 			`,
 			expectedErrs: []string{"Object rest type is not iterable"},
 		},
+		"AliasedObjectRestSpreadIntoTuple": {
+			// When the object rest is aliased via val before being spread,
+			// bind() must propagate IsObjectRest to the new representative
+			// TypeVar so the tuple spread check still catches it.
+			input: `
+				val foo = fn ({x, ...rest}) {
+					val alias = rest
+					return [x, ...alias]
+				}
+				val r = foo({x: 1, y: 2})
+			`,
+			expectedErrs: []string{"Object rest type is not iterable"},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -343,6 +343,17 @@ func TestRowTypesErrors(t *testing.T) {
 		// PropertyTypeMismatchError enhancement fires when two closed
 		// objects are unified directly (not through widenable type vars).
 		// See also: TestRowTypesPassToTypedFunction for related tests.
+		"ChainedDestructuringWithRestAndSpread": {
+			// Rest from object destructuring spread into a tuple produces
+			// a RestSpreadType wrapping a non-iterable object — see #411.
+			input: `
+				val foo = fn ({x, ...rest}) {
+					return [x, ...rest]
+				}
+				val r = foo({x: 1, y: 2})
+			`,
+			expectedErrs: []string{"Object rest type is not iterable"},
+		},
 	}
 
 	for name, test := range tests {
@@ -2452,26 +2463,7 @@ func TestDestructuringObjectPatterns(t *testing.T) {
 				"r":   "[1, [2, {z: 3}]]",
 			},
 		},
-		"ChainedDestructuringWithRestAndSpread": {
-			// Both functions destructure with rest — rest from outer
-			// is passed to inner which also has a rest element.
-			// NOTE: r's type [1, 2, ...{z: 3}] contains a spread of a
-			// non-iterable object type. This should be an error — see #411.
-			input: `
-				val foo = fn ({y, ...rest}) {
-					return [y, ...rest]
-				}
-				val bar = fn ({x, ...rest}) {
-					return [x, ...foo(rest)]
-				}
-				val r = bar({x: 1, y: 2, z: 3})
-			`,
-			expectedTypes: map[string]string{
-				"foo": "fn <T0, T1>({y: T0, ...rest: T1}) -> [T0, ...T1]",
-				"bar": "fn <T0, T1, T2>({x: T0, ...rest: {y: T1, ...T2}}) -> [T0, T1, ...T2]",
-				"r":   "[1, 2, ...{z: 3}]",
-			},
-		},
+		// ChainedDestructuringWithRestAndSpread moved to TestRowTypesErrors — see #411.
 		"RestPassedToTypedFunction": {
 			// Rest from destructuring passed to a function with a type annotation.
 			// The rest gets typed as {y: number, z: string} from the process call,

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1857,6 +1857,9 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []
 						// representative of this equivalence class after binding.
 						typeVar2.Constraint = typeVar1.Constraint
 					}
+					// Propagate IsObjectRest so that Prune() returns a TypeVar
+					// that preserves the marker for the tuple spread check.
+					typeVar2.IsObjectRest = typeVar2.IsObjectRest || typeVar1.IsObjectRest
 					typeVar1.Instance = t2
 					typeVar1.SetProvenance(&type_system.TypeProvenance{
 						Type: t2,

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -195,6 +195,7 @@ type TypeVarType struct {
 	Widenable       bool             // true for type vars whose type is inferred from usage (e.g. property values on open objects)
 	IsParam         bool             // true for type vars created for unannotated function parameters
 	InstanceChain   []*TypeVarType   // populated by Prune when this TypeVar's Instance is another TypeVar (alias chain from bind); stores all TypeVars in the chain before path compression collapses it
+	IsObjectRest    bool             // true for type vars created for object rest patterns (e.g. {a, ...rest})
 	ArrayConstraint *ArrayConstraint // non-nil when numeric indexing has been observed; resolved during closing
 	provenance      Provenance
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The type checker now detects and reports "Object rest type is not iterable" when an object-rest value is used in iterable/spread contexts (e.g., tuple/array spread). Previously-accepted destructuring/spread cases now produce this clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->