### PR TITLE
Fix #434: parse qualified enum variants without parens as patterns

### DIFF
--- a/internal/checker/tests/match_test.go
+++ b/internal/checker/tests/match_test.go
@@ -43,12 +43,12 @@ func TestMatchTargetTypeInference(t *testing.T) {
 			input: `
 				enum Option<T> {
 					Some(value: T),
-					None(),
+					None,
 				}
 				declare val option: Option<number>
 				val result = match option {
 					Option.Some(value) => value,
-					Option.None() => "none",
+					Option.None => "none",
 				}
 			`,
 			expectedValues: map[string]string{
@@ -62,12 +62,12 @@ func TestMatchTargetTypeInference(t *testing.T) {
 			input: `
 				enum Option<T> {
 					Some(value: T),
-					None(),
+					None,
 				}
 				declare val option: Option<string>
 				val result = match option {
 					Option.Some(value) => value,
-					Option.None() => "none",
+					Option.None => "none",
 				}
 			`,
 			expectedValues: map[string]string{
@@ -79,12 +79,12 @@ func TestMatchTargetTypeInference(t *testing.T) {
 			input: `
 				enum Option<T> {
 					Some(value: T),
-					None(),
+					None,
 				}
 				val add1 = fn (option) {
 					return match option {
 						Option.Some(value) => value + 1,
-						Option.None() => 0,
+						Option.None => 0,
 					}
 				}
 			`,
@@ -96,12 +96,12 @@ func TestMatchTargetTypeInference(t *testing.T) {
 			input: `
 				enum Option<T> {
 					Some(value: T),
-					None(),
+					None,
 				}
 				val describe = fn (option) {
 					return match option {
 						Option.Some(value) => value,
-						Option.None() => "none",
+						Option.None => "none",
 					}
 				}
 			`,
@@ -221,7 +221,7 @@ func TestMatchTargetTypeInference(t *testing.T) {
 			input: `
 				enum Option<T> {
 					Some(value: T),
-					None(),
+					None,
 				}
 				enum Result<T, E> {
 					Ok(value: T),
@@ -250,12 +250,12 @@ func TestMatchTargetTypeInference(t *testing.T) {
 			input: `
 				enum Option<T> {
 					Some(value: T),
-					None(),
+					None,
 				}
 				val describe = fn (option: Option<number>) {
 					return match option {
 						Option.Some(value) => value,
-						Option.None() => 0,
+						Option.None => 0,
 					}
 				}
 			`,

--- a/internal/parser/__snapshots__/pattern_test.snap
+++ b/internal/parser/__snapshots__/pattern_test.snap
@@ -1058,3 +1058,33 @@
     inferredType: nil,
 }
 ---
+
+[TestParsePatternNoErrors/QualifiedExtractPatternNoArgs - 1]
+&ast.ExtractorPat{
+    Name: &ast.Member{
+        Left: &ast.Ident{
+            Name: "Option",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:1},
+                End:      ast.Location{Line:1, Column:7},
+                SourceID: 0,
+            },
+        },
+        Right: &ast.Ident{
+            Name: "None",
+            span: ast.Span{
+                Start:    ast.Location{Line:1, Column:8},
+                End:      ast.Location{Line:1, Column:12},
+                SourceID: 0,
+            },
+        },
+    },
+    Args: nil,
+    span: ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:12},
+        SourceID: 0,
+    },
+    inferredType: nil,
+}
+---

--- a/internal/parser/pattern.go
+++ b/internal/parser/pattern.go
@@ -19,11 +19,13 @@ func (p *Parser) pattern(allowIdentDefault bool, allowColonTypeAnn bool) ast.Pat
 		p.lexer.consume() // consume first identifier
 
 		// Skip through any dots and identifiers (qualified identifier)
+		isQualified := false
 		for p.lexer.peek().Type == Dot {
 			p.lexer.consume() // consume dot
 			next := p.lexer.peek()
 			if next.Type == Identifier || isTypeKeywordIdentifier(next.Type) {
 				p.lexer.consume() // consume identifier
+				isQualified = true
 			} else {
 				break
 			}
@@ -37,6 +39,12 @@ func (p *Parser) pattern(allowIdentDefault bool, allowColonTypeAnn bool) ast.Pat
 			return p.extractorPat(token)
 		} else if next.Type == OpenBrace {
 			return p.instancePat(token)
+		} else if isQualified {
+			// Qualified name without parens (e.g., Option.None) is an
+			// extractor pattern with zero arguments.
+			qualIdent := p.parseQualifiedIdent(token)
+			span := qualIdent.Span()
+			return ast.NewExtractorPat(qualIdent, nil, span)
 		} else {
 			return p.identPat(token, allowIdentDefault, allowColonTypeAnn)
 		}

--- a/internal/parser/pattern_test.go
+++ b/internal/parser/pattern_test.go
@@ -77,6 +77,9 @@ func TestParsePatternNoErrors(t *testing.T) {
 		"NamespacedExtractPattern": {
 			input: "MyNamespace.Foo(a, b)",
 		},
+		"QualifiedExtractPatternNoArgs": {
+			input: "Option.None",
+		},
 		"InstancePattern": {
 			input: "Point {x, y}",
 		},


### PR DESCRIPTION
## Summary
- Qualified names like `Option.None` are now parsed as `ExtractorPat` with zero arguments, instead of only being recognized when followed by `()`
- This makes pattern syntax consistent with enum declaration syntax where no-param variants omit parentheses
- Updated existing tests to use the no-parens syntax

## Test plan
- [x] Added parser snapshot test `QualifiedExtractPatternNoArgs` for `Option.None`
- [x] Updated existing checker tests to use `Option.None` without parens
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pattern matching syntax: Qualified type identifiers can now be recognized and used as extractor patterns without requiring parentheses. This allows for cleaner, more intuitive pattern matching code, particularly when working with enum variants and constructor patterns (e.g., `Option.None` instead of `Option.None()`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->