### PR TITLE
Fix #446

### DIFF
--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1600,15 +1600,6 @@ func (c *Checker) getEnumTypeFromExtractor(ctx Context, p *ast.ExtractorPat) typ
 				}
 				returnType = SubstituteTypeParams(returnType, substitutions)
 			}
-			// TODO(#446): The constructor return type has TypeAlias: nil because
-			// the enum's type alias is created after the constructor. This
-			// fallback resolution can be removed once inferEnumDecl forward-
-			// declares the TypeAlias before processing variants.
-			if ref, ok := returnType.(*type_system.TypeRefType); ok && ref.TypeAlias == nil {
-				if typeAlias := resolveQualifiedTypeAlias(ctx, ref.Name); typeAlias != nil {
-					returnType = type_system.NewTypeRefTypeFromQualIdent(ref.Provenance(), ref.Name, typeAlias, ref.TypeArgs...)
-				}
-			}
 			return returnType
 		}
 	}

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -464,6 +464,17 @@ func (c *Checker) inferEnumDecl(ctx Context, decl *ast.EnumDecl) []Error {
 		typeArgs[i] = type_system.NewTypeRefType(nil, typeParams[i].Name, nil)
 	}
 
+	// Forward-declare the enum's TypeAlias with a placeholder before processing
+	// variants. This ensures constructor return types can reference the TypeAlias
+	// directly, eliminating the need for fallback resolution in downstream consumers.
+	enumPlaceholder := c.FreshVar(&ast.NodeProvenance{Node: decl})
+	typeAlias := &type_system.TypeAlias{
+		Type:       enumPlaceholder,
+		TypeParams: typeParams,
+		Exported:   decl.Export(),
+	}
+	ctx.Scope.SetTypeAlias(decl.Name.Name, typeAlias)
+
 	variantTypes := make([]type_system.Type, len(decl.Elems))
 
 	for i, elem := range decl.Elems {
@@ -489,7 +500,7 @@ func (c *Checker) inferEnumDecl(ctx Context, decl *ast.EnumDecl) []Error {
 				&ast.NodeProvenance{Node: elem},
 				typeParams,
 				params,
-				type_system.NewTypeRefType(nil, decl.Name.Name, nil, typeArgs...),
+				type_system.NewTypeRefType(nil, decl.Name.Name, typeAlias, typeArgs...),
 				type_system.NewNeverType(nil),
 			)
 			constructorElem := &type_system.ConstructorElem{Fn: funcType}
@@ -600,18 +611,13 @@ func (c *Checker) inferEnumDecl(ctx Context, decl *ast.EnumDecl) []Error {
 		}
 	}
 
-	// Build the union type for the enum itself. The enum's top-level type
-	// alias is a union of all variant types (e.g. Option<T> = Option.Some<T> | Option.None).
+	// Build the union type for the enum itself and unify it with the
+	// placeholder that was forward-declared before processing variants.
 	enumUnionType := type_system.NewUnionType(
 		&ast.NodeProvenance{Node: decl}, variantTypes...)
 
-	typeAlias := &type_system.TypeAlias{
-		Type:       enumUnionType,
-		TypeParams: typeParams,
-		Exported:   decl.Export(),
-	}
-
-	ctx.Scope.SetTypeAlias(decl.Name.Name, typeAlias)
+	unifyErrors := c.Unify(ctx, enumPlaceholder, enumUnionType)
+	errors = slices.Concat(errors, unifyErrors)
 
 	return errors
 }

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1277,14 +1277,7 @@ func (c *Checker) unifyExtractor(
 	// TODO(#430): We might have to expand the subject if the type alias
 	// it's using points to another type alias.
 	if typeRef, ok := subject.(*type_system.TypeRefType); ok {
-		// TODO(#446): The constructor return type has TypeAlias: nil because
-		// the enum's type alias is created after the constructor. This
-		// fallback resolution can be removed once inferEnumDecl forward-
-		// declares the TypeAlias before processing variants.
 		typeAlias := typeRef.TypeAlias
-		if typeAlias == nil {
-			typeAlias = resolveQualifiedTypeAlias(ctx, typeRef.Name)
-		}
 		if typeAlias != nil && len(typeRef.TypeArgs) >= len(typeAlias.TypeParams) {
 			substitutions := make(map[string]type_system.Type)
 			for i, typeParam := range typeAlias.TypeParams {


### PR DESCRIPTION
## Summary

- Forward-declare the enum's `TypeAlias` with a `FreshVar` placeholder in `inferEnumDecl` **before** processing variants (mirroring the existing pattern in `infer_module.go`), then unify the placeholder with the real union type after all variants are built
- Constructor return types now reference the `TypeAlias` directly instead of `nil`
- Remove fallback scope resolution in `getEnumTypeFromExtractor` (`infer_expr.go`) and `unifyExtractor` (`unify.go`) that was needed when `TypeAlias` was `nil`

## Test plan

- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)