### PR TITLE
Implement Plan A: expand TypeRefTypes at match site

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -88,6 +88,8 @@ func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool
 	return true
 }
 
+// TODO(#452): Extract a separate ExpandNonRefTypes helper for the count=0 case
+// to make call sites self-documenting.
 func (c *Checker) ExpandType(ctx Context, t type_system.Type, expandTypeRefsCount int) (type_system.Type, []Error) {
 	return c.expandTypeWithConfig(ctx, t, expandTypeRefsCount, 0)
 }

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -27,6 +27,42 @@ func isSymbolIndexKey(key MemberAccessKey) bool {
 	return isSymbol
 }
 
+// canExpandTypeRef checks whether a TypeRefType can be expanded (i.e., it
+// resolves to a non-nominal, non-self-referential type alias). Used as a
+// predicate only — the actual expansion is done by ExpandType which creates
+// fresh copies to prevent mutation of shared TypeAlias types.
+func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool {
+	typeAlias := t.TypeAlias
+	if typeAlias == nil {
+		typeAlias = resolveQualifiedTypeAlias(ctx, t.Name)
+	}
+	if typeAlias == nil {
+		return false
+	}
+
+	expandedType := type_system.Prune(typeAlias.Type)
+
+	// Don't expand nominal object types — nominal semantics are enforced
+	// in the ObjectType vs ObjectType case in unifyMatched. Expanding here
+	// would bypass nominal identity checks and can cause infinite loops
+	// for self-referential class types.
+	if obj, ok := expandedType.(*type_system.ObjectType); ok && obj.Nominal {
+		return false
+	}
+
+	// Don't expand self-referential aliases (e.g., type param A whose alias
+	// Type is TypeRefType(A)). These occur at type parameter creation sites
+	// where the alias is a forward-reference placeholder. Expanding would
+	// produce a new copy of the same TypeRefType, causing an infinite loop.
+	if ref, ok := expandedType.(*type_system.TypeRefType); ok {
+		if type_system.QualIdentToString(ref.Name) == type_system.QualIdentToString(t.Name) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (c *Checker) ExpandType(ctx Context, t type_system.Type, expandTypeRefsCount int) (type_system.Type, []Error) {
 	return c.expandTypeWithConfig(ctx, t, expandTypeRefsCount, 0)
 }

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -40,6 +40,13 @@ func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool
 		return false
 	}
 
+	// Don't expand type parameter placeholder aliases. These are marker
+	// entries (IsTypeParam=true) created at type parameter creation sites;
+	// expanding them would destroy the parameter's identity.
+	if typeAlias.IsTypeParam {
+		return false
+	}
+
 	expandedType := type_system.Prune(typeAlias.Type)
 
 	// Don't expand nominal object types — nominal semantics are enforced
@@ -50,14 +57,32 @@ func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool
 		return false
 	}
 
-	// Don't expand self-referential aliases (e.g., type param A whose alias
-	// Type is TypeRefType(A)). These occur at type parameter creation sites
-	// where the alias is a forward-reference placeholder. Expanding would
-	// produce a new copy of the same TypeRefType, causing an infinite loop.
-	if ref, ok := expandedType.(*type_system.TypeRefType); ok {
-		if type_system.QualIdentToString(ref.Name) == type_system.QualIdentToString(t.Name) {
-			return false
+	// Don't expand if following the alias chain leads back to the original
+	// TypeRefType (direct or transitive cycle). Walk the chain of
+	// TypeRefType → TypeAlias links with a visited set to detect cycles
+	// like A→B→A.
+	originName := type_system.QualIdentToString(t.Name)
+	visited := map[string]bool{originName: true}
+	cur := expandedType
+	for {
+		ref, ok := cur.(*type_system.TypeRefType)
+		if !ok {
+			break
 		}
+		refName := type_system.QualIdentToString(ref.Name)
+		if visited[refName] {
+			return false // cycle detected
+		}
+		visited[refName] = true
+		// Follow the chain
+		alias := ref.TypeAlias
+		if alias == nil {
+			alias = resolveQualifiedTypeAlias(ctx, ref.Name)
+		}
+		if alias == nil {
+			break
+		}
+		cur = type_system.Prune(alias.Type)
 	}
 
 	return true

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -600,8 +600,9 @@ func GeneralizeFuncType(funcType *type_system.FuncType) {
 		// Bind the type var to a TypeRefType referencing the new type param.
 		// All existing references to this type var will resolve via Prune.
 		tv.Instance = type_system.NewTypeRefType(nil, name, &type_system.TypeAlias{
-			Type:       type_system.NewUnknownType(nil),
-			TypeParams: []*type_system.TypeParam{},
+			Type:        type_system.NewUnknownType(nil),
+			TypeParams:  []*type_system.TypeParam{},
+			IsTypeParam: true,
 		})
 	}
 

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -98,8 +98,9 @@ func (c *Checker) inferFuncTypeParams(
 			t = typeParam.Constraint
 		}
 		funcCtx.Scope.SetTypeAlias(typeParam.Name, &type_system.TypeAlias{
-			Type:       t,
-			TypeParams: []*type_system.TypeParam{},
+			Type:        t,
+			TypeParams:  []*type_system.TypeParam{},
+			IsTypeParam: true,
 		})
 	}
 

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -375,8 +375,9 @@ func (c *Checker) InferComponent(
 						t = typeParam.Constraint
 					}
 					declCtx.Scope.SetTypeAlias(typeParam.Name, &type_system.TypeAlias{
-						Type:       t,
-						TypeParams: []*type_system.TypeParam{},
+						Type:        t,
+						TypeParams:  []*type_system.TypeParam{},
+						IsTypeParam: true,
 					})
 				}
 
@@ -640,8 +641,9 @@ func (c *Checker) InferComponent(
 						t = typeParam.Constraint
 					}
 					declCtx.Scope.SetTypeAlias(typeParam.Name, &type_system.TypeAlias{
-						Type:       t,
-						TypeParams: []*type_system.TypeParam{},
+						Type:        t,
+						TypeParams:  []*type_system.TypeParam{},
+						IsTypeParam: true,
 					})
 				}
 			case *ast.InterfaceDecl:

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -246,8 +246,9 @@ func (c *Checker) buildTypeParams(
 		// Add this type parameter to the scope for subsequent parameters
 		typeParamTypeRef := type_system.NewTypeRefType(nil, typeParam.Name, nil)
 		typeParamAlias := &type_system.TypeAlias{
-			Type:       typeParamTypeRef,
-			TypeParams: []*type_system.TypeParam{},
+			Type:        typeParamTypeRef,
+			TypeParams:  []*type_system.TypeParam{},
+			IsTypeParam: true,
 		}
 		typeCtx.Scope.SetTypeAlias(typeParam.Name, typeParamAlias)
 	}

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -154,8 +154,9 @@ func (c *Checker) inferTypeAnn(
 			for _, name := range names {
 				inferTypeRef := type_system.NewTypeRefType(nil, name, nil)
 				inferTypeAlias := &type_system.TypeAlias{
-					Type:       inferTypeRef,
-					TypeParams: []*type_system.TypeParam{},
+					Type:        inferTypeRef,
+					TypeParams:  []*type_system.TypeParam{},
+					IsTypeParam: true,
 				}
 				condScope.SetTypeAlias(name, inferTypeAlias)
 			}
@@ -390,8 +391,9 @@ func (c *Checker) inferObjectTypeAnn(
 				// Add the type parameter as a type alias to the scope
 				typeParamTypeRef := type_system.NewTypeRefType(nil, elem.TypeParam.Name, nil)
 				typeParamAlias := &type_system.TypeAlias{
-					Type:       typeParamTypeRef,
-					TypeParams: []*type_system.TypeParam{},
+					Type:        typeParamTypeRef,
+					TypeParams:  []*type_system.TypeParam{},
+					IsTypeParam: true,
 				}
 				mappedScope.SetTypeAlias(elem.TypeParam.Name, typeParamAlias)
 

--- a/internal/checker/tests/infer_class_decl_test.go
+++ b/internal/checker/tests/infer_class_decl_test.go
@@ -653,12 +653,11 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 }
 
 // TestNominalClassUnificationTerminates verifies that unifying two different
-// nominal classes terminates and produces an error. This exercises the
-// last-resort TypeRefType expansion path in unifyPruned, where canExpandTypeRef
-// refuses nominal types but ExpandType(t, 1) expands them as a fallback. After
-// expansion, the ObjectType vs ObjectType case rejects the mismatch via obj.ID.
-// A self-referential class (Node with a "next" field of its own type) is
-// included to verify that the expansion doesn't loop infinitely.
+// nominal classes terminates and produces an error. For nominal TypeRefTypes,
+// ExpandType returns nil (the visitor checks Nominal and bails), so the
+// last-resort branch in unifyPruned is a no-op and execution falls through to
+// CannotUnifyTypesError. A self-referential class (Node with a "next" field of
+// its own type) is included to verify that the expansion loop doesn't hang.
 func TestNominalClassUnificationTerminates(t *testing.T) {
 	source := &ast.Source{
 		ID:   0,

--- a/internal/checker/tests/infer_class_decl_test.go
+++ b/internal/checker/tests/infer_class_decl_test.go
@@ -688,5 +688,6 @@ func TestNominalClassUnificationTerminates(t *testing.T) {
 		IsPatMatch: false,
 	}
 	inferErrors := c.InferModule(inferCtx, module)
-	assert.NotEmpty(t, inferErrors, "Expected a type error when assigning Node to Leaf")
+	assert.Len(t, inferErrors, 1)
+	assert.Equal(t, "Node cannot be assigned to Leaf", inferErrors[0].Message())
 }

--- a/internal/checker/tests/infer_class_decl_test.go
+++ b/internal/checker/tests/infer_class_decl_test.go
@@ -651,3 +651,42 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestNominalClassUnificationTerminates verifies that unifying two different
+// nominal classes terminates and produces an error. This exercises the
+// last-resort TypeRefType expansion path in unifyPruned, where canExpandTypeRef
+// refuses nominal types but ExpandType(t, 1) expands them as a fallback. After
+// expansion, the ObjectType vs ObjectType case rejects the mismatch via obj.ID.
+// A self-referential class (Node with a "next" field of its own type) is
+// included to verify that the expansion doesn't loop infinitely.
+func TestNominalClassUnificationTerminates(t *testing.T) {
+	source := &ast.Source{
+		ID:   0,
+		Path: "input.esc",
+		Contents: `
+			class Node(value: number, next: Node | null) {
+				value,
+				next,
+			}
+			class Leaf(value: number) {
+				value,
+			}
+			val n = Node(1, null)
+			val l: Leaf = n
+		`,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+	assert.Len(t, parseErrors, 0)
+
+	c := NewChecker()
+	inferCtx := Context{
+		Scope:      Prelude(c),
+		IsAsync:    false,
+		IsPatMatch: false,
+	}
+	inferErrors := c.InferModule(inferCtx, module)
+	assert.NotEmpty(t, inferErrors, "Expected a type error when assigning Node to Leaf")
+}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -253,22 +253,22 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			continue
 		}
 
-		// Last resort for nominal TypeRefTypes (e.g. classes) that
-		// canExpandTypeRef refused. This is needed for pattern matching
-		// against nominal types: `match p { {foo} => foo }` requires
-		// expanding to access properties. ExpandType(t, 1) always expands
-		// TypeRefTypes via the visitor regardless of nominality — the visitor
-		// simply resolves the alias without checking nominal semantics.
-		// Nominal semantics are enforced downstream in the ObjectType vs
-		// ObjectType case in unifyMatched (which allows structural comparison
-		// in pattern-matching mode via ctx.IsPatMatch).
+		// Last resort for TypeRefTypes that canExpandTypeRef refused (e.g.
+		// refs blocked by IsTypeParam, or cycle detection). ExpandType may
+		// still expand these if the alias resolves to a non-nominal type.
+		// For nominal TypeRefTypes (classes), ExpandType returns nil (the
+		// visitor checks Nominal and bails), so lastResortT == t and this
+		// branch is a no-op — execution falls through to CannotUnifyTypesError.
 		//
-		// Termination: after expansion, unifyWithDepth(depth+1) re-enters
-		// unifyMatched with two concrete types (typically ObjectTypes). For
-		// nominal types, obj.ID mismatch produces an immediate error unless
-		// ctx.IsPatMatch allows structural comparison over finite property
-		// sets. In both cases the recursion bottoms out without re-entering
-		// this last-resort path.
+		// For non-nominal refused refs (e.g. cycle-blocked aliases),
+		// ExpandType may return a different type, triggering unifyWithDepth.
+		// This is needed for pattern matching against structural types:
+		// `match p { {foo} => foo }` requires expanding the TypeRefType to
+		// access the ObjectType's properties.
+		//
+		// Termination: unifyWithDepth(depth+1) re-enters unifyMatched with
+		// concrete types. For structural types, unification proceeds over
+		// finite property sets and bottoms out without re-entering this path.
 		if isRef1 || isRef2 {
 			lastResortT1, _ := c.ExpandType(ctx, t1, 1)
 			lastResortT2, _ := c.ExpandType(ctx, t2, 1)

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -14,11 +14,11 @@ import (
 // expansion and retry is appropriate.
 type noMatchError struct{}
 
-func (e *noMatchError) isError()          {}
-func (e *noMatchError) Span() ast.Span   { return DEFAULT_SPAN }
-func (e *noMatchError) Error() string    { return "no match" }
-func (e *noMatchError) Message() string  { return "no match" }
-func (e *noMatchError) IsWarning() bool  { return false }
+func (e *noMatchError) isError()        {}
+func (e *noMatchError) Span() ast.Span  { return DEFAULT_SPAN }
+func (e *noMatchError) Error() string   { return "no match" }
+func (e *noMatchError) Message() string { return "no match" }
+func (e *noMatchError) IsWarning() bool { return false }
 
 // isNoMatch checks whether the error list consists solely of a noMatchError
 // sentinel, indicating that unifyMatched found no applicable case.
@@ -193,6 +193,10 @@ func (c *Checker) unifyWithDepth(ctx Context, t1, t2 type_system.Type, depth int
 	return errors
 }
 
+// maxExpansionRetries bounds the non-TypeRef expansion loop in unifyPruned.
+// Only the TypeOfType/CondType continue path can iterate; TypeRefType expansion
+// exits via unifyWithDepth (bounded by maxUnifyDepth). This constant is a
+// safety net against unexpected infinite expansion, not a normal retry limit.
 const maxExpansionRetries = 10
 
 func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) []Error {
@@ -252,6 +256,13 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 		// Nominal semantics are enforced downstream in the ObjectType vs
 		// ObjectType case in unifyMatched (which allows structural comparison
 		// in pattern-matching mode via ctx.IsPatMatch).
+		//
+		// Termination: after expansion, unifyWithDepth(depth+1) re-enters
+		// unifyMatched with two concrete types (typically ObjectTypes). For
+		// nominal types, obj.ID mismatch produces an immediate error unless
+		// ctx.IsPatMatch allows structural comparison over finite property
+		// sets. In both cases the recursion bottoms out without re-entering
+		// this last-resort path.
 		if isRef1 || isRef2 {
 			lastResortT1, _ := c.ExpandType(ctx, t1, 1)
 			lastResortT2, _ := c.ExpandType(ctx, t2, 1)

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -220,7 +220,9 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 		// Try expanding TypeRefTypes. Use canExpandTypeRef as a "should we
 		// expand?" predicate, then delegate to ExpandType + unifyWithDepth
 		// for the actual retry. ExpandType creates fresh copies via the
-		// visitor (preventing mutation of shared TypeAlias types — Issue 9),
+		// visitor (preventing mutation of shared TypeAlias types, e.g.
+		// `type Point = {x: number, y: number}; val p: Point = {x: 1, y: 2}`
+		// would corrupt Point's alias if unification mutated the shared pointer),
 		// and unifyWithDepth provides Prune + widening on the expanded result.
 		refCanExpand := false
 		if isRef1 && c.canExpandTypeRef(ctx, ref1) {
@@ -237,7 +239,9 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 
 		// Try expanding TypeOfType and other non-TypeRef expandable types.
 		// ExpandType with count=0 skips TypeRef expansion (already handled).
-		// Pointer-equality check is reliable here (see Issue 3 notes).
+		// Pointer-equality check is reliable here: ExpandType(t, 0) returns
+		// the same pointer when t contains nothing expandable at count=0
+		// (e.g. an ObjectType with only TypeRefType properties).
 		nonRefExpT1, _ := c.ExpandType(ctx, t1, 0)
 		nonRefExpT2, _ := c.ExpandType(ctx, t2, 0)
 		if nonRefExpT1 != t1 || nonRefExpT2 != t2 {
@@ -249,8 +253,10 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			continue
 		}
 
-		// Issue 10: Last resort for TypeRefTypes that canExpandTypeRef
-		// refused (e.g. nominal types). ExpandType(t, 1) always expands
+		// Last resort for nominal TypeRefTypes (e.g. classes) that
+		// canExpandTypeRef refused. This is needed for pattern matching
+		// against nominal types: `match p { {foo} => foo }` requires
+		// expanding to access properties. ExpandType(t, 1) always expands
 		// TypeRefTypes via the visitor regardless of nominality — the visitor
 		// simply resolves the alias without checking nominal semantics.
 		// Nominal semantics are enforced downstream in the ObjectType vs

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -9,6 +9,27 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
+// noMatchError is a sentinel error indicating that no case in unifyMatched
+// handled the type combination. unifyPruned uses this to decide whether
+// expansion and retry is appropriate.
+type noMatchError struct{}
+
+func (e *noMatchError) isError()          {}
+func (e *noMatchError) Span() ast.Span   { return DEFAULT_SPAN }
+func (e *noMatchError) Error() string    { return "no match" }
+func (e *noMatchError) Message() string  { return "no match" }
+func (e *noMatchError) IsWarning() bool  { return false }
+
+// isNoMatch checks whether the error list consists solely of a noMatchError
+// sentinel, indicating that unifyMatched found no applicable case.
+func isNoMatch(errors []Error) bool {
+	if len(errors) == 1 {
+		_, ok := errors[0].(*noMatchError)
+		return ok
+	}
+	return false
+}
+
 // getSpanFromType extracts the span from a type's provenance if available
 func getSpanFromType(t type_system.Type) ast.Span {
 	if t == nil {
@@ -172,7 +193,80 @@ func (c *Checker) unifyWithDepth(ctx Context, t1, t2 type_system.Type, depth int
 	return errors
 }
 
+const maxExpansionRetries = 10
+
 func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) []Error {
+	for attempt := 0; attempt < maxExpansionRetries; attempt++ {
+		errors := c.unifyMatched(ctx, t1, t2, depth)
+		if len(errors) == 0 {
+			return nil
+		}
+
+		// If a case in unifyMatched handled the types and returned errors,
+		// those errors are authoritative — don't try expansion.
+		if !isNoMatch(errors) {
+			return errors
+		}
+
+		// From here, no case in unifyMatched matched. Try expansion.
+
+		ref1, isRef1 := t1.(*type_system.TypeRefType)
+		ref2, isRef2 := t2.(*type_system.TypeRefType)
+
+		// Try expanding TypeRefTypes. Use canExpandTypeRef as a "should we
+		// expand?" predicate, then delegate to ExpandType + unifyWithDepth
+		// for the actual retry. ExpandType creates fresh copies via the
+		// visitor (preventing mutation of shared TypeAlias types — Issue 9),
+		// and unifyWithDepth provides Prune + widening on the expanded result.
+		refCanExpand := false
+		if isRef1 && c.canExpandTypeRef(ctx, ref1) {
+			refCanExpand = true
+		}
+		if isRef2 && c.canExpandTypeRef(ctx, ref2) {
+			refCanExpand = true
+		}
+		if refCanExpand {
+			refExpT1, _ := c.ExpandType(ctx, t1, 1)
+			refExpT2, _ := c.ExpandType(ctx, t2, 1)
+			return c.unifyWithDepth(ctx, refExpT1, refExpT2, depth+1)
+		}
+
+		// Try expanding TypeOfType and other non-TypeRef expandable types.
+		// ExpandType with count=0 skips TypeRef expansion (already handled).
+		// Pointer-equality check is reliable here (see Issue 3 notes).
+		nonRefExpT1, _ := c.ExpandType(ctx, t1, 0)
+		nonRefExpT2, _ := c.ExpandType(ctx, t2, 0)
+		if nonRefExpT1 != t1 || nonRefExpT2 != t2 {
+			// Prune after expansion to resolve any TypeVarTypes returned by
+			// expansion (e.g. TypeOfType resolves to a scope binding's
+			// TypeVarType, which must be pruned before re-entering unifyMatched).
+			t1 = type_system.Prune(nonRefExpT1)
+			t2 = type_system.Prune(nonRefExpT2)
+			continue
+		}
+
+		// Issue 10: Last resort for TypeRefTypes that canExpandTypeRef
+		// refused (e.g. nominal types). ExpandType(t, 1) always expands
+		// TypeRefTypes via the visitor regardless of nominality — the visitor
+		// simply resolves the alias without checking nominal semantics.
+		// Nominal semantics are enforced downstream in the ObjectType vs
+		// ObjectType case in unifyMatched (which allows structural comparison
+		// in pattern-matching mode via ctx.IsPatMatch).
+		if isRef1 || isRef2 {
+			lastResortT1, _ := c.ExpandType(ctx, t1, 1)
+			lastResortT2, _ := c.ExpandType(ctx, t2, 1)
+			if lastResortT1 != t1 || lastResortT2 != t2 {
+				return c.unifyWithDepth(ctx, lastResortT1, lastResortT2, depth+1)
+			}
+		}
+
+		// Nothing could be expanded, return a real error
+		return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
+	}
+	return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
+}
+
+func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) []Error {
 
 	// | TypeVarType, ErrorType -> bind
 	// | ErrorType, TypeVarType -> bind
@@ -500,13 +594,6 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 				}
 				return errors
 			}
-		}
-	}
-	// | TypeRefType, TypeRefType (different alias name) -> ...
-	if ref1, ok := t1.(*type_system.TypeRefType); ok {
-		if ref2, ok := t2.(*type_system.TypeRefType); ok && ref1.Name != ref2.Name {
-			// panic(fmt.Sprintf("TODO: unify types %#v and %#v", ref1, ref2))
-			// TODO
 		}
 	}
 	// | LitType, PrimType -> ...
@@ -1186,26 +1273,7 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 		}}
 	}
 
-	retry := false
-	expandedT1, _ := c.ExpandType(ctx, t1, 1)
-	if expandedT1 != t1 {
-		t1 = expandedT1
-		retry = true
-	}
-	expandedT2, _ := c.ExpandType(ctx, t2, 1)
-	if expandedT2 != t2 {
-		t2 = expandedT2
-		retry = true
-	}
-
-	if retry {
-		return c.unifyWithDepth(ctx, t1, t2, depth+1)
-	}
-
-	return []Error{&CannotUnifyTypesError{
-		T1: t1,
-		T2: t2,
-	}}
+	return []Error{&noMatchError{}}
 }
 
 // unifyExtractor unifies a subject type against an ExtractorType by finding

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -260,9 +260,10 @@ func (t *TypeVarType) String() string {
 }
 
 type TypeAlias struct {
-	Type       Type
-	TypeParams []*TypeParam
-	Exported   bool
+	Type        Type
+	TypeParams  []*TypeParam
+	Exported    bool
+	IsTypeParam bool // true for type parameter scope entries, not real aliases
 }
 
 type TypeRefType struct {
@@ -2746,8 +2747,9 @@ func (t *NamespaceType) Accept(v TypeVisitor) Type {
 		if newType != typeAlias.Type {
 			changed = true
 			newTypes[name] = &TypeAlias{
-				Type:       newType,
-				TypeParams: typeAlias.TypeParams,
+				Type:        newType,
+				TypeParams:  typeAlias.TypeParams,
+				IsTypeParam: typeAlias.IsTypeParam,
 			}
 		} else {
 			newTypes[name] = typeAlias

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -2749,6 +2749,7 @@ func (t *NamespaceType) Accept(v TypeVisitor) Type {
 			newTypes[name] = &TypeAlias{
 				Type:        newType,
 				TypeParams:  typeAlias.TypeParams,
+				Exported:    typeAlias.Exported,
 				IsTypeParam: typeAlias.IsTypeParam,
 			}
 		} else {

--- a/planning/taming_recursion/plan_a_typeref_expansion.md
+++ b/planning/taming_recursion/plan_a_typeref_expansion.md
@@ -26,7 +26,7 @@ The retry loop is reached when neither `t1` nor `t2` matches any of the explicit
 cases in `unifyPruned`. After reviewing all cases, the scenarios that fall through
 to the retry are:
 
-1. **TypeRefType + TypeRefType (different alias)** — Lines 506-510 have a TODO and
+1. **TypeRefType + TypeRefType (different alias)** — Lines 505-511 have a TODO and
    do nothing, so these fall through.
 2. **TypeRefType + any non-TypeRef concrete type** — e.g. `TypeRefType` vs
    `ObjectType`, `PrimType`, `LitType`, `UnionType`, etc. There is no case that
@@ -48,9 +48,9 @@ to the final `CannotUnifyTypesError`.
 `expandTypeRef` (expand_type.go:1617) returns an `UnknownTypeError` when the
 TypeRefType refers to something that isn't a type alias (e.g. enum variant `RGB`).
 The old `ExpandType` also errored in this case but returned `NeverType`, which
-unifies with everything. A new `tryExpandTypeRef` helper is needed that returns
-`(type, bool)` instead — returning `(nil, false)` when resolution fails, so the
-caller can fall through gracefully.
+unifies with everything. A new `canExpandTypeRef` helper is needed that returns
+`bool` — returning `false` when resolution fails, so the caller can fall through
+gracefully.
 
 ### Issue 2: Stack overflow from recursive `unifyWithDepth` calls
 
@@ -131,8 +131,8 @@ it via same-alias TypeRefType comparison. The retry loop's expansion of `T` to
 **New code (broken when expansion is before cases):** The in-place expansion loop
 runs BEFORE the union cases. `TypeRefType(T)` is expanded to `unknown` before the
 `_, UnionType` case gets a chance to match it. Then `unknown` (top type) can't be
-assigned to any member of `number | T`, since `UnknownType` on the left side always
-errors (line 290).
+assigned to any member of `number | T`, since `UnknownType` on the left side
+errors unless the right side is also `UnknownType` (line 286-294).
 
 **Root cause:** The `TypeAlias` struct has no way to distinguish a regular type
 alias from a type parameter constraint. Both look identical:
@@ -149,7 +149,7 @@ TypeAlias{Type: unknown, TypeParams: [], Exported: false}
 
 1. **Add `IsTypeParam` flag to `TypeAlias`:** Add an `IsTypeParam bool` field to the
    `TypeAlias` struct. Set it to `true` at all type parameter creation sites. The
-   `tryExpandTypeRef` helper checks this flag and returns `(nil, false)` for type
+   `canExpandTypeRef` helper checks this flag and returns `false` for type
    parameter aliases, preventing expansion from destroying the parameter's identity.
 
    ```go
@@ -190,7 +190,190 @@ different in the type system, at the cost of a larger refactor (scope API change
 every type name resolution path would need to check both maps). The `IsTypeParam` flag
 is the pragmatic first step; the full separation can be done later if warranted.
 
-## Plan (revised)
+## Discovered issues from implementation attempt
+
+The following issues were discovered during an actual implementation attempt
+(beyond the earlier prototyping phase).
+
+### Issue 5: `bind()` side effects leak through the expansion loop
+
+**Problem:** When `unifyMatched` calls `bind(t1, t2)` for a TypeVarType, `bind`
+both **returns errors** (from constraint checking) and **sets `Instance`** as a
+side effect. In the old code, errors from `unifyPruned` were returned directly.
+In the new code, the expansion loop sees the errors and tries to "fix" them by
+expanding TypeRefTypes — but the binding already happened, so the retry can
+produce incorrect results.
+
+**Example:** `fn bar(items: Array<string>)` / `fn foo(items) { items[0] = 42;
+bar(items) }` — the constraint check `number vs string` correctly fails inside
+`bind`, but the expansion loop then expands `Array<string>` structurally and
+retries, accidentally succeeding.
+
+**Fix:** After `unifyMatched` returns errors, check if either `t1` or `t2` is a
+TypeVarType. If so, the error came from `bind` and is authoritative — return
+immediately without attempting expansion. This is correct because `bind` handles
+all TypeVarType cases exhaustively; expansion cannot help.
+
+### Issue 6: Same-alias TypeRefTypes expanded after type-arg mismatch
+
+**Problem:** When `Array<number>` vs `Array<string>` fails in the same-alias case
+(type args don't match), the expansion loop expands both to their structural
+ObjectTypes and retries. The structural comparison may succeed incorrectly or
+produce confusing errors, when the same-alias type-arg error was the correct answer.
+
+**Fix:** Before attempting expansion, check if both sides are same-alias
+TypeRefTypes via `sameTypeRef()`. If so, return the error immediately — the
+same-alias case in `unifyMatched` already compared their type args definitively.
+
+### Issue 7: Self-referential type parameter aliases cause infinite expansion loop
+
+**Problem:** `infer_stmt.go:buildTypeParams` creates self-referential aliases for
+type parameters: type param `A` gets `TypeAlias{Type: TypeRefType(A)}`. Each call
+to `canExpandTypeRef`/expansion "expands" `A` into a new copy of `TypeRefType(A)`, causing
+an infinite loop bounded only by `maxExpansionRetries`. Three creation sites produce
+self-referential aliases:
+- `infer_stmt.go:buildTypeParams` — type declaration type params
+- `infer_type_ann.go` — conditional type `infer` params
+- `infer_type_ann.go` — mapped type params
+
+The old code avoided this because `ExpandType(t, 1)` decrements an internal counter
+and stops after one level, then the retry called `unifyWithDepth` with `depth+1`,
+eventually hitting `maxUnifyDepth`.
+
+**Fix:** In `canExpandTypeRef`, after resolving the alias, check if the expanded
+type is a TypeRefType with the same name as the input. If so, return `(nil, false)`
+to prevent the self-referential loop.
+
+```go
+if ref, ok := expandedType.(*type_system.TypeRefType); ok {
+    if type_system.QualIdentToString(ref.Name) == type_system.QualIdentToString(t.Name) {
+        return nil, false
+    }
+}
+```
+
+This is more targeted than `IsTypeParam` (which blocks ALL type param expansion).
+The self-referentiality check blocks only the cycle (`A→A`) while allowing
+constraint chains (`C→B` where `C: B`) to expand normally.
+
+Note: This does NOT catch mutual recursion (`A→B→A`). Mutual recursion would still
+loop until `maxExpansionRetries`. This is acceptable for now — Plan B's visited set
+will handle mutual recursion properly.
+
+### Issue 8: Type param constraint chains blocked by `IsTypeParam`
+
+**Problem:** The `IsTypeParam` flag on `canExpandTypeRef` prevents ALL type
+parameter expansion, including constraint chains like `C: B, B: A, A: string`.
+When `C` vs `A` fails in `unifyMatched` (different names), the expansion loop
+needs to expand `C → B's constraint` and `A → string` to eventually unify. But
+`IsTypeParam` blocks this.
+
+**Example:** `fn convert<C: B, B: A, A: string>(x: C) -> A { return x }` — the
+return type check needs `C` expanded through the chain to verify it's assignable
+to `A`.
+
+**Fix:** Remove the `IsTypeParam` check from `canExpandTypeRef`. The Issue 4 fix
+(expansion AFTER case-matching) already provides the necessary defense — the
+same-alias case in `unifyMatched` handles `T vs T` before expansion runs, so type
+parameter identity is preserved where it matters. The self-referentiality check
+from Issue 7 prevents the infinite loop that `IsTypeParam` was also guarding
+against.
+
+The `IsTypeParam` field should still be added to `TypeAlias` (it's useful
+documentation and may be needed for future use), but `canExpandTypeRef` should NOT
+check it.
+
+### Issue 9: Expanded TypeAlias types share mutable pointers
+
+**Problem:** Directly using `typeAlias.Type` from a resolved alias (as an earlier
+prototype did) passes a shared pointer into the `TypeAlias` struct. When the
+expansion loop passes this to `unifyMatched`, property-by-property unification can
+**mutate** the shared type via TypeVarType binding, corrupting the type alias for
+all future uses.
+
+The `TypeAlias.Type` is often a `TypeVarType` (not the concrete type). For
+example, `type Point = {x: number, y: number}` creates a TypeAlias whose Type is
+a TypeVarType bound to the ObjectType `{x: number, y: number}`. If this
+TypeVarType were passed directly to `unifyMatched`, the bind logic could rebind it
+to the literal type from the other side of the unification (e.g., `{x: 1, y: 2}`),
+permanently corrupting Point's alias.
+
+**Confirmed via debugging:** For `val p: Point = {x: 1, y: 2}`, Point's
+`TypeAlias.Type` changes from `TypeVarType({x: number, y: number})` to
+`TypeVarType({x: mut? 1, y: mut? 2})` after `Unify(initType, taType)`.
+
+The old code avoided this because `ExpandType(ctx, t, 1)` creates **fresh copies**
+via the visitor's Accept mechanism. The copies are structurally identical but
+pointer-distinct, so unification side effects don't propagate back to the alias.
+
+**Fix:** Use `canExpandTypeRef` as a predicate only (it returns `bool`, not the
+expanded type). When it returns `true`, delegate to `ExpandType(ctx, t, 1)` (which
+creates fresh copies via the visitor) followed by `unifyWithDepth(ctx, expanded1,
+expanded2, depth+1)`. The `unifyWithDepth` call:
+1. Prunes both types (resolving TypeVarTypes to concrete types)
+2. Goes through the full unification pipeline (including widening)
+3. Works on fresh copies, not shared TypeAlias pointers
+
+This means `canExpandTypeRef` handles the "should we expand?" decision, but the
+actual expansion + retry goes through `ExpandType` + `unifyWithDepth`. The
+`depth+1` parameter bounds the recursion (same as the old code).
+
+**Why this doesn't reintroduce Issue 2 (stack overflow):** In the old code, EVERY
+failed case triggered `unifyWithDepth` recursion (via the catch-all retry loop). In
+the new code, `unifyWithDepth` is only called when a TypeRefType was actually
+expanded — not for every failed match. The recursion depth is proportional to the
+alias chain depth (typically 1-3 levels), not to the number of type properties.
+For React SVG elements with 200+ properties, each property's unification calls
+`c.Unify()` (which starts its own `unifyWithDepth` at depth 0), but the expansion
+recursion adds at most one extra frame per alias level — not per property.
+
+**Impact on Plans B and C:** This approach means `depth+1` recursion is still used
+for TypeRefType expansion, so `maxUnifyDepth` remains necessary as a safety net.
+Plan B's visited set will need to be threaded through `unifyWithDepth` calls (which
+was already the plan). Plan C's goal of removing `maxUnifyDepth` may need to keep
+it as a fallback even after the visited set is in place, unless the visited set
+provably prevents all unbounded recursion through this path.
+
+### Issue 10: Nominal types need ExpandType for pattern matching
+
+**Problem:** `canExpandTypeRef` blocks expansion of nominal ObjectTypes (classes)
+to prevent bypassing nominal identity checks. But pattern matching against nominal
+types (`match p { {foo} => foo }`) requires expanding the TypeRefType to access
+the ObjectType's properties and report `PropertyNotFoundError`.
+
+In the old code, `ExpandType(t, 1)` always expanded TypeRefTypes regardless of
+nominality. The nominal semantics were enforced in the ObjectType vs ObjectType
+case in `unifyMatched`, which allows structural comparison in pattern-matching
+mode (`ctx.IsPatMatch`).
+
+**Fix:** Keep the nominal check in `canExpandTypeRef` (it prevents infinite loops
+from self-referential class types). For TypeRefTypes where `canExpandTypeRef`
+returns false (nominal, unresolved, etc.), fall through to `ExpandType(ctx, t, 1)`
+as a last resort. `ExpandType` always expands TypeRefTypes via the visitor
+regardless of nominality — the visitor simply resolves the alias without checking
+nominal semantics. This matches the old code's behavior where ExpandType always
+expanded, and the nominal semantics were handled downstream in the ObjectType vs
+ObjectType case in `unifyMatched`.
+
+In the `unifyPruned` loop, after `canExpandTypeRef` returns false and
+`ExpandType(ctx, t, 0)` also fails, add a final fallback:
+
+```go
+// Last resort: ExpandType with count=1 for TypeRefTypes that
+// canExpandTypeRef refused (e.g. nominal types).
+if isRef1 || isRef2 {
+    lastResortT1, _ := c.ExpandType(ctx, t1, 1)
+    lastResortT2, _ := c.ExpandType(ctx, t2, 1)
+    if lastResortT1 != t1 || lastResortT2 != t2 {
+        return c.unifyWithDepth(ctx, lastResortT1, lastResortT2, depth+1)
+    }
+}
+```
+
+This uses `unifyWithDepth` (not `continue`) for the same shared-pointer safety
+reasons as Issue 9.
+
+## Plan (revised after implementation attempt)
 
 ### Step 1: Add `IsTypeParam` flag to `TypeAlias` and update creation sites
 
@@ -199,56 +382,82 @@ Add `IsTypeParam bool` to the `TypeAlias` struct in `type_system/types.go`. Then
 above. The default `false` is correct for all existing regular aliases, so no other
 sites need changes.
 
-### Step 2: Add `tryExpandTypeRef` helper
+Note: Per Issue 8, `canExpandTypeRef` does NOT check this flag — the
+self-referentiality check (Issue 7) and expansion-after-matching ordering (Issue 4)
+provide sufficient protection. The flag is still valuable as documentation and for
+potential future use.
+
+### Step 2: Add `canExpandTypeRef` helper
 
 Add a new method to `Checker` (in expand_type.go) that attempts to expand a
-TypeRefType without erroring:
+TypeRefType without erroring. This function is used only as a "should we expand?"
+predicate — it returns `bool`, not the expanded type. The actual expansion is done
+by `ExpandType(ctx, t, 1)` which creates fresh copies (see Issue 9).
 
 ```go
-func (c *Checker) tryExpandTypeRef(ctx Context, t *type_system.TypeRefType) (type_system.Type, bool) {
+func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool {
     typeAlias := t.TypeAlias
     if typeAlias == nil {
         typeAlias = resolveQualifiedTypeAlias(ctx, t.Name)
     }
     if typeAlias == nil {
-        return nil, false
+        return false
     }
 
-    // Don't expand type parameter references — preserve their identity
-    if typeAlias.IsTypeParam {
-        return nil, false
-    }
+    expandedType := type_system.Prune(typeAlias.Type)
 
-    expandedType := typeAlias.Type
-
-    // Don't expand nominal object types.
-    // NOTE: Currently only ObjectType can be nominal. If other nominal types
-    // are added in the future, this check should be extended.
+    // Don't expand nominal object types — nominal semantics are enforced
+    // in the ObjectType vs ObjectType case in unifyMatched. Expanding here
+    // would bypass nominal identity checks and can cause infinite loops
+    // for self-referential class types.
     if obj, ok := expandedType.(*type_system.ObjectType); ok && obj.Nominal {
-        return nil, false
+        return false
     }
 
-    // Handle type parameter substitution if the type is generic
-    if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
-        substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
-        expandedType = SubstituteTypeParams(typeAlias.Type, substitutions)
+    // Don't expand self-referential aliases (e.g., type param A whose alias
+    // Type is TypeRefType(A)). These occur at type parameter creation sites
+    // where the alias is a forward-reference placeholder. Expanding would
+    // produce a new copy of the same TypeRefType, causing an infinite loop.
+    if ref, ok := expandedType.(*type_system.TypeRefType); ok {
+        if type_system.QualIdentToString(ref.Name) == type_system.QualIdentToString(t.Name) {
+            return false
+        }
     }
 
-    return expandedType, true
+    return true
 }
 ```
 
-### Step 3: Extract case-matching into `unifyMatched`, add expansion loop in `unifyPruned`
+Note: The self-referentiality check compares `QualIdentToString` names. This is
+sufficient because `QualIdent` includes namespace qualification, so same-named type
+parameters in different scopes will have distinct qualified names. However, mutual
+recursion (`A→B→A`) is NOT caught — see Issue 7 notes on this limitation.
+
+Key differences from the original plan:
+- **Returns `bool` only** — the expanded type is not needed since the actual
+  expansion is delegated to `ExpandType(ctx, t, 1)` (Issue 9). This avoids
+  computing substitutions for generic aliases only to discard the result.
+- **Prunes `typeAlias.Type`** before checking — the alias Type is often a
+  TypeVarType, not a concrete type. Without pruning, the nominal and
+  self-referentiality checks would see a TypeVarType instead of the underlying type.
+- **No `IsTypeParam` check** — removed per Issue 8. The self-referentiality check
+  handles the infinite loop case, and constraint chains need expansion to work.
+- **Self-referentiality check added** — per Issue 7. Detects `A→A` cycles.
+
+### Step 3: Extract case-matching into `unifyMatched`, add expansion logic in `unifyPruned`
 
 Rename the current `unifyPruned` to `unifyMatched` (the function that contains all
-the explicit type-matching cases). Then rewrite `unifyPruned` as a small loop that:
+the explicit type-matching cases). Then rewrite `unifyPruned` as a loop that:
 1. Calls `unifyMatched` with the current types
 2. If matching succeeds, returns immediately
-3. If matching fails, tries expanding TypeRefTypes and TypeOfTypes
-4. If anything expanded, retries from step 1 with the expanded types
-5. If nothing expanded, returns the original error
+3. If matching fails, applies guards (Issue 5, 6) and tries expansion
+4. If a TypeRefType expanded, delegates to `unifyWithDepth` (Issue 9)
+5. If non-TypeRef types expanded (TypeOfType etc.), retries via the loop
+6. If nothing expanded, returns the original error
 
 ```go
+const maxExpansionRetries = 10
+
 func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) []Error {
     for attempt := 0; attempt < maxExpansionRetries; attempt++ {
         errors := c.unifyMatched(ctx, t1, t2, depth)
@@ -256,39 +465,65 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
             return nil
         }
 
-        // Try expanding TypeRefTypes
-        expanded := false
-        if ref1, ok := t1.(*type_system.TypeRefType); ok {
-            if exp, ok := c.tryExpandTypeRef(ctx, ref1); ok {
-                t1 = exp
-                expanded = true
-            }
+        // Issue 5: If either type is a TypeVarType, the error came from bind
+        // (constraint checking). Expansion cannot help — return immediately.
+        if _, ok := t1.(*type_system.TypeVarType); ok {
+            return errors
         }
-        if ref2, ok := t2.(*type_system.TypeRefType); ok {
-            if exp, ok := c.tryExpandTypeRef(ctx, ref2); ok {
-                t2 = exp
-                expanded = true
-            }
+        if _, ok := t2.(*type_system.TypeVarType); ok {
+            return errors
         }
-        if expanded {
-            // Note: if only one side expanded, the other stays as-is. On the
-            // retry, the already-expanded side won't be a TypeRefType anymore,
-            // so it won't attempt expansion again. This is correct — if the
-            // retry still fails, we fall through to the ExpandType(t, 0)
-            // fallback which handles non-TypeRef expandable types.
-            continue
+
+        // Issue 6: Don't expand same-alias TypeRefTypes — the same-alias case
+        // in unifyMatched already compared their type args definitively.
+        ref1, isRef1 := t1.(*type_system.TypeRefType)
+        ref2, isRef2 := t2.(*type_system.TypeRefType)
+        if isRef1 && isRef2 && c.sameTypeRef(ref1, ref2) {
+            return errors
+        }
+
+        // Try expanding TypeRefTypes. Use canExpandTypeRef as a "should we
+        // expand?" predicate, then delegate to ExpandType + unifyWithDepth
+        // for the actual retry. ExpandType creates fresh copies via the
+        // visitor (preventing mutation of shared TypeAlias types — Issue 9),
+        // and unifyWithDepth provides Prune + widening on the expanded result.
+        refCanExpand := false
+        if isRef1 && c.canExpandTypeRef(ctx, ref1) {
+            refCanExpand = true
+        }
+        if isRef2 && c.canExpandTypeRef(ctx, ref2) {
+            refCanExpand = true
+        }
+        if refCanExpand {
+            refExpT1, _ := c.ExpandType(ctx, t1, 1)
+            refExpT2, _ := c.ExpandType(ctx, t2, 1)
+            return c.unifyWithDepth(ctx, refExpT1, refExpT2, depth+1)
         }
 
         // Try expanding TypeOfType and other non-TypeRef expandable types.
-        // ExpandType errors are treated as "no expansion possible" — the error
-        // from ExpandType is not actionable here since we're speculatively
-        // trying expansion, and the original unifyMatched error is more useful.
-        expandedT1, _ := c.ExpandType(ctx, t1, 0)
-        expandedT2, _ := c.ExpandType(ctx, t2, 0)
-        if expandedT1 != t1 || expandedT2 != t2 {
-            t1 = expandedT1
-            t2 = expandedT2
+        // ExpandType with count=0 skips TypeRef expansion (already handled).
+        // Pointer-equality check is reliable here (see Issue 3 notes).
+        nonRefExpT1, _ := c.ExpandType(ctx, t1, 0)
+        nonRefExpT2, _ := c.ExpandType(ctx, t2, 0)
+        if nonRefExpT1 != t1 || nonRefExpT2 != t2 {
+            t1 = nonRefExpT1
+            t2 = nonRefExpT2
             continue
+        }
+
+        // Issue 10: Last resort for TypeRefTypes that canExpandTypeRef
+        // refused (e.g. nominal types). ExpandType(t, 1) always expands
+        // TypeRefTypes via the visitor regardless of nominality — the visitor
+        // simply resolves the alias without checking nominal semantics.
+        // Nominal semantics are enforced downstream in the ObjectType vs
+        // ObjectType case in unifyMatched (which allows structural comparison
+        // in pattern-matching mode via ctx.IsPatMatch).
+        if isRef1 || isRef2 {
+            lastResortT1, _ := c.ExpandType(ctx, t1, 1)
+            lastResortT2, _ := c.ExpandType(ctx, t2, 1)
+            if lastResortT1 != t1 || lastResortT2 != t2 {
+                return c.unifyWithDepth(ctx, lastResortT1, lastResortT2, depth+1)
+            }
         }
 
         // Nothing could be expanded, return the original error
@@ -297,6 +532,16 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
     return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 }
 ```
+
+Note: `ExpandType` returns `(Type, []Error)`. The errors are ignored (via `_`)
+throughout this function. This matches the existing retry loop behavior (lines
+1190-1196). It is safe because: (a) `ExpandType` errors come from `expandTypeRef`
+returning `UnknownTypeError` for unresolvable TypeRefTypes (Issue 1), and
+`canExpandTypeRef` already screens these out; (b) for the non-TypeRef path
+(`count=0`), TypeRefTypes are skipped entirely so `expandTypeRef` is never called;
+(c) for the Issue 10 last-resort path, expansion failure is detected by pointer
+equality (`lastResortT1 != t1`) and the function falls through to return the
+original `unifyMatched` errors.
 
 The existing case-matching code moves to `unifyMatched` with no changes to its
 body or indentation. The do-nothing different-alias case (lines 505-511) and the
@@ -307,8 +552,21 @@ matched, triggering the expansion logic.
 Note: The **same-alias** TypeRefType case (lines 448-504, `c.sameTypeRef(ref1, ref2)`)
 is kept in `unifyMatched`. When two TypeRefTypes refer to the same alias, they match
 directly via type argument unification without needing expansion. Only the
-**different-alias** case is removed, since `unifyPruned`'s expansion loop now handles
+**different-alias** case is removed, since `unifyPruned`'s expansion logic now handles
 it by expanding both sides and retrying.
+
+**Key design decision — `unifyWithDepth` vs `continue`:** TypeRefType expansion
+delegates to `unifyWithDepth` (a recursive call) rather than looping via `continue`.
+This is necessary because:
+- `unifyWithDepth` prunes types, resolving shared TypeVarType pointers to concrete
+  types before they enter `unifyMatched` (prevents Issue 9 corruption)
+- `unifyWithDepth` provides the widening fallback for Widenable TypeVarTypes
+- `ExpandType(ctx, t, 1)` creates fresh copies, preventing mutation of shared state
+- The recursion depth is bounded by `depth+1` and proportional to alias chain depth
+  (typically 1-3), not to property count (which caused Issue 2)
+
+Non-TypeRef expansion (TypeOfType etc.) uses `continue` because `ExpandType(ctx, t, 0)`
+already creates copies and the pointer-equality check prevents spurious retries.
 
 ### Step 4: Audit other ExpandType calls in unify.go
 
@@ -322,18 +580,14 @@ to the retry loop and should be preserved:
 
 ### Step 5: Set an appropriate loop bound
 
-After this change, the loop counter in `unifyPruned` controls expansion retries
-rather than recursive call depth. The semantics have changed: each iteration
-expands one layer of type aliases, so the max iterations equals the max alias
-chain depth (e.g. `type A = B`, `type B = C`, `type C = number` → 3 iterations).
+The loop in `unifyPruned` now primarily handles non-TypeRef expansion (TypeOfType
+etc.) via the `continue` path. TypeRefType expansion exits via `unifyWithDepth`
+(which has its own `maxUnifyDepth` bound). The `maxExpansionRetries` constant
+guards against unexpected loops in the non-TypeRef path.
 
-Use a dedicated constant (e.g. `maxExpansionRetries = 10`) rather than reusing
-`maxUnifyDepth`. A value of 10 provides generous headroom — typical alias chains
-are 1-3 levels deep, and anything deeper than 10 likely indicates a cycle.
-
-After Plan B (visited-set) is implemented, the loop bound becomes a safety net
-rather than the primary cycle-prevention mechanism, and could potentially be
-removed entirely.
+Use a dedicated constant (e.g. `maxExpansionRetries = 10`). After Plan B
+(visited-set) is implemented, both `maxExpansionRetries` and `maxUnifyDepth`
+become safety nets rather than primary cycle-prevention mechanisms.
 
 ## Testing strategy
 
@@ -363,6 +617,22 @@ removed entirely.
 6. **Test React types** — Verify `TestImportInferenceScript/NamespaceImportReact`
    passes without stack overflow, confirming the loop-based approach handles large
    types.
+7. **Test bind error propagation (Issue 5)** — The existing test for
+   `fn bar(items: Array<string>)` / `fn foo(items) { items[0] = 42; bar(items) }`
+   should continue to report a `number vs string` constraint error. Verify
+   expansion does not mask it.
+8. **Test same-alias type-arg mismatch (Issue 6)** — Verify that
+   `Array<number> vs Array<string>` produces a type-arg error, not a structural
+   comparison error from expanding both aliases.
+9. **Test self-referential type params (Issue 7)** — Existing tests with generic
+   type declarations (e.g. `type Pair<A, B> = ...`) exercise the self-referential
+   alias path. Verify no infinite loops or hangs.
+10. **Test alias corruption (Issue 9)** — Verify that after
+    `val p: Point = {x: 1, y: 2}`, using `Point` again in a subsequent declaration
+    still refers to `{x: number, y: number}`, not the literal types.
+11. **Test pattern matching on nominal types (Issue 10)** — Existing getter/setter
+    and pattern-matching tests exercise this path. Verify `PropertyNotFoundError`
+    is reported correctly when destructuring a nominal type.
 
 ## Risks
 
@@ -370,14 +640,23 @@ removed entirely.
   loop for expansion (e.g. a `CondType` or `IndexType` that somehow reaches
   `unifyPruned` unexpanded), those would now fail with `CannotUnifyTypesError`
   instead of being retried. Mitigation: run the full test suite and React type
-  tests to catch these. The `ExpandType(ctx, t, 0)` fallback at the bottom of the
-  loop handles most of these.
-- **Double expansion**: The TypeRefType + TypeRefType (different alias) case
-  expands both `t1` and `t2` if both are TypeRefTypes. If the expanded form is
-  itself a `TypeRefType`, it will be expanded again on the next loop iteration.
-  This is correct behavior but relies on the loop counter to prevent cycles with
-  recursive aliases (which will be properly handled by Plan B).
+  tests to catch these. The `ExpandType(ctx, t, 0)` fallback handles most of these,
+  and the `ExpandType(ctx, t, 1)` last resort (Issue 10) covers the rest.
+- **Shared mutable state**: TypeAlias types are shared across all references to the
+  alias. Any code path that passes a TypeAlias.Type pointer directly to unification
+  risks corruption via TypeVarType rebinding. The plan mitigates this by: (a) using
+  `ExpandType` to create fresh copies before `unifyWithDepth`, and (b) pruning in
+  `canExpandTypeRef` to resolve TypeVarTypes before nominal/self-referential checks.
+  New code touching TypeAlias.Type should be audited for this pattern.
 - **Wasted case matching**: `TypeRefType + ObjectType` falls through all cases in
   `unifyMatched` before being expanded in the `unifyPruned` loop. This is
   functionally correct but slightly less efficient than early expansion. The cost
   is negligible since case matching is cheap compared to type expansion.
+- **`unifyWithDepth` recursion**: TypeRefType expansion now uses `unifyWithDepth`
+  recursion (with `depth+1`) rather than a purely iterative loop. This is bounded
+  by alias chain depth (typically 1-3) and `maxUnifyDepth`, not by property count.
+  Plan B's visited set will provide additional protection against cycles.
+- **Mutual recursion not handled**: The self-referentiality check in
+  `canExpandTypeRef` only catches direct cycles (`A→A`), not mutual recursion
+  (`A→B→A`). These rely on `maxExpansionRetries`/`maxUnifyDepth` until Plan B adds
+  proper cycle detection.

--- a/planning/taming_recursion/plan_a_typeref_expansion.md
+++ b/planning/taming_recursion/plan_a_typeref_expansion.md
@@ -1,18 +1,20 @@
 # Plan A: Expand at the TypeRefType match site, not in a catch-all retry
 
+**Status: Implemented (PR #451)**
+
 ## Goal
 
-Replace the catch-all retry loop at the bottom of `unifyPruned` (lines 1189-1203)
-with explicit `TypeRefType` handling. This makes expansion predictable: it only
-happens for the type kinds that need it, retrying as needed within a bounded
-loop to peel through alias chains.
+Replace the catch-all retry loop at the bottom of `unifyPruned` with explicit
+`TypeRefType` handling. This makes expansion predictable: it only happens for the
+type kinds that need it, retrying as needed within a bounded loop to peel through
+alias chains.
 
 ## Background
 
-Currently, when `unifyPruned` fails to match any explicit case, it falls through to
-a retry loop that calls `ExpandType(ctx, t, 1)` on both sides. If either side
-expanded (detected by pointer inequality), it recurses into `unifyWithDepth` with
-`depth + 1`. This has two problems:
+Previously, when `unifyPruned` failed to match any explicit case, it fell through to
+a retry loop that called `ExpandType(ctx, t, 1)` on both sides. If either side
+expanded (detected by pointer inequality), it recursed into `unifyWithDepth` with
+`depth + 1`. This had two problems:
 
 1. `ExpandType` always allocates new objects, so `expandedT1 != t1` is always true
    for expandable types, even when the result is structurally identical.
@@ -20,87 +22,65 @@ expanded (detected by pointer inequality), it recurses into `unifyWithDepth` wit
    `IndexType`), but these are already handled in their own cases within
    `ExpandType`'s visitor. The retry loop re-expands types that don't need it.
 
-## Analysis of what reaches the retry loop
+## Analysis of what reached the retry loop
 
-The retry loop is reached when neither `t1` nor `t2` matches any of the explicit
-cases in `unifyPruned`. After reviewing all cases, the scenarios that fall through
-to the retry are:
+The retry loop was reached when neither `t1` nor `t2` matched any of the explicit
+cases in `unifyPruned`. After reviewing all cases, the scenarios that fell through
+to the retry were:
 
-1. **TypeRefType + TypeRefType (different alias)** — Lines 505-511 have a TODO and
-   do nothing, so these fall through.
+1. **TypeRefType + TypeRefType (different alias)** — The old code had a TODO and
+   did nothing, so these fell through.
 2. **TypeRefType + any non-TypeRef concrete type** — e.g. `TypeRefType` vs
-   `ObjectType`, `PrimType`, `LitType`, `UnionType`, etc. There is no case that
-   handles "one side is a TypeRefType, the other is something else."
-3. **TypeOfType + any type** — `TypeOfType` (e.g. `typeof obj`) has no explicit case
-   in `unifyPruned` and relies on the retry loop's `ExpandType` to resolve it.
-4. **Unrecognized type combinations** — Any pair of types that doesn't match the
+   `ObjectType`, `PrimType`, `LitType`, `UnionType`, etc. There was no case that
+   handled "one side is a TypeRefType, the other is something else."
+3. **TypeOfType + any type** — `TypeOfType` (e.g. `typeof obj`) had no explicit case
+   in `unifyPruned` and relied on the retry loop's `ExpandType` to resolve it.
+4. **Unrecognized type combinations** — Any pair of types that didn't match the
    listed cases (e.g. `NullType` + `ObjectType`). These should be genuine
    unification errors.
 
-In cases 1-3, the retry loop expands the types and retries. In case 4, expansion
-doesn't change either type, so the retry doesn't fire and the function falls through
+In cases 1-3, the retry loop expanded the types and retried. In case 4, expansion
+didn't change either type, so the retry didn't fire and the function fell through
 to the final `CannotUnifyTypesError`.
 
-## Discovered issues from prototyping
+## Issues discovered and resolved
 
 ### Issue 1: `expandTypeRef` fails on non-alias TypeRefTypes
 
-`expandTypeRef` (expand_type.go:1617) returns an `UnknownTypeError` when the
-TypeRefType refers to something that isn't a type alias (e.g. enum variant `RGB`).
-The old `ExpandType` also errored in this case but returned `NeverType`, which
-unifies with everything. A new `canExpandTypeRef` helper is needed that returns
-`bool` — returning `false` when resolution fails, so the caller can fall through
-gracefully.
+`expandTypeRef` returned an `UnknownTypeError` when the TypeRefType referred to
+something that isn't a type alias (e.g. enum variant `RGB`). The `canExpandTypeRef`
+helper was added, returning `false` when resolution fails so the caller falls
+through gracefully.
 
 ### Issue 2: Stack overflow from recursive `unifyWithDepth` calls
 
 Calling `unifyWithDepth(ctx, expandedT1, t2, depth+1)` for each TypeRefType
-expansion adds a full `unifyWithDepth` → `unifyPruned` frame to the call stack.
+expansion added a full `unifyWithDepth` → `unifyPruned` frame to the call stack.
 For types with many properties (React SVG elements: 200+ properties), each property
-may be a TypeRefType that triggers another expansion round. Since property-by-property
-unification uses `c.Unify()` (which resets depth to 0), the depth counter cannot
-prevent stack overflow — the stack overflows before `maxUnifyDepth` is reached.
+may be a TypeRefType that triggers another expansion round.
 
-**Fix**: Use an in-place expansion loop instead of recursive calls. See the plan
-below for the structure that avoids adding indentation to the existing case-matching
-code.
+**Resolution:** The `noMatchError` sentinel approach means expansion only happens
+when no case matched — not on every failed match. The recursion depth is
+proportional to the alias chain depth (typically 1-3 levels), not to the number of
+type properties.
 
 ### Issue 3: TypeOfType also relies on the retry loop
 
-`TypeOfType` (e.g. `typeof obj`) has no explicit case in `unifyPruned`. The retry
-loop expands it via `ExpandType`, which resolves the `typeof` expression to the
-value's type. Without the retry loop, `ObjectType` vs `TypeOfType` (found in the
-getter/setter tests) fails with `CannotUnifyTypesError`.
+`TypeOfType` (e.g. `typeof obj`) had no explicit case in `unifyPruned`. The retry
+loop expanded it via `ExpandType`, which resolves the `typeof` expression to the
+value's type.
 
-**Fix**: Add a targeted expansion for non-TypeRefType expandable types using
-`ExpandType(ctx, t, 0)` (count=0 skips TypeRef expansion, since those are already
-handled). Only retry when the type actually changed (to avoid the pointer-inequality
-trap with ObjectTypes).
-
-Note: `ExpandType` with count=0 does NOT expand TypeRefTypes (since
-`expandTypeRefsCount == 0` returns nil in the visitor). It DOES expand TypeOfType,
-CondType, and other non-TypeRef expandable types. For plain ObjectTypes with only
-TypeRefType properties, `ExpandType(obj, 0)` returns the same pointer since nothing
-inside changes — so the pointer-inequality check is reliable here.
-
-**Why pointer identity is preserved**: The visitor's `Accept` implementations track
-whether any child changed. When the visitor returns nil for a child (as it does for
-TypeRefType when count=0), the Accept method keeps the original pointer. If no
-children changed, the parent returns its own original pointer. This propagates up
-the tree, so `ExpandType(ctx, t, 0) == t` (pointer equality) when `t` contains
-nothing expandable at count=0.
+**Resolution:** Non-TypeRef expansion uses `ExpandType(ctx, t, 0)` (count=0 skips
+TypeRef expansion). Only retries when the type actually changed (pointer-equality
+check). `ExpandType(t, 0)` returns the same pointer when `t` contains nothing
+expandable at count=0 (e.g. an ObjectType with only TypeRefType properties).
 
 ### Issue 4: Type parameter references expanded to their constraints
 
-**This is the most fundamental issue.** `TypeRefType` is used to represent both
-type alias references (`type Foo = ...`) and type parameter references (`<T>`).
-For type parameters, the `TypeAlias` field on the `TypeRefType` is set to a
-`TypeAlias` whose `Type` is the parameter's constraint (e.g. `unknown` for
-unbounded `<T>`).
-
-When TypeRefType expansion runs BEFORE the case-matching logic, expanding
-`TypeRefType(T)` resolves the TypeAlias and returns the constraint `unknown`. This
-destroys the type parameter's identity, breaking union member matching.
+`TypeRefType` is used to represent both type alias references (`type Foo = ...`)
+and type parameter references (`<T>`). Expanding `TypeRefType(T)` resolves the
+TypeAlias and returns the constraint `unknown`, destroying the type parameter's
+identity.
 
 **Example failure** (`ClassWithGenericMethod` test):
 
@@ -114,549 +94,139 @@ class Box(value: number) {
 }
 ```
 
-When checking the return type, the checker unifies the inferred return type
-`number | T` with the declared return type `number | T`. This enters the
-`UnionType, _` case which iterates over the left union's members:
+**Resolution (two parts):**
 
-- `number` vs `number | T` → matches `number` member → OK
-- `TypeRefType(T)` vs `number | T` → enters `_, UnionType` case, which probes:
-  - `TypeRefType(T)` vs `number` → fails
-  - `TypeRefType(T)` vs `TypeRefType(T)` → same-alias case → succeeds!
+1. Added `IsTypeParam bool` to `TypeAlias` struct. Set to `true` at all type
+   parameter creation sites. `canExpandTypeRef` checks this flag and returns
+   `false` for type parameter aliases.
 
-**Old code (working):** The retry loop runs AFTER the case-matching logic. By the
-time `TypeRefType(T)` reaches the retry loop, the union case has already matched
-it via same-alias TypeRefType comparison. The retry loop's expansion of `T` to
-`unknown` is never reached for this case.
-
-**New code (broken when expansion is before cases):** The in-place expansion loop
-runs BEFORE the union cases. `TypeRefType(T)` is expanded to `unknown` before the
-`_, UnionType` case gets a chance to match it. Then `unknown` (top type) can't be
-assigned to any member of `number | T`, since `UnknownType` on the left side
-errors unless the right side is also `UnknownType` (line 286-294).
-
-**Root cause:** The `TypeAlias` struct has no way to distinguish a regular type
-alias from a type parameter constraint. Both look identical:
-
-```go
-// Regular type alias: type Foo = unknown
-TypeAlias{Type: unknown, TypeParams: [], Exported: false}
-
-// Type parameter constraint: <T> (implicit unknown constraint)
-TypeAlias{Type: unknown, TypeParams: [], Exported: false}
-```
-
-**Fix (two parts):**
-
-1. **Add `IsTypeParam` flag to `TypeAlias`:** Add an `IsTypeParam bool` field to the
-   `TypeAlias` struct. Set it to `true` at all type parameter creation sites. The
-   `canExpandTypeRef` helper checks this flag and returns `false` for type
-   parameter aliases, preventing expansion from destroying the parameter's identity.
-
-   ```go
-   type TypeAlias struct {
-       Type        Type
-       TypeParams  []*TypeParam
-       Exported    bool
-       IsTypeParam bool // true for type parameter scope entries, not real aliases
-   }
-   ```
-
-   Creation sites that need `IsTypeParam: true`:
-   - `infer_func.go` — function type params (`inferFuncTypeParams`)
-   - `infer_stmt.go` — type params in `buildTypeParams`
-   - `infer_module.go` — class type params and enum type params
-   - `generalize.go` — generalized type vars bound to TypeRefType
-   - `infer_type_ann.go` — `infer` types in conditional types and mapped type params
-
-   Creation sites that stay `IsTypeParam: false` (default):
-   - `infer_stmt.go` — `Self` alias for interfaces
-   - `infer_expr.go` — `Self` alias for object expressions
-   - `infer_import.go` — re-exported aliases (copies from existing aliases)
-   - All regular type/class/enum/interface declarations in `infer_module.go`
-
-2. **Position expansion AFTER case-matching:** The case-matching code gets a chance to
-   handle TypeRefTypes via same-alias comparison and union member matching first. Only
-   when no case matches do we expand and retry. This provides defense in depth — the
-   ordering prevents the issue in practice, and the flag prevents it explicitly.
-
-Both parts are used in the plan below.
-
-**Future direction:** If `TypeAlias` serving double duty for both real aliases and type
-parameters continues to cause issues, a cleaner separation would be to stop storing
-type parameters as `TypeAlias` entries entirely. Instead, store `*TypeParam` directly
-in a separate `TypeParams` map on `Namespace`/`Scope`, with dedicated
-`GetTypeParam`/`SetTypeParam` methods. This would make the two concepts explicitly
-different in the type system, at the cost of a larger refactor (scope API changes, and
-every type name resolution path would need to check both maps). The `IsTypeParam` flag
-is the pragmatic first step; the full separation can be done later if warranted.
-
-## Discovered issues from implementation attempt
-
-The following issues were discovered during an actual implementation attempt
-(beyond the earlier prototyping phase).
+2. Expansion runs AFTER case-matching (via `noMatchError` sentinel). The union
+   member matching and same-alias comparison handle `T vs T` before expansion
+   has a chance to destroy the parameter's identity.
 
 ### Issue 5: `bind()` side effects leak through the expansion loop
 
-**Problem:** When `unifyMatched` calls `bind(t1, t2)` for a TypeVarType, `bind`
-both **returns errors** (from constraint checking) and **sets `Instance`** as a
-side effect. In the old code, errors from `unifyPruned` were returned directly.
-In the new code, the expansion loop sees the errors and tries to "fix" them by
-expanding TypeRefTypes — but the binding already happened, so the retry can
-produce incorrect results.
+When `unifyMatched` calls `bind(t1, t2)` for a TypeVarType, `bind` both returns
+errors and sets `Instance` as a side effect.
 
-**Example:** `fn bar(items: Array<string>)` / `fn foo(items) { items[0] = 42;
-bar(items) }` — the constraint check `number vs string` correctly fails inside
-`bind`, but the expansion loop then expands `Array<string>` structurally and
-retries, accidentally succeeding.
-
-**Fix:** After `unifyMatched` returns errors, check if either `t1` or `t2` is a
-TypeVarType. If so, the error came from `bind` and is authoritative — return
-immediately without attempting expansion. This is correct because `bind` handles
-all TypeVarType cases exhaustively; expansion cannot help.
+**Resolution:** The `noMatchError` sentinel approach handles this naturally.
+`bind` errors are authoritative (not `noMatchError`), so `unifyPruned` returns
+them immediately without attempting expansion.
 
 ### Issue 6: Same-alias TypeRefTypes expanded after type-arg mismatch
 
-**Problem:** When `Array<number>` vs `Array<string>` fails in the same-alias case
-(type args don't match), the expansion loop expands both to their structural
-ObjectTypes and retries. The structural comparison may succeed incorrectly or
-produce confusing errors, when the same-alias type-arg error was the correct answer.
+When `Array<number>` vs `Array<string>` failed in the same-alias case, the
+expansion loop could expand both to structural ObjectTypes and retry incorrectly.
 
-**Fix:** Before attempting expansion, check if both sides are same-alias
-TypeRefTypes via `sameTypeRef()`. If so, return the error immediately — the
-same-alias case in `unifyMatched` already compared their type args definitively.
+**Resolution:** Same as Issue 5 — the same-alias case returns authoritative
+errors (not `noMatchError`), so expansion is never attempted.
 
 ### Issue 7: Self-referential type parameter aliases cause infinite expansion loop
 
-**Problem:** `infer_stmt.go:buildTypeParams` creates self-referential aliases for
-type parameters: type param `A` gets `TypeAlias{Type: TypeRefType(A)}`. Each call
-to `canExpandTypeRef`/expansion "expands" `A` into a new copy of `TypeRefType(A)`, causing
-an infinite loop bounded only by `maxExpansionRetries`. Three creation sites produce
-self-referential aliases:
-- `infer_stmt.go:buildTypeParams` — type declaration type params
-- `infer_type_ann.go` — conditional type `infer` params
-- `infer_type_ann.go` — mapped type params
+`infer_stmt.go:buildTypeParams` creates self-referential aliases for type
+parameters: type param `A` gets `TypeAlias{Type: TypeRefType(A)}`. Each call to
+`canExpandTypeRef`/expansion "expands" `A` into a new copy of `TypeRefType(A)`.
 
-The old code avoided this because `ExpandType(t, 1)` decrements an internal counter
-and stops after one level, then the retry called `unifyWithDepth` with `depth+1`,
-eventually hitting `maxUnifyDepth`.
-
-**Fix:** In `canExpandTypeRef`, after resolving the alias, check if the expanded
-type is a TypeRefType with the same name as the input. If so, return `(nil, false)`
-to prevent the self-referential loop.
-
-```go
-if ref, ok := expandedType.(*type_system.TypeRefType); ok {
-    if type_system.QualIdentToString(ref.Name) == type_system.QualIdentToString(t.Name) {
-        return nil, false
-    }
-}
-```
-
-This is more targeted than `IsTypeParam` (which blocks ALL type param expansion).
-The self-referentiality check blocks only the cycle (`A→A`) while allowing
-constraint chains (`C→B` where `C: B`) to expand normally.
-
-Note: This does NOT catch mutual recursion (`A→B→A`). Mutual recursion would still
-loop until `maxExpansionRetries`. This is acceptable for now — Plan B's visited set
-will handle mutual recursion properly.
+**Resolution:** `canExpandTypeRef` walks the alias chain with a visited set to
+detect both direct cycles (`A→A`) and transitive cycles (`A→B→A`).
 
 ### Issue 8: Type param constraint chains blocked by `IsTypeParam`
 
-**Problem:** The `IsTypeParam` flag on `canExpandTypeRef` prevents ALL type
-parameter expansion, including constraint chains like `C: B, B: A, A: string`.
-When `C` vs `A` fails in `unifyMatched` (different names), the expansion loop
-needs to expand `C → B's constraint` and `A → string` to eventually unify. But
-`IsTypeParam` blocks this.
+The original plan called for removing the `IsTypeParam` check from
+`canExpandTypeRef`, relying only on the self-referentiality check (Issue 7) and
+expansion-after-matching ordering (Issue 4).
 
-**Example:** `fn convert<C: B, B: A, A: string>(x: C) -> A { return x }` — the
-return type check needs `C` expanded through the chain to verify it's assignable
-to `A`.
-
-**Fix:** Remove the `IsTypeParam` check from `canExpandTypeRef`. The Issue 4 fix
-(expansion AFTER case-matching) already provides the necessary defense — the
-same-alias case in `unifyMatched` handles `T vs T` before expansion runs, so type
-parameter identity is preserved where it matters. The self-referentiality check
-from Issue 7 prevents the infinite loop that `IsTypeParam` was also guarding
-against.
-
-The `IsTypeParam` field should still be added to `TypeAlias` (it's useful
-documentation and may be needed for future use), but `canExpandTypeRef` should NOT
-check it.
+**Resolution:** The `IsTypeParam` check was kept in `canExpandTypeRef`. It
+provides an additional safety guard. If constraint chain expansion (`C: B, B: A,
+A: string`) is needed in the future, this can be revisited.
 
 ### Issue 9: Expanded TypeAlias types share mutable pointers
 
-**Problem:** Directly using `typeAlias.Type` from a resolved alias (as an earlier
-prototype did) passes a shared pointer into the `TypeAlias` struct. When the
-expansion loop passes this to `unifyMatched`, property-by-property unification can
-**mutate** the shared type via TypeVarType binding, corrupting the type alias for
-all future uses.
+Directly using `typeAlias.Type` from a resolved alias passes a shared pointer
+into the `TypeAlias` struct. Unification can mutate the shared type via
+TypeVarType binding, corrupting the type alias for all future uses.
 
-The `TypeAlias.Type` is often a `TypeVarType` (not the concrete type). For
-example, `type Point = {x: number, y: number}` creates a TypeAlias whose Type is
-a TypeVarType bound to the ObjectType `{x: number, y: number}`. If this
-TypeVarType were passed directly to `unifyMatched`, the bind logic could rebind it
-to the literal type from the other side of the unification (e.g., `{x: 1, y: 2}`),
-permanently corrupting Point's alias.
-
-**Confirmed via debugging:** For `val p: Point = {x: 1, y: 2}`, Point's
-`TypeAlias.Type` changes from `TypeVarType({x: number, y: number})` to
-`TypeVarType({x: mut? 1, y: mut? 2})` after `Unify(initType, taType)`.
-
-The old code avoided this because `ExpandType(ctx, t, 1)` creates **fresh copies**
-via the visitor's Accept mechanism. The copies are structurally identical but
-pointer-distinct, so unification side effects don't propagate back to the alias.
-
-**Fix:** Use `canExpandTypeRef` as a predicate only (it returns `bool`, not the
-expanded type). When it returns `true`, delegate to `ExpandType(ctx, t, 1)` (which
-creates fresh copies via the visitor) followed by `unifyWithDepth(ctx, expanded1,
-expanded2, depth+1)`. The `unifyWithDepth` call:
-1. Prunes both types (resolving TypeVarTypes to concrete types)
-2. Goes through the full unification pipeline (including widening)
-3. Works on fresh copies, not shared TypeAlias pointers
-
-This means `canExpandTypeRef` handles the "should we expand?" decision, but the
-actual expansion + retry goes through `ExpandType` + `unifyWithDepth`. The
-`depth+1` parameter bounds the recursion (same as the old code).
-
-**Why this doesn't reintroduce Issue 2 (stack overflow):** In the old code, EVERY
-failed case triggered `unifyWithDepth` recursion (via the catch-all retry loop). In
-the new code, `unifyWithDepth` is only called when a TypeRefType was actually
-expanded — not for every failed match. The recursion depth is proportional to the
-alias chain depth (typically 1-3 levels), not to the number of type properties.
-For React SVG elements with 200+ properties, each property's unification calls
-`c.Unify()` (which starts its own `unifyWithDepth` at depth 0), but the expansion
-recursion adds at most one extra frame per alias level — not per property.
-
-**Impact on Plans B and C:** This approach means `depth+1` recursion is still used
-for TypeRefType expansion, so `maxUnifyDepth` remains necessary as a safety net.
-Plan B's visited set will need to be threaded through `unifyWithDepth` calls (which
-was already the plan). Plan C's goal of removing `maxUnifyDepth` may need to keep
-it as a fallback even after the visited set is in place, unless the visited set
-provably prevents all unbounded recursion through this path.
+**Resolution:** `canExpandTypeRef` is a predicate only (returns `bool`). When it
+returns `true`, expansion is done by `ExpandType(ctx, t, 1)` which creates fresh
+copies via the visitor, then delegates to `unifyWithDepth` with `depth+1`.
 
 ### Issue 10: Nominal types need ExpandType for pattern matching
 
-**Problem:** `canExpandTypeRef` blocks expansion of nominal ObjectTypes (classes)
-to prevent bypassing nominal identity checks. But pattern matching against nominal
-types (`match p { {foo} => foo }`) requires expanding the TypeRefType to access
-the ObjectType's properties and report `PropertyNotFoundError`.
+`canExpandTypeRef` blocks expansion of nominal ObjectTypes (classes) to prevent
+bypassing nominal identity checks. But pattern matching against nominal types
+(`match p { {foo} => foo }`) requires expanding the TypeRefType to access the
+ObjectType's properties.
 
-In the old code, `ExpandType(t, 1)` always expanded TypeRefTypes regardless of
-nominality. The nominal semantics were enforced in the ObjectType vs ObjectType
-case in `unifyMatched`, which allows structural comparison in pattern-matching
-mode (`ctx.IsPatMatch`).
+**Resolution:** Added a last-resort expansion path: after `canExpandTypeRef`
+returns false and `ExpandType(ctx, t, 0)` also fails, fall through to
+`ExpandType(ctx, t, 1)` for any remaining TypeRefTypes. Nominal semantics are
+enforced downstream in the ObjectType vs ObjectType case in `unifyMatched`.
 
-**Fix:** Keep the nominal check in `canExpandTypeRef` (it prevents infinite loops
-from self-referential class types). For TypeRefTypes where `canExpandTypeRef`
-returns false (nominal, unresolved, etc.), fall through to `ExpandType(ctx, t, 1)`
-as a last resort. `ExpandType` always expands TypeRefTypes via the visitor
-regardless of nominality — the visitor simply resolves the alias without checking
-nominal semantics. This matches the old code's behavior where ExpandType always
-expanded, and the nominal semantics were handled downstream in the ObjectType vs
-ObjectType case in `unifyMatched`.
+## What was implemented
 
-In the `unifyPruned` loop, after `canExpandTypeRef` returns false and
-`ExpandType(ctx, t, 0)` also fails, add a final fallback:
+### Key architectural changes
 
-```go
-// Last resort: ExpandType with count=1 for TypeRefTypes that
-// canExpandTypeRef refused (e.g. nominal types).
-if isRef1 || isRef2 {
-    lastResortT1, _ := c.ExpandType(ctx, t1, 1)
-    lastResortT2, _ := c.ExpandType(ctx, t2, 1)
-    if lastResortT1 != t1 || lastResortT2 != t2 {
-        return c.unifyWithDepth(ctx, lastResortT1, lastResortT2, depth+1)
-    }
-}
-```
+1. **`noMatchError` sentinel**: `unifyMatched` (the extracted case-matching
+   function) returns `[]Error{&noMatchError{}}` when no case handles the type
+   combination. `unifyPruned` uses `isNoMatch(errors)` to distinguish "no case
+   matched" (safe to try expansion) from "a case matched but failed"
+   (authoritative error). This subsumes the originally planned Issue 5
+   (TypeVarType guard) and Issue 6 (same-alias guard) — both produce
+   authoritative errors, not `noMatchError`.
 
-This uses `unifyWithDepth` (not `continue`) for the same shared-pointer safety
-reasons as Issue 9.
+2. **`canExpandTypeRef` predicate** (in `expand_type.go`): Returns `bool` only.
+   Blocks expansion for:
+   - `nil` TypeAlias (unresolvable)
+   - `IsTypeParam` aliases (type parameter placeholders)
+   - Nominal ObjectTypes (classes)
+   - Self-referential aliases via transitive cycle detection (A→B→A) using a
+     visited set
 
-## Plan (revised after implementation attempt)
+3. **`IsTypeParam` flag on `TypeAlias`**: Set at all type parameter creation
+   sites (7 locations: `infer_func.go`, `infer_stmt.go`, `infer_module.go` x2,
+   `generalize.go`, `infer_type_ann.go` x2). Checked by `canExpandTypeRef`.
 
-### Step 1: Add `IsTypeParam` flag to `TypeAlias` and update creation sites
+4. **Three-tier expansion in `unifyPruned`**:
+   - Tier 1: `canExpandTypeRef` → `ExpandType(t, 1)` → `unifyWithDepth(depth+1)`
+     for expandable TypeRefTypes
+   - Tier 2: `ExpandType(t, 0)` + pointer-equality check + Prune → `continue`
+     for non-TypeRef expandable types (TypeOfType, etc.)
+   - Tier 3: `ExpandType(t, 1)` + pointer-equality check →
+     `unifyWithDepth(depth+1)` as last resort for nominal/refused TypeRefTypes
 
-Add `IsTypeParam bool` to the `TypeAlias` struct in `type_system/types.go`. Then set
-`IsTypeParam: true` at all type parameter creation sites listed in the Issue 4 fix
-above. The default `false` is correct for all existing regular aliases, so no other
-sites need changes.
+### Files changed
 
-Note: Per Issue 8, `canExpandTypeRef` does NOT check this flag — the
-self-referentiality check (Issue 7) and expansion-after-matching ordering (Issue 4)
-provide sufficient protection. The flag is still valuable as documentation and for
-potential future use.
+- `internal/checker/unify.go` — Extracted `unifyMatched` from `unifyPruned`,
+  added `noMatchError` sentinel, added three-tier expansion loop, removed the
+  old catch-all retry loop and do-nothing different-alias TypeRefType case
+- `internal/checker/expand_type.go` — Added `canExpandTypeRef` predicate with
+  transitive cycle detection
+- `internal/type_system/types.go` — Added `IsTypeParam bool` to `TypeAlias`
+  struct and `NamespaceType.Accept` copy
+- `internal/checker/generalize.go` — Set `IsTypeParam: true`
+- `internal/checker/infer_func.go` — Set `IsTypeParam: true`
+- `internal/checker/infer_module.go` — Set `IsTypeParam: true` (2 sites)
+- `internal/checker/infer_stmt.go` — Set `IsTypeParam: true`
+- `internal/checker/infer_type_ann.go` — Set `IsTypeParam: true` (2 sites)
+- `internal/checker/tests/infer_class_decl_test.go` — Added
+  `TestNominalClassUnificationTerminates` regression test
 
-### Step 2: Add `canExpandTypeRef` helper
+### Differences from the original plan
 
-Add a new method to `Checker` (in expand_type.go) that attempts to expand a
-TypeRefType without erroring. This function is used only as a "should we expand?"
-predicate — it returns `bool`, not the expanded type. The actual expansion is done
-by `ExpandType(ctx, t, 1)` which creates fresh copies (see Issue 9).
+| Aspect | Original plan | Actual implementation |
+|--------|---------------|----------------------|
+| Guard for Issue 5 (TypeVarType) | Explicit `TypeVarType` check before expansion | Subsumed by `noMatchError` sentinel — `bind` returns authoritative errors |
+| Guard for Issue 6 (same-alias) | Explicit `sameTypeRef` check before expansion | Subsumed by `noMatchError` sentinel — same-alias case returns authoritative errors |
+| `IsTypeParam` in `canExpandTypeRef` | Removed per Issue 8 (self-ref check sufficient) | Kept — provides additional safety |
+| Self-referentiality check | Direct cycle only (`A→A`) | Transitive cycle detection (`A→B→A`) via visited set |
+| Non-TypeRef expansion | Used `continue` without Prune | Added Prune after expansion to resolve TypeVarTypes before re-entering `unifyMatched` |
 
-```go
-func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool {
-    typeAlias := t.TypeAlias
-    if typeAlias == nil {
-        typeAlias = resolveQualifiedTypeAlias(ctx, t.Name)
-    }
-    if typeAlias == nil {
-        return false
-    }
+## Remaining work (Plans B and C)
 
-    expandedType := type_system.Prune(typeAlias.Type)
-
-    // Don't expand nominal object types — nominal semantics are enforced
-    // in the ObjectType vs ObjectType case in unifyMatched. Expanding here
-    // would bypass nominal identity checks and can cause infinite loops
-    // for self-referential class types.
-    if obj, ok := expandedType.(*type_system.ObjectType); ok && obj.Nominal {
-        return false
-    }
-
-    // Don't expand self-referential aliases (e.g., type param A whose alias
-    // Type is TypeRefType(A)). These occur at type parameter creation sites
-    // where the alias is a forward-reference placeholder. Expanding would
-    // produce a new copy of the same TypeRefType, causing an infinite loop.
-    if ref, ok := expandedType.(*type_system.TypeRefType); ok {
-        if type_system.QualIdentToString(ref.Name) == type_system.QualIdentToString(t.Name) {
-            return false
-        }
-    }
-
-    return true
-}
-```
-
-Note: The self-referentiality check compares `QualIdentToString` names. This is
-sufficient because `QualIdent` includes namespace qualification, so same-named type
-parameters in different scopes will have distinct qualified names. However, mutual
-recursion (`A→B→A`) is NOT caught — see Issue 7 notes on this limitation.
-
-Key differences from the original plan:
-- **Returns `bool` only** — the expanded type is not needed since the actual
-  expansion is delegated to `ExpandType(ctx, t, 1)` (Issue 9). This avoids
-  computing substitutions for generic aliases only to discard the result.
-- **Prunes `typeAlias.Type`** before checking — the alias Type is often a
-  TypeVarType, not a concrete type. Without pruning, the nominal and
-  self-referentiality checks would see a TypeVarType instead of the underlying type.
-- **No `IsTypeParam` check** — removed per Issue 8. The self-referentiality check
-  handles the infinite loop case, and constraint chains need expansion to work.
-- **Self-referentiality check added** — per Issue 7. Detects `A→A` cycles.
-
-### Step 3: Extract case-matching into `unifyMatched`, add expansion logic in `unifyPruned`
-
-Rename the current `unifyPruned` to `unifyMatched` (the function that contains all
-the explicit type-matching cases). Then rewrite `unifyPruned` as a loop that:
-1. Calls `unifyMatched` with the current types
-2. If matching succeeds, returns immediately
-3. If matching fails, applies guards (Issue 5, 6) and tries expansion
-4. If a TypeRefType expanded, delegates to `unifyWithDepth` (Issue 9)
-5. If non-TypeRef types expanded (TypeOfType etc.), retries via the loop
-6. If nothing expanded, returns the original error
-
-```go
-const maxExpansionRetries = 10
-
-func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) []Error {
-    for attempt := 0; attempt < maxExpansionRetries; attempt++ {
-        errors := c.unifyMatched(ctx, t1, t2, depth)
-        if len(errors) == 0 {
-            return nil
-        }
-
-        // Issue 5: If either type is a TypeVarType, the error came from bind
-        // (constraint checking). Expansion cannot help — return immediately.
-        if _, ok := t1.(*type_system.TypeVarType); ok {
-            return errors
-        }
-        if _, ok := t2.(*type_system.TypeVarType); ok {
-            return errors
-        }
-
-        // Issue 6: Don't expand same-alias TypeRefTypes — the same-alias case
-        // in unifyMatched already compared their type args definitively.
-        ref1, isRef1 := t1.(*type_system.TypeRefType)
-        ref2, isRef2 := t2.(*type_system.TypeRefType)
-        if isRef1 && isRef2 && c.sameTypeRef(ref1, ref2) {
-            return errors
-        }
-
-        // Try expanding TypeRefTypes. Use canExpandTypeRef as a "should we
-        // expand?" predicate, then delegate to ExpandType + unifyWithDepth
-        // for the actual retry. ExpandType creates fresh copies via the
-        // visitor (preventing mutation of shared TypeAlias types — Issue 9),
-        // and unifyWithDepth provides Prune + widening on the expanded result.
-        refCanExpand := false
-        if isRef1 && c.canExpandTypeRef(ctx, ref1) {
-            refCanExpand = true
-        }
-        if isRef2 && c.canExpandTypeRef(ctx, ref2) {
-            refCanExpand = true
-        }
-        if refCanExpand {
-            refExpT1, _ := c.ExpandType(ctx, t1, 1)
-            refExpT2, _ := c.ExpandType(ctx, t2, 1)
-            return c.unifyWithDepth(ctx, refExpT1, refExpT2, depth+1)
-        }
-
-        // Try expanding TypeOfType and other non-TypeRef expandable types.
-        // ExpandType with count=0 skips TypeRef expansion (already handled).
-        // Pointer-equality check is reliable here (see Issue 3 notes).
-        nonRefExpT1, _ := c.ExpandType(ctx, t1, 0)
-        nonRefExpT2, _ := c.ExpandType(ctx, t2, 0)
-        if nonRefExpT1 != t1 || nonRefExpT2 != t2 {
-            t1 = nonRefExpT1
-            t2 = nonRefExpT2
-            continue
-        }
-
-        // Issue 10: Last resort for TypeRefTypes that canExpandTypeRef
-        // refused (e.g. nominal types). ExpandType(t, 1) always expands
-        // TypeRefTypes via the visitor regardless of nominality — the visitor
-        // simply resolves the alias without checking nominal semantics.
-        // Nominal semantics are enforced downstream in the ObjectType vs
-        // ObjectType case in unifyMatched (which allows structural comparison
-        // in pattern-matching mode via ctx.IsPatMatch).
-        if isRef1 || isRef2 {
-            lastResortT1, _ := c.ExpandType(ctx, t1, 1)
-            lastResortT2, _ := c.ExpandType(ctx, t2, 1)
-            if lastResortT1 != t1 || lastResortT2 != t2 {
-                return c.unifyWithDepth(ctx, lastResortT1, lastResortT2, depth+1)
-            }
-        }
-
-        // Nothing could be expanded, return the original error
-        return errors
-    }
-    return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
-}
-```
-
-Note: `ExpandType` returns `(Type, []Error)`. The errors are ignored (via `_`)
-throughout this function. This matches the existing retry loop behavior (lines
-1190-1196). It is safe because: (a) `ExpandType` errors come from `expandTypeRef`
-returning `UnknownTypeError` for unresolvable TypeRefTypes (Issue 1), and
-`canExpandTypeRef` already screens these out; (b) for the non-TypeRef path
-(`count=0`), TypeRefTypes are skipped entirely so `expandTypeRef` is never called;
-(c) for the Issue 10 last-resort path, expansion failure is detected by pointer
-equality (`lastResortT1 != t1`) and the function falls through to return the
-original `unifyMatched` errors.
-
-The existing case-matching code moves to `unifyMatched` with no changes to its
-body or indentation. The do-nothing different-alias case (lines 505-511) and the
-old retry loop (lines 1189-1203) are both deleted. The final `CannotUnifyTypesError`
-at the end of `unifyMatched` remains — it signals to `unifyPruned` that no case
-matched, triggering the expansion logic.
-
-Note: The **same-alias** TypeRefType case (lines 448-504, `c.sameTypeRef(ref1, ref2)`)
-is kept in `unifyMatched`. When two TypeRefTypes refer to the same alias, they match
-directly via type argument unification without needing expansion. Only the
-**different-alias** case is removed, since `unifyPruned`'s expansion logic now handles
-it by expanding both sides and retrying.
-
-**Key design decision — `unifyWithDepth` vs `continue`:** TypeRefType expansion
-delegates to `unifyWithDepth` (a recursive call) rather than looping via `continue`.
-This is necessary because:
-- `unifyWithDepth` prunes types, resolving shared TypeVarType pointers to concrete
-  types before they enter `unifyMatched` (prevents Issue 9 corruption)
-- `unifyWithDepth` provides the widening fallback for Widenable TypeVarTypes
-- `ExpandType(ctx, t, 1)` creates fresh copies, preventing mutation of shared state
-- The recursion depth is bounded by `depth+1` and proportional to alias chain depth
-  (typically 1-3), not to property count (which caused Issue 2)
-
-Non-TypeRef expansion (TypeOfType etc.) uses `continue` because `ExpandType(ctx, t, 0)`
-already creates copies and the pointer-equality check prevents spurious retries.
-
-### Step 4: Audit other ExpandType calls in unify.go
-
-There are two other `ExpandType` calls in the case-matching code that are unrelated
-to the retry loop and should be preserved:
-
-- **Line 345-346**: `KeyOfType` expansion — both sides are `KeyOfType`, expand their
-  inner types. Keep as-is.
-- **Line 1055**: Union + ObjectType — expands each union member to check if it's an
-  `ObjectType`. Keep as-is.
-
-### Step 5: Set an appropriate loop bound
-
-The loop in `unifyPruned` now primarily handles non-TypeRef expansion (TypeOfType
-etc.) via the `continue` path. TypeRefType expansion exits via `unifyWithDepth`
-(which has its own `maxUnifyDepth` bound). The `maxExpansionRetries` constant
-guards against unexpected loops in the non-TypeRef path.
-
-Use a dedicated constant (e.g. `maxExpansionRetries = 10`). After Plan B
-(visited-set) is implemented, both `maxExpansionRetries` and `maxUnifyDepth`
-become safety nets rather than primary cycle-prevention mechanisms.
-
-## Testing strategy
-
-1. **Run the full test suite** — This is a behavioral refactor; all existing tests
-   should pass without changes.
-2. **Verify depth behavior** — Add debug logging (temporary) to count the maximum
-   loop iterations reached during the test suite. After this change, the max should
-   correspond to the actual nesting depth of type alias chains.
-3. **Test TypeRefType + TypeRefType (different alias)** — Write a test with two
-   different type aliases that resolve to the same structural type and verify they
-   unify:
-   ```escalier
-   type Foo = { x: number }
-   type Bar = { x: number }
-   val a: Foo = ...
-   val b: Bar = a  // should succeed
-   ```
-4. **Test TypeRefType + concrete type** — Write a test where one side is a type
-   alias and the other is an inline type:
-   ```escalier
-   type Foo = { x: number }
-   val a: Foo = { x: 5 }  // TypeRefType vs ObjectType
-   ```
-5. **Test generic methods** — Verify `ClassWithGenericMethod` and
-   `ObjectWithGenericMethods` pass, confirming type parameter identity is preserved
-   through union matching.
-6. **Test React types** — Verify `TestImportInferenceScript/NamespaceImportReact`
-   passes without stack overflow, confirming the loop-based approach handles large
-   types.
-7. **Test bind error propagation (Issue 5)** — The existing test for
-   `fn bar(items: Array<string>)` / `fn foo(items) { items[0] = 42; bar(items) }`
-   should continue to report a `number vs string` constraint error. Verify
-   expansion does not mask it.
-8. **Test same-alias type-arg mismatch (Issue 6)** — Verify that
-   `Array<number> vs Array<string>` produces a type-arg error, not a structural
-   comparison error from expanding both aliases.
-9. **Test self-referential type params (Issue 7)** — Existing tests with generic
-   type declarations (e.g. `type Pair<A, B> = ...`) exercise the self-referential
-   alias path. Verify no infinite loops or hangs.
-10. **Test alias corruption (Issue 9)** — Verify that after
-    `val p: Point = {x: 1, y: 2}`, using `Point` again in a subsequent declaration
-    still refers to `{x: number, y: number}`, not the literal types.
-11. **Test pattern matching on nominal types (Issue 10)** — Existing getter/setter
-    and pattern-matching tests exercise this path. Verify `PropertyNotFoundError`
-    is reported correctly when destructuring a nominal type.
-
-## Risks
-
-- **Missed cases**: If there are non-`TypeRefType` types that relied on the retry
-  loop for expansion (e.g. a `CondType` or `IndexType` that somehow reaches
-  `unifyPruned` unexpanded), those would now fail with `CannotUnifyTypesError`
-  instead of being retried. Mitigation: run the full test suite and React type
-  tests to catch these. The `ExpandType(ctx, t, 0)` fallback handles most of these,
-  and the `ExpandType(ctx, t, 1)` last resort (Issue 10) covers the rest.
-- **Shared mutable state**: TypeAlias types are shared across all references to the
-  alias. Any code path that passes a TypeAlias.Type pointer directly to unification
-  risks corruption via TypeVarType rebinding. The plan mitigates this by: (a) using
-  `ExpandType` to create fresh copies before `unifyWithDepth`, and (b) pruning in
-  `canExpandTypeRef` to resolve TypeVarTypes before nominal/self-referential checks.
-  New code touching TypeAlias.Type should be audited for this pattern.
-- **Wasted case matching**: `TypeRefType + ObjectType` falls through all cases in
-  `unifyMatched` before being expanded in the `unifyPruned` loop. This is
-  functionally correct but slightly less efficient than early expansion. The cost
-  is negligible since case matching is cheap compared to type expansion.
-- **`unifyWithDepth` recursion**: TypeRefType expansion now uses `unifyWithDepth`
-  recursion (with `depth+1`) rather than a purely iterative loop. This is bounded
-  by alias chain depth (typically 1-3) and `maxUnifyDepth`, not by property count.
-  Plan B's visited set will provide additional protection against cycles.
-- **Mutual recursion not handled**: The self-referentiality check in
-  `canExpandTypeRef` only catches direct cycles (`A→A`), not mutual recursion
-  (`A→B→A`). These rely on `maxExpansionRetries`/`maxUnifyDepth` until Plan B adds
-  proper cycle detection.
+- `maxUnifyDepth` and `maxExpansionRetries` remain as safety nets. Plan B's
+  visited set will make them unnecessary.
+- `canExpandTypeRef`'s transitive cycle detection handles alias chains but not
+  arbitrary mutual recursion through structural types. Plan B's visited set
+  handles this properly.
+- The `depth+1` recursion for TypeRefType expansion means `maxUnifyDepth` is
+  still load-bearing for deep alias chains. Plan B removes this dependency.

--- a/planning/taming_recursion/plan_b_visited_set.md
+++ b/planning/taming_recursion/plan_b_visited_set.md
@@ -1,8 +1,6 @@
 # Plan B: Visited-set / seen-pairs memoization
 
-**Prerequisite:** Plan A (expand at TypeRefType match site) should be implemented
-first. The catch-all retry loop would interfere with visited-set tracking because
-it creates new type objects on every iteration, defeating pointer-based identity.
+**Prerequisite:** Plan A (expand at TypeRefType match site) — **implemented in PR #451**.
 
 ## Goal
 
@@ -13,22 +11,26 @@ future support for recursive type aliases.
 
 ## Background
 
-After Plan A, TypeRefType expansion is handled by a loop in `unifyPruned` (bounded
-by `maxExpansionRetries`). When `canExpandTypeRef` returns true, the loop delegates
-to `ExpandType(ctx, t, 1)` (which creates fresh copies) followed by
-`unifyWithDepth` with `depth+1`. For non-TypeRef expandable types (TypeOfType etc.),
-the loop uses `ExpandType(ctx, t, 0)` and retries via `continue`. The `depth`
-parameter reflects both TypeRefType expansion recursion (bounded by alias chain
-depth, typically 1-3) and structural recursion from subcomponent unification. The
-loop bound is still an arbitrary limit — there's no guarantee that
-`maxExpansionRetries = 10` is sufficient for all programs, and reducing it risks
-rejecting valid programs.
+After Plan A, TypeRefType expansion is handled by a three-tier expansion loop in
+`unifyPruned`:
 
-The standard approach in type checkers is co-inductive unification: if you
-encounter a pair `(t1, t2)` that you've already started unifying, assume it will
-succeed. This is sound for recursive types because the only way to encounter the
-same pair twice is through a cycle in the type structure, and the non-cyclic parts
-of the type have already been checked.
+- **Tier 1**: When `canExpandTypeRef` returns true, delegates to
+  `ExpandType(ctx, t, 1)` (which creates fresh copies) followed by
+  `unifyWithDepth` with `depth+1`.
+- **Tier 2**: For non-TypeRef expandable types (TypeOfType etc.), uses
+  `ExpandType(ctx, t, 0)` with Prune and retries via `continue`.
+- **Tier 3**: Last resort for nominal/refused TypeRefTypes — `ExpandType(ctx, t, 1)`
+  with pointer-equality check, then `unifyWithDepth(depth+1)`.
+
+The `noMatchError` sentinel in `unifyMatched` distinguishes "no case matched"
+(safe to try expansion) from "a case matched but failed" (authoritative error),
+which eliminated the need for explicit TypeVarType and same-alias guards.
+
+`canExpandTypeRef` blocks expansion for `IsTypeParam` aliases, nominal types, and
+transitive self-referential cycles (A→B→A via visited set). However, the loop bound
+`maxExpansionRetries = 10` and `maxUnifyDepth = 50` remain as safety nets. These
+are arbitrary limits — a program that needs more expansion steps will get a spurious
+type error. Plan B removes both limits by adding proper cycle detection.
 
 ## Design decisions
 
@@ -136,6 +138,12 @@ object properties, rest spread types). Structural forwarding calls should pass
 `depth` unchanged. Once the visited set is in place, `depth` becomes purely
 diagnostic.
 
+**Note on `noMatchError` interaction:** Plan A's `noMatchError` sentinel means
+`unifyPruned` only attempts expansion when `isNoMatch(errors)` is true. The visited
+set check should be added inside the expansion paths (Tiers 1 and 3), not before
+calling `unifyMatched`. This preserves the sentinel's role in distinguishing
+"no case matched" from "authoritative error".
+
 Change the internal signatures:
 
 ```go
@@ -169,19 +177,10 @@ throughout `unify.go` that need to be updated. A systematic approach:
 
 ### Step 3: Add cycle detection at the TypeRefType expansion site
 
-After Plan A, TypeRefType expansion lives in `unifyPruned`'s loop. When
-`canExpandTypeRef` returns true, the loop delegates to `ExpandType(ctx, t, 1)`
-(which creates fresh copies) followed by `unifyWithDepth` with `depth+1`.
-Cycle detection should be added before this delegation: check whether the pair
-`(t1, t2)` has already been seen. If so, apply the co-inductive assumption
-(return success).
-
-Note: `canExpandTypeRef` (added by Plan A) is a bool predicate that checks
-whether a `TypeRefType` can be expanded (resolves alias, checks nominal/
-self-referential guards). It does not perform the actual expansion — that's
-done by `ExpandType`, which uses the visitor pattern. The `expandSeen` set
-from Step 4 applies to `ExpandType` calls; the `unifySeen` check here guards
-the `unifyWithDepth` recursion.
+After Plan A, TypeRefType expansion lives in `unifyPruned`'s three-tier loop. Cycle
+detection should be added in Tier 1 (before `canExpandTypeRef` delegation) and
+Tier 3 (last-resort expansion): check whether the pair `(t1, t2)` has already been
+seen. If so, apply the co-inductive assumption (return success).
 
 ```go
 func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int, seen unifySeen) []Error {
@@ -191,7 +190,9 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int, s
             return nil
         }
 
-        // ... Issue 5 (TypeVarType guard) and Issue 6 (same-alias guard) as in Plan A ...
+        if !isNoMatch(errors) {
+            return errors
+        }
 
         // Try expanding TypeRefTypes with cycle detection
         ref1, isRef1 := t1.(*type_system.TypeRefType)
@@ -214,9 +215,8 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int, s
             return c.unifyWithDepth(ctx, refExpT1, refExpT2, depth+1, seen)
         }
 
-        // ... ExpandType(ctx, t, 0) fallback for non-TypeRef types,
-        //     Issue 10 last-resort ExpandType(ctx, t, 1), and
-        //     error return as in Plan A ...
+        // Tier 2: ExpandType(ctx, t, 0) for non-TypeRef types...
+        // Tier 3: last-resort ExpandType(ctx, t, 1) with cycle check...
     }
     return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 }
@@ -337,13 +337,10 @@ type TypeExpansionVisitor struct {
 ```
 
 **Important:** `ExpandType` calls itself recursively in several places
-(intersection distribution at line 186, keyof distribution at lines 288-301,
-mapped element expansion at line 1484). These recursive calls currently create
-a fresh visitor with its own counter values. After this change, the `expandSeen`
-map must be passed through to these recursive calls so that cycles spanning
-multiple levels of expansion are detected. Concretely, add an `expandSeen`
-parameter to `expandTypeWithConfig` and pass `v.seen` from the visitor at each
-internal `ExpandType` call site.
+(intersection distribution, keyof distribution, mapped element expansion). These
+recursive calls currently create a fresh visitor with its own counter values.
+After this change, the `expandSeen` map must be passed through to these recursive
+calls so that cycles spanning multiple levels of expansion are detected.
 
 In the `TypeRefType` case of `ExitType`:
 
@@ -377,12 +374,11 @@ stored, and the second occurrence reuses the cached result.
 Once the visited-set is in place and the test suite passes, remove the hard
 limits that the visited set supersedes:
 
-- The `maxUnifyDepth` constant (line 94) and the depth check at lines 119-121
-  in `unifyWithDepth`.
-- The `maxExpansionRetries` constant in `unifyPruned` (added by Plan A). With
-  the visited set detecting cycles, the loop will naturally terminate when no
-  further expansion is possible. Replace the loop bound with a generous safety
-  limit (e.g. 100) or remove it entirely if the visited set is proven reliable.
+- The `maxUnifyDepth` constant and the depth check in `unifyWithDepth`.
+- The `maxExpansionRetries` constant in `unifyPruned`. With the visited set
+  detecting cycles, the loop will naturally terminate when no further expansion is
+  possible. Replace the loop bound with a generous safety limit (e.g. 100) or
+  remove it entirely if the visited set is proven reliable.
 
 Keep the `depth` parameter in `unifyWithDepth` for now — it is still useful for
 debugging (e.g. logging when depth exceeds some threshold) and for Plan C's
@@ -404,6 +400,12 @@ With cycle detection in place, evaluate whether these can be simplified or remov
 - **`insideKeyOfTarget`**: The seen set in `ExpandType` would catch `keyof` cycles
   if the expansion of `keyof T` triggers re-expansion of the same alias. Test
   whether removing this counter causes any test failures. If not, remove it.
+
+**Note:** After Plan A, `canExpandTypeRef`'s transitive cycle detection (A→B→A
+via visited set) partially overlaps with the `expandSeen` visited set. Once Plan B
+is implemented, the transitive cycle check in `canExpandTypeRef` becomes redundant
+for cycle prevention (though it may still be useful as an optimization to avoid
+entering `ExpandType` + `unifyWithDepth` for known cycles).
 
 ## Testing strategy
 

--- a/planning/taming_recursion/plan_b_visited_set.md
+++ b/planning/taming_recursion/plan_b_visited_set.md
@@ -13,13 +13,16 @@ future support for recursive type aliases.
 
 ## Background
 
-After Plan A, TypeRefType expansion is handled by an iterative loop in
-`unifyPruned` (bounded by `maxExpansionRetries`) rather than recursive
-`unifyWithDepth` calls. The `depth` parameter in `unifyWithDepth` is no longer
-incremented for TypeRef expansion — it only reflects structural recursion depth
-from subcomponent unification. The loop bound is still an arbitrary limit —
-there's no guarantee that `maxExpansionRetries = 10` is sufficient for all
-programs, and reducing it risks rejecting valid programs.
+After Plan A, TypeRefType expansion is handled by a loop in `unifyPruned` (bounded
+by `maxExpansionRetries`). When `canExpandTypeRef` returns true, the loop delegates
+to `ExpandType(ctx, t, 1)` (which creates fresh copies) followed by
+`unifyWithDepth` with `depth+1`. For non-TypeRef expandable types (TypeOfType etc.),
+the loop uses `ExpandType(ctx, t, 0)` and retries via `continue`. The `depth`
+parameter reflects both TypeRefType expansion recursion (bounded by alias chain
+depth, typically 1-3) and structural recursion from subcomponent unification. The
+loop bound is still an arbitrary limit — there's no guarantee that
+`maxExpansionRetries = 10` is sufficient for all programs, and reducing it risks
+rejecting valid programs.
 
 The standard approach in type checkers is co-inductive unification: if you
 encounter a pair `(t1, t2)` that you've already started unifying, assume it will
@@ -125,13 +128,13 @@ type unifySeen map[unifyPairKey]bool
 
 ### Step 2: Thread `unifySeen` through unification
 
-**Depth note:** After Plan A, TypeRefType expansion no longer increments `depth`
-— it is handled by the iterative loop in `unifyPruned` (bounded by
-`maxExpansionRetries`). The `depth` parameter only reflects structural recursion
-from subcomponent unification (tuple elements, array element types, function
-parameters, object properties, rest spread types), and these forwarding calls
-should pass `depth` unchanged. Once the visited set is in place, `depth` becomes
-purely diagnostic.
+**Depth note:** After Plan A, TypeRefType expansion delegates to `unifyWithDepth`
+with `depth+1` (bounded by alias chain depth, typically 1-3). The `depth` parameter
+reflects both TypeRefType expansion recursion and structural recursion from
+subcomponent unification (tuple elements, array element types, function parameters,
+object properties, rest spread types). Structural forwarding calls should pass
+`depth` unchanged. Once the visited set is in place, `depth` becomes purely
+diagnostic.
 
 Change the internal signatures:
 
@@ -166,16 +169,19 @@ throughout `unify.go` that need to be updated. A systematic approach:
 
 ### Step 3: Add cycle detection at the TypeRefType expansion site
 
-After Plan A, TypeRefType expansion lives in `unifyPruned`'s iterative loop,
-which calls `tryExpandTypeRef` and retries `unifyMatched` with the expanded
-types. Cycle detection should be added to this loop: before expanding a
-TypeRefType, check whether the pair `(t1, t2)` has already been seen. If so,
-apply the co-inductive assumption (return success).
+After Plan A, TypeRefType expansion lives in `unifyPruned`'s loop. When
+`canExpandTypeRef` returns true, the loop delegates to `ExpandType(ctx, t, 1)`
+(which creates fresh copies) followed by `unifyWithDepth` with `depth+1`.
+Cycle detection should be added before this delegation: check whether the pair
+`(t1, t2)` has already been seen. If so, apply the co-inductive assumption
+(return success).
 
-Note: `tryExpandTypeRef` (added by Plan A) resolves a `TypeRefType`'s alias and
-substitutes type parameters without recursively expanding nested references.
-It does not call `ExpandType`, so the `expandSeen` set from Step 4 is not
-consulted here — cycles are caught by the `unifySeen` check in the loop.
+Note: `canExpandTypeRef` (added by Plan A) is a bool predicate that checks
+whether a `TypeRefType` can be expanded (resolves alias, checks nominal/
+self-referential guards). It does not perform the actual expansion — that's
+done by `ExpandType`, which uses the visitor pattern. The `expandSeen` set
+from Step 4 applies to `ExpandType` calls; the `unifySeen` check here guards
+the `unifyWithDepth` recursion.
 
 ```go
 func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int, seen unifySeen) []Error {
@@ -185,34 +191,32 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int, s
             return nil
         }
 
+        // ... Issue 5 (TypeVarType guard) and Issue 6 (same-alias guard) as in Plan A ...
+
         // Try expanding TypeRefTypes with cycle detection
-        expanded := false
-        if ref1, ok := t1.(*type_system.TypeRefType); ok {
+        ref1, isRef1 := t1.(*type_system.TypeRefType)
+        ref2, isRef2 := t2.(*type_system.TypeRefType)
+        refCanExpand := false
+        if isRef1 && c.canExpandTypeRef(ctx, ref1) {
+            refCanExpand = true
+        }
+        if isRef2 && c.canExpandTypeRef(ctx, ref2) {
+            refCanExpand = true
+        }
+        if refCanExpand {
             key := makeUnifyPairKey(t1, t2)
             if seen[key] {
                 return nil // co-inductive assumption: assume success
             }
             seen[key] = true
-            if exp, ok := c.tryExpandTypeRef(ctx, ref1); ok {
-                t1 = exp
-                expanded = true
-            }
+            refExpT1, _ := c.ExpandType(ctx, t1, 1)
+            refExpT2, _ := c.ExpandType(ctx, t2, 1)
+            return c.unifyWithDepth(ctx, refExpT1, refExpT2, depth+1, seen)
         }
-        if ref2, ok := t2.(*type_system.TypeRefType); ok {
-            key := makeUnifyPairKey(t1, t2)
-            if seen[key] {
-                return nil // co-inductive assumption: assume success
-            }
-            seen[key] = true
-            if exp, ok := c.tryExpandTypeRef(ctx, ref2); ok {
-                t2 = exp
-                expanded = true
-            }
-        }
-        if expanded {
-            continue
-        }
-        // ... ExpandType(ctx, t, 0) fallback and error return as in Plan A ...
+
+        // ... ExpandType(ctx, t, 0) fallback for non-TypeRef types,
+        //     Issue 10 last-resort ExpandType(ctx, t, 1), and
+        //     error return as in Plan A ...
     }
     return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 }

--- a/planning/taming_recursion/plan_c_verify_unify_recursion.md
+++ b/planning/taming_recursion/plan_c_verify_unify_recursion.md
@@ -21,9 +21,11 @@ scenarios:
    excessive recursion during unification with Array types.
 3. **Large ObjectType instances** (e.g. React SVG attributes with 200+ properties)
 
-Plan A replaced the retry loop with an iterative expansion loop in `unifyPruned`
-that calls `unifyMatched` for case-matching and `tryExpandTypeRef` for TypeRef
-expansion, eliminating the pointer-inequality-driven retries that caused
+Plan A replaced the retry loop with an expansion loop in `unifyPruned` that calls
+`unifyMatched` for case-matching and `canExpandTypeRef` (a bool predicate) to
+decide whether TypeRef expansion should be attempted. When expansion is possible,
+`ExpandType(ctx, t, 1)` creates fresh copies and `unifyWithDepth` with `depth+1`
+retries unification, eliminating the pointer-inequality-driven retries that caused
 scenarios 1 and 3. Plan B added visited-set cycle detection, removing the
 `maxUnifyDepth` safety net and the `maxExpansionRetries` loop bound.
 
@@ -67,11 +69,12 @@ by Plan B to propagate the seen set. After Plan A, these cases live in
 - `unifyTuples` helper: calls `c.Unify` on each pair of tuple elements
 
 Each of these should be `c.unifyWithDepth(ctx, ..., depth, seen)` after Plan B —
-propagating the seen set but keeping the same depth. After Plan A, TypeRefType
-expansion is handled iteratively in `unifyPruned`'s loop and does not increment
-`depth`. The `depth` parameter only reflects structural recursion depth from
-subcomponent unification (these forwarding calls), which should pass `depth`
-unchanged. If any `c.Unify` calls were missed during Plan B, fix them.
+propagating the seen set and keeping the same depth. After Plan A, TypeRefType
+expansion delegates to `unifyWithDepth` with `depth+1` (bounded by alias chain
+depth, typically 1-3). The `depth` parameter reflects both TypeRefType expansion
+recursion and structural recursion from subcomponent unification. Structural
+forwarding calls (these tuple/array cases) should pass `depth` unchanged. If any
+`c.Unify` calls were missed during Plan B, fix them.
 
 ### Step 2: Audit `ExpandType` calls that remain in unify.go
 
@@ -79,13 +82,14 @@ After Plan A, two `ExpandType` call sites remain in `unifyMatched` (the
 case-matching function extracted from the original `unifyPruned`):
 
 1. **KeyOfType expansion** (lines 345-346): Expands both `keyof` types to get their
-   concrete keys, then unifies the results. Per Step 1's principle, this is not a
-   TypeRef expansion, so it should forward the same depth:
+   concrete keys, then unifies the results. This is a structural forwarding call
+   (not a TypeRef expansion), so it should forward the same depth:
    `c.unifyWithDepth(ctx, expandedKeys1, expandedKeys2, depth, seen)`.
 
    **Risk:** If the expanded keys contain TypeRefTypes, they'll be expanded again on
-   re-entry to `unifyPruned` via Plan A's explicit cases (which do increment depth).
-   The visited set from Plan B handles cycles. Verify with a test case like:
+   re-entry to `unifyPruned` via Plan A's expansion logic (which delegates to
+   `unifyWithDepth` with `depth+1`). The visited set from Plan B handles cycles.
+   Verify with a test case like:
    ```escalier
    type A = { x: number, y: string }
    type B = { x: number, y: string }

--- a/planning/taming_recursion/plan_c_verify_unify_recursion.md
+++ b/planning/taming_recursion/plan_c_verify_unify_recursion.md
@@ -1,17 +1,17 @@
-# Plan C: Verify and harden unification recursion (issue #1)
+# Plan C: Verify and harden unification recursion
 
-**Prerequisites:** Plans A and B are implemented.
+**Prerequisites:** Plans A and B are implemented. Plan A is done (PR #451).
 
 ## Goal
 
-Confirm that the three pathological scenarios described in issue #1 are fully
-resolved after Plans A and B, address any remaining edge cases where unification
-can still recurse excessively, and clean up residual workaround code.
+Confirm that the three pathological scenarios described in research.md issue #1 are
+fully resolved after Plans A and B, address any remaining edge cases where
+unification can still recurse excessively, and clean up residual workaround code.
 
 ## Background
 
-Issue #1 described unbounded recursion in `unifyPruned`'s retry loop for three
-scenarios:
+Research.md issue #1 described unbounded recursion in the old `unifyPruned` retry
+loop for three scenarios:
 
 1. **TypeRefType with TypeAlias set** (e.g. `HTMLAttributeAnchorTarget`, `Array<any>`)
 2. **TupleType with rest spreads** — the original issue referenced multi-spread
@@ -21,37 +21,33 @@ scenarios:
    excessive recursion during unification with Array types.
 3. **Large ObjectType instances** (e.g. React SVG attributes with 200+ properties)
 
-Plan A replaced the retry loop with an expansion loop in `unifyPruned` that calls
-`unifyMatched` for case-matching and `canExpandTypeRef` (a bool predicate) to
-decide whether TypeRef expansion should be attempted. When expansion is possible,
-`ExpandType(ctx, t, 1)` creates fresh copies and `unifyWithDepth` with `depth+1`
-retries unification, eliminating the pointer-inequality-driven retries that caused
-scenarios 1 and 3. Plan B added visited-set cycle detection, removing the
-`maxUnifyDepth` safety net and the `maxExpansionRetries` loop bound.
+Plan A (PR #451) replaced the retry loop with a `noMatchError` sentinel in
+`unifyMatched` and a three-tier expansion loop in `unifyPruned`:
+- Tier 1: `canExpandTypeRef` → `ExpandType(t, 1)` → `unifyWithDepth(depth+1)`
+- Tier 2: `ExpandType(t, 0)` + Prune → `continue` for non-TypeRef types
+- Tier 3: Last-resort `ExpandType(t, 1)` for nominal/refused TypeRefTypes
+
+The `noMatchError` sentinel ensures expansion is only attempted when no case in
+`unifyMatched` handled the types — authoritative errors from `bind`, same-alias
+comparison, etc. are returned immediately. `canExpandTypeRef` blocks `IsTypeParam`
+aliases, nominal types, and transitive self-referential cycles (A→B→A).
+
+Plan B adds visited-set cycle detection, removing `maxUnifyDepth` and
+`maxExpansionRetries`.
 
 However, several areas need verification:
 
 - The `ExpandType` calls that remain in `unifyMatched` — the KeyOfType expansion
-  case (which expands both `keyof` types to get their concrete keys) and the
-  Union+ObjectType expansion case (which expands each union member to check if
-  it's an `ObjectType`) — were not part of the retry loop but still call
-  `ExpandType` with a fresh context. After Plan B removes the hard limits, these
-  calls rely entirely on the `expandSeen` visited set in `ExpandType` for
-  termination.
-- The Tuple+Array and Array+Tuple interaction paths in `unifyMatched` (including
-  the `TupleType, ArrayType` case, the `ArrayType, TupleType` case, the
-  `ArrayType, ArrayType` case, and the `RestSpreadType, ArrayType` case) all
-  call `c.Unify` recursively — notably on rest spread types (e.g.
-  `c.Unify(ctx, rest.Type, array2)`). If a rest spread contains an `Array<T>`
-  where `T` itself references the tuple, this could recurse. After Plan B
-  removes the hard limits, the `unifySeen` set should catch this — but only if
-  each of these `c.Unify` calls was correctly changed to
-  `c.unifyWithDepth(..., seen)` so that `unifySeen` is propagated. A missed
-  call site would create a fresh `unifySeen` set via the public `c.Unify`
-  entry point, which cannot detect cycles that started in the parent call.
+  case and the Union+ObjectType expansion case — were not part of the retry loop
+  but still call `ExpandType` with a fresh context. After Plan B removes the hard
+  limits, these calls rely entirely on the `expandSeen` visited set in `ExpandType`
+  for termination.
+- The Tuple+Array and Array+Tuple interaction paths in `unifyMatched` all call
+  `c.Unify` recursively — notably on rest spread types. After Plan B removes the
+  hard limits, the `unifySeen` set should catch this — but only if each of these
+  `c.Unify` calls was correctly changed to `c.unifyWithDepth(..., seen)`.
 - The `c.Unify` calls inside `unifyTuples`, `unifyFuncTypes`, and `bind` must
-  similarly propagate `unifySeen` via `c.unifyWithDepth(..., seen)`. A missed
-  call site has the same risk: a fresh seen set that can't detect cycles.
+  similarly propagate `unifySeen`.
 
 ## Plan
 
@@ -59,77 +55,63 @@ However, several areas need verification:
 
 Verify that all `c.Unify` calls in the Tuple+Array interaction paths were updated
 by Plan B to propagate the seen set. After Plan A, these cases live in
-`unifyMatched` (the case-matching function called by `unifyPruned`'s loop):
+`unifyMatched`:
 
-- `TupleType, ArrayType` case (lines 376-397): calls `c.Unify` for each tuple
-  element and for rest spread types
-- `ArrayType, TupleType` case (lines 399-421): mirror of above
-- `ArrayType, ArrayType` case (lines 422-435): calls `c.Unify` on element types
-- `RestSpreadType, ArrayType` case (lines 436-441): calls `c.Unify` on rest type
+- `TupleType, ArrayType` case: calls `c.Unify` for each tuple element and rest
+  spread types
+- `ArrayType, TupleType` case: mirror of above
+- `ArrayType, ArrayType` case: calls `c.Unify` on element types
+- `RestSpreadType, ArrayType` case: calls `c.Unify` on rest type
 - `unifyTuples` helper: calls `c.Unify` on each pair of tuple elements
 
-Each of these should be `c.unifyWithDepth(ctx, ..., depth, seen)` after Plan B —
-propagating the seen set and keeping the same depth. After Plan A, TypeRefType
-expansion delegates to `unifyWithDepth` with `depth+1` (bounded by alias chain
-depth, typically 1-3). The `depth` parameter reflects both TypeRefType expansion
-recursion and structural recursion from subcomponent unification. Structural
-forwarding calls (these tuple/array cases) should pass `depth` unchanged. If any
-`c.Unify` calls were missed during Plan B, fix them.
+Each should be `c.unifyWithDepth(ctx, ..., depth, seen)` after Plan B —
+propagating the seen set and keeping the same depth (structural forwarding, not
+alias expansion). If any calls were missed, fix them.
 
 ### Step 2: Audit `ExpandType` calls that remain in unify.go
 
-After Plan A, two `ExpandType` call sites remain in `unifyMatched` (the
-case-matching function extracted from the original `unifyPruned`):
+After Plan A, two `ExpandType` call sites remain in `unifyMatched`:
 
-1. **KeyOfType expansion** (lines 345-346): Expands both `keyof` types to get their
-   concrete keys, then unifies the results. This is a structural forwarding call
-   (not a TypeRef expansion), so it should forward the same depth:
+1. **KeyOfType expansion**: Expands both `keyof` types to get concrete keys, then
+   unifies the results. This is structural forwarding (not TypeRef expansion), so
+   it should forward the same depth:
    `c.unifyWithDepth(ctx, expandedKeys1, expandedKeys2, depth, seen)`.
 
-   **Risk:** If the expanded keys contain TypeRefTypes, they'll be expanded again on
-   re-entry to `unifyPruned` via Plan A's expansion logic (which delegates to
-   `unifyWithDepth` with `depth+1`). The visited set from Plan B handles cycles.
-   Verify with a test case like:
+   **Risk:** If the expanded keys contain TypeRefTypes, they'll be expanded again
+   on re-entry to `unifyPruned` via Plan A's expansion logic (Tier 1 with
+   `depth+1`). Plan B's visited set handles cycles. Verify with a test case like:
    ```escalier
    type A = { x: number, y: string }
    type B = { x: number, y: string }
    // keyof A should unify with keyof B
    ```
 
-2. **Union+ObjectType expansion** (line 1055): Expands each union member one level
-   to check if it's an `ObjectType`. This is a one-shot expansion (not recursive)
-   and doesn't call `unifyWithDepth` directly on the result.
+2. **Union+ObjectType expansion**: Expands each union member one level to check if
+   it's an `ObjectType`. This is one-shot (not recursive) and doesn't call
+   `unifyWithDepth` directly on the result.
 
-   **Risk:** Low. The expansion is bounded by the number of union members, and each
-   member is expanded only once. **No change needed.**
+   **Risk:** Low. Bounded by union member count. **No change needed.**
 
 ### Step 3: Validate the three original scenarios
 
-Write targeted tests that reproduce the three scenarios from issue #1 and verify
-they terminate promptly (not after hitting a depth limit):
+Write targeted tests that reproduce the three scenarios from research.md issue #1
+and verify they terminate promptly (not after hitting a depth limit):
 
 #### Scenario 1: TypeRefType with TypeAlias set
 
 ```escalier
-// HTMLAttributeAnchorTarget-like scenario: type alias used in annotation
+// HTMLAttributeAnchorTarget-like scenario
 type Target = "_self" | "_blank" | "_parent" | "_top"
 val t: Target = "_blank"
 ```
 
 ```escalier
-// Array<any> scenario: unifying Array types with different references
+// Array<any> scenario
 val a: Array<any> = [1, "hello", true]
 val b: Array<any> = a
 ```
 
 #### Scenario 2: TupleType with rest spreads
-
-> **Note:** Escalier (like TypeScript) does not allow tuple types to contain
-> multiple rest/spread elements. The examples below from the original issue
-> inventory are invalid syntax. This scenario may not be reproducible as
-> described. If single-spread tuples can still trigger excessive recursion
-> (e.g. `[number, ...Array<number>]` vs `Array<number>`), add a test for that
-> instead.
 
 ```escalier
 // Single rest spread — valid
@@ -168,6 +150,9 @@ func TestUnifyRecursionTerminates(t *testing.T) {
 Each test should verify both correctness (unification succeeds or fails as expected)
 and termination (no timeout or stack overflow).
 
+**Note:** Plan A already added `TestNominalClassUnificationTerminates` which tests
+self-referential nominal class unification through the last-resort expansion path.
+
 ### Step 5: Remove residual workaround code and comments
 
 After verifying all tests pass:
@@ -179,18 +164,22 @@ After verifying all tests pass:
    recursion cases, remove the `depth` parameter from `unifyWithDepth` entirely
    to simplify the interface. If there is value in keeping it (e.g. for logging
    or as a last-resort safety net during development), add a comment making clear
-   it is diagnostic-only and not a termination mechanism. If depth is removed,
-   update the guidance in Step 1 accordingly (the "should pass `depth` unchanged"
-   notes become moot).
+   it is diagnostic-only and not a termination mechanism.
 
-2. **Update the TODO at expand_type.go:343-345** — After Plan B adds visited-set
-   cycle detection to `ExpandType`, the TODO about marking type aliases as recursive
+2. **Evaluate `canExpandTypeRef`'s transitive cycle detection.** After Plan B adds
+   the `unifySeen` and `expandSeen` visited sets, the transitive cycle check
+   (A→B→A) in `canExpandTypeRef` becomes redundant for cycle prevention. Consider
+   keeping it as an optimization (avoids entering `ExpandType` + `unifyWithDepth`
+   for known cycles) or removing it to simplify `canExpandTypeRef`.
+
+3. **Update the TODO at expand_type.go** — After Plan B adds visited-set cycle
+   detection to `ExpandType`, the TODO about marking type aliases as recursive
    can be updated to reflect that cycle detection is now handled dynamically. The
    `Recursive` flag on `TypeAlias` is no longer a prerequisite for correctness,
    though it could still be useful as an optimization (skip visited-set tracking
    for non-recursive aliases).
 
-3. **Clean up comments** in `unifyPruned` and `unifyMatched` that reference the
+4. **Clean up comments** in `unifyPruned` and `unifyMatched` that reference the
    old retry loop or explain why certain cases fall through to it.
 
 ### Step 6: Performance validation
@@ -223,16 +212,15 @@ above are additive.
   Tuple/Array paths that should propagate `seen`, cycles involving tuples with
   recursive rest spreads could still diverge. Step 1 of this plan specifically
   audits these sites.
-- **ExpandType calls without visited set**: The `ExpandType` calls at lines 345
-  and 1055 create their own expansion context. If the types being expanded contain
-  recursive aliases, the expansion-side visited set (from Plan B) should catch
-  them, but this depends on `ExpandType` correctly threading its own seen set
-  through recursive calls. Step 2 verifies this.
+- **ExpandType calls without visited set**: The `ExpandType` calls in `unifyMatched`
+  (KeyOfType and Union+ObjectType cases) create their own expansion context. If the
+  types being expanded contain recursive aliases, the expansion-side visited set
+  (from Plan B) should catch them, but this depends on `ExpandType` correctly
+  threading its own seen set through recursive calls. Step 2 verifies this.
 - **Performance regression**: Unlikely but possible if the visited-set map becomes
   a bottleneck for very hot unification paths. Step 6 checks for this.
 - **Thread safety**: The `unifySeen` and `expandSeen` maps are created per top-level
   call and threaded through parameters, so they are not shared across goroutines.
   If the checker ever runs concurrently (e.g. checking multiple files in parallel),
   this design is safe because each `Unify`/`ExpandType` entry point creates its own
-  seen set. However, if internal helper functions are ever changed to spawn
-  goroutines that share a seen map, the maps would need synchronization.
+  seen set.

--- a/planning/taming_recursion/planning.md
+++ b/planning/taming_recursion/planning.md
@@ -6,11 +6,13 @@ for the full issue inventory.
 ## Plan index
 
 - **[Plan A: Expand at the TypeRefType match site](plan_a_typeref_expansion.md)** —
-  Replace the catch-all retry loop with an iterative expansion loop in
-  `unifyPruned` that calls a new `unifyMatched` function for case-matching and
-  `tryExpandTypeRef` for TypeRef expansion. Adds an `IsTypeParam` flag to
-  `TypeAlias` to prevent expanding type parameter references. Prerequisite for
-  Plan B.
+  Replace the catch-all retry loop with an expansion loop in `unifyPruned` that
+  calls a new `unifyMatched` function for case-matching and `canExpandTypeRef`
+  (a bool predicate) to decide whether TypeRef expansion should be attempted.
+  Actual expansion uses `ExpandType(ctx, t, 1)` for fresh copies, then delegates
+  to `unifyWithDepth` with `depth+1`. Adds an `IsTypeParam` flag to `TypeAlias`
+  (for documentation/future use; not checked by `canExpandTypeRef`).
+  Prerequisite for Plan B.
 
 - **[Plan B: Visited-set / seen-pairs memoization](plan_b_visited_set.md)** —
   Add cycle detection via visited sets to both `Unify` and `ExpandType`. Enables
@@ -33,7 +35,7 @@ Which [research.md](research.md) issues each plan addresses:
 | #3 | `skipTypeRefsCount` suppresses expansion inside structural types | B (visited set makes this less critical; evaluated for removal in step 6) |
 | #4 | `insideKeyOfTarget` prevents nested keyof expansion | B (visited set may subsume this; evaluated for removal in step 6) |
 | #5 | `getMemberType` expansion loop relies on pointer identity | — (deferred; low complexity to fix after Plan B provides a visited-set primitive — add an iteration limit or use the `expandSeen` set) |
-| #6 | `ExpandType` and `unifyPruned` use different recursion strategies | A (unify uses `tryExpandTypeRef` for TypeRefs and `ExpandType(t, 0)` only for non-TypeRef types), B (shared cycle detection primitive) |
+| #6 | `ExpandType` and `unifyPruned` use different recursion strategies | A (unify uses `canExpandTypeRef` predicate + `ExpandType(t, 1)` for TypeRefs and `ExpandType(t, 0)` for non-TypeRef types), B (shared cycle detection primitive) |
 | #7 | No visited-set or seen-pairs mechanism | B (adds visited sets to both Unify and ExpandType) |
 | #8 | Package loading cycle prevention | — (working correctly, no changes needed) |
 | #9 | Library file discovery visited set | — (working correctly, no changes needed) |

--- a/planning/taming_recursion/planning.md
+++ b/planning/taming_recursion/planning.md
@@ -6,13 +6,13 @@ for the full issue inventory.
 ## Plan index
 
 - **[Plan A: Expand at the TypeRefType match site](plan_a_typeref_expansion.md)** —
-  Replace the catch-all retry loop with an expansion loop in `unifyPruned` that
-  calls a new `unifyMatched` function for case-matching and `canExpandTypeRef`
-  (a bool predicate) to decide whether TypeRef expansion should be attempted.
-  Actual expansion uses `ExpandType(ctx, t, 1)` for fresh copies, then delegates
-  to `unifyWithDepth` with `depth+1`. Adds an `IsTypeParam` flag to `TypeAlias`
-  (for documentation/future use; not checked by `canExpandTypeRef`).
-  Prerequisite for Plan B.
+  **Implemented (PR #451).** Replaced the catch-all retry loop with a
+  `noMatchError` sentinel in `unifyMatched` and an expansion loop in `unifyPruned`.
+  `canExpandTypeRef` (a bool predicate) decides whether TypeRef expansion should be
+  attempted; it blocks nominal types, `IsTypeParam` aliases, and transitive
+  self-referential cycles (A→B→A). Actual expansion uses `ExpandType(ctx, t, 1)`
+  for fresh copies, then delegates to `unifyWithDepth` with `depth+1`. Adds an
+  `IsTypeParam` flag to `TypeAlias`, checked by `canExpandTypeRef`.
 
 - **[Plan B: Visited-set / seen-pairs memoization](plan_b_visited_set.md)** —
   Add cycle detection via visited sets to both `Unify` and `ExpandType`. Enables
@@ -30,12 +30,12 @@ Which [research.md](research.md) issues each plan addresses:
 
 | Issue | Description | Plan(s) |
 |-------|-------------|---------|
-| #1 | Unification retry loop creates unbounded recursion | A (replaces retry loop with iterative expansion), B (removes depth limit and expansion loop bound), C (validates fix, regression tests) |
+| #1 | Unification retry loop creates unbounded recursion | **A (done)**: replaces retry loop with iterative expansion + `noMatchError` sentinel; B (removes depth limit and expansion loop bound); C (validates fix, regression tests) |
 | #2 | Recursive type aliases cannot be expanded | B (visited set in ExpandType enables cycle detection) |
 | #3 | `skipTypeRefsCount` suppresses expansion inside structural types | B (visited set makes this less critical; evaluated for removal in step 6) |
 | #4 | `insideKeyOfTarget` prevents nested keyof expansion | B (visited set may subsume this; evaluated for removal in step 6) |
 | #5 | `getMemberType` expansion loop relies on pointer identity | — (deferred; low complexity to fix after Plan B provides a visited-set primitive — add an iteration limit or use the `expandSeen` set) |
-| #6 | `ExpandType` and `unifyPruned` use different recursion strategies | A (unify uses `canExpandTypeRef` predicate + `ExpandType(t, 1)` for TypeRefs and `ExpandType(t, 0)` for non-TypeRef types), B (shared cycle detection primitive) |
+| #6 | `ExpandType` and `unifyPruned` use different recursion strategies | **A (done)**: unify uses `canExpandTypeRef` predicate + `ExpandType(t, 1)` for TypeRefs and `ExpandType(t, 0)` for non-TypeRef types; B (shared cycle detection primitive) |
 | #7 | No visited-set or seen-pairs mechanism | B (adds visited sets to both Unify and ExpandType) |
 | #8 | Package loading cycle prevention | — (working correctly, no changes needed) |
 | #9 | Library file discovery visited set | — (working correctly, no changes needed) |

--- a/planning/taming_recursion/research.md
+++ b/planning/taming_recursion/research.md
@@ -8,24 +8,32 @@ problems before designing solutions.
 
 ## 1. Unification retry loop creates unbounded recursion
 
-**Location:** `unify.go:1189-1203`
+**Location:** `unify.go` (previously lines 1189-1203, now replaced)
 
-When `unifyPruned` fails to unify two types, it calls `ExpandType(ctx, t, 1)` on
-both sides and retries if either expansion produced a different object. The problem
-is that `ExpandType` allocates new type objects on every call, so the pointer
-comparison `expandedT1 != t1` is always true for any expandable type — even when
-the expansion is structurally identical.
+**Status: Addressed by Plan A (PR #451).**
 
-This causes unbounded recursion for:
+When `unifyPruned` failed to unify two types, it called `ExpandType(ctx, t, 1)` on
+both sides and retried if either expansion produced a different object. The problem
+was that `ExpandType` allocates new type objects on every call, so the pointer
+comparison `expandedT1 != t1` was always true for any expandable type — even when
+the expansion was structurally identical.
+
+This caused unbounded recursion for:
 - `TypeRefType` with `TypeAlias` set (e.g. `HTMLAttributeAnchorTarget`, `Array<any>`)
 - `TupleType` with rest spreads that expand to include the full `Array` interface
 - Large `ObjectType` instances (e.g. React SVG attributes with 200+ properties)
   where nested type references keep producing new objects
 
-**Current workaround:** A hard depth limit (`maxUnifyDepth = 50` at `unify.go:94`)
-that returns `CannotUnifyTypesError` when exceeded (`unify.go:119-121`). This is a
-blunt instrument — it can reject valid programs if they happen to need more than 50
-expansion steps, and it wastes work on the 49 expansions that precede the cutoff.
+**Previous workaround:** A hard depth limit (`maxUnifyDepth = 50`) that returned
+`CannotUnifyTypesError` when exceeded. This was a blunt instrument — it could reject
+valid programs if they happened to need more than 50 expansion steps.
+
+**Current state:** Plan A replaced the retry loop with a `noMatchError` sentinel in
+`unifyMatched` and a three-tier expansion loop in `unifyPruned`. Expansion only
+happens when no case matched (not on every failed match), and recursion depth is
+proportional to alias chain depth (typically 1-3), not property count.
+`maxUnifyDepth` and `maxExpansionRetries` remain as safety nets until Plan B adds
+visited-set cycle detection.
 
 ---
 
@@ -43,6 +51,9 @@ no way to detect the cycle and stop.
 
 This blocks support for linked lists, trees, JSON values, and other recursive data
 structures that are common in real programs.
+
+**Plan B** will add a visited set to `ExpandType` that detects cycles dynamically,
+making the `Recursive` flag unnecessary for correctness.
 
 ---
 
@@ -100,17 +111,21 @@ infinite loop. This is a fragile ordering dependency.
 
 ## 6. `ExpandType` and `unifyPruned` use different recursion strategies that don't compose
 
+**Status: Partially addressed by Plan A (PR #451).**
+
 `ExpandType` uses three independent counters (`expandTypeRefsCount`,
 `skipTypeRefsCount`, `insideKeyOfTarget`) while `unifyPruned` uses a depth counter
-(`depth`). These mechanisms were designed independently and interact in subtle ways:
+(`depth`). These mechanisms were designed independently and interact in subtle ways.
 
-- `unifyPruned` calls `ExpandType` with a fresh count of `1` on each retry, so the
-  expansion counters reset every time — the depth limit in `Unify` is the only thing
-  preventing infinite retries.
-- `ExpandType` calls itself recursively (e.g. for intersection distribution at
-  line 186, keyof distribution at lines 288-301, mapped element expansion at
-  line 1484), each time with its own counter values. There is no shared state
-  between these recursive calls to detect that the overall expansion is cycling.
+**Previous state:** `unifyPruned` called `ExpandType` with a fresh count of `1` on
+each retry, so the expansion counters reset every time — the depth limit in `Unify`
+was the only thing preventing infinite retries.
+
+**Current state:** After Plan A, `unifyPruned` calls `ExpandType` only when the
+`noMatchError` sentinel indicates no case matched, and only for specific type kinds
+(TypeRefTypes via `canExpandTypeRef`, non-TypeRef types via count=0, nominal
+last-resort via count=1). The depth limit is still the safety net, but expansion is
+much more targeted. Plan B will add a shared visited-set primitive.
 
 ---
 
@@ -128,6 +143,11 @@ TypeScript, OCaml, and other production type checkers) for handling recursive ty
 Without this, every recursion-prevention mechanism must be an ad-hoc counter or
 depth limit, and adding support for recursive type aliases will require a
 fundamental change to the expansion strategy.
+
+**Note:** Plan A added a small visited set inside `canExpandTypeRef` for detecting
+transitive alias cycles (A→B→A), but this is scoped to the predicate only — it
+does not provide general cycle detection for unification or expansion. Plan B
+addresses this fully.
 
 ---
 
@@ -164,8 +184,8 @@ Issues 8 and 9 are working correctly and are excluded from these rankings.
 |------|-------|-----|
 | 1 | #2 — Recursive type aliases cannot be expanded | **Blocks entire feature.** Users cannot define linked lists, trees, JSON types, or any recursive data structure. This is a missing capability, not just a bug. |
 | 2 | #7 — No visited-set / seen-pairs mechanism | **Root cause of most other issues.** The absence of this primitive forces every recursion site to invent its own ad-hoc guard. It also makes #2 unsolvable without an architectural change. |
-| 3 | #1 — Unify retry loop / depth limit | **Can reject valid programs.** The depth limit is arbitrary — a program that needs 51 expansion steps to unify will get a spurious type error. It also wastes significant work on the preceding 50 attempts. |
-| 4 | #6 — Non-composing recursion strategies | **Makes the system unpredictable.** Because `Unify` resets `ExpandType`'s counters on every retry, the depth limit in `Unify` is the only real safety net. If it's ever removed or raised, expansion can diverge. |
+| 3 | #1 — ~~Unify retry loop / depth limit~~ | **Addressed by Plan A.** The retry loop has been replaced with targeted expansion. `maxUnifyDepth` remains as a safety net until Plan B. |
+| 4 | #6 — ~~Non-composing recursion strategies~~ | **Partially addressed by Plan A.** Expansion is now targeted by type kind. Plan B will add a shared cycle-detection primitive. |
 | 5 | #5 — `getMemberType` expansion loop | **Fragile but currently working.** Adding a new type kind without updating the terminal-type checks would silently introduce an infinite loop. The `globalThis` ordering dependency is a maintenance hazard. |
 | 6 | #3 — `skipTypeRefsCount` suppression | **Over-suppresses expansion.** Can prevent needed expansion inside structural types, potentially causing unification to fail when it shouldn't. The effect is hard to observe because it manifests as "unification didn't try hard enough" rather than an explicit error. |
 | 7 | #4 — `insideKeyOfTarget` guard | **Narrow scope, works for its case.** Only affects `keyof keyof T` patterns. Low impact because these patterns are uncommon and the guard correctly handles the ones that do occur. |
@@ -176,8 +196,8 @@ Issues 8 and 9 are working correctly and are excluded from these rankings.
 |------|-------|-----|
 | 1 | #7 — No visited-set / seen-pairs mechanism | **Architectural change.** Requires threading shared state through both `ExpandType` and `Unify`, which currently have no shared context beyond the `Checker` receiver. Every call site that creates a new visitor or calls `ExpandType` independently would need to participate. Design decisions include: what constitutes identity for a type pair, whether to use co-inductive assumption (assume success on re-encounter) or just stop expansion, and how to handle type arguments in cycle detection. |
 | 2 | #2 — Recursive type aliases cannot be expanded | **Depends on #7.** Even after adding a visited set, there are design questions: should recursive aliases be detected statically (mark `TypeAlias.Recursive` during definition) or dynamically (detect during expansion)? Static detection requires analyzing the alias graph, which is its own problem for mutually recursive types. Dynamic detection is simpler but means every expansion pays the cost of cycle tracking. |
-| 3 | #6 — Non-composing recursion strategies | **Requires redesigning the expand/unify interface.** The core question is whether expansion should happen lazily (on demand during unification) or eagerly (fully expand before unifying). Either choice has ripple effects across both systems. A unified recursion-tracking context shared between `ExpandType` and `Unify` would address this but is effectively the same work as #7. |
-| 4 | #1 — Unify retry loop / depth limit | **Multiple possible fixes, ranging from simple to thorough.** The simplest fix (structural equality instead of pointer identity) is localized to a few lines but doesn't address the underlying issue. A more thorough fix (expand `TypeRefType` explicitly in `unifyPruned` rather than in a catch-all retry) requires restructuring the bottom of `unifyPruned` and understanding all the cases the retry currently handles. |
+| 3 | #6 — Non-composing recursion strategies | **Partially addressed by Plan A.** The remaining work is adding a shared cycle-detection primitive (Plan B), which is effectively the same work as #7. |
+| 4 | #1 — Unify retry loop / depth limit | **Addressed by Plan A.** The remaining safety-net removal (dropping `maxUnifyDepth`) depends on Plan B. |
 | 5 | #3 — `skipTypeRefsCount` suppression | **Requires understanding when expansion is actually needed.** The counter exists because expanding type refs inside object/function types was causing problems, but the exact failure modes aren't documented. Removing or refining it requires identifying those failure modes and ensuring the replacement handles them. |
 | 6 | #5 — `getMemberType` expansion loop | **Incremental fix.** Could be hardened by adding a small iteration limit or a seen-set of types already attempted. The terminal-type list could be made exhaustive by switching to a default-break pattern instead of listing specific types. |
 | 7 | #4 — `insideKeyOfTarget` guard | **Already works.** If a visited-set mechanism (#7) is added, this counter becomes redundant and can be removed. Until then, it's fine as-is. |
@@ -189,8 +209,9 @@ Issues 8 and 9 are working correctly and are excluded from these rankings.
   non-composing strategies (#6) are the ongoing maintenance cost. Addressing #7
   would make #2 tractable and #6 largely moot.
 
-- Issue #1 (unify retry loop) could be improved independently with a localized fix
-  (structural equality check), but a full solution also benefits from #7.
+- Issue #1 has been addressed by Plan A. The remaining work is removing the safety
+  nets (`maxUnifyDepth`, `maxExpansionRetries`) once Plan B provides proper cycle
+  detection.
 
 - Issues #3, #4, and #5 are lower priority and could be cleaned up incrementally,
   especially after #7 provides a principled cycle-detection mechanism that subsumes


### PR DESCRIPTION
## Summary

- Replace the catch-all retry loop at the bottom of `unifyPruned` with explicit TypeRefType handling via a new `canExpandTypeRef` predicate and bounded expansion loop
- Extract case-matching into `unifyMatched` with a `noMatchError` sentinel to distinguish "no case matched" (safe to try expansion) from "a case matched but failed" (authoritative error)
- Add `IsTypeParam` flag to `TypeAlias` struct, set at all 7 type parameter creation sites
- Remove the do-nothing different-alias TypeRefType case

This addresses issues documented in the plan: stack overflow from recursive `unifyWithDepth` calls (Issue 2), `TypeOfType` relying on retry loop (Issue 3), type parameter identity destruction (Issue 4), bind side-effect leaks (Issue 5), same-alias expansion after type-arg mismatch (Issue 6), self-referential alias loops (Issue 7), shared mutable pointer corruption (Issue 9), and nominal type pattern matching (Issue 10).

## Test plan

- [x] Full test suite passes (`go test ./...`)
- [x] Intersection test preserved (no spurious normalization via `noMatchError` sentinel)
- [x] Getter/setter test preserved (Prune after non-TypeRef expansion)
- [x] React type tests pass without stack overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of recursive and self-referential types to prevent unification loops
  * More robust unification retries with guarded expansion to resolve mismatches

* **Refactor**
  * Improved type expansion and retry control to reduce spurious failures
  * Type-alias metadata enhanced to distinguish type-parameter placeholders

* **Tests**
  * Added a test ensuring nominal class unification terminates

* **Documentation**
  * Updated plans describing the revised expansion and recursion strategy
<!-- end of auto-generated comment: release notes by coderabbit.ai -->