### PR TITLE
feat(codegen): add fallback else branch for exhaustive match expressions

### DIFF
--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -2656,12 +2656,53 @@ func (b *Builder) buildMatchExpr(expr *ast.MatchExpr) (Expr, []Stmt) {
 	}
 
 	if currentStmt != nil {
+		// Check if the last case (outermost if) has a catch-all pattern.
+		// If not, add a trailing else that throws for runtime safety.
+		// This handles exhaustive matches verified at compile time where
+		// the runtime value might not match any branch (e.g. due to
+		// unsound type casts or FFI boundaries).
+		lastCase := expr.Cases[len(expr.Cases)-1]
+		if !isCatchAllPattern(lastCase.Pattern) {
+			throwMsg := NewLitExpr(NewStrLit("non-exhaustive match", nil), expr)
+			throwExpr := NewNewExpr(
+				NewIdentExpr("Error", "", expr),
+				[]Expr{throwMsg},
+				expr,
+			)
+			throwStmt := NewThrowStmt(throwExpr, expr)
+			throwBlock := NewBlockStmt([]Stmt{throwStmt}, expr)
+			currentStmt = addElseBranch(currentStmt, throwBlock)
+		}
+
 		// Post-process to convert "else if (true)" to "else"
 		currentStmt = simplifyTrueLiterals(currentStmt)
 		stmts = append(stmts, currentStmt)
 	}
 
 	return tempVar, stmts
+}
+
+// isCatchAllPattern returns true if the pattern matches everything (wildcard or bare identifier without type annotation)
+func isCatchAllPattern(pattern ast.Pat) bool {
+	switch p := pattern.(type) {
+	case *ast.WildcardPat:
+		return true
+	case *ast.IdentPat:
+		return p.TypeAnn == nil
+	default:
+		return false
+	}
+}
+
+// addElseBranch adds an else branch to the deepest nested if statement in the chain
+func addElseBranch(stmt Stmt, elseBlock *BlockStmt) Stmt {
+	if ifStmt, ok := stmt.(*IfStmt); ok {
+		if ifStmt.Alt == nil {
+			return NewIfStmt(ifStmt.Test, ifStmt.Cons, elseBlock, ifStmt.Source())
+		}
+		return NewIfStmt(ifStmt.Test, ifStmt.Cons, addElseBranch(ifStmt.Alt, elseBlock), ifStmt.Source())
+	}
+	return stmt
 }
 
 // simplifyTrueLiterals recursively converts "else if (true)" to "else" in if-else chains


### PR DESCRIPTION
## Summary

Fixes #443

When all match branches use type-annotated patterns (e.g. `n: number`, `s: string`) and the match is verified as exhaustive at compile time, the generated JavaScript previously had no trailing `else` clause. This meant that if the runtime value didn't match any branch (e.g. due to unsound type casts or FFI boundaries), the result would silently be `undefined` rather than throwing an error.

## Changes

Added a safety net in `buildMatchExpr`: when the last case is not a catch-all pattern (wildcard or bare identifier), a trailing `else { throw new Error("non-exhaustive match") }` is generated.

### Implementation

1. **`isCatchAllPattern()`** — detects if a pattern is a catch-all (`WildcardPat` or `IdentPat` without `TypeAnn`)
2. **`addElseBranch()`** — recursively traverses the if-else chain to add an else branch to the deepest nested if
3. In `buildMatchExpr`, after building the if-else chain but before simplification, check if the last case is a catch-all. If not, append the throw branch.

### Example

Before (Escalier input):
```escalier
declare val x: number | string
val result = match x {
    n: number => n,
    s: string => s,
}
```

After (generated JS):
```js
if (typeof temp === "number") {
  // ...
} else if (typeof temp === "string") {
  // ...
} else {
  throw new Error("non-exhaustive match");
}
```

Matches with wildcard/bare-identifier final cases (which are inherently catch-all) are **not** affected.

## Testing

- All codegen tests pass: `go test ./internal/codegen/` ✅
- `go build ./internal/codegen/` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-exhaustive match expressions now throw a runtime error when no pattern cases match, ensuring all possible input combinations are explicitly handled or result in a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->