### PR TITLE
Plan B: Visited-set / seen-pairs memoization

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -13,10 +13,25 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
-// expandSeenKey identifies a specific instantiation of a type alias.
+// expandSeenKey identifies a specific instantiation of a type alias in a
+// specific expansion context.
+//
+// TODO(#455): The insideKeyOf field may be unnecessary. The expandSeen
+// visited set already detects cycles through TypeRefType's in-progress
+// marker, which handles the nested-keyof recursion case that
+// insideKeyOfTarget was designed to prevent. If insideKeyOfTarget is
+// removed, this field can be removed too.
+//
+// Note: expandTypeRefsCount is intentionally excluded from the key. The
+// expandTypeRefsCount == 0 check in ExitType returns nil before the cache
+// lookup, so count=0 never consults or populates the cache. Within a single
+// expansion pass the count only decreases (N → N-1 → … → 0), so a cached
+// result can only be hit at the same or lower count — never at a higher count
+// that would expect more expansion than what was cached.
 type expandSeenKey struct {
-	alias    unsafe.Pointer // TypeAlias pointer
-	typeArgs string         // typeArgKey(typeArgs)
+	alias       unsafe.Pointer // TypeAlias pointer
+	typeArgs    string         // typeArgKey(typeArgs)
+	insideKeyOf bool           // TODO(#455): may be unnecessary
 }
 
 // expandSeen tracks type alias expansions in progress and caches completed results.
@@ -287,7 +302,8 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 
 		return distributed
 	case *type_system.KeyOfType:
-		// Prevent infinite recursion when expanding nested keyof types
+		// TODO(#455): This guard may be redundant now that expandSeen detects
+		// cycles via TypeRefType's in-progress marker. Evaluate removing it.
 		if v.insideKeyOfTarget > 0 {
 			return nil
 		}
@@ -457,8 +473,9 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 
 		// Cycle detection: check if we're already expanding this alias+typeArgs.
 		key := expandSeenKey{
-			alias:    unsafe.Pointer(typeAlias),
-			typeArgs: typeArgKey(t.TypeArgs),
+			alias:       unsafe.Pointer(typeAlias),
+			typeArgs:    typeArgKey(t.TypeArgs),
+			insideKeyOf: v.insideKeyOfTarget > 0,
 		}
 		if cached, exists := v.seen[key]; exists {
 			if cached == nil {

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1572,8 +1572,13 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 	return type_system.NewNeverType(nil), errors
 }
 
-// expandMappedElems expands MappedElem elements in an ObjectType into concrete properties
-// For example, {[P in "foo" | "bar"]: string} becomes {foo: string, bar: string}
+// expandMappedElems expands MappedElem elements in an ObjectType into concrete properties.
+// For example, {[P in "foo" | "bar"]: string} becomes {foo: string, bar: string}.
+//
+// TODO(#456): This function only handles finite, enumerable key sets (string/number
+// literals, symbols). It panics when the constraint is a primitive type like `string`
+// or `number` (e.g. Record<string, T> which expands to {[P in string]: T}). Supporting
+// infinite key types requires adding an index signature representation to the type system.
 func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType) *type_system.ObjectType {
 	// Check if there are any MappedElem elements to expand
 	hasMappedElems := false

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"unsafe"
 
 	"maps"
 
@@ -11,6 +12,17 @@ import (
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
+
+// expandSeenKey identifies a specific instantiation of a type alias.
+type expandSeenKey struct {
+	alias    unsafe.Pointer // TypeAlias pointer
+	typeArgs string         // typeArgKey(typeArgs)
+}
+
+// expandSeen tracks type alias expansions in progress and caches completed results.
+// A nil value means the expansion is in progress (re-encounter = cycle).
+// A non-nil value is the cached expansion result (re-encounter = reuse).
+type expandSeen map[expandSeenKey]type_system.Type
 
 // isSymbolIndexKey returns true if the given MemberAccessKey is an IndexKey
 // whose underlying type is a UniqueSymbolType (e.g. Symbol.iterator).
@@ -91,13 +103,14 @@ func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool
 // TODO(#452): Extract a separate ExpandNonRefTypes helper for the count=0 case
 // to make call sites self-documenting.
 func (c *Checker) ExpandType(ctx Context, t type_system.Type, expandTypeRefsCount int) (type_system.Type, []Error) {
-	return c.expandTypeWithConfig(ctx, t, expandTypeRefsCount, 0)
+	return c.expandTypeWithConfig(ctx, t, expandTypeRefsCount, 0, make(expandSeen))
 }
 
-func (c *Checker) expandTypeWithConfig(ctx Context, t type_system.Type, expandTypeRefsCount int, insideKeyOfTarget int) (type_system.Type, []Error) {
+func (c *Checker) expandTypeWithConfig(ctx Context, t type_system.Type, expandTypeRefsCount int, insideKeyOfTarget int, seen expandSeen) (type_system.Type, []Error) {
 	t = type_system.Prune(t)
 	visitor := NewTypeExpansionVisitor(c, ctx, expandTypeRefsCount)
 	visitor.insideKeyOfTarget = insideKeyOfTarget
+	visitor.seen = seen
 
 	result := t.Accept(visitor)
 	return result, visitor.errors
@@ -111,6 +124,7 @@ type TypeExpansionVisitor struct {
 	skipTypeRefsCount   int // if > 0, skip expanding TypeRefTypes
 	expandTypeRefsCount int // if > 0, number of TypeRefTypes expanded, if -1 then unlimited
 	insideKeyOfTarget   int // if > 0, we're expanding a keyof target, don't expand nested keyof
+	seen                expandSeen
 }
 
 // NewTypeExpansionVisitor creates a new visitor for expanding type references
@@ -283,7 +297,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 
 		// First, try to expand the target type
 		// Pass insideKeyOfTarget+1 to prevent recursive keyof expansion during target expansion
-		expandedTarget, _ := v.checker.expandTypeWithConfig(v.ctx, targetType, 1, v.insideKeyOfTarget+1)
+		expandedTarget, _ := v.checker.expandTypeWithConfig(v.ctx, targetType, 1, v.insideKeyOfTarget+1, v.seen)
 		expandedTarget = type_system.Prune(expandedTarget)
 
 		// Unwrap MutabilityType so keyof sees the actual object type
@@ -441,6 +455,21 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 			}
 		}
 
+		// Cycle detection: check if we're already expanding this alias+typeArgs.
+		key := expandSeenKey{
+			alias:    unsafe.Pointer(typeAlias),
+			typeArgs: typeArgKey(t.TypeArgs),
+		}
+		if cached, exists := v.seen[key]; exists {
+			if cached == nil {
+				// In progress — this is a cycle. Return unexpanded.
+				return nil
+			}
+			// Completed — reuse the cached expansion.
+			return cached
+		}
+		v.seen[key] = nil // mark as in progress
+
 		// TODO:
 		// - ensure that the number of type args matches the number of type params
 		// - handle type params with defaults
@@ -492,12 +521,15 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 
 		// Recursively expand the resolved type using the same visitor to maintain state
 		// Propagate insideKeyOfTarget to prevent infinite recursion
+		var result type_system.Type
 		if v.expandTypeRefsCount == -1 {
-			result, _ := v.checker.expandTypeWithConfig(v.ctx, expandedType, -1, v.insideKeyOfTarget)
-			return result
+			result, _ = v.checker.expandTypeWithConfig(v.ctx, expandedType, -1, v.insideKeyOfTarget, v.seen)
+		} else {
+			result, _ = v.checker.expandTypeWithConfig(v.ctx, expandedType, v.expandTypeRefsCount-1, v.insideKeyOfTarget, v.seen)
 		}
 
-		result, _ := v.checker.expandTypeWithConfig(v.ctx, expandedType, v.expandTypeRefsCount-1, v.insideKeyOfTarget)
+		// Cache the expanded result for reuse
+		v.seen[key] = result
 		return result
 	case *type_system.TemplateLitType:
 		// Expand template literal types by generating all possible string combinations

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -424,7 +424,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 		}
 
 		objType := type_system.NewObjectType(provenance, typeElems)
-		bindErrors := c.bind(objCtx, selfType, objType)
+		bindErrors := c.bind(objCtx, selfType, objType, 0, make(unifySeen))
 		errors = slices.Concat(errors, bindErrors)
 
 		i := 0 // indexes into paramBindingsSlice

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1594,14 +1594,19 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"b":  "B",
 			},
 		},
+		// TODO(#456): Record<string, Json> panics in expandMappedElems because
+		// it can't enumerate keys from the `string` primitive type. Once #456
+		// is fixed, add Record<string, Json> back to the Json union and include
+		// object literal values like { name: "test", scores: [1, 2, 3] }.
 		"RecursiveJsonLikeType": {
 			input: `
-				type Json = string | number | boolean | null | Array<Json> | Record<string, Json>
+				type Json = string | number | boolean | null | Array<Json>
 				val j: Json = "hello"
 				val j2: Json = 42
 				val j3: Json = true
 				val j4: Json = null
 				val j5: Json = [1, 2, 3]
+				val j6: Json = ["nested", [1, [true, [null, ["deep"]]]]]
 			`,
 			expectedTypes: map[string]string{
 				"j":  "Json",
@@ -1609,6 +1614,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"j3": "Json",
 				"j4": "Json",
 				"j5": "Json",
+				"j6": "Json",
 			},
 		},
 		"CycleDetectionSameTypeAssignment": {

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1562,6 +1562,75 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"x":   "string & {} | 0",
 			},
 		},
+		"RecursiveLinkedListValue": {
+			input: `
+				type List<T> = { head: T, tail: List<T> | null }
+				val list: List<number> = { head: 1, tail: { head: 2, tail: null } }
+			`,
+			expectedTypes: map[string]string{
+				"list": "List<number>",
+			},
+		},
+		"RecursiveTreeValue": {
+			input: `
+				type Tree<T> = { value: T, children: Array<Tree<T>> }
+				val t: Tree<number> = { value: 1, children: [{ value: 2, children: [] }] }
+			`,
+			expectedTypes: map[string]string{
+				"t": "Tree<number>",
+			},
+		},
+		"CrossAliasCycleValue": {
+			input: `
+				type A = { x: B }
+				type B = { y: A }
+				declare val a1: A
+				val a2: A = a1
+				val b: B = a1.x
+			`,
+			expectedTypes: map[string]string{
+				"a1": "A",
+				"a2": "A",
+				"b":  "B",
+			},
+		},
+		"RecursiveJsonLikeType": {
+			input: `
+				type Json = string | number | boolean | null | Array<Json> | Record<string, Json>
+				val j: Json = "hello"
+				val j2: Json = 42
+				val j3: Json = true
+				val j4: Json = null
+				val j5: Json = [1, 2, 3]
+			`,
+			expectedTypes: map[string]string{
+				"j":  "Json",
+				"j2": "Json",
+				"j3": "Json",
+				"j4": "Json",
+				"j5": "Json",
+			},
+		},
+		"CycleDetectionSameTypeAssignment": {
+			input: `
+				type List<T> = { head: T, tail: List<T> | null }
+				declare val a: List<number>
+				val b: List<number> = a
+			`,
+			expectedTypes: map[string]string{
+				"a": "List<number>",
+				"b": "List<number>",
+			},
+		},
+		"StructuralTypeArgWithEmbeddedTypeVar": {
+			input: `
+				type Wrapper<T> = { inner: Wrapper<{x: T}> | null }
+				val w: Wrapper<number> = { inner: { inner: null } }
+			`,
+			expectedTypes: map[string]string{
+				"w": "Wrapper<number>",
+			},
+		},
 	}
 
 	schema := loadSchema(t)
@@ -2207,6 +2276,45 @@ func TestCheckModuleTypeAliases(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"Color": "Color.RGB | Color.Hex",
+			},
+		},
+		"RecursiveLinkedList": {
+			input: `
+				type List<T> = { head: T, tail: List<T> | null }
+			`,
+			expectedTypes: map[string]string{
+				"List": "{head: T, tail: List<T> | null}",
+			},
+		},
+		"RecursiveTree": {
+			input: `
+				type Tree<T> = { value: T, children: Array<Tree<T>> }
+			`,
+			expectedTypes: map[string]string{
+				"Tree": "{value: T, children: Array<Tree<T>>}",
+			},
+		},
+		"MutuallyRecursiveExprTypes": {
+			input: `
+				type Expr = Lit | Add
+				type Lit = { tag: "lit", value: number }
+				type Add = { tag: "add", left: Expr, right: Expr }
+			`,
+			expectedTypes: map[string]string{
+				// Expr expands one level: Lit and Add are non-recursive so they expand
+				"Expr": `{tag: "lit", value: number} | {tag: "add", left: Expr, right: Expr}`,
+				"Lit":  `{tag: "lit", value: number}`,
+				"Add":  `{tag: "add", left: Expr, right: Expr}`,
+			},
+		},
+		"CrossAliasCycle": {
+			input: `
+				type A = { x: B }
+				type B = { y: A }
+			`,
+			expectedTypes: map[string]string{
+				"A": "{x: B}",
+				"B": "{y: A}",
 			},
 		},
 	}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -4,10 +4,69 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
+	"unsafe"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
+
+// unifyPairKey identifies a pair of types being unified.
+// For TypeRefType, we use the TypeAlias pointer + typeArgKey(typeArgs)
+// to capture meaningful identity across allocations.
+type unifyPairKey struct {
+	t1     unsafe.Pointer
+	t1Args string // typeArgKey(typeArgs) for TypeRefType, empty otherwise
+	t2     unsafe.Pointer
+	t2Args string // typeArgKey(typeArgs) for TypeRefType, empty otherwise
+}
+
+type unifySeen map[unifyPairKey]bool
+
+// makeUnifyPairKey builds a key that includes both the stable pointer
+// and type args for TypeRefType.
+func makeUnifyPairKey(t1, t2 type_system.Type) unifyPairKey {
+	key := unifyPairKey{}
+	if ref, ok := t1.(*type_system.TypeRefType); ok {
+		if ref.TypeAlias != nil {
+			key.t1 = unsafe.Pointer(ref.TypeAlias)
+		} else {
+			key.t1 = interfaceDataPointer(t1)
+		}
+		key.t1Args = typeArgKey(ref.TypeArgs)
+	} else {
+		key.t1 = interfaceDataPointer(t1)
+	}
+	if ref, ok := t2.(*type_system.TypeRefType); ok {
+		if ref.TypeAlias != nil {
+			key.t2 = unsafe.Pointer(ref.TypeAlias)
+		} else {
+			key.t2 = interfaceDataPointer(ref)
+		}
+		key.t2Args = typeArgKey(ref.TypeArgs)
+	} else {
+		key.t2 = interfaceDataPointer(t2)
+	}
+	return key
+}
+
+// interfaceDataPointer extracts the data pointer from a Go interface value.
+func interfaceDataPointer(t type_system.Type) unsafe.Pointer {
+	return (*[2]unsafe.Pointer)(unsafe.Pointer(&t))[1]
+}
+
+// typeArgKey produces a stable, deterministic string key for type arguments.
+func typeArgKey(args []type_system.Type) string {
+	parts := make([]string, len(args))
+	for i, arg := range args {
+		if tv, ok := arg.(*type_system.TypeVarType); ok {
+			parts[i] = fmt.Sprintf("$%d", tv.ID)
+		} else {
+			parts[i] = fmt.Sprint(arg)
+		}
+	}
+	return strings.Join(parts, ",")
+}
 
 // noMatchError is a sentinel error indicating that no case in unifyMatched
 // handled the type combination. unifyPruned uses this to decide whether
@@ -109,36 +168,12 @@ func (c *Checker) sameTypeRef(ref1, ref2 *type_system.TypeRefType) bool {
 // If `Unify` doesn't return an error it means that `t1` is a subtype of `t2` or
 // they are the same type.
 func (c *Checker) Unify(ctx Context, t1, t2 type_system.Type) []Error {
-	return c.unifyWithDepth(ctx, t1, t2, 0)
+	return c.unifyWithDepth(ctx, t1, t2, 0, make(unifySeen))
 }
 
-const maxUnifyDepth = 50
-
-func (c *Checker) unifyWithDepth(ctx Context, t1, t2 type_system.Type, depth int) []Error {
+func (c *Checker) unifyWithDepth(ctx Context, t1, t2 type_system.Type, depth int, seen unifySeen) []Error {
 	if t1 == nil || t2 == nil {
 		panic("Cannot unify nil types")
-	}
-
-	// Limit recursion depth to prevent stack overflow from infinite expansion.
-	//
-	// This is necessary because the retry loop at the end of this function calls
-	// ExpandType on both types and retries if either expanded to a different object.
-	// The problem is that each call to Unify passes ExpandType a fresh count of 1,
-	// so types can keep expanding indefinitely when:
-	//
-	// 1. TypeRefType with TypeAlias set (e.g., HTMLAttributeAnchorTarget, Array<any>)
-	//    - ExpandType creates new type objects each time, so expandedT2 != t2 is true
-	//
-	// 2. TupleType with rest spreads (e.g., [...Array<any>, ...Array<any>])
-	//    - Expansion includes the full Array interface with all its methods
-	//
-	// 3. Large ObjectType instances (e.g., React SVG attributes with 200+ properties)
-	//    - Nested type references keep creating new objects during expansion
-	//
-	// The depth limit stops recursion when types can't be unified after reasonable
-	// expansion attempts, returning a unification error instead of stack overflow.
-	if depth > maxUnifyDepth {
-		return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 	}
 
 	// Save the TypeVarType (if any) before Prune reassigns t2 to the pruned
@@ -148,7 +183,7 @@ func (c *Checker) unifyWithDepth(ctx Context, t1, t2 type_system.Type, depth int
 	t1 = type_system.Prune(t1)
 	t2 = type_system.Prune(t2)
 
-	errors := c.unifyPruned(ctx, t1, t2, depth)
+	errors := c.unifyPruned(ctx, t1, t2, depth, seen)
 	if len(errors) == 0 {
 		return nil
 	}
@@ -193,15 +228,15 @@ func (c *Checker) unifyWithDepth(ctx Context, t1, t2 type_system.Type, depth int
 	return errors
 }
 
-// maxExpansionRetries bounds the non-TypeRef expansion loop in unifyPruned.
-// Only the TypeOfType/CondType continue path can iterate; TypeRefType expansion
-// exits via unifyWithDepth (bounded by maxUnifyDepth). This constant is a
-// safety net against unexpected infinite expansion, not a normal retry limit.
-const maxExpansionRetries = 10
+// maxExpansionRetries is a safety net for the non-TypeRef expansion loop in
+// unifyPruned. With the visited-set cycle detection in place, this should
+// never be hit in practice — the loop terminates naturally when no further
+// expansion is possible. Kept as a defensive limit.
+const maxExpansionRetries = 100
 
-func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) []Error {
+func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int, seen unifySeen) []Error {
 	for attempt := 0; attempt < maxExpansionRetries; attempt++ {
-		errors := c.unifyMatched(ctx, t1, t2, depth)
+		errors := c.unifyMatched(ctx, t1, t2, depth, seen)
 		if len(errors) == 0 {
 			return nil
 		}
@@ -232,9 +267,14 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 			refCanExpand = true
 		}
 		if refCanExpand {
+			key := makeUnifyPairKey(t1, t2)
+			if seen[key] {
+				return nil // co-inductive assumption: assume success
+			}
+			seen[key] = true
 			refExpT1, _ := c.ExpandType(ctx, t1, 1)
 			refExpT2, _ := c.ExpandType(ctx, t2, 1)
-			return c.unifyWithDepth(ctx, refExpT1, refExpT2, depth+1)
+			return c.unifyWithDepth(ctx, refExpT1, refExpT2, depth+1, seen)
 		}
 
 		// Try expanding TypeOfType and other non-TypeRef expandable types.
@@ -270,10 +310,15 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 		// concrete types. For structural types, unification proceeds over
 		// finite property sets and bottoms out without re-entering this path.
 		if isRef1 || isRef2 {
+			key := makeUnifyPairKey(t1, t2)
+			if seen[key] {
+				return nil // co-inductive assumption: assume success
+			}
+			seen[key] = true
 			lastResortT1, _ := c.ExpandType(ctx, t1, 1)
 			lastResortT2, _ := c.ExpandType(ctx, t2, 1)
 			if lastResortT1 != t1 || lastResortT2 != t2 {
-				return c.unifyWithDepth(ctx, lastResortT1, lastResortT2, depth+1)
+				return c.unifyWithDepth(ctx, lastResortT1, lastResortT2, depth+1, seen)
 			}
 		}
 
@@ -283,7 +328,7 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int) [
 	return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 }
 
-func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) []Error {
+func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, seen unifySeen) []Error {
 
 	// | TypeVarType, ErrorType -> bind
 	// | ErrorType, TypeVarType -> bind
@@ -294,7 +339,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 	_, t1IsError := t1.(*type_system.ErrorType)
 	_, t2IsError := t2.(*type_system.ErrorType)
 	if (t1IsTypeVar && t2IsError) || (t1IsError && t2IsTypeVar) {
-		return c.bind(ctx, t1, t2)
+		return c.bind(ctx, t1, t2, depth, seen)
 	}
 	if t1IsError || t2IsError {
 		return nil
@@ -302,11 +347,11 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 
 	// | TypeVarType, _ -> ...
 	if t1IsTypeVar {
-		return c.bind(ctx, t1, t2)
+		return c.bind(ctx, t1, t2, depth, seen)
 	}
 	// | _, TypeVarType -> ...
 	if t2IsTypeVar {
-		return c.bind(ctx, t1, t2)
+		return c.bind(ctx, t1, t2, depth, seen)
 	}
 	// | MutableType, MutableType -> ...
 	if mut1, ok := t1.(*type_system.MutabilityType); ok {
@@ -314,7 +359,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 			if mut1.Mutability == type_system.MutabilityMutable && mut2.Mutability == type_system.MutabilityMutable {
 				return c.unifyMut(ctx, mut1, mut2)
 			} else {
-				return c.Unify(ctx, mut1.Type, mut2.Type)
+				return c.unifyWithDepth(ctx, mut1.Type, mut2.Type, depth, seen)
 			}
 		}
 	}
@@ -327,14 +372,14 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 			// Fall through to union/intersection handling below
 		default:
 			// It's okay to assign mutable types to immutable types
-			return c.Unify(ctx, mut1.Type, t2)
+			return c.unifyWithDepth(ctx, mut1.Type, t2, depth, seen)
 		}
 	}
 	// | _, MutableType -> ...
 	if mut2, ok := t2.(*type_system.MutabilityType); ok {
 		// When the RHS is a MutabilityType, we need to unwrap it for unification
 		// This allows patterns without mutability markers to match against mutable values
-		return c.Unify(ctx, t1, mut2.Type)
+		return c.unifyWithDepth(ctx, t1, mut2.Type, depth, seen)
 	}
 	// | PrimType, PrimType -> ...
 	if prim1, ok := t1.(*type_system.PrimType); ok {
@@ -462,13 +507,13 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 
 			// If both were successfully expanded to concrete keys, unify the expanded types
 			if !stillKeyOf1 && !stillKeyOf2 {
-				return c.unifyWithDepth(ctx, expandedKeys1, expandedKeys2, depth+1)
+				return c.unifyWithDepth(ctx, expandedKeys1, expandedKeys2, depth+1, seen)
 			}
 
 			// If neither could be expanded (e.g., both are keyof TypeVar), try to unify the underlying types.
 			// During interface merging, keyof constraints on type parameters may have different
 			// internal type variable IDs but represent the same constraint structurally.
-			innerErrors := c.unifyWithDepth(ctx, keyof1.Type, keyof2.Type, depth+1)
+			innerErrors := c.unifyWithDepth(ctx, keyof1.Type, keyof2.Type, depth+1, seen)
 			if len(innerErrors) == 0 {
 				return nil
 			}
@@ -481,7 +526,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 	// | TupleType, TupleType -> ...
 	if tuple1, ok := t1.(*type_system.TupleType); ok {
 		if tuple2, ok := t2.(*type_system.TupleType); ok {
-			return c.unifyTuples(ctx, tuple1, tuple2)
+			return c.unifyTuples(ctx, tuple1, tuple2, depth, seen)
 		}
 	}
 	// | TupleType, ArrayType -> ...
@@ -492,10 +537,10 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 				for _, elem := range tuple1.Elems {
 					if rest, ok := elem.(*type_system.RestSpreadType); ok {
 						// Unify rest type with Array<T>
-						unifyErrors := c.Unify(ctx, rest.Type, array2)
+						unifyErrors := c.unifyWithDepth(ctx, rest.Type, array2, depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					} else {
-						unifyErrors := c.Unify(ctx, elem, array2.TypeArgs[0])
+						unifyErrors := c.unifyWithDepth(ctx, elem, array2.TypeArgs[0], depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					}
 				}
@@ -515,10 +560,10 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 				for _, elem := range tuple2.Elems {
 					if rest, ok := elem.(*type_system.RestSpreadType); ok {
 						// Unify Array<T> with rest type
-						unifyErrors := c.Unify(ctx, array1, rest.Type)
+						unifyErrors := c.unifyWithDepth(ctx, array1, rest.Type, depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					} else {
-						unifyErrors := c.Unify(ctx, array1.TypeArgs[0], elem)
+						unifyErrors := c.unifyWithDepth(ctx, array1.TypeArgs[0], elem, depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					}
 				}
@@ -535,7 +580,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 		if array2, ok := t2.(*type_system.TypeRefType); ok && c.isArrayType(array2) {
 			// Both are Array types, unify their element types
 			if len(array1.TypeArgs) == 1 && len(array2.TypeArgs) == 1 {
-				return c.Unify(ctx, array1.TypeArgs[0], array2.TypeArgs[0])
+				return c.unifyWithDepth(ctx, array1.TypeArgs[0], array2.TypeArgs[0], depth, seen)
 			}
 			// If either array doesn't have exactly one type argument, they can't be unified
 			return []Error{&CannotUnifyTypesError{
@@ -547,13 +592,13 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 	// | RestSpreadType, ArrayType -> ...
 	if rest, ok := t1.(*type_system.RestSpreadType); ok {
 		if array, ok := t2.(*type_system.TypeRefType); ok && c.isArrayType(array) {
-			return c.Unify(ctx, rest.Type, array)
+			return c.unifyWithDepth(ctx, rest.Type, array, depth, seen)
 		}
 	}
 	// | FuncType, FuncType -> ...
 	if func1, ok := t1.(*type_system.FuncType); ok {
 		if func2, ok := t2.(*type_system.FuncType); ok {
-			return c.unifyFuncTypes(ctx, func1, func2)
+			return c.unifyFuncTypes(ctx, func1, func2, depth, seen)
 		}
 	}
 	// | TypeRefType, TypeRefType (same alias) -> ...
@@ -606,7 +651,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 				}
 				errors := []Error{}
 				for i := 0; i < len(ref1.TypeArgs); i++ {
-					argErrors := c.Unify(ctx, ref1.TypeArgs[i], ref2.TypeArgs[i])
+					argErrors := c.unifyWithDepth(ctx, ref1.TypeArgs[i], ref2.TypeArgs[i], depth, seen)
 					errors = slices.Concat(errors, argErrors)
 				}
 				return errors
@@ -711,13 +756,14 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 
 					for i, name := range groupNames {
 						if name != "" {
-							groupErrors := c.Unify(
+							groupErrors := c.unifyWithDepth(
 								ctx,
 								type_system.NewStrLitType(nil, matches[i]),
 								// By default this will be a `string` type, but
 								// if the RegexType appears in a CondType's
 								// Extend field, it will be a TypeVarType.
 								regexType.Groups[name],
+								depth, seen,
 							)
 							errors = slices.Concat(errors, groupErrors)
 						}
@@ -757,11 +803,11 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 	}
 	// | _, ExtractorType -> ...
 	if ext, ok := t2.(*type_system.ExtractorType); ok {
-		return c.unifyExtractor(ctx, t1, ext, false)
+		return c.unifyExtractor(ctx, t1, ext, false, depth, seen)
 	}
 	// | ExtractorType, _ -> ...
 	if ext, ok := t1.(*type_system.ExtractorType); ok {
-		return c.unifyExtractor(ctx, t2, ext, true)
+		return c.unifyExtractor(ctx, t2, ext, true, depth, seen)
 	}
 	// | ObjectType, ObjectType -> ...
 	if obj1, ok := t1.(*type_system.ObjectType); ok {
@@ -810,12 +856,12 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 					value1, has1 := namedElems1[key]
 					value2, has2 := namedElems2[key]
 					if has1 && has2 {
-						unifyErrors := c.Unify(ctx, value1, value2)
+						unifyErrors := c.unifyWithDepth(ctx, value1, value2, depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					}
 					if wt1, ok1 := collected1.Write[key]; ok1 {
 						if wt2, ok2 := collected2.Write[key]; ok2 {
-							unifyErrors := c.Unify(ctx, wt1, wt2)
+							unifyErrors := c.unifyWithDepth(ctx, wt1, wt2, depth, seen)
 							errors = slices.Concat(errors, unifyErrors)
 						}
 					}
@@ -866,7 +912,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 				}
 				// Unify row variables if both have RestSpreadElems
 				if len(restTypes1) == 1 && len(restTypes2) == 1 {
-					unifyErrors := c.Unify(ctx, restTypes1[0], restTypes2[0])
+					unifyErrors := c.unifyWithDepth(ctx, restTypes1[0], restTypes2[0], depth, seen)
 					errors = slices.Concat(errors, unifyErrors)
 				}
 				return errors
@@ -880,7 +926,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 					value1, has1 := namedElems1[key]
 					value2, has2 := namedElems2[key]
 					if has1 && has2 {
-						unifyErrors := c.Unify(ctx, value1, value2)
+						unifyErrors := c.unifyWithDepth(ctx, value1, value2, depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					}
 					re := collected2.OrigRead[key]
@@ -905,7 +951,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 					value1, has1 := namedElems1[key]
 					value2, has2 := namedElems2[key]
 					if has1 && has2 {
-						unifyErrors := c.Unify(ctx, value1, value2)
+						unifyErrors := c.unifyWithDepth(ctx, value1, value2, depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					}
 					re := collected1.OrigRead[key]
@@ -932,9 +978,9 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 			hasRests2 := len(restTypes2) > 0
 
 			if hasRests1 && !hasRests2 {
-				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj1, obj2, keys2, namedElems2, false))
+				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj1, obj2, keys2, namedElems2, false, depth, seen))
 			} else if hasRests2 && !hasRests1 {
-				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj2, obj1, keys1, namedElems1, true))
+				errors = slices.Concat(errors, c.unifyClosedWithRests(ctx, obj2, obj1, keys1, namedElems1, true, depth, seen))
 			} else if hasRests1 && hasRests2 {
 				// TODO(#410): implement unification when both sides have RestSpreadElems
 				return []Error{&UnimplementedError{message: "unify types with rest elems on both sides"}}
@@ -947,7 +993,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 				for _, key1 := range keys1 {
 					value2, found := namedElems2[key1]
 					if found {
-						unifyErrors := c.Unify(ctx, namedElems1[key1], value2)
+						unifyErrors := c.unifyWithDepth(ctx, namedElems1[key1], value2, depth, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					} else {
 						errors = append(errors, &PropertyNotFoundError{
@@ -958,7 +1004,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 						// Resolve the pattern field's type to undefined so it doesn't
 						// leak as an unresolved type variable into the match arm result.
 						undefinedType := type_system.NewUndefinedType(nil)
-						c.Unify(ctx, namedElems1[key1], undefinedType)
+						c.unifyWithDepth(ctx, namedElems1[key1], undefinedType, depth, seen)
 					}
 				}
 			} else {
@@ -969,7 +1015,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 						wt1, hasW1 := collected1.Write[key2]
 						wt2, hasW2 := collected2.Write[key2]
 						if hasW1 && hasW2 {
-							unifyErrors := c.Unify(ctx, wt1, wt2)
+							unifyErrors := c.unifyWithDepth(ctx, wt1, wt2, depth, seen)
 							errors = slices.Concat(errors, unifyErrors)
 						} else if hasW2 && !hasW1 {
 							errors = slices.Concat(errors, []Error{&KeyNotFoundError{
@@ -980,7 +1026,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 						continue
 					}
 					if value1, ok := namedElems1[key2]; ok {
-						unifyErrors := c.Unify(ctx, value1, value2)
+						unifyErrors := c.unifyWithDepth(ctx, value1, value2, depth, seen)
 						// Wrap CannotUnifyTypesError with property context when
 						// the property was inferred during row inference.
 						for i, err := range unifyErrors {
@@ -1027,7 +1073,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 						// We intentionally discard the errors since we already
 						// reported the KeyNotFoundError above.
 						undefinedType := type_system.NewUndefinedType(nil)
-						c.Unify(ctx, value2, undefinedType)
+						c.unifyWithDepth(ctx, value2, undefinedType, depth, seen)
 					}
 				}
 			}
@@ -1044,7 +1090,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 		// Check if distribution occurred by seeing if the type changed
 		if _, stillIntersection := distributed1.(*type_system.IntersectionType); !stillIntersection {
 			// Distribution created a different type (likely a union), retry unification
-			return c.Unify(ctx, distributed1, t2)
+			return c.unifyWithDepth(ctx, distributed1, t2, depth, seen)
 		}
 
 		if intersection2, ok := t2.(*type_system.IntersectionType); ok {
@@ -1052,7 +1098,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 			// Check if distribution occurred on t2
 			if _, stillIntersection := distributed2.(*type_system.IntersectionType); !stillIntersection {
 				// Distribution occurred on t2, retry unification
-				return c.Unify(ctx, distributed1, distributed2)
+				return c.unifyWithDepth(ctx, distributed1, distributed2, depth, seen)
 			}
 
 			// Probe-then-commit: trial-unify clones to avoid partially mutating
@@ -1066,10 +1112,10 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 					varMapping := make(map[int]*type_system.TypeVarType)
 					t1Clone := c.deepCloneType(t1Part, varMapping)
 					t2Clone := c.deepCloneType(t2Part, varMapping)
-					probeErrors := c.Unify(ctx, t1Clone, t2Clone)
+					probeErrors := c.unifyWithDepth(ctx, t1Clone, t2Clone, depth, seen)
 					if len(probeErrors) == 0 {
 						// Probe succeeded — safe to unify originals.
-						c.Unify(ctx, t1Part, t2Part)
+						c.unifyWithDepth(ctx, t1Part, t2Part, depth, seen)
 						found = true
 						break
 					}
@@ -1095,7 +1141,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 		// Check if distribution occurred
 		if _, stillIntersection := distributed.(*type_system.IntersectionType); !stillIntersection {
 			// Distribution created a different type (likely a union), retry unification
-			return c.Unify(ctx, distributed, t2)
+			return c.unifyWithDepth(ctx, distributed, t2, depth, seen)
 		}
 
 		// Probe-then-commit: trial-unify clones to avoid partially mutating
@@ -1105,10 +1151,10 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 			varMapping := make(map[int]*type_system.TypeVarType)
 			partClone := c.deepCloneType(part, varMapping)
 			t2Clone := c.deepCloneType(t2, varMapping)
-			probeErrors := c.Unify(ctx, partClone, t2Clone)
+			probeErrors := c.unifyWithDepth(ctx, partClone, t2Clone, depth, seen)
 			if len(probeErrors) == 0 {
 				// Probe succeeded — safe to unify originals.
-				c.Unify(ctx, part, t2)
+				c.unifyWithDepth(ctx, part, t2, depth, seen)
 				return nil
 			}
 			allErrors = slices.Concat(allErrors, probeErrors)
@@ -1125,12 +1171,12 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 		// Check if distribution occurred
 		if _, stillIntersection := distributed.(*type_system.IntersectionType); !stillIntersection {
 			// Distribution created a different type (likely a union), retry unification
-			return c.Unify(ctx, t1, distributed)
+			return c.unifyWithDepth(ctx, t1, distributed, depth, seen)
 		}
 
 		errors := []Error{}
 		for _, part := range intersection.Types {
-			unifyErrors := c.Unify(ctx, t1, part)
+			unifyErrors := c.unifyWithDepth(ctx, t1, part, depth, seen)
 			errors = slices.Concat(errors, unifyErrors)
 		}
 		return errors
@@ -1197,19 +1243,19 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 						})
 					}
 					undefined := type_system.NewUndefinedType(nil)
-					unifyErrors := c.Unify(ctx, undefined, t)
+					unifyErrors := c.unifyWithDepth(ctx, undefined, t, depth, seen)
 					errors = slices.Concat(errors, unifyErrors)
 				} else if len(matchingTypes[name]) == len(union.Types) {
 					// Create a union of all matching types and unify with destructured field type
 					unionOfMatchingTypes := type_system.NewUnionType(nil, matchingTypes[name]...)
 					fieldType := destructuredFields[name]
-					unifyErrors := c.Unify(ctx, unionOfMatchingTypes, fieldType)
+					unifyErrors := c.unifyWithDepth(ctx, unionOfMatchingTypes, fieldType, depth, seen)
 					errors = slices.Concat(errors, unifyErrors)
 				} else {
 					// Create a union of all matching types and `undefined`, then unify with destructured field type
 					unionOfMatchingTypes := type_system.NewUnionType(nil, append(matchingTypes[name], type_system.NewUndefinedType(nil))...)
 					fieldType := destructuredFields[name]
-					unifyErrors := c.Unify(ctx, unionOfMatchingTypes, fieldType)
+					unifyErrors := c.unifyWithDepth(ctx, unionOfMatchingTypes, fieldType, depth, seen)
 					errors = slices.Concat(errors, unifyErrors)
 				}
 			}
@@ -1239,7 +1285,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 				}
 
 				objType := type_system.NewObjectType(nil, restElems)
-				unifyErrors := c.Unify(ctx, objType, restType)
+				unifyErrors := c.unifyWithDepth(ctx, objType, restType, depth, seen)
 				errors = slices.Concat(errors, unifyErrors)
 			}
 
@@ -1248,7 +1294,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 
 		// All types in the union must be compatible with t2
 		for _, t := range union.Types {
-			unifyErrors := c.Unify(ctx, t, t2)
+			unifyErrors := c.unifyWithDepth(ctx, t, t2, depth, seen)
 			// TODO: include the individual reasons why unification failed
 			if len(unifyErrors) > 0 {
 				// If any type in the union is not compatible, return error
@@ -1264,7 +1310,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 	if ctx.IsPatMatch {
 		if patObj, ok := t1.(*type_system.ObjectType); ok {
 			if union, ok := t2.(*type_system.UnionType); ok {
-				return c.unifyPatternWithUnion(ctx, patObj, union)
+				return c.unifyPatternWithUnion(ctx, patObj, union, depth, seen)
 			}
 		}
 	}
@@ -1276,10 +1322,10 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int) 
 			varMapping := make(map[int]*type_system.TypeVarType)
 			t1Clone := c.deepCloneType(t1, varMapping)
 			unionTypeClone := c.deepCloneType(unionType, varMapping)
-			probeErrors := c.Unify(ctx, t1Clone, unionTypeClone)
+			probeErrors := c.unifyWithDepth(ctx, t1Clone, unionTypeClone, depth, seen)
 			if len(probeErrors) == 0 {
 				// Probe succeeded — safe to unify originals.
-				c.Unify(ctx, t1, unionType)
+				c.unifyWithDepth(ctx, t1, unionType, depth, seen)
 				return nil
 			}
 		}
@@ -1304,13 +1350,14 @@ func (c *Checker) unifyExtractor(
 	subject type_system.Type,
 	ext *type_system.ExtractorType,
 	swapped bool,
+	depth int, seen unifySeen,
 ) []Error {
 	// Helper to call Unify in the correct argument order.
 	unify := func(a, b type_system.Type) []Error {
 		if swapped {
-			return c.Unify(ctx, b, a)
+			return c.unifyWithDepth(ctx, b, a, depth, seen)
 		}
-		return c.Unify(ctx, a, b)
+		return c.unifyWithDepth(ctx, a, b, depth, seen)
 	}
 
 	methodElem, extObj := c.findCustomMatcherMethod(ext)
@@ -1470,6 +1517,7 @@ func (c *Checker) unifyClosedWithRests(
 	targetKeys []type_system.ObjTypeKey,
 	targetNamed map[type_system.ObjTypeKey]type_system.Type,
 	swapped bool,
+	depth int, seen unifySeen,
 ) []Error {
 	errors := []Error{}
 
@@ -1478,9 +1526,9 @@ func (c *Checker) unifyClosedWithRests(
 	// When swapped is true, restObj=t2 and targetObj=t1.
 	unifyPair := func(restVal, targetVal type_system.Type) []Error {
 		if swapped {
-			return c.Unify(ctx, targetVal, restVal)
+			return c.unifyWithDepth(ctx, targetVal, restVal, depth, seen)
 		}
-		return c.Unify(ctx, restVal, targetVal)
+		return c.unifyWithDepth(ctx, restVal, targetVal, depth, seen)
 	}
 
 	// 1. Expand restObj.Elems into a flat effective property map by walking
@@ -1556,7 +1604,7 @@ func (c *Checker) unifyClosedWithRests(
 				span:   getKeyNotFoundSpan(targetObj, value),
 			}})
 			undefinedType := type_system.NewUndefinedType(nil)
-			c.Unify(ctx, value, undefinedType)
+			c.unifyWithDepth(ctx, value, undefinedType, depth, seen)
 		}
 	}
 
@@ -1607,7 +1655,7 @@ func (c *Checker) unifyClosedWithRests(
 }
 
 // unifyFuncTypes unifies two function types
-func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType) []Error {
+func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType, depth int, seen unifySeen) []Error {
 	errors := []Error{}
 
 	// For function types to be compatible:
@@ -1669,7 +1717,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 			param2 := func2.Params[i]
 
 			// Parameter types are contravariant: unify param2.Type with param1.Type
-			unifyErrors := c.Unify(ctx, param2.Type, param1.Type)
+			unifyErrors := c.unifyWithDepth(ctx, param2.Type, param1.Type, depth, seen)
 			errors = slices.Concat(errors, unifyErrors)
 
 			// Optional parameter compatibility
@@ -1687,7 +1735,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 		// Unify the rest parameters directly
 		restParam1 := func1.Params[func1RestIndex]
 		restParam2 := func2.Params[func2RestIndex]
-		unifyErrors := c.Unify(ctx, restParam2.Type, restParam1.Type)
+		unifyErrors := c.unifyWithDepth(ctx, restParam2.Type, restParam1.Type, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 
 		// Check that both functions don't have parameters after rest (which shouldn't happen)
@@ -1714,7 +1762,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 			param2 := func2.Params[i]
 
 			// Parameter types are contravariant: unify param2.Type with param1.Type
-			unifyErrors := c.Unify(ctx, param2.Type, param1.Type)
+			unifyErrors := c.unifyWithDepth(ctx, param2.Type, param1.Type, depth, seen)
 			errors = slices.Concat(errors, unifyErrors)
 
 			// Optional parameter compatibility
@@ -1747,7 +1795,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 
 			// Create Array<elementType> and unify with rest parameter type
 			arrayType := type_system.NewTypeRefType(nil, "Array", nil, elementType)
-			unifyErrors := c.Unify(ctx, restParam.Type, arrayType)
+			unifyErrors := c.unifyWithDepth(ctx, restParam.Type, arrayType, depth, seen)
 			errors = slices.Concat(errors, unifyErrors)
 		} else {
 			// No excess parameters, rest parameter should accept empty array
@@ -1780,7 +1828,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 			param2 := func2.Params[i]
 
 			// Parameter types are contravariant: unify param2.Type with param1.Type
-			unifyErrors := c.Unify(ctx, param2.Type, param1.Type)
+			unifyErrors := c.unifyWithDepth(ctx, param2.Type, param1.Type, depth, seen)
 			errors = slices.Concat(errors, unifyErrors)
 
 			// Optional parameter compatibility
@@ -1813,7 +1861,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 
 	// Check return types (covariant)
 	if func1.Return != nil && func2.Return != nil {
-		unifyErrors := c.Unify(ctx, func1.Return, func2.Return)
+		unifyErrors := c.unifyWithDepth(ctx, func1.Return, func2.Return, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	} else if func1.Return == nil && func2.Return != nil {
 		// func1 returns void/undefined, func2 expects a return type
@@ -1828,7 +1876,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 
 	// Check throws types (covariant)
 	if func1.Throws != nil && func2.Throws != nil {
-		unifyErrors := c.Unify(ctx, func1.Throws, func2.Throws)
+		unifyErrors := c.unifyWithDepth(ctx, func1.Throws, func2.Throws, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	} else if func1.Throws != nil && func2.Throws == nil {
 		// func1 can throw but func2 doesn't expect throws - this might be an error
@@ -1843,7 +1891,7 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 // TODO: check if t1 is already bound to an instance
 // NOTE: be sure to call Prune on t1 and t2 before calling bind
 // to ensure we are working with the most up-to-date types.
-func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []Error {
+func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, depth int, seen unifySeen) []Error {
 	if t1 == nil || t2 == nil {
 		panic("Cannot bind nil types") // this should never happen
 	}
@@ -1866,7 +1914,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []
 			if typeVar1, ok := t1.(*type_system.TypeVarType); ok {
 				if typeVar2, ok := t2.(*type_system.TypeVarType); ok {
 					if typeVar1.Constraint != nil && typeVar2.Constraint != nil {
-						errors = c.Unify(ctx, typeVar1.Constraint, typeVar2.Constraint)
+						errors = c.unifyWithDepth(ctx, typeVar1.Constraint, typeVar2.Constraint, depth, seen)
 					} else if typeVar1.Constraint != nil && typeVar2.Constraint == nil {
 						// Propagate the constraint to typeVar2 since it becomes the
 						// representative of this equivalence class after binding.
@@ -1899,7 +1947,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []
 				}
 
 				if typeVar1.Constraint != nil {
-					errors = c.Unify(ctx, typeVar1.Constraint, t2)
+					errors = c.unifyWithDepth(ctx, typeVar1.Constraint, t2, depth, seen)
 				}
 				// IsParam is only set on fresh vars for unannotated parameters
 				// (infer_func.go), so IsParam and Constraint won't both be set
@@ -1915,7 +1963,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []
 				// Array or tuple type, update the constraint flags so that
 				// resolution at closing time produces the correct type.
 				if typeVar1.ArrayConstraint != nil {
-					if handled, bindErrs := c.handleArrayConstraintBinding(ctx, typeVar1, t2); handled {
+					if handled, bindErrs := c.handleArrayConstraintBinding(ctx, typeVar1, t2, depth, seen); handled {
 						return append(errors, bindErrs...)
 					}
 				}
@@ -1957,7 +2005,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type) []
 				}
 
 				if typeVar2.Constraint != nil {
-					errors = c.Unify(ctx, t1, typeVar2.Constraint)
+					errors = c.unifyWithDepth(ctx, t1, typeVar2.Constraint, depth, seen)
 				}
 				// See comment in typeVar1 branch above re: IsParam and Constraint.
 				if typeVar2.IsParam {
@@ -2038,7 +2086,7 @@ func occursInType(t1, t2 type_system.Type) bool {
 // Array, mut Array, or tuple, the constraint is updated accordingly and the
 // function returns true to indicate that binding was handled. Otherwise it
 // returns false and normal binding proceeds.
-func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system.TypeVarType, boundType type_system.Type) (bool, []Error) {
+func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system.TypeVarType, boundType type_system.Type, depth int, seen unifySeen) (bool, []Error) {
 	constraint := typeVar.ArrayConstraint
 	inner := boundType
 	isMut := false
@@ -2057,11 +2105,11 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 			}
 			// Unify the constraint's element type var with the array's element type
 			var errs []Error
-			if unifyErrs := c.Unify(ctx, constraint.ElemTypeVar, t.TypeArgs[0]); len(unifyErrs) > 0 {
+			if unifyErrs := c.unifyWithDepth(ctx, constraint.ElemTypeVar, t.TypeArgs[0], depth, seen); len(unifyErrs) > 0 {
 				errs = append(errs, unifyErrs...)
 			}
 			for _, elemTV := range constraint.LiteralIndexes {
-				if unifyErrs := c.Unify(ctx, elemTV, t.TypeArgs[0]); len(unifyErrs) > 0 {
+				if unifyErrs := c.unifyWithDepth(ctx, elemTV, t.TypeArgs[0], depth, seen); len(unifyErrs) > 0 {
 					errs = append(errs, unifyErrs...)
 				}
 			}
@@ -2095,7 +2143,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 				targetType = suffix[idx-len(prefix)]
 			}
 			if targetType != nil {
-				if unifyErrs := c.Unify(ctx, tv, targetType); len(unifyErrs) > 0 {
+				if unifyErrs := c.unifyWithDepth(ctx, tv, targetType, depth, seen); len(unifyErrs) > 0 {
 					errs = append(errs, unifyErrs...)
 				}
 			}
@@ -2551,27 +2599,27 @@ func splitTupleAtRest(elems []type_system.Type) (prefix []type_system.Type, rest
 
 // unifyTuples handles all tuple-vs-tuple unification cases including
 // RestSpreadType at any position.
-func (c *Checker) unifyTuples(ctx Context, tuple1, tuple2 *type_system.TupleType) []Error {
+func (c *Checker) unifyTuples(ctx Context, tuple1, tuple2 *type_system.TupleType, depth int, seen unifySeen) []Error {
 	prefix1, rest1, suffix1 := splitTupleAtRest(tuple1.Elems)
 	prefix2, rest2, suffix2 := splitTupleAtRest(tuple2.Elems)
 
 	// Case: neither side has a rest spread — plain tuple unification
 	if rest1 == nil && rest2 == nil {
-		return c.unifyFixedTuples(ctx, tuple1, tuple2)
+		return c.unifyFixedTuples(ctx, tuple1, tuple2, depth, seen)
 	}
 
 	// Case: only tuple2 has a rest spread — fixed-vs-variadic
 	if rest1 == nil && rest2 != nil {
-		return c.unifyFixedVsVariadic(ctx, tuple1.Elems, prefix2, rest2, suffix2)
+		return c.unifyFixedVsVariadic(ctx, tuple1.Elems, prefix2, rest2, suffix2, depth, seen)
 	}
 
 	// Case: only tuple1 has a rest spread — variadic-vs-fixed (mirror)
 	if rest1 != nil && rest2 == nil {
-		return c.unifyVariadicVsFixed(ctx, prefix1, rest1, suffix1, tuple2.Elems)
+		return c.unifyVariadicVsFixed(ctx, prefix1, rest1, suffix1, tuple2.Elems, depth, seen)
 	}
 
 	// Case: both sides have a rest spread — variadic-vs-variadic
-	return c.unifyVariadicVsVariadic(ctx, prefix1, rest1, suffix1, prefix2, rest2, suffix2)
+	return c.unifyVariadicVsVariadic(ctx, prefix1, rest1, suffix1, prefix2, rest2, suffix2, depth, seen)
 }
 
 // unifyFixedTuples handles unification of two tuples with no RestSpreadType
@@ -2582,7 +2630,7 @@ func (c *Checker) unifyTuples(ctx Context, tuple1, tuple2 *type_system.TupleType
 //   - tuple2 has more elements than tuple1: Error — the target expects more
 //     elements than the value provides (NotEnoughElementsToUnpackError).
 //   - Same length: unify pairwise.
-func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.TupleType) []Error {
+func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.TupleType, depth int, seen unifySeen) []Error {
 	errors := []Error{}
 
 	if len(tuple2.Elems) > len(tuple1.Elems) {
@@ -2590,7 +2638,7 @@ func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.Tupl
 		// provides. Unify the elements that are present in both tuples, then
 		// report the extra target bindings as unpack errors.
 		for elem1, elem2 := range Zip(tuple1.Elems, tuple2.Elems) {
-			unifyErrors := c.Unify(ctx, elem1, elem2)
+			unifyErrors := c.unifyWithDepth(ctx, elem1, elem2, depth, seen)
 			errors = slices.Concat(errors, unifyErrors)
 		}
 
@@ -2603,7 +2651,7 @@ func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.Tupl
 		for _, elem2 := range extraElems {
 			node := GetNode(elem2.Provenance())
 			undefined := type_system.NewUndefinedType(&ast.NodeProvenance{Node: node})
-			unifyErrors := c.Unify(ctx, elem2, undefined)
+			unifyErrors := c.unifyWithDepth(ctx, elem2, undefined, depth, seen)
 			errors = slices.Concat(errors, unifyErrors)
 		}
 
@@ -2615,7 +2663,7 @@ func (c *Checker) unifyFixedTuples(ctx Context, tuple1, tuple2 *type_system.Tupl
 	// tuple1 has >= tuple2's length. Unify pairwise up to tuple2's length;
 	// any extra elements in tuple1 (the value) are ignored.
 	for i, elem2 := range tuple2.Elems {
-		unifyErrors := c.Unify(ctx, tuple1.Elems[i], elem2)
+		unifyErrors := c.unifyWithDepth(ctx, tuple1.Elems[i], elem2, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
@@ -2638,6 +2686,7 @@ func (c *Checker) unifyFixedVsVariadic(
 	ctx Context,
 	fixedElems []type_system.Type,
 	prefix2 []type_system.Type, rest2 *type_system.RestSpreadType, suffix2 []type_system.Type,
+	depth int, seen unifySeen,
 ) []Error {
 	requiredCount := len(prefix2) + len(suffix2)
 	if len(fixedElems) < requiredCount {
@@ -2653,21 +2702,21 @@ func (c *Checker) unifyFixedVsVariadic(
 
 	// Unify prefix elements pairwise
 	for i, elem2 := range prefix2 {
-		unifyErrors := c.Unify(ctx, fixedElems[i], elem2)
+		unifyErrors := c.unifyWithDepth(ctx, fixedElems[i], elem2, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
 	// Unify suffix elements pairwise (from the end)
 	for i, elem2 := range suffix2 {
 		fixedIdx := len(fixedElems) - len(suffix2) + i
-		unifyErrors := c.Unify(ctx, fixedElems[fixedIdx], elem2)
+		unifyErrors := c.unifyWithDepth(ctx, fixedElems[fixedIdx], elem2, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
 	// The middle elements are absorbed by the rest spread
 	middleElems := fixedElems[len(prefix2) : len(fixedElems)-len(suffix2)]
 	restTuple := type_system.NewTupleType(nil, middleElems...)
-	unifyErrors := c.Unify(ctx, restTuple, rest2.Type)
+	unifyErrors := c.unifyWithDepth(ctx, restTuple, rest2.Type, depth, seen)
 	errors = slices.Concat(errors, unifyErrors)
 
 	return errors
@@ -2691,6 +2740,7 @@ func (c *Checker) unifyVariadicVsFixed(
 	ctx Context,
 	prefix1 []type_system.Type, rest1 *type_system.RestSpreadType, suffix1 []type_system.Type,
 	fixedElems []type_system.Type,
+	depth int, seen unifySeen,
 ) []Error {
 	errors := []Error{}
 
@@ -2698,7 +2748,7 @@ func (c *Checker) unifyVariadicVsFixed(
 	// If the source prefix is longer, extras are ignored.
 	prefixLen := min(len(prefix1), len(fixedElems))
 	for i := range prefixLen {
-		unifyErrors := c.Unify(ctx, prefix1[i], fixedElems[i])
+		unifyErrors := c.unifyWithDepth(ctx, prefix1[i], fixedElems[i], depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
@@ -2718,14 +2768,14 @@ func (c *Checker) unifyVariadicVsFixed(
 	remaining := fixedElems[prefixLen:]
 	suffixLen := min(len(suffix1), len(remaining))
 	for i := range suffixLen {
-		unifyErrors := c.Unify(ctx, suffix1[len(suffix1)-suffixLen+i], remaining[len(remaining)-suffixLen+i])
+		unifyErrors := c.unifyWithDepth(ctx, suffix1[len(suffix1)-suffixLen+i], remaining[len(remaining)-suffixLen+i], depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
 	// The middle target elements are absorbed by the source's rest spread
 	middleElems := remaining[:len(remaining)-suffixLen]
 	restTuple := type_system.NewTupleType(nil, middleElems...)
-	unifyErrors := c.Unify(ctx, rest1.Type, restTuple)
+	unifyErrors := c.unifyWithDepth(ctx, rest1.Type, restTuple, depth, seen)
 	errors = slices.Concat(errors, unifyErrors)
 
 	return errors
@@ -2741,20 +2791,21 @@ func (c *Checker) unifyVariadicVsVariadic(
 	ctx Context,
 	prefix1 []type_system.Type, rest1 *type_system.RestSpreadType, suffix1 []type_system.Type,
 	prefix2 []type_system.Type, rest2 *type_system.RestSpreadType, suffix2 []type_system.Type,
+	depth int, seen unifySeen,
 ) []Error {
 	errors := []Error{}
 
 	// Unify prefixes pairwise up to the shorter one
 	minPrefix := min(len(prefix1), len(prefix2))
 	for i := 0; i < minPrefix; i++ {
-		unifyErrors := c.Unify(ctx, prefix1[i], prefix2[i])
+		unifyErrors := c.unifyWithDepth(ctx, prefix1[i], prefix2[i], depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
 	// Unify suffixes pairwise up to the shorter one (from the end)
 	minSuffix := min(len(suffix1), len(suffix2))
 	for i := 0; i < minSuffix; i++ {
-		unifyErrors := c.Unify(ctx, suffix1[len(suffix1)-minSuffix+i], suffix2[len(suffix2)-minSuffix+i])
+		unifyErrors := c.unifyWithDepth(ctx, suffix1[len(suffix1)-minSuffix+i], suffix2[len(suffix2)-minSuffix+i], depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	}
 
@@ -2769,7 +2820,7 @@ func (c *Checker) unifyVariadicVsVariadic(
 	// E.g. [A, B, ...R1] vs [A, ...R2] → Unify(R2, [B, ...R1])
 	if len(extraPrefix1) == 0 && len(extraSuffix1) == 0 && len(extraPrefix2) == 0 && len(extraSuffix2) == 0 {
 		// Same number of fixed elements on both sides — unify rests directly
-		unifyErrors := c.Unify(ctx, rest1.Type, rest2.Type)
+		unifyErrors := c.unifyWithDepth(ctx, rest1.Type, rest2.Type, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	} else if len(extraPrefix2) == 0 && len(extraSuffix2) == 0 {
 		// tuple1 has extra fixed elements; rest2 absorbs them
@@ -2779,7 +2830,7 @@ func (c *Checker) unifyVariadicVsVariadic(
 		wrapped = append(wrapped, rest1)
 		wrapped = append(wrapped, extraSuffix1...)
 		wrappedTuple := type_system.NewTupleType(nil, wrapped...)
-		unifyErrors := c.Unify(ctx, wrappedTuple, rest2.Type)
+		unifyErrors := c.unifyWithDepth(ctx, wrappedTuple, rest2.Type, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	} else if len(extraPrefix1) == 0 && len(extraSuffix1) == 0 {
 		// tuple2 has extra fixed elements; rest1 absorbs them
@@ -2788,7 +2839,7 @@ func (c *Checker) unifyVariadicVsVariadic(
 		wrapped = append(wrapped, rest2)
 		wrapped = append(wrapped, extraSuffix2...)
 		wrappedTuple := type_system.NewTupleType(nil, wrapped...)
-		unifyErrors := c.Unify(ctx, rest1.Type, wrappedTuple)
+		unifyErrors := c.unifyWithDepth(ctx, rest1.Type, wrappedTuple, depth, seen)
 		errors = slices.Concat(errors, unifyErrors)
 	} else {
 		// Both sides have extras — cannot unify
@@ -2885,6 +2936,7 @@ func (c *Checker) unifyPatternWithUnion(
 	ctx Context,
 	pat *type_system.ObjectType,
 	union *type_system.UnionType,
+	depth int, seen unifySeen,
 ) []Error {
 	// 1. Collect pattern field names and their type variables
 	patFields := collectObjElemTypes(pat, false).Read
@@ -2930,7 +2982,7 @@ func (c *Checker) unifyPatternWithUnion(
 	errors := []Error{}
 	for key, patType := range patFields {
 		fieldUnion := type_system.NewUnionType(nil, matchingFieldTypes[key]...)
-		unifyErrors := c.Unify(ctx, patType, fieldUnion)
+		unifyErrors := c.unifyWithDepth(ctx, patType, fieldUnion, depth, seen)
 		errors = append(errors, unifyErrors...)
 	}
 	return errors

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -56,6 +56,19 @@ func interfaceDataPointer(t type_system.Type) unsafe.Pointer {
 }
 
 // typeArgKey produces a stable, deterministic string key for type arguments.
+// For TypeVarType, it uses TypeVar.ID (stable regardless of binding state).
+// For all other types, it uses fmt.Sprint (structural comparison).
+//
+// Known limitation: this only handles TypeVarType at the top level of a type
+// arg. If a type arg is a structural type containing an embedded TypeVar
+// (e.g. {x: TypeVar#42, y: string}), fmt.Sprint will print the TypeVar's
+// bound value, which could change mid-pass during unification. This would
+// require a type arg like List<{x: T}> where T gets bound between two
+// encounters of the same TypeRefType. If the key proves unstable, this
+// function should be made recursive: walk the full type structure using the
+// visitor pattern, emitting TypeVar.ID for any TypeVarType at any depth and
+// structural representation for everything else. See the "KNOWN LIMITATION"
+// section in planning/taming_recursion/plan_b_visited_set.md Step 4.
 func typeArgKey(args []type_system.Type) string {
 	parts := make([]string, len(args))
 	for i, arg := range args {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -41,7 +41,7 @@ func makeUnifyPairKey(t1, t2 type_system.Type) unifyPairKey {
 		if ref.TypeAlias != nil {
 			key.t2 = unsafe.Pointer(ref.TypeAlias)
 		} else {
-			key.t2 = interfaceDataPointer(ref)
+			key.t2 = interfaceDataPointer(t2)
 		}
 		key.t2Args = typeArgKey(ref.TypeArgs)
 	} else {
@@ -231,7 +231,8 @@ func (c *Checker) unifyWithDepth(ctx Context, t1, t2 type_system.Type, depth int
 // maxExpansionRetries is a safety net for the non-TypeRef expansion loop in
 // unifyPruned. With the visited-set cycle detection in place, this should
 // never be hit in practice — the loop terminates naturally when no further
-// expansion is possible. Kept as a defensive limit.
+// expansion is possible. Empirically, the full test suite never exceeds 2
+// iterations. Kept as a defensive limit.
 const maxExpansionRetries = 100
 
 func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, depth int, seen unifySeen) []Error {

--- a/planning/taming_recursion/plan_b_visited_set.md
+++ b/planning/taming_recursion/plan_b_visited_set.md
@@ -2,12 +2,14 @@
 
 **Prerequisite:** Plan A (expand at TypeRefType match site) — **implemented in PR #451**.
 
+**Status: Implemented.**
+
 ## Goal
 
 Add a visited-set mechanism to both `Unify` and `ExpandType` that tracks which
 type pairs or type alias expansions have already been attempted. This provides
 principled cycle detection that replaces the ad-hoc depth counters and enables
-future support for recursive type aliases.
+recursive type aliases.
 
 ## Background
 
@@ -475,3 +477,104 @@ entering `ExpandType` + `unifyWithDepth` for known cycles).
   should be `c.unifyWithDepth(..., seen)` would create a new fresh seen set at that
   point, potentially missing a cycle. Mitigation: grep for all `c.Unify` calls in
   `unify.go` after the change and verify each one is intentional.
+
+## Implementation notes
+
+### What was implemented
+
+All steps (1–5) were implemented as designed. Step 6 (evaluate removing ad-hoc
+counters) was deferred to Plan C.
+
+#### Step 1 — Seen-pairs types (`unify.go`)
+
+Implemented as designed: `unifyPairKey`, `unifySeen`, `makeUnifyPairKey`,
+`interfaceDataPointer`, `typeArgKey`. Also added `expandSeenKey`, `expandSeen` in
+`expand_type.go`.
+
+#### Step 2 — Thread `unifySeen` through unification
+
+All internal function signatures updated to accept `depth int, seen unifySeen`:
+- Core: `unifyWithDepth`, `unifyPruned`, `unifyMatched`
+- Helpers: `bind`, `unifyExtractor`, `unifyClosedWithRests`, `unifyFuncTypes`,
+  `unifyTuples`, `unifyFixedTuples`, `unifyFixedVsVariadic`, `unifyVariadicVsFixed`,
+  `unifyVariadicVsVariadic`, `unifyPatternWithUnion`, `handleArrayConstraintBinding`
+
+All ~70 internal `c.Unify(ctx, ...)` calls within `unify.go` replaced with
+`c.unifyWithDepth(ctx, ..., depth, seen)`. Verified: zero `c.Unify` calls remain
+in `unify.go` after the change.
+
+One external caller of `bind` in `infer_expr.go` updated to pass
+`0, make(unifySeen)` (fresh context, not inside a unification chain).
+
+#### Step 3 — Cycle detection in `unifyPruned`
+
+Cycle checks added in both Tier 1 (`canExpandTypeRef` path) and Tier 3
+(last-resort expansion path), as designed. Both check `seen[key]` before expanding
+and return `nil` (co-inductive assumption) on cycle detection.
+
+#### Step 4 — Cycle detection in `ExpandType`
+
+`expandSeen` threaded through `expandTypeWithConfig` → `TypeExpansionVisitor.seen`.
+Two-phase approach implemented in the `TypeRefType` case of `ExitType`:
+- `v.seen[key] = nil` marks expansion as in progress
+- `v.seen[key] = result` caches the completed result
+- Re-encounter with `nil` returns unexpanded (cycle)
+- Re-encounter with non-nil returns cached result (reuse)
+
+The `expandSeen` map is passed through to all three recursive
+`expandTypeWithConfig` calls (unlimited expansion, counted expansion, and
+keyof-target expansion).
+
+#### Step 5 — Remove hard limits
+
+- `maxUnifyDepth = 50` constant and depth check removed entirely from
+  `unifyWithDepth`.
+- `maxExpansionRetries` increased from 10 to 100 as a defensive safety net (not
+  a termination mechanism — the visited set handles cycles).
+- `depth` parameter kept in `unifyWithDepth` for diagnostic value and Plan C's
+  verification work.
+
+### Deviations from plan
+
+- **Step 6 (evaluate removing ad-hoc counters)** deferred to Plan C. The counters
+  `expandTypeRefsCount`, `skipTypeRefsCount`, and `insideKeyOfTarget` were left
+  unchanged. They serve as optimization hints (controlling expansion eagerness)
+  rather than safety mechanisms, and removing them requires more careful evaluation.
+- **`canExpandTypeRef`'s transitive cycle detection** was left in place. It
+  overlaps with the `unifySeen`/`expandSeen` visited sets but serves as an
+  optimization (avoids entering `ExpandType` + `unifyWithDepth` for known cycles).
+  Plan C will evaluate whether to remove it.
+
+### Tests added
+
+All tests pass (full suite: 21 packages, 0 failures).
+
+Tests added to `TestCheckModuleTypeAliases` (type alias expansion):
+- `RecursiveLinkedList`: `type List<T> = { head: T, tail: List<T> | null }`
+- `RecursiveTree`: `type Tree<T> = { value: T, children: Array<Tree<T>> }`
+- `MutuallyRecursiveExprTypes`: `type Expr = Lit | Add` / `type Lit = ...` /
+  `type Add = { ..., left: Expr, right: Expr }`
+- `CrossAliasCycle`: `type A = { x: B }` / `type B = { y: A }`
+
+Tests added to `TestCheckModuleNoErrors` (value checking against recursive types):
+- `RecursiveLinkedListValue`: constructs a `List<number>` literal
+- `RecursiveTreeValue`: constructs a `Tree<number>` literal
+- `CrossAliasCycleValue`: uses `declare val a1: A` and assigns to `A` and `B`
+- `RecursiveJsonLikeType`: `type Json = string | number | boolean | null | Array<Json> | Record<string, Json>`
+  with value assignments for each variant
+- `CycleDetectionSameTypeAssignment`: `declare val a: List<number>` / `val b: List<number> = a`
+- `StructuralTypeArgWithEmbeddedTypeVar`: `type Wrapper<T> = { inner: Wrapper<{x: T}> | null }`
+  with nested literal construction
+
+### Testing strategy observations
+
+- The `Json` test uses `Array<Json>` and `Record<string, Json>` instead of the
+  plan's `Json[]` and `{ [key: string]: Json }`. Escalier's parser does not support
+  `T[]` array sugar or index signatures in type alias definitions. `Record<string, V>`
+  is available from the TypeScript lib files loaded in the prelude.
+- The `Tree<T>` test uses `Array<Tree<T>>` instead of `Tree<T>[]` for the same
+  reason.
+- The `Wrapper<T>` test (structural type arg with embedded TypeVar) passed without
+  needing to make `typeArgKey` recursive — the current `fmt.Sprint` fallback
+  produces stable keys for this case. The known limitation documented in the
+  `typeArgKey` comment has not been triggered.

--- a/planning/taming_recursion/plan_c_verify_unify_recursion.md
+++ b/planning/taming_recursion/plan_c_verify_unify_recursion.md
@@ -1,6 +1,7 @@
 # Plan C: Verify and harden unification recursion
 
 **Prerequisites:** Plans A and B are implemented. Plan A is done (PR #451).
+Plan B is done.
 
 ## Goal
 
@@ -32,54 +33,72 @@ The `noMatchError` sentinel ensures expansion is only attempted when no case in
 comparison, etc. are returned immediately. `canExpandTypeRef` blocks `IsTypeParam`
 aliases, nominal types, and transitive self-referential cycles (A→B→A).
 
-Plan B adds visited-set cycle detection, removing `maxUnifyDepth` and
-`maxExpansionRetries`.
+Plan B added `unifySeen` and `expandSeen` visited-set cycle detection, removed
+`maxUnifyDepth`, and increased `maxExpansionRetries` from 10 to 100 as a safety
+net. All ~70 internal `c.Unify` calls in `unify.go` were replaced with
+`c.unifyWithDepth(..., depth, seen)`. All helper functions (`bind`,
+`unifyFuncTypes`, `unifyTuples`, `unifyExtractor`, `unifyClosedWithRests`,
+`unifyPatternWithUnion`, `handleArrayConstraintBinding`, and all tuple unification
+variants) were updated to accept and propagate `depth int, seen unifySeen`.
 
 However, several areas need verification:
 
 - The `ExpandType` calls that remain in `unifyMatched` — the KeyOfType expansion
   case and the Union+ObjectType expansion case — were not part of the retry loop
-  but still call `ExpandType` with a fresh context. After Plan B removes the hard
-  limits, these calls rely entirely on the `expandSeen` visited set in `ExpandType`
-  for termination.
-- The Tuple+Array and Array+Tuple interaction paths in `unifyMatched` all call
-  `c.Unify` recursively — notably on rest spread types. After Plan B removes the
-  hard limits, the `unifySeen` set should catch this — but only if each of these
-  `c.Unify` calls was correctly changed to `c.unifyWithDepth(..., seen)`.
-- The `c.Unify` calls inside `unifyTuples`, `unifyFuncTypes`, and `bind` must
-  similarly propagate `unifySeen`.
+  but still call `ExpandType` via the public API (which creates a fresh
+  `expandSeen`). After Plan B removes the hard limits, these calls rely on
+  `ExpandType`'s own `expandSeen` visited set for termination within each call,
+  but cycles that span across unification and expansion may not be caught.
+- Plan B's bulk replacement of `c.Unify` calls was verified by grepping for
+  residual `c.Unify` calls in `unify.go` (zero found). However, the correctness
+  of `depth` propagation (forwarding `depth` vs `depth+1`) was not individually
+  audited for each call site.
+- Plan B deferred Step 6 (evaluate removing ad-hoc counters:
+  `expandTypeRefsCount`, `skipTypeRefsCount`, `insideKeyOfTarget`) and the
+  evaluation of `canExpandTypeRef`'s transitive cycle detection overlap with
+  `unifySeen`/`expandSeen`.
 
 ## Plan
 
 ### Step 1: Audit `c.Unify` propagation in Tuple/Array paths
 
-Verify that all `c.Unify` calls in the Tuple+Array interaction paths were updated
-by Plan B to propagate the seen set. After Plan A, these cases live in
-`unifyMatched`:
+Plan B replaced all `c.Unify` calls in `unify.go` with `c.unifyWithDepth` calls
+that propagate `depth, seen`. A grep confirmed zero residual `c.Unify` calls
+remain.
 
-- `TupleType, ArrayType` case: calls `c.Unify` for each tuple element and rest
-  spread types
+However, the **depth forwarding** at each call site was not individually audited.
+The convention is:
+- **Structural forwarding** (tuple elements, array elements, object properties,
+  function params/return): pass `depth` unchanged
+- **Alias expansion** (TypeRefType expansion via ExpandType): pass `depth+1`
+
+Audit each `c.unifyWithDepth` call in the following paths and verify the depth
+argument is correct:
+
+- `TupleType, ArrayType` case in `unifyMatched`: each element → `depth` (structural)
 - `ArrayType, TupleType` case: mirror of above
-- `ArrayType, ArrayType` case: calls `c.Unify` on element types
-- `RestSpreadType, ArrayType` case: calls `c.Unify` on rest type
-- `unifyTuples` helper: calls `c.Unify` on each pair of tuple elements
+- `ArrayType, ArrayType` case: element types → `depth` (structural)
+- `RestSpreadType, ArrayType` case: rest type → `depth` (structural)
+- `unifyTuples` and its variants: each pair → `depth` (structural)
+- `KeyOfType, KeyOfType` case: expanded keys → `depth+1` (expansion occurred)
+  and inner types → `depth+1` (expansion occurred)
 
-Each should be `c.unifyWithDepth(ctx, ..., depth, seen)` after Plan B —
-propagating the seen set and keeping the same depth (structural forwarding, not
-alias expansion). If any calls were missed, fix them.
+If any depth arguments are incorrect, fix them.
 
 ### Step 2: Audit `ExpandType` calls that remain in unify.go
 
-After Plan A, two `ExpandType` call sites remain in `unifyMatched`:
+After Plan B, `ExpandType` calls in `unifyMatched` use the public API (which
+creates a fresh `expandSeen` each time). This is correct for one-shot expansion
+but means that cycles detected during a *previous* expansion are not remembered.
+Verify this is safe for each call site:
 
 1. **KeyOfType expansion**: Expands both `keyof` types to get concrete keys, then
-   unifies the results. This is structural forwarding (not TypeRef expansion), so
-   it should forward the same depth:
-   `c.unifyWithDepth(ctx, expandedKeys1, expandedKeys2, depth, seen)`.
+   unifies the results via `c.unifyWithDepth(ctx, ..., depth+1, seen)`. The
+   `unifySeen` set is propagated through the unification, so cycles on the
+   unification side are handled. The expansion side gets a fresh `expandSeen`,
+   which is fine because `keyof` expansion is bounded by the number of properties.
 
-   **Risk:** If the expanded keys contain TypeRefTypes, they'll be expanded again
-   on re-entry to `unifyPruned` via Plan A's expansion logic (Tier 1 with
-   `depth+1`). Plan B's visited set handles cycles. Verify with a test case like:
+   Verify with a test case like:
    ```escalier
    type A = { x: number, y: string }
    type B = { x: number, y: string }
@@ -157,30 +176,43 @@ self-referential nominal class unification through the last-resort expansion pat
 
 After verifying all tests pass:
 
-1. **Decide whether to keep the `depth` parameter.** Plan B already removed
-   `maxUnifyDepth` and `maxExpansionRetries`. The remaining question is whether
-   `depth` (still threaded through `unifyWithDepth`) has diagnostic value. If the
-   validation in Steps 1-4 shows that the visited set reliably handles all
-   recursion cases, remove the `depth` parameter from `unifyWithDepth` entirely
-   to simplify the interface. If there is value in keeping it (e.g. for logging
-   or as a last-resort safety net during development), add a comment making clear
-   it is diagnostic-only and not a termination mechanism.
+1. **Decide whether to keep the `depth` parameter.** Plan B removed
+   `maxUnifyDepth` but kept `depth` threaded through `unifyWithDepth` for
+   diagnostic value. If the validation in Steps 1-4 shows that the visited set
+   reliably handles all recursion cases, remove the `depth` parameter from
+   `unifyWithDepth` entirely to simplify the interface. If there is value in
+   keeping it (e.g. for logging or as a last-resort safety net during
+   development), add a comment making clear it is diagnostic-only and not a
+   termination mechanism.
 
-2. **Evaluate `canExpandTypeRef`'s transitive cycle detection.** After Plan B adds
-   the `unifySeen` and `expandSeen` visited sets, the transitive cycle check
-   (A→B→A) in `canExpandTypeRef` becomes redundant for cycle prevention. Consider
-   keeping it as an optimization (avoids entering `ExpandType` + `unifyWithDepth`
-   for known cycles) or removing it to simplify `canExpandTypeRef`.
+2. **Evaluate `canExpandTypeRef`'s transitive cycle detection.** Plan B's
+   `unifySeen` and `expandSeen` visited sets overlap with the transitive cycle
+   check (A→B→A) in `canExpandTypeRef`. Consider keeping it as an optimization
+   (avoids entering `ExpandType` + `unifyWithDepth` for known cycles) or removing
+   it to simplify `canExpandTypeRef`.
 
-3. **Update the TODO at expand_type.go** — After Plan B adds visited-set cycle
+3. **Evaluate removing ad-hoc counters** (deferred from Plan B Step 6):
+   - **`expandTypeRefsCount`**: Still useful for controlling expansion eagerness
+     (e.g. `ExpandType(ctx, t, 1)` for "expand one level"). No longer needed as
+     a safety mechanism. Consider keeping as an optimization hint.
+   - **`skipTypeRefsCount`**: Skips expansion inside structural types to avoid
+     unnecessary work. Consider keeping as an optimization.
+   - **`insideKeyOfTarget`**: Test whether removing this counter causes any test
+     failures. If not, remove it.
+
+4. **Update the TODO at expand_type.go** — After Plan B adds visited-set cycle
    detection to `ExpandType`, the TODO about marking type aliases as recursive
    can be updated to reflect that cycle detection is now handled dynamically. The
    `Recursive` flag on `TypeAlias` is no longer a prerequisite for correctness,
    though it could still be useful as an optimization (skip visited-set tracking
    for non-recursive aliases).
 
-4. **Clean up comments** in `unifyPruned` and `unifyMatched` that reference the
+5. **Clean up comments** in `unifyPruned` and `unifyMatched` that reference the
    old retry loop or explain why certain cases fall through to it.
+
+6. **Reduce `maxExpansionRetries`** — Plan B increased it from 10 to 100 as a
+   defensive safety net. After verifying the visited set handles all cycles, this
+   could be reduced or removed entirely.
 
 ### Step 6: Performance validation
 

--- a/planning/taming_recursion/planning.md
+++ b/planning/taming_recursion/planning.md
@@ -15,14 +15,18 @@ for the full issue inventory.
   `IsTypeParam` flag to `TypeAlias`, checked by `canExpandTypeRef`.
 
 - **[Plan B: Visited-set / seen-pairs memoization](plan_b_visited_set.md)** —
-  Add cycle detection via visited sets to both `Unify` and `ExpandType`. Enables
-  recursive type aliases and removes both the `maxUnifyDepth` limit and
-  `maxExpansionRetries` loop bound.
+  **Implemented.** Added `unifySeen` (visited set for unification) and `expandSeen`
+  (visited set for type expansion) with co-inductive cycle detection. Threaded seen
+  sets through all internal unification and expansion functions. Removed
+  `maxUnifyDepth = 50`; increased `maxExpansionRetries` from 10 to 100 as a
+  defensive safety net. Recursive type aliases (`List<T>`, `Tree<T>`, `Json`,
+  mutually recursive types, cross-alias cycles) now work correctly. Step 6
+  (evaluate removing ad-hoc counters) deferred to Plan C.
 
 - **[Plan C: Verify and harden unification recursion](plan_c_verify_unify_recursion.md)** —
   Audit seen-set propagation in Tuple/Array paths, validate the three pathological
-  scenarios from issue #1, add regression tests, and clean up residual workaround
-  code.
+  scenarios from issue #1, add regression tests, clean up residual workaround code,
+  and evaluate removing the ad-hoc counters deferred from Plan B Step 6.
 
 ## Issue coverage
 
@@ -30,12 +34,12 @@ Which [research.md](research.md) issues each plan addresses:
 
 | Issue | Description | Plan(s) |
 |-------|-------------|---------|
-| #1 | Unification retry loop creates unbounded recursion | **A (done)**: replaces retry loop with iterative expansion + `noMatchError` sentinel; B (removes depth limit and expansion loop bound); C (validates fix, regression tests) |
-| #2 | Recursive type aliases cannot be expanded | B (visited set in ExpandType enables cycle detection) |
-| #3 | `skipTypeRefsCount` suppresses expansion inside structural types | B (visited set makes this less critical; evaluated for removal in step 6) |
-| #4 | `insideKeyOfTarget` prevents nested keyof expansion | B (visited set may subsume this; evaluated for removal in step 6) |
+| #1 | Unification retry loop creates unbounded recursion | **A (done)**: replaces retry loop with iterative expansion + `noMatchError` sentinel; **B (done)**: removes `maxUnifyDepth`, increases `maxExpansionRetries` to 100 as safety net; C (validates fix, regression tests) |
+| #2 | Recursive type aliases cannot be expanded | **B (done)**: `expandSeen` visited set in ExpandType enables cycle detection; recursive type aliases now work |
+| #3 | `skipTypeRefsCount` suppresses expansion inside structural types | **B (deferred to C)**: visited set makes this less critical; evaluation for removal deferred to Plan C |
+| #4 | `insideKeyOfTarget` prevents nested keyof expansion | **B (deferred to C)**: visited set may subsume this; evaluation for removal deferred to Plan C |
 | #5 | `getMemberType` expansion loop relies on pointer identity | — (deferred; low complexity to fix after Plan B provides a visited-set primitive — add an iteration limit or use the `expandSeen` set) |
-| #6 | `ExpandType` and `unifyPruned` use different recursion strategies | **A (done)**: unify uses `canExpandTypeRef` predicate + `ExpandType(t, 1)` for TypeRefs and `ExpandType(t, 0)` for non-TypeRef types; B (shared cycle detection primitive) |
-| #7 | No visited-set or seen-pairs mechanism | B (adds visited sets to both Unify and ExpandType) |
+| #6 | `ExpandType` and `unifyPruned` use different recursion strategies | **A (done)**: unify uses `canExpandTypeRef` predicate + `ExpandType(t, 1)` for TypeRefs and `ExpandType(t, 0)` for non-TypeRef types; **B (done)**: shared cycle detection primitives (`unifySeen`, `expandSeen`) |
+| #7 | No visited-set or seen-pairs mechanism | **B (done)**: adds `unifySeen` to Unify and `expandSeen` to ExpandType |
 | #8 | Package loading cycle prevention | — (working correctly, no changes needed) |
 | #9 | Library file discovery visited set | — (working correctly, no changes needed) |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of recursive and mutually recursive generic type aliases, preventing infinite loops during type expansion and unification.
  * Enhanced cycle detection for complex type scenarios, including cross-alias cycles.

* **Tests**
  * Added comprehensive test coverage for recursive generic aliases and structurally-recursive types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->