### PR TITLE
Handle property access in lvalues/rvalues correctly

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -96,7 +96,7 @@ func (v *TypeExpansionVisitor) resolveTypeOfQualIdent(ident type_system.QualIden
 			OptChain: false,
 			span:     span,
 		}
-		memberType, memberErrors := v.checker.getMemberType(v.ctx, leftType, propKey)
+		memberType, memberErrors := v.checker.getMemberType(v.ctx, leftType, propKey, AccessRead)
 		v.errors = slices.Concat(v.errors, memberErrors)
 		return memberType
 	default:
@@ -456,7 +456,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 
 		// Use getMemberType to resolve the property access
 		key := IndexKey{Type: expandedIndex, span: span}
-		memberType, memberErrors := v.checker.getMemberType(v.ctx, expandedTarget, key)
+		memberType, memberErrors := v.checker.getMemberType(v.ctx, expandedTarget, key, AccessRead)
 		v.errors = slices.Concat(v.errors, memberErrors)
 		return memberType
 	case *type_system.TypeOfType:
@@ -470,8 +470,10 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 	return nil
 }
 
-// getMemberType is a unified function for getting types from objects via property access or indexing
-func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key MemberAccessKey) (type_system.Type, []Error) {
+// getMemberType is a unified function for getting types from objects via property access or indexing.
+// mode indicates whether the access is a read (rvalue) or write (lvalue), which affects
+// getter/setter resolution: reads use getters, writes use setters.
+func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key MemberAccessKey, mode AccessMode) (type_system.Type, []Error) {
 	errors := []Error{}
 
 	objType = type_system.Prune(objType)
@@ -517,7 +519,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 	switch t := objType.(type) {
 	case *type_system.MutabilityType:
 		// For mutable types, get the access from the inner type
-		return c.getMemberType(ctx, t.Type, key)
+		return c.getMemberType(ctx, t.Type, key, mode)
 	case *type_system.TypeRefType:
 		// Handle Array numeric index access (skip symbol keys like Symbol.iterator)
 		if indexKey, ok := key.(IndexKey); ok && type_system.QualIdentToString(t.Name) == "Array" && !isSymbolIndexKey(key) {
@@ -528,7 +530,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 
 		// Try to expand the type alias and call getAccessType recursively
 		expandType, expandErrors := c.expandTypeRef(ctx, t)
-		accessType, accessErrors := c.getMemberType(ctx, expandType, key)
+		accessType, accessErrors := c.getMemberType(ctx, expandType, key, mode)
 
 		errors = slices.Concat(errors, accessErrors, expandErrors)
 
@@ -591,7 +593,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 				Name:     type_system.NewIdent("Array"),
 				TypeArgs: []type_system.Type{elemUnion},
 			}
-			return c.getMemberType(ctx, arrayRef, key)
+			return c.getMemberType(ctx, arrayRef, key, mode)
 		}
 		// TupleType doesn't support other property access
 		errors = append(errors, &ExpectedObjectError{Type: objType, span: key.Span()})
@@ -615,7 +617,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 				TypeArgs: []type_system.Type{},
 			}
 			if _, ok := key.(PropertyKey); ok || isSymbolIndexKey(key) {
-				return c.getMemberType(ctx, builtinRef, key)
+				return c.getMemberType(ctx, builtinRef, key, mode)
 			}
 		}
 		// Not a supported primitive method call
@@ -641,7 +643,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 				TypeArgs: []type_system.Type{},
 			}
 			if _, ok := key.(PropertyKey); ok || isSymbolIndexKey(key) {
-				return c.getMemberType(ctx, builtinRef, key)
+				return c.getMemberType(ctx, builtinRef, key, mode)
 			}
 		}
 		// Fallback handling for other literals
@@ -655,16 +657,16 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 				Name:     type_system.NewIdent("Function"),
 				TypeArgs: []type_system.Type{},
 			}
-			return c.getMemberType(ctx, functionRef, key)
+			return c.getMemberType(ctx, functionRef, key, mode)
 		}
 		// FuncType doesn't support index access
 		errors = append(errors, &ExpectedObjectError{Type: objType, span: key.Span()})
 		return type_system.NewNeverType(nil), errors
 
 	case *type_system.ObjectType:
-		return c.getObjectAccess(t, key, errors)
+		return c.getObjectAccess(t, key, mode, errors)
 	case *type_system.UnionType:
-		return c.getUnionAccess(ctx, t, key, errors)
+		return c.getUnionAccess(ctx, t, key, mode, errors)
 	case *type_system.NamespaceType:
 		if propKey, ok := key.(PropertyKey); ok {
 			if value := t.Namespace.Values[propKey.Name]; value != nil {
@@ -684,7 +686,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 		errors = append(errors, &ExpectedObjectError{Type: objType, span: key.Span()})
 		return type_system.NewNeverType(nil), errors
 	case *type_system.IntersectionType:
-		return c.getIntersectionAccess(ctx, t, key, errors)
+		return c.getIntersectionAccess(ctx, t, key, mode, errors)
 	case *type_system.TypeVarType:
 		// TODO(#389): Check t.Constraint before synthesizing an open object.
 		// Constrained type variables (e.g. `<T: {name: string}>`) should resolve
@@ -845,10 +847,8 @@ func getSpreadPropertyType(objType *type_system.ObjectType, name string) type_sy
 }
 
 // getObjectAccess handles property and index access on ObjectType.
-// TODO(#412): differentiate between read and write access so that
-// GetterElem returns the getter's return type for reads and SetterElem
-// returns the setter's parameter type for writes.
-func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAccessKey, errors []Error) (type_system.Type, []Error) {
+// mode controls getter/setter resolution: AccessRead uses getters, AccessWrite uses setters.
+func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAccessKey, mode AccessMode, errors []Error) (type_system.Type, []Error) {
 	switch k := key.(type) {
 	case PropertyKey:
 		// Search elements in reverse order so that later elements override
@@ -870,11 +870,11 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					return elem.Fn, errors
 				}
 			case *type_system.GetterElem:
-				if elem.Name == targetKey {
+				if elem.Name == targetKey && mode == AccessRead {
 					return elem.Fn.Return, errors
 				}
 			case *type_system.SetterElem:
-				if elem.Name == targetKey {
+				if elem.Name == targetKey && mode == AccessWrite {
 					return elem.Fn.Params[0].Type, errors
 				}
 			case *type_system.RestSpreadElem:
@@ -918,7 +918,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 
 			if extendsObjType, ok := extendsType.(*type_system.ObjectType); ok {
 				// Recursively check the extended type
-				return c.getObjectAccess(extendsObjType, key, errors)
+				return c.getObjectAccess(extendsObjType, key, mode, errors)
 			}
 
 			// If the extended type cannot be resolved to an ObjectType,
@@ -961,11 +961,11 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 							return elem.Fn, errors
 						}
 					case *type_system.GetterElem:
-						if elem.Name == targetKey {
+						if elem.Name == targetKey && mode == AccessRead {
 							return elem.Fn.Return, errors
 						}
 					case *type_system.SetterElem:
-						if elem.Name == targetKey {
+						if elem.Name == targetKey && mode == AccessWrite {
 							return elem.Fn.Params[0].Type, errors
 						}
 					case *type_system.RestSpreadElem:
@@ -1007,16 +1007,16 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						return elem.Fn, errors
 					}
 				case *type_system.GetterElem:
-					if elem.Name == symKey {
+					if elem.Name == symKey && mode == AccessRead {
 						return elem.Fn.Return, errors
 					}
 				case *type_system.SetterElem:
-					if elem.Name == symKey {
+					if elem.Name == symKey && mode == AccessWrite {
 						return elem.Fn.Params[0].Type, errors
 					}
 				case *type_system.RestSpreadElem:
 					if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-						symPropType, symPropErrors := c.getObjectAccess(resolvedObj, key, nil)
+						symPropType, symPropErrors := c.getObjectAccess(resolvedObj, key, mode, nil)
 						if len(symPropErrors) == 0 {
 							return symPropType, errors
 						}
@@ -1048,7 +1048,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 			}
 			if extendsObjType, ok := extendsType.(*type_system.ObjectType); ok {
 				// Recursively check the extended type
-				return c.getObjectAccess(extendsObjType, key, errors)
+				return c.getObjectAccess(extendsObjType, key, mode, errors)
 			}
 		}
 
@@ -1230,7 +1230,7 @@ func (c *Checker) getArrayConstraintPropertyAccess(ctx Context, t *type_system.T
 	constraint.MethodElemVars = append(constraint.MethodElemVars, freshElem)
 
 	tempArrayType := type_system.NewTypeRefType(nil, "Array", arrayAlias, freshElem)
-	resultType, accessErrors := c.getMemberType(ctx, tempArrayType, PropertyKey{Name: propName})
+	resultType, accessErrors := c.getMemberType(ctx, tempArrayType, PropertyKey{Name: propName}, AccessRead)
 	errors = slices.Concat(errors, accessErrors)
 
 	// Classify the method as mutating or read-only.
@@ -1317,7 +1317,7 @@ func (c *Checker) isArrayMutatingMethod(methodName string) bool {
 }
 
 // getUnionAccess handles property and index access on UnionType
-func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, key MemberAccessKey, errors []Error) (type_system.Type, []Error) {
+func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, key MemberAccessKey, mode AccessMode, errors []Error) (type_system.Type, []Error) {
 	propKey, isPropertyKey := key.(PropertyKey)
 
 	definedElems := c.getDefinedElems(unionType)
@@ -1332,7 +1332,7 @@ func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, 
 
 	if len(definedElems) == 1 {
 		if undefinedCount == 0 {
-			return c.getMemberType(ctx, definedElems[0], key)
+			return c.getMemberType(ctx, definedElems[0], key, mode)
 		}
 
 		if undefinedCount > 0 && isPropertyKey && !propKey.OptChain {
@@ -1340,7 +1340,7 @@ func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, 
 			return type_system.NewUndefinedType(nil), errors
 		}
 
-		pType, pErrors := c.getMemberType(ctx, definedElems[0], key)
+		pType, pErrors := c.getMemberType(ctx, definedElems[0], key, mode)
 		errors = slices.Concat(errors, pErrors)
 		// Only add undefined if the inner result doesn't already contain it
 		// (e.g. from a nested optional chain on a TypeVarType).
@@ -1354,7 +1354,7 @@ func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, 
 		// Get the member type from each element in the union and combine them
 		memberTypes := []type_system.Type{}
 		for _, elem := range definedElems {
-			memberType, memberErrors := c.getMemberType(ctx, elem, key)
+			memberType, memberErrors := c.getMemberType(ctx, elem, key, mode)
 			errors = slices.Concat(errors, memberErrors)
 			memberTypes = append(memberTypes, memberType)
 		}
@@ -1381,7 +1381,7 @@ func (c *Checker) getUnionAccess(ctx Context, unionType *type_system.UnionType, 
 }
 
 // getIntersectionAccess handles property and index access on IntersectionType
-func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_system.IntersectionType, key MemberAccessKey, errors []Error) (type_system.Type, []Error) {
+func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_system.IntersectionType, key MemberAccessKey, mode AccessMode, errors []Error) (type_system.Type, []Error) {
 	// For an intersection A & B, member access should:
 	// 1. If all parts are object types, merge their properties (the result is the intersection of matching property types)
 	// 2. Otherwise, try to access from each part and use the first successful one
@@ -1410,7 +1410,7 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 		foundAny := false
 
 		for _, objType := range objectTypes {
-			memberType, memberErrors := c.getObjectAccess(objType, key, nil)
+			memberType, memberErrors := c.getObjectAccess(objType, key, mode, nil)
 			// Only include results from object types that have this property
 			if len(memberErrors) == 0 {
 				memberTypes = append(memberTypes, memberType)
@@ -1448,7 +1448,7 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 	// First, collect all properties from object type parts
 	memberTypesFromObjects := []type_system.Type{}
 	for _, objType := range objectTypes {
-		memberType, memberErrors := c.getObjectAccess(objType, key, nil)
+		memberType, memberErrors := c.getObjectAccess(objType, key, mode, nil)
 		if len(memberErrors) == 0 {
 			memberTypesFromObjects = append(memberTypesFromObjects, memberType)
 		}
@@ -1475,7 +1475,7 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 		if _, ok := unwrapped.(*type_system.ObjectType); ok {
 			continue
 		}
-		memberType, memberErrors := c.getMemberType(ctx, part, key)
+		memberType, memberErrors := c.getMemberType(ctx, part, key, mode)
 		if len(memberErrors) == 0 {
 			return memberType, errors
 		}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -806,46 +806,6 @@ func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
 	return nil
 }
 
-// getSpreadPropertyType looks up a property in an ObjectType using JavaScript
-// spread semantics: PropertyElems and MethodElems are copied as-is, GetterElems
-// yield their return type, and SetterElems are skipped (setter-only properties
-// are not readable in a spread). Returns nil if the property is not found.
-func getSpreadPropertyType(objType *type_system.ObjectType, name string) type_system.Type {
-	targetKey := type_system.NewStrKey(name)
-	for i := len(objType.Elems) - 1; i >= 0; i-- {
-		switch elem := objType.Elems[i].(type) {
-		case *type_system.PropertyElem:
-			if elem.Name == targetKey {
-				propType := elem.Value
-				if elem.Optional {
-					propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
-				}
-				return propType
-			}
-		case *type_system.MethodElem:
-			if elem.Name == targetKey {
-				return elem.Fn
-			}
-		case *type_system.GetterElem:
-			if elem.Name == targetKey {
-				return elem.Fn.Return
-			}
-		case *type_system.SetterElem:
-			// Setter-only properties are not readable in a spread — skip.
-			if elem.Name == targetKey {
-				return nil
-			}
-		case *type_system.RestSpreadElem:
-			if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-				if propType := getSpreadPropertyType(resolvedObj, name); propType != nil {
-					return propType
-				}
-			}
-		}
-	}
-	return nil
-}
-
 // getObjectAccess handles property and index access on ObjectType.
 // mode controls getter/setter resolution: AccessRead uses getters, AccessWrite uses setters.
 func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAccessKey, mode AccessMode, errors []Error) (type_system.Type, []Error) {
@@ -879,8 +839,9 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				}
 			case *type_system.RestSpreadElem:
 				if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-					if propType := getSpreadPropertyType(resolvedObj, k.Name); propType != nil {
-						return propType, errors
+					spreadType, spreadErrors := c.getObjectAccess(resolvedObj, key, mode, nil)
+					if len(spreadErrors) == 0 {
+						return spreadType, errors
 					}
 				}
 			case *type_system.MappedElem:
@@ -970,8 +931,9 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						}
 					case *type_system.RestSpreadElem:
 						if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-							if propType := getSpreadPropertyType(resolvedObj, strLit.Value); propType != nil {
-								return propType, errors
+							spreadType, spreadErrors := c.getObjectAccess(resolvedObj, key, mode, nil)
+							if len(spreadErrors) == 0 {
+								return spreadType, errors
 							}
 						}
 					case *type_system.MappedElem:

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -24,16 +24,19 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 		neverType := type_system.NewNeverType(nil)
 
 		if expr.Op == ast.Assign {
-			// TODO: check if expr.Left is a valid lvalue
-			leftType, leftErrors := c.inferExpr(ctx, expr.Left)
 			rightType, rightErrors := c.inferExpr(ctx, expr.Right)
+			errors = rightErrors
 
-			errors = slices.Concat(leftErrors, rightErrors)
+			var leftType type_system.Type
 
-			// Check if we're trying to mutate an immutable object
 			if memberExpr, ok := expr.Left.(*ast.MemberExpr); ok {
 				objType, objErrors := c.inferExpr(ctx, memberExpr.Object)
 				errors = slices.Concat(errors, objErrors)
+
+				key := PropertyKey{Name: memberExpr.Prop.Name, OptChain: memberExpr.OptChain, span: memberExpr.Prop.Span()}
+				var leftErrors []Error
+				leftType, leftErrors = c.getMemberType(ctx, objType, key, AccessWrite)
+				errors = slices.Concat(errors, leftErrors)
 
 				// Check if the property is readonly (this check takes precedence)
 				if c.isPropertyReadonly(ctx, objType, memberExpr.Prop.Name) {
@@ -59,19 +62,22 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				}
 			} else if indexExpr, ok := expr.Left.(*ast.IndexExpr); ok {
 				objType, objErrors := c.inferExpr(ctx, indexExpr.Object)
-				errors = slices.Concat(errors, objErrors)
-
-				// Check if the property is readonly when using string literal index
 				indexType, indexErrors := c.inferExpr(ctx, indexExpr.Index)
-				errors = slices.Concat(errors, indexErrors)
+				errors = slices.Concat(errors, objErrors, indexErrors)
+
+				key := IndexKey{Type: indexType, span: indexExpr.Index.Span()}
+				var leftErrors []Error
+				leftType, leftErrors = c.getMemberType(ctx, objType, key, AccessWrite)
+				errors = slices.Concat(errors, leftErrors)
 
 				// Unwrap MutabilityType if present
-				if mutType, ok := indexType.(*type_system.MutabilityType); ok {
-					indexType = mutType.Type
+				unwrappedIndexType := indexType
+				if mutType, ok := unwrappedIndexType.(*type_system.MutabilityType); ok {
+					unwrappedIndexType = mutType.Type
 				}
 
 				isReadonly := false
-				if litType, ok := indexType.(*type_system.LitType); ok {
+				if litType, ok := unwrappedIndexType.(*type_system.LitType); ok {
 					if strLit, ok := litType.Lit.(*type_system.StrLit); ok {
 						if c.isPropertyReadonly(ctx, objType, strLit.Value) {
 							isReadonly = true
@@ -84,7 +90,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					// Even if the type is mutable, readonly properties cannot be mutated
 					errors = append(errors, &CannotMutateReadonlyPropertyError{
 						Type:     objType,
-						Property: indexType.String(),
+						Property: unwrappedIndexType.String(),
 						span:     expr.Left.Span(),
 					})
 				} else {
@@ -96,7 +102,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 						// Open object types start without a MutabilityType wrapper —
 						// mark the property as written since we now know mutation occurs.
 						marked := false
-						if litType, ok := indexType.(*type_system.LitType); ok {
+						if litType, ok := unwrappedIndexType.(*type_system.LitType); ok {
 							if strLit, ok := litType.Lit.(*type_system.StrLit); ok {
 								marked = markPropertyWritten(pruned, strLit.Value)
 							}
@@ -112,6 +118,11 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 						}
 					}
 				}
+			} else {
+				// IdentExpr or other — infer normally (variable assignment, not member access)
+				var leftErrors []Error
+				leftType, leftErrors = c.inferExpr(ctx, expr.Left)
+				errors = slices.Concat(errors, leftErrors)
 			}
 
 			// RHS must be a subtype of LHS because we're assigning RHS to LHS
@@ -202,7 +213,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			errors = objErrors
 		} else {
 			key := PropertyKey{Name: expr.Prop.Name, OptChain: expr.OptChain, span: expr.Prop.Span()}
-			propType, propErrors := c.getMemberType(ctx, objType, key)
+			propType, propErrors := c.getMemberType(ctx, objType, key, AccessRead)
 
 			exprType = propType
 
@@ -226,7 +237,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			exprType = type_system.NewErrorType(nil)
 		} else {
 			key := IndexKey{Type: indexType, span: expr.Index.Span()}
-			accessType, accessErrors := c.getMemberType(ctx, objType, key)
+			accessType, accessErrors := c.getMemberType(ctx, objType, key, AccessRead)
 			exprType = accessType
 			errors = slices.Concat(errors, accessErrors)
 		}

--- a/internal/checker/infer_jsx.go
+++ b/internal/checker/infer_jsx.go
@@ -536,7 +536,7 @@ func (c *Checker) resolveJSXComponentType(ctx Context, tagName ast.QualIdent) (t
 
 		// Get the property from the resolved type
 		key := PropertyKey{Name: name.Right.Name, OptChain: false, span: name.Right.Span()}
-		propType, propErrors := c.getMemberType(ctx, leftType, key)
+		propType, propErrors := c.getMemberType(ctx, leftType, key, AccessRead)
 		errors = append(errors, propErrors...)
 
 		if propType == nil {

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -874,7 +874,7 @@ func (c *Checker) InferComponent(
 							OptChain: false,
 							span:     DEFAULT_SPAN,
 						}
-						customMatcher, _ := c.getMemberType(ctx, symbol.Type, symKey)
+						customMatcher, _ := c.getMemberType(ctx, symbol.Type, symKey, AccessRead)
 
 						// Create the SymbolKeyMap for the object type
 						symbolKeyMap := make(map[int]any)

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -512,7 +512,7 @@ func (c *Checker) inferEnumDecl(ctx Context, decl *ast.EnumDecl) []Error {
 			}
 			// Symbol.customMatcher is a well-known global that is always present
 			// in the prelude, so the error can safely be ignored here.
-			customMatcher, _ := c.getMemberType(ctx, symbol.Type, symKey)
+			customMatcher, _ := c.getMemberType(ctx, symbol.Type, symKey, AccessRead)
 
 			symbolKeyMap := make(map[int]any)
 

--- a/internal/checker/iterable.go
+++ b/internal/checker/iterable.go
@@ -103,7 +103,7 @@ func (c *Checker) GetIterableElementType(ctx Context, t type_system.Type) type_s
 		span: ast.Span{},
 	}
 
-	iteratorMethod, errors := c.getMemberType(ctx, t, indexKey)
+	iteratorMethod, errors := c.getMemberType(ctx, t, indexKey, AccessRead)
 	if len(errors) > 0 {
 		return nil
 	}
@@ -138,7 +138,7 @@ func (c *Checker) unifyIteratorNextReturn(ctx Context, t type_system.Type) (type
 
 	// Look up the `next` method on the candidate type
 	nextKey := PropertyKey{Name: "next", span: ast.Span{}}
-	nextMethod, errors := c.getMemberType(ctx, t, nextKey)
+	nextMethod, errors := c.getMemberType(ctx, t, nextKey, AccessRead)
 	if len(errors) > 0 {
 		return nil, nil
 	}
@@ -217,7 +217,7 @@ func (c *Checker) GetIteratorReturnType(ctx Context, t type_system.Type) type_sy
 		span: ast.Span{},
 	}
 
-	iteratorMethod, errors := c.getMemberType(ctx, t, indexKey)
+	iteratorMethod, errors := c.getMemberType(ctx, t, indexKey, AccessRead)
 	if len(errors) > 0 {
 		return nil
 	}
@@ -255,7 +255,7 @@ func (c *Checker) GetAsyncIterableElementType(ctx Context, t type_system.Type) t
 		span: ast.Span{},
 	}
 
-	iteratorMethod, errors := c.getMemberType(ctx, t, indexKey)
+	iteratorMethod, errors := c.getMemberType(ctx, t, indexKey, AccessRead)
 	if len(errors) > 0 {
 		return nil
 	}

--- a/internal/checker/member_access.go
+++ b/internal/checker/member_access.go
@@ -5,6 +5,14 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
+// AccessMode indicates whether a member access is a read (rvalue) or write (lvalue).
+type AccessMode int
+
+const (
+	AccessRead  AccessMode = iota // reading a property (getters apply)
+	AccessWrite                   // writing to a property (setters apply)
+)
+
 // MemberAccessKey represents either a property name or an index for accessing object/array elements
 type MemberAccessKey interface {
 	isMemberAccessKey()

--- a/internal/checker/tests/getter_setter_test.go
+++ b/internal/checker/tests/getter_setter_test.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	. "github.com/escalier-lang/escalier/internal/checker"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetterSetterAccess(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		expectedErrors []string
+	}{
+		"ReadGetterOnlyProperty": {
+			input: `
+				class Circle(radius: number) {
+					radius,
+					get area(self) -> number {
+						return 3.14 * self.radius * self.radius
+					},
+				}
+				val c = Circle(5)
+				val area = c.area
+			`,
+			expectedErrors: nil,
+		},
+		"WriteGetterOnlyPropertyShouldError": {
+			input: `
+				class Circle(radius: number) {
+					radius,
+					get area(self) -> number {
+						return 3.14 * self.radius * self.radius
+					},
+				}
+				val c: mut Circle = Circle(5)
+				fn main() {
+					c.area = 100
+				}
+			`,
+			expectedErrors: []string{
+				"Unknown property 'area' in object type {radius: number, get area(self) -> number}",
+				"100 cannot be assigned to undefined",
+			},
+		},
+		"WriteSetterOnlyProperty": {
+			input: `
+				class Temperature(celsius: number) {
+					celsius,
+					set fahrenheit(mut self, value: number) {
+						self.celsius = (value - 32) * 5 / 9
+					},
+				}
+				val temp: mut Temperature = Temperature(25)
+				fn main() {
+					temp.fahrenheit = 86
+				}
+			`,
+			expectedErrors: nil,
+		},
+		"ReadSetterOnlyPropertyShouldError": {
+			input: `
+				class Temperature(celsius: number) {
+					celsius,
+					set fahrenheit(mut self, value: number) {
+						self.celsius = (value - 32) * 5 / 9
+					},
+				}
+				val temp = Temperature(25)
+				val f = temp.fahrenheit
+			`,
+			expectedErrors: []string{
+				"Unknown property 'fahrenheit' in object type {celsius: number, set fahrenheit(mut self, value: number) -> undefined}",
+			},
+		},
+		"ReadAndWriteWithBothGetterAndSetter": {
+			input: `
+				declare fn split(s: string, delimiter: string) -> Array<string>
+				class Person(firstName: string, lastName: string) {
+					firstName,
+					lastName,
+					get fullName(self) -> string {
+						return self.firstName ++ " " ++ self.lastName
+					},
+					set fullName(mut self, value: string) {
+						val parts = split(value, " ")
+						self.firstName = parts[0]
+						self.lastName = parts[1]
+					},
+				}
+				val person: mut Person = Person("John", "Doe")
+				val name = person.fullName
+				fn main() {
+					person.fullName = "Jane Smith"
+				}
+			`,
+			expectedErrors: nil,
+		},
+		"ObjectLiteralReadGetter": {
+			input: `
+				val value: number = 5
+				val obj = {
+					get value(self) {
+						return self._value
+					},
+					_value: value,
+				}
+				val v = obj.value
+			`,
+			expectedErrors: nil,
+		},
+		"ObjectLiteralWriteSetterOnly": {
+			input: `
+				val obj = {
+					_value: 0:number,
+					set value(mut self, v: number) {
+						self._value = v
+					},
+				}
+				val mobj: mut typeof obj = obj
+				fn main() {
+					mobj.value = 42
+				}
+			`,
+			expectedErrors: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := &ast.Source{
+				ID:       0,
+				Path:     "input.esc",
+				Contents: test.input,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+
+			assert.Len(t, parseErrors, 0, "Expected no parse errors")
+
+			c := NewChecker()
+			inferCtx := Context{
+				Scope:      Prelude(c),
+				IsAsync:    false,
+				IsPatMatch: false,
+			}
+			inferErrors := c.InferModule(inferCtx, module)
+
+			var errorMessages []string
+			for _, err := range inferErrors {
+				errorMessages = append(errorMessages, err.Message())
+			}
+			assert.Equal(t, test.expectedErrors, errorMessages)
+		})
+	}
+}

--- a/internal/checker/tests/getter_setter_test.go
+++ b/internal/checker/tests/getter_setter_test.go
@@ -128,6 +128,49 @@ func TestGetterSetterAccess(t *testing.T) {
 			`,
 			expectedErrors: nil,
 		},
+		"WriteSetterViaSpreadSource": {
+			input: `
+				class Base(_v: number) {
+					_v,
+					set value(mut self, v: number) {
+						self._v = v
+					},
+				}
+				val b: mut Base = Base(1)
+				fn main() {
+					b.value = 42
+				}
+			`,
+			expectedErrors: nil,
+		},
+		"ReadGetterViaSpreadSource": {
+			input: `
+				class Base(_v: number) {
+					_v,
+					get value(self) -> number {
+						return self._v
+					},
+				}
+				val obj = {_v: 0, ...Base(1)}
+				val v = obj.value
+			`,
+			expectedErrors: nil,
+		},
+		"ReadSetterViaSpreadSourceShouldError": {
+			input: `
+				class Base(_v: number) {
+					_v,
+					set value(mut self, v: number) {
+						self._v = v
+					},
+				}
+				val obj = {_v: 0, ...Base(1)}
+				val v = obj.value
+			`,
+			expectedErrors: []string{
+				"Unknown property 'value' in object type {_v: 0, ...Base}",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/getter_setter_test.go
+++ b/internal/checker/tests/getter_setter_test.go
@@ -184,10 +184,12 @@ func TestGetterSetterAccess(t *testing.T) {
 					set s(mut self, v: string) {},
 				}
 				fn foo(u: A | B) {
-					val {x, ...rest} = u
+					val {x, s, ...rest} = u
 				}
 			`,
-			expectedErrors: nil,
+			expectedErrors: []string{
+				"Unknown property 's' in object type A | B",
+			},
 		},
 	}
 

--- a/internal/checker/tests/getter_setter_test.go
+++ b/internal/checker/tests/getter_setter_test.go
@@ -171,6 +171,24 @@ func TestGetterSetterAccess(t *testing.T) {
 				"Unknown property 'value' in object type {_v: 0, ...Base}",
 			},
 		},
+		// Union rest path - setter-only keys on union members
+		// should not cause nil values in the rest object.
+		"UnionDestructureWithRestSkipsSetterOnlyFields": {
+			input: `
+				class A(x: number) {
+					x,
+					set s(mut self, v: number) {},
+				}
+				class B(x: string) {
+					x,
+					set s(mut self, v: string) {},
+				}
+				fn foo(u: A | B) {
+					val {x, ...rest} = u
+				}
+			`,
+			expectedErrors: nil,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -901,8 +901,10 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			// downstream inference and error reporting.
 			if obj1.Open && obj2.Open {
 				for _, key := range keys1 {
-					if value2, ok := namedElems2[key]; ok {
-						unifyErrors := c.Unify(ctx, namedElems1[key], value2)
+					value1, has1 := namedElems1[key]
+					value2, has2 := namedElems2[key]
+					if has1 && has2 {
+						unifyErrors := c.Unify(ctx, value1, value2)
 						errors = slices.Concat(errors, unifyErrors)
 					}
 					if wt1, ok1 := collected1.Write[key]; ok1 {
@@ -914,25 +916,44 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 				}
 				// Add elems from obj2 not in obj1 to obj1.
 				// Share the original elem pointers (not copies) so that mutable
-				// fields like Written are visible to both open types — they are
+				// fields like Written are visible to both open types - they are
 				// in the same inference scope and represent the same parameter.
+				//
+				// Read and write presence are checked independently because a
+				// property name can be split across separate GetterElem (read)
+				// and SetterElem (write) elements, tracked in different maps.
+				// For example, given:
+				//   obj1 = { get x(self) -> number }  // Read["x"] exists, Write["x"] absent
+				//   obj2 = { set x(mut self, v: number) }  // Read["x"] absent, Write["x"] exists
+				// A single check against namedElems1 (the read map) would see
+				// "x" already present in obj1 and skip the merge, losing obj2's
+				// setter. By checking read and write separately, the setter is
+				// correctly appended so obj1 ends up with both get x and set x.
 				for _, key := range keys2 {
-					if _, ok := namedElems1[key]; !ok {
-						if re, ok := collected2.OrigRead[key]; ok {
+					re := collected2.OrigRead[key]
+					we := collected2.OrigWrite[key]
+					if re != nil {
+						if _, has := namedElems1[key]; !has {
 							obj1.Elems = append(obj1.Elems, re)
 						}
-						if we, ok := collected2.OrigWrite[key]; ok && we != collected2.OrigRead[key] {
+					}
+					if we != nil && we != re {
+						if _, has := collected1.Write[key]; !has {
 							obj1.Elems = append(obj1.Elems, we)
 						}
 					}
 				}
 				// Add elems from obj1 not in obj2 to obj2.
 				for _, key := range keys1 {
-					if _, ok := namedElems2[key]; !ok {
-						if re, ok := collected1.OrigRead[key]; ok {
+					re := collected1.OrigRead[key]
+					we := collected1.OrigWrite[key]
+					if re != nil {
+						if _, has := namedElems2[key]; !has {
 							obj2.Elems = append(obj2.Elems, re)
 						}
-						if we, ok := collected1.OrigWrite[key]; ok && we != collected1.OrigRead[key] {
+					}
+					if we != nil && we != re {
+						if _, has := collected2.Write[key]; !has {
 							obj2.Elems = append(obj2.Elems, we)
 						}
 					}
@@ -955,13 +976,16 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 					if has1 && has2 {
 						unifyErrors := c.Unify(ctx, value1, value2)
 						errors = slices.Concat(errors, unifyErrors)
-					} else if !has1 {
-						// Elem in closed but not in open: copy and add to open type.
-						// Copy PropertyElems to avoid sharing mutable fields (Written).
-						if re, ok := collected2.OrigRead[key]; ok {
-							obj1.Elems = append(obj1.Elems, copyObjTypeElem(re))
-						}
-						if we, ok := collected2.OrigWrite[key]; ok && we != collected2.OrigRead[key] {
+					}
+					re := collected2.OrigRead[key]
+					we := collected2.OrigWrite[key]
+					// Copy missing read elem from closed to open.
+					if re != nil && !has1 {
+						obj1.Elems = append(obj1.Elems, copyObjTypeElem(re))
+					}
+					// Copy missing write elem from closed to open (skip if same as read elem).
+					if we != nil && we != re {
+						if _, hasW1 := collected1.Write[key]; !hasW1 {
 							obj1.Elems = append(obj1.Elems, copyObjTypeElem(we))
 						}
 					}
@@ -977,13 +1001,16 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 					if has1 && has2 {
 						unifyErrors := c.Unify(ctx, value1, value2)
 						errors = slices.Concat(errors, unifyErrors)
-					} else if !has2 {
-						// Elem in closed but not in open: copy and add to open type.
-						// Copy PropertyElems to avoid sharing mutable fields (Written).
-						if re, ok := collected1.OrigRead[key]; ok {
-							obj2.Elems = append(obj2.Elems, copyObjTypeElem(re))
-						}
-						if we, ok := collected1.OrigWrite[key]; ok && we != collected1.OrigRead[key] {
+					}
+					re := collected1.OrigRead[key]
+					we := collected1.OrigWrite[key]
+					// Copy missing read elem from closed to open.
+					if re != nil && !has2 {
+						obj2.Elems = append(obj2.Elems, copyObjTypeElem(re))
+					}
+					// Copy missing write elem from closed to open (skip if same as read elem).
+					if we != nil && we != re {
+						if _, hasW2 := collected2.Write[key]; !hasW2 {
 							obj2.Elems = append(obj2.Elems, copyObjTypeElem(we))
 						}
 					}
@@ -1031,8 +1058,19 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			} else {
 				for _, key2 := range keys2 {
 					value2, has2 := namedElems2[key2]
+					// Unify write types for setter-only keys.
 					if !has2 {
-						// Setter-only key — no readable type to unify.
+						wt1, hasW1 := collected1.Write[key2]
+						wt2, hasW2 := collected2.Write[key2]
+						if hasW1 && hasW2 {
+							unifyErrors := c.Unify(ctx, wt1, wt2)
+							errors = slices.Concat(errors, unifyErrors)
+						} else if hasW2 && !hasW1 {
+							errors = slices.Concat(errors, []Error{&KeyNotFoundError{
+								Object: obj1,
+								Key:    key2,
+							}})
+						}
 						continue
 					}
 					if value1, ok := namedElems1[key2]; ok {
@@ -1219,11 +1257,16 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 					// If restType is specified, collect remaining fields
 					if restType != nil {
 						for _, key := range collectedUnionObj.Keys {
+							readType := collectedUnionObj.Read[key]
+							if readType == nil {
+								// Setter-only key — not readable, skip.
+								continue
+							}
 							if _, ok := destructuredFields[key]; !ok {
 								if _, exists := remainingFields[key]; !exists {
 									remainingFieldsOrder = append(remainingFieldsOrder, key)
 								}
-								remainingFields[key] = append(remainingFields[key], collectedUnionObj.Read[key])
+								remainingFields[key] = append(remainingFields[key], readType)
 							}
 						}
 					}
@@ -1486,9 +1529,14 @@ func (c *Checker) unifyClosedWithRests(
 	remainingElems := []type_system.ObjTypeElem{}
 	for _, key := range targetKeys {
 		if !usedTargetKeys[key] {
+			value := targetNamed[key]
+			if value == nil {
+				// Setter-only key — not readable, skip.
+				continue
+			}
 			remainingElems = append(remainingElems, &type_system.PropertyElem{
 				Name:  key,
-				Value: targetNamed[key],
+				Value: value,
 			})
 		}
 	}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -881,72 +881,17 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 
 			errors := []Error{}
 
-			namedElems1 := make(map[type_system.ObjTypeKey]type_system.Type)
-			namedElems2 := make(map[type_system.ObjTypeKey]type_system.Type)
-			origElems1 := make(map[type_system.ObjTypeKey]type_system.ObjTypeElem)
-			origElems2 := make(map[type_system.ObjTypeKey]type_system.ObjTypeElem)
+			collected1 := collectObjElemTypes(obj1, true, true)
+			namedElems1 := collected1.Named
+			origElems1 := collected1.OrigElems
+			keys1 := collected1.Keys
+			restTypes1 := collected1.RestTypes
 
-			keys1 := []type_system.ObjTypeKey{} // original order of keys in obj1
-			keys2 := []type_system.ObjTypeKey{} // original order of keys in obj2
-
-			var restTypes1 []type_system.Type
-			var restTypes2 []type_system.Type
-
-			for _, elem := range obj1.Elems {
-				switch elem := elem.(type) {
-				case *type_system.MethodElem:
-					namedElems1[elem.Name] = elem.Fn
-					origElems1[elem.Name] = elem
-					keys1 = append(keys1, elem.Name)
-				case *type_system.GetterElem:
-					namedElems1[elem.Name] = elem.Fn.Return
-					origElems1[elem.Name] = elem
-					keys1 = append(keys1, elem.Name)
-				case *type_system.SetterElem:
-					namedElems1[elem.Name] = elem.Fn.Params[0].Type
-					origElems1[elem.Name] = elem
-					keys1 = append(keys1, elem.Name)
-				case *type_system.PropertyElem:
-					propType := elem.Value
-					if elem.Optional {
-						propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
-					}
-					namedElems1[elem.Name] = propType
-					origElems1[elem.Name] = elem
-					keys1 = append(keys1, elem.Name)
-				case *type_system.RestSpreadElem:
-					restTypes1 = append(restTypes1, elem.Value)
-				default: // skip other types of elems
-				}
-			}
-
-			for _, elem := range obj2.Elems {
-				switch elem := elem.(type) {
-				case *type_system.MethodElem:
-					namedElems2[elem.Name] = elem.Fn
-					origElems2[elem.Name] = elem
-					keys2 = append(keys2, elem.Name)
-				case *type_system.GetterElem:
-					namedElems2[elem.Name] = elem.Fn.Return
-					origElems2[elem.Name] = elem
-					keys2 = append(keys2, elem.Name)
-				case *type_system.SetterElem:
-					namedElems2[elem.Name] = elem.Fn.Params[0].Type
-					origElems2[elem.Name] = elem
-					keys2 = append(keys2, elem.Name)
-				case *type_system.PropertyElem:
-					propType := elem.Value
-					if elem.Optional {
-						propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
-					}
-					namedElems2[elem.Name] = propType
-					origElems2[elem.Name] = elem
-					keys2 = append(keys2, elem.Name)
-				case *type_system.RestSpreadElem:
-					restTypes2 = append(restTypes2, elem.Value)
-				default: // skip other types of elems
-				}
-			}
+			collected2 := collectObjElemTypes(obj2, true, true)
+			namedElems2 := collected2.Named
+			origElems2 := collected2.OrigElems
+			keys2 := collected2.Keys
+			restTypes2 := collected2.RestTypes
 
 			// Open-vs-open: unify shared properties, merge non-shared,
 			// unify row variables.
@@ -1217,26 +1162,11 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 	if union, ok := t1.(*type_system.UnionType); ok {
 		// special-case unification of union with object type
 		if obj, ok := t2.(*type_system.ObjectType); ok {
-			destructuredFields := make(map[type_system.ObjTypeKey]type_system.Type)
+			collectedObj := collectObjElemTypes(obj, true, false)
+			destructuredFields := collectedObj.Named
 			var restType type_system.Type
-			for _, elem := range obj.Elems {
-				switch elem := elem.(type) {
-				case *type_system.MethodElem:
-					destructuredFields[elem.Name] = elem.Fn
-				case *type_system.GetterElem:
-					destructuredFields[elem.Name] = elem.Fn.Return
-				case *type_system.SetterElem:
-					destructuredFields[elem.Name] = elem.Fn.Params[0].Type
-				case *type_system.PropertyElem:
-					propType := elem.Value
-					if elem.Optional {
-						propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
-					}
-					destructuredFields[elem.Name] = propType
-				case *type_system.RestSpreadElem:
-					restType = elem.Value
-				default: // skip other types of elems
-				}
+			if len(collectedObj.RestTypes) > 0 {
+				restType = collectedObj.RestTypes[0]
 			}
 
 			matchingTypes := make(map[type_system.ObjTypeKey][]type_system.Type)
@@ -1246,76 +1176,21 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 
 			for _, unionType := range union.Types {
 				if unionObj, ok := unionType.(*type_system.ObjectType); ok {
+					collectedUnionObj := collectObjElemTypes(unionObj, true, false)
 					for name := range destructuredFields {
-						var t type_system.Type
-						// Find the type of the field with this name in the union object
-						for _, elem := range unionObj.Elems {
-							switch elem := elem.(type) {
-							case *type_system.MethodElem:
-								if elem.Name == name {
-									t = elem.Fn
-								}
-							case *type_system.GetterElem:
-								if elem.Name == name {
-									t = elem.Fn.Return
-								}
-							case *type_system.SetterElem:
-								if elem.Name == name {
-									t = elem.Fn.Params[0].Type
-								}
-							case *type_system.PropertyElem:
-								if elem.Name == name {
-									propType := elem.Value
-									if elem.Optional {
-										propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
-									}
-									t = propType
-								}
-							default: // skip other types of elems
-							}
-						}
-						if t != nil {
+						if t, ok := collectedUnionObj.Named[name]; ok {
 							matchingTypes[name] = append(matchingTypes[name], t)
 						}
 					}
 
 					// If restType is specified, collect remaining fields
 					if restType != nil {
-						for _, elem := range unionObj.Elems {
-							switch elem := elem.(type) {
-							case *type_system.MethodElem:
-								if _, ok := destructuredFields[elem.Name]; !ok {
-									if _, exists := remainingFields[elem.Name]; !exists {
-										remainingFieldsOrder = append(remainingFieldsOrder, elem.Name)
-									}
-									remainingFields[elem.Name] = append(remainingFields[elem.Name], elem.Fn)
+						for _, key := range collectedUnionObj.Keys {
+							if _, ok := destructuredFields[key]; !ok {
+								if _, exists := remainingFields[key]; !exists {
+									remainingFieldsOrder = append(remainingFieldsOrder, key)
 								}
-							case *type_system.GetterElem:
-								if _, ok := destructuredFields[elem.Name]; !ok {
-									if _, exists := remainingFields[elem.Name]; !exists {
-										remainingFieldsOrder = append(remainingFieldsOrder, elem.Name)
-									}
-									remainingFields[elem.Name] = append(remainingFields[elem.Name], elem.Fn.Return)
-								}
-							case *type_system.SetterElem:
-								if _, ok := destructuredFields[elem.Name]; !ok {
-									if _, exists := remainingFields[elem.Name]; !exists {
-										remainingFieldsOrder = append(remainingFieldsOrder, elem.Name)
-									}
-									remainingFields[elem.Name] = append(remainingFields[elem.Name], elem.Fn.Params[0].Type)
-								}
-							case *type_system.PropertyElem:
-								if _, ok := destructuredFields[elem.Name]; !ok {
-									propType := elem.Value
-									if elem.Optional {
-										propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
-									}
-									if _, exists := remainingFields[elem.Name]; !exists {
-										remainingFieldsOrder = append(remainingFieldsOrder, elem.Name)
-									}
-									remainingFields[elem.Name] = append(remainingFields[elem.Name], propType)
-								}
-							default: // skip other types of elems
+								remainingFields[key] = append(remainingFields[key], collectedUnionObj.Named[key])
 							}
 						}
 					}
@@ -2810,25 +2685,63 @@ func (c *Checker) unifyVariadicVsVariadic(
 	return errors
 }
 
-// collectNamedElems extracts readable named property types from an ObjectType.
-// It handles PropertyElem (including optional), MethodElem, and GetterElem.
-// SetterElem is excluded because setters are write-only and cannot be read
-// during pattern matching.
-func collectNamedElems(obj *type_system.ObjectType) map[type_system.ObjTypeKey]type_system.Type {
-	result := make(map[type_system.ObjTypeKey]type_system.Type)
+// elemNameAndType returns the name and readable type for a named element.
+// Returns ok=false for non-named elements (CallableElem, ConstructorElem,
+// MappedElem, RestSpreadElem, etc.).
+// When includeSetters is false, SetterElem returns ok=false.
+// Optional PropertyElems have their type wrapped as T | undefined.
+func elemNameAndType(elem type_system.ObjTypeElem, includeSetters bool) (
+	name type_system.ObjTypeKey, typ type_system.Type, ok bool,
+) {
+	switch elem := elem.(type) {
+	case *type_system.PropertyElem:
+		propType := elem.Value
+		if elem.Optional {
+			propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
+		}
+		return elem.Name, propType, true
+	case *type_system.MethodElem:
+		return elem.Name, elem.Fn, true
+	case *type_system.GetterElem:
+		return elem.Name, elem.Fn.Return, true
+	case *type_system.SetterElem:
+		if includeSetters {
+			return elem.Name, elem.Fn.Params[0].Type, true
+		}
+		return type_system.ObjTypeKey{}, nil, false
+	default:
+		return type_system.ObjTypeKey{}, nil, false
+	}
+}
+
+// collectedElemTypes holds the result of collectObjElemTypes.
+type collectedElemTypes struct {
+	Named     map[type_system.ObjTypeKey]type_system.Type
+	Keys      []type_system.ObjTypeKey                        // in insertion order
+	OrigElems map[type_system.ObjTypeKey]type_system.ObjTypeElem // nil if not requested
+	RestTypes []type_system.Type
+}
+
+// collectObjElemTypes extracts named property types from an ObjectType.
+// It handles PropertyElem (including optional→T|undefined), MethodElem,
+// GetterElem, and optionally SetterElem. RestSpreadElem values are collected
+// separately in RestTypes.
+func collectObjElemTypes(obj *type_system.ObjectType, includeSetters bool, collectOrigElems bool) collectedElemTypes {
+	result := collectedElemTypes{
+		Named: make(map[type_system.ObjTypeKey]type_system.Type),
+	}
+	if collectOrigElems {
+		result.OrigElems = make(map[type_system.ObjTypeKey]type_system.ObjTypeElem)
+	}
 	for _, elem := range obj.Elems {
-		switch elem := elem.(type) {
-		case *type_system.PropertyElem:
-			propType := elem.Value
-			if elem.Optional {
-				propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
+		if name, typ, ok := elemNameAndType(elem, includeSetters); ok {
+			result.Named[name] = typ
+			result.Keys = append(result.Keys, name)
+			if collectOrigElems {
+				result.OrigElems[name] = elem
 			}
-			result[elem.Name] = propType
-		case *type_system.MethodElem:
-			result[elem.Name] = elem.Fn
-		case *type_system.GetterElem:
-			result[elem.Name] = elem.Fn.Return
-		default: // skip SetterElem, CallableElem, NewableElem, RestSpreadElem, etc.
+		} else if rest, ok := elem.(*type_system.RestSpreadElem); ok {
+			result.RestTypes = append(result.RestTypes, rest.Value)
 		}
 	}
 	return result
@@ -2840,7 +2753,7 @@ func (c *Checker) unifyPatternWithUnion(
 	union *type_system.UnionType,
 ) []Error {
 	// 1. Collect pattern field names and their type variables
-	patFields := collectNamedElems(pat)
+	patFields := collectObjElemTypes(pat, false, false).Named
 
 	// 2. For each union member, check if it has ALL pattern fields.
 	//    Union members may be TypeRefTypes (e.g. class names) that need expansion.
@@ -2852,7 +2765,7 @@ func (c *Checker) unifyPatternWithUnion(
 		if !ok {
 			continue // skip non-object union members (e.g. primitive types)
 		}
-		memberFields := collectNamedElems(memberObj)
+		memberFields := collectObjElemTypes(memberObj, false, false).Named
 
 		allMatch := true
 		for key := range patFields {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -881,15 +881,13 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 
 			errors := []Error{}
 
-			collected1 := collectObjElemTypes(obj1, true, true)
-			namedElems1 := collected1.Named
-			origElems1 := collected1.OrigElems
+			collected1 := collectObjElemTypes(obj1, true)
+			namedElems1 := collected1.Read
 			keys1 := collected1.Keys
 			restTypes1 := collected1.RestTypes
 
-			collected2 := collectObjElemTypes(obj2, true, true)
-			namedElems2 := collected2.Named
-			origElems2 := collected2.OrigElems
+			collected2 := collectObjElemTypes(obj2, true)
+			namedElems2 := collected2.Read
 			keys2 := collected2.Keys
 			restTypes2 := collected2.RestTypes
 
@@ -907,6 +905,12 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 						unifyErrors := c.Unify(ctx, namedElems1[key], value2)
 						errors = slices.Concat(errors, unifyErrors)
 					}
+					if wt1, ok1 := collected1.Write[key]; ok1 {
+						if wt2, ok2 := collected2.Write[key]; ok2 {
+							unifyErrors := c.Unify(ctx, wt1, wt2)
+							errors = slices.Concat(errors, unifyErrors)
+						}
+					}
 				}
 				// Add elems from obj2 not in obj1 to obj1.
 				// Share the original elem pointers (not copies) so that mutable
@@ -914,13 +918,23 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 				// in the same inference scope and represent the same parameter.
 				for _, key := range keys2 {
 					if _, ok := namedElems1[key]; !ok {
-						obj1.Elems = append(obj1.Elems, origElems2[key])
+						if re, ok := collected2.OrigRead[key]; ok {
+							obj1.Elems = append(obj1.Elems, re)
+						}
+						if we, ok := collected2.OrigWrite[key]; ok && we != collected2.OrigRead[key] {
+							obj1.Elems = append(obj1.Elems, we)
+						}
 					}
 				}
 				// Add elems from obj1 not in obj2 to obj2.
 				for _, key := range keys1 {
 					if _, ok := namedElems2[key]; !ok {
-						obj2.Elems = append(obj2.Elems, origElems1[key])
+						if re, ok := collected1.OrigRead[key]; ok {
+							obj2.Elems = append(obj2.Elems, re)
+						}
+						if we, ok := collected1.OrigWrite[key]; ok && we != collected1.OrigRead[key] {
+							obj2.Elems = append(obj2.Elems, we)
+						}
 					}
 				}
 				// Unify row variables if both have RestSpreadElems
@@ -936,13 +950,20 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			// Open-only properties are allowed (structural subtyping).
 			if obj1.Open && !obj2.Open {
 				for _, key := range keys2 {
-					if value1, ok := namedElems1[key]; ok {
-						unifyErrors := c.Unify(ctx, value1, namedElems2[key])
+					value1, has1 := namedElems1[key]
+					value2, has2 := namedElems2[key]
+					if has1 && has2 {
+						unifyErrors := c.Unify(ctx, value1, value2)
 						errors = slices.Concat(errors, unifyErrors)
-					} else {
+					} else if !has1 {
 						// Elem in closed but not in open: copy and add to open type.
 						// Copy PropertyElems to avoid sharing mutable fields (Written).
-						obj1.Elems = append(obj1.Elems, copyObjTypeElem(origElems2[key]))
+						if re, ok := collected2.OrigRead[key]; ok {
+							obj1.Elems = append(obj1.Elems, copyObjTypeElem(re))
+						}
+						if we, ok := collected2.OrigWrite[key]; ok && we != collected2.OrigRead[key] {
+							obj1.Elems = append(obj1.Elems, copyObjTypeElem(we))
+						}
 					}
 				}
 				return errors
@@ -951,13 +972,20 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			// Closed(t1)-vs-open(t2): same logic, but t1 is closed and t2 is open.
 			if !obj1.Open && obj2.Open {
 				for _, key := range keys1 {
-					if value2, ok := namedElems2[key]; ok {
-						unifyErrors := c.Unify(ctx, namedElems1[key], value2)
+					value1, has1 := namedElems1[key]
+					value2, has2 := namedElems2[key]
+					if has1 && has2 {
+						unifyErrors := c.Unify(ctx, value1, value2)
 						errors = slices.Concat(errors, unifyErrors)
-					} else {
+					} else if !has2 {
 						// Elem in closed but not in open: copy and add to open type.
 						// Copy PropertyElems to avoid sharing mutable fields (Written).
-						obj2.Elems = append(obj2.Elems, copyObjTypeElem(origElems1[key]))
+						if re, ok := collected1.OrigRead[key]; ok {
+							obj2.Elems = append(obj2.Elems, copyObjTypeElem(re))
+						}
+						if we, ok := collected1.OrigWrite[key]; ok && we != collected1.OrigRead[key] {
+							obj2.Elems = append(obj2.Elems, copyObjTypeElem(we))
+						}
 					}
 				}
 				return errors
@@ -981,10 +1009,11 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 				// In pattern-matching mode: unify shared properties, and verify
 				// all pattern fields (keys1) exist on the target (keys2).
 				// Target fields not in the pattern are silently skipped (partial matching).
+				// namedElems2 is the Read map, so setter-only properties won't appear
+				// here and are correctly treated as not found for pattern matching.
 				for _, key1 := range keys1 {
-					_, isSetter := origElems2[key1].(*type_system.SetterElem)
 					value2, found := namedElems2[key1]
-					if found && !isSetter {
+					if found {
 						unifyErrors := c.Unify(ctx, namedElems1[key1], value2)
 						errors = slices.Concat(errors, unifyErrors)
 					} else {
@@ -1001,7 +1030,11 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 				}
 			} else {
 				for _, key2 := range keys2 {
-					value2 := namedElems2[key2]
+					value2, has2 := namedElems2[key2]
+					if !has2 {
+						// Setter-only key — no readable type to unify.
+						continue
+					}
 					if value1, ok := namedElems1[key2]; ok {
 						unifyErrors := c.Unify(ctx, value1, value2)
 						// Wrap CannotUnifyTypesError with property context when
@@ -1009,13 +1042,13 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 						for i, err := range unifyErrors {
 							if cue, ok := err.(*CannotUnifyTypesError); ok {
 								var inferredAt *MemberAccessKeyProvenance
-								if pe, ok := origElems2[key2].(*type_system.PropertyElem); ok {
+								if pe, ok := collected2.OrigRead[key2].(*type_system.PropertyElem); ok {
 									if makp, ok := pe.Provenance.(*MemberAccessKeyProvenance); ok {
 										inferredAt = makp
 									}
 								}
 								if inferredAt == nil {
-									if pe, ok := origElems1[key2].(*type_system.PropertyElem); ok {
+									if pe, ok := collected1.OrigRead[key2].(*type_system.PropertyElem); ok {
 										if makp, ok := pe.Provenance.(*MemberAccessKeyProvenance); ok {
 											inferredAt = makp
 										}
@@ -1039,7 +1072,7 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 							Key:    key2,
 							span:   getKeyNotFoundSpan(obj1, value2),
 						}
-						if propElem, ok := origElems2[key2].(*type_system.PropertyElem); ok {
+						if propElem, ok := collected2.OrigRead[key2].(*type_system.PropertyElem); ok {
 							if makp, ok := propElem.Provenance.(*MemberAccessKeyProvenance); ok {
 								knfErr.InferredAt = makp
 							}
@@ -1162,8 +1195,8 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 	if union, ok := t1.(*type_system.UnionType); ok {
 		// special-case unification of union with object type
 		if obj, ok := t2.(*type_system.ObjectType); ok {
-			collectedObj := collectObjElemTypes(obj, true, false)
-			destructuredFields := collectedObj.Named
+			collectedObj := collectObjElemTypes(obj, false)
+			destructuredFields := collectedObj.Read
 			var restType type_system.Type
 			if len(collectedObj.RestTypes) > 0 {
 				restType = collectedObj.RestTypes[0]
@@ -1176,9 +1209,9 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 
 			for _, unionType := range union.Types {
 				if unionObj, ok := unionType.(*type_system.ObjectType); ok {
-					collectedUnionObj := collectObjElemTypes(unionObj, true, false)
+					collectedUnionObj := collectObjElemTypes(unionObj, false)
 					for name := range destructuredFields {
-						if t, ok := collectedUnionObj.Named[name]; ok {
+						if t, ok := collectedUnionObj.Read[name]; ok {
 							matchingTypes[name] = append(matchingTypes[name], t)
 						}
 					}
@@ -1190,7 +1223,7 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 								if _, exists := remainingFields[key]; !exists {
 									remainingFieldsOrder = append(remainingFieldsOrder, key)
 								}
-								remainingFields[key] = append(remainingFields[key], collectedUnionObj.Named[key])
+								remainingFields[key] = append(remainingFields[key], collectedUnionObj.Read[key])
 							}
 						}
 					}
@@ -2685,63 +2718,81 @@ func (c *Checker) unifyVariadicVsVariadic(
 	return errors
 }
 
-// elemNameAndType returns the name and readable type for a named element.
-// Returns ok=false for non-named elements (CallableElem, ConstructorElem,
-// MappedElem, RestSpreadElem, etc.).
-// When includeSetters is false, SetterElem returns ok=false.
-// Optional PropertyElems have their type wrapped as T | undefined.
-func elemNameAndType(elem type_system.ObjTypeElem, includeSetters bool) (
-	name type_system.ObjTypeKey, typ type_system.Type, ok bool,
-) {
-	switch elem := elem.(type) {
-	case *type_system.PropertyElem:
-		propType := elem.Value
-		if elem.Optional {
-			propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
-		}
-		return elem.Name, propType, true
-	case *type_system.MethodElem:
-		return elem.Name, elem.Fn, true
-	case *type_system.GetterElem:
-		return elem.Name, elem.Fn.Return, true
-	case *type_system.SetterElem:
-		if includeSetters {
-			return elem.Name, elem.Fn.Params[0].Type, true
-		}
-		return type_system.ObjTypeKey{}, nil, false
-	default:
-		return type_system.ObjTypeKey{}, nil, false
-	}
-}
-
 // collectedElemTypes holds the result of collectObjElemTypes.
+// Read and Write maps track readable and writable types separately:
+//   - PropertyElem/MethodElem populate Read (and PropertyElem also populates Write)
+//   - GetterElem populates Read only
+//   - SetterElem populates Write only
 type collectedElemTypes struct {
-	Named     map[type_system.ObjTypeKey]type_system.Type
-	Keys      []type_system.ObjTypeKey                        // in insertion order
-	OrigElems map[type_system.ObjTypeKey]type_system.ObjTypeElem // nil if not requested
+	Read      map[type_system.ObjTypeKey]type_system.Type        // readable types (Property, Method, Getter)
+	Write     map[type_system.ObjTypeKey]type_system.Type        // writable types (Property, Setter)
+	Keys      []type_system.ObjTypeKey                           // all names, deduplicated, in insertion order
+	OrigRead  map[type_system.ObjTypeKey]type_system.ObjTypeElem // original readable elem; nil if not requested
+	OrigWrite map[type_system.ObjTypeKey]type_system.ObjTypeElem // original writable elem; nil if not requested
 	RestTypes []type_system.Type
 }
 
-// collectObjElemTypes extracts named property types from an ObjectType.
-// It handles PropertyElem (including optional→T|undefined), MethodElem,
-// GetterElem, and optionally SetterElem. RestSpreadElem values are collected
-// separately in RestTypes.
-func collectObjElemTypes(obj *type_system.ObjectType, includeSetters bool, collectOrigElems bool) collectedElemTypes {
+// collectObjElemTypes extracts named property types from an ObjectType into
+// separate Read and Write maps. RestSpreadElem values are collected separately
+// in RestTypes.
+func collectObjElemTypes(obj *type_system.ObjectType, collectOrigElems bool) collectedElemTypes {
 	result := collectedElemTypes{
-		Named: make(map[type_system.ObjTypeKey]type_system.Type),
+		Read:  make(map[type_system.ObjTypeKey]type_system.Type),
+		Write: make(map[type_system.ObjTypeKey]type_system.Type),
 	}
 	if collectOrigElems {
-		result.OrigElems = make(map[type_system.ObjTypeKey]type_system.ObjTypeElem)
+		result.OrigRead = make(map[type_system.ObjTypeKey]type_system.ObjTypeElem)
+		result.OrigWrite = make(map[type_system.ObjTypeKey]type_system.ObjTypeElem)
 	}
+	seen := make(map[type_system.ObjTypeKey]bool)
 	for _, elem := range obj.Elems {
-		if name, typ, ok := elemNameAndType(elem, includeSetters); ok {
-			result.Named[name] = typ
-			result.Keys = append(result.Keys, name)
-			if collectOrigElems {
-				result.OrigElems[name] = elem
+		switch elem := elem.(type) {
+		case *type_system.PropertyElem:
+			propType := elem.Value
+			if elem.Optional {
+				propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
 			}
-		} else if rest, ok := elem.(*type_system.RestSpreadElem); ok {
-			result.RestTypes = append(result.RestTypes, rest.Value)
+			result.Read[elem.Name] = propType
+			result.Write[elem.Name] = propType
+			if !seen[elem.Name] {
+				result.Keys = append(result.Keys, elem.Name)
+				seen[elem.Name] = true
+			}
+			if collectOrigElems {
+				result.OrigRead[elem.Name] = elem
+				result.OrigWrite[elem.Name] = elem
+			}
+		case *type_system.MethodElem:
+			result.Read[elem.Name] = elem.Fn
+			if !seen[elem.Name] {
+				result.Keys = append(result.Keys, elem.Name)
+				seen[elem.Name] = true
+			}
+			if collectOrigElems {
+				result.OrigRead[elem.Name] = elem
+			}
+		case *type_system.GetterElem:
+			result.Read[elem.Name] = elem.Fn.Return
+			if !seen[elem.Name] {
+				result.Keys = append(result.Keys, elem.Name)
+				seen[elem.Name] = true
+			}
+			if collectOrigElems {
+				result.OrigRead[elem.Name] = elem
+			}
+		case *type_system.SetterElem:
+			result.Write[elem.Name] = elem.Fn.Params[0].Type
+			if !seen[elem.Name] {
+				result.Keys = append(result.Keys, elem.Name)
+				seen[elem.Name] = true
+			}
+			if collectOrigElems {
+				result.OrigWrite[elem.Name] = elem
+			}
+		case *type_system.RestSpreadElem:
+			result.RestTypes = append(result.RestTypes, elem.Value)
+		default:
+			// skip CallableElem, ConstructorElem, MappedElem, etc.
 		}
 	}
 	return result
@@ -2753,7 +2804,7 @@ func (c *Checker) unifyPatternWithUnion(
 	union *type_system.UnionType,
 ) []Error {
 	// 1. Collect pattern field names and their type variables
-	patFields := collectObjElemTypes(pat, false, false).Named
+	patFields := collectObjElemTypes(pat, false).Read
 
 	// 2. For each union member, check if it has ALL pattern fields.
 	//    Union members may be TypeRefTypes (e.g. class names) that need expansion.
@@ -2765,7 +2816,7 @@ func (c *Checker) unifyPatternWithUnion(
 		if !ok {
 			continue // skip non-object union members (e.g. primitive types)
 		}
-		memberFields := collectObjElemTypes(memberObj, false, false).Named
+		memberFields := collectObjElemTypes(memberObj, false).Read
 
 		allMatch := true
 		for key := range patFields {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1241,16 +1241,23 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			}
 
 			matchingTypes := make(map[type_system.ObjTypeKey][]type_system.Type)
+			// Track which destructured fields exist as write-only (setter)
+			// across union members so we can distinguish "field doesn't exist"
+			// from "field exists but is not readable."
+			writeOnlyFields := make(map[type_system.ObjTypeKey]bool)
 			// Track remaining fields for rest spread handling
 			remainingFields := make(map[type_system.ObjTypeKey][]type_system.Type)
 			remainingFieldsOrder := []type_system.ObjTypeKey{} // Track order of keys
 
 			for _, unionType := range union.Types {
-				if unionObj, ok := unionType.(*type_system.ObjectType); ok {
+				expanded, _ := c.ExpandType(ctx, unionType, 1)
+				if unionObj, ok := expanded.(*type_system.ObjectType); ok {
 					collectedUnionObj := collectObjElemTypes(unionObj, false)
 					for name := range destructuredFields {
 						if t, ok := collectedUnionObj.Read[name]; ok {
 							matchingTypes[name] = append(matchingTypes[name], t)
+						} else if _, ok := collectedUnionObj.Write[name]; ok {
+							writeOnlyFields[name] = true
 						}
 					}
 
@@ -1274,8 +1281,15 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			}
 			errors := []Error{}
 			for name, t := range destructuredFields {
-				// if destructuredFields[name] doesn't exist, unify `undefined` with `t`
 				if _, ok := matchingTypes[name]; !ok {
+					if writeOnlyFields[name] {
+						// Field exists as a setter on at least one union
+						// member but is not readable — report an error.
+						errors = append(errors, &UnknownPropertyError{
+							ObjectType: union,
+							Property:   name.String(),
+						})
+					}
 					undefined := type_system.NewUndefinedType(nil)
 					unifyErrors := c.Unify(ctx, undefined, t)
 					errors = slices.Concat(errors, unifyErrors)


### PR DESCRIPTION
- **update collectObjElemTypes so that it can be used in more places**
- **Fix #412**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member access now models explicit read vs write intent (read/write modes added).

* **Bug Fixes**
  * Consistent getter vs setter selection for reads and writes across property/index operations, JSX components, iterators, enum/member lookups, and assignments.

* **Refactor**
  * Consolidated object/member handling and spread/unification to preserve getter/setter semantics and correct presence/absence of keys.

* **Tests**
  * Added tests validating getter/setter read/write, spread, and destructuring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->