### PR TITLE
Cache expanded types in getMemberType (#453)

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -16,6 +16,7 @@ type Checker struct {
 	PackageRegistry       *PackageRegistry           // Registry for package namespaces (separate from scope chain)
 	GlobalScope           *Scope                     // Explicit reference to global scope (contains globals like Array, Promise, etc.)
 	FileScopes            map[int]*Scope             // Populated by InferModule: SourceID → file-specific scope
+	expandCache           expandSeen                 // Cross-call cache for getMemberType's expansion loop (#453)
 }
 
 func NewChecker() *Checker {
@@ -27,6 +28,7 @@ func NewChecker() *Checker {
 		OverloadDecls:         make(map[string][]*ast.FuncDecl),
 		PackageRegistry:       NewPackageRegistry(),
 		GlobalScope:           nil, // Will be set by initializeGlobalScope() during prelude loading
+		expandCache:           make(expandSeen),
 	}
 }
 

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -40,14 +40,16 @@ type expandSeenKey struct {
 type expandSeen map[expandSeenKey]type_system.Type
 
 // typeVarDetector is a TypeVisitor that detects unresolved type variables.
-// TypeVarType.Accept prunes first, so EnterType only sees unresolved vars.
+// Only unresolved TypeVarTypes (Instance == nil) are flagged; resolved ones
+// are pruned through by Accept and their instances are visited normally.
 type typeVarDetector struct{ found bool }
 
-func (d *typeVarDetector) EnterType(t type_system.Type) type_system.Type {
-	if _, ok := t.(*type_system.TypeVarType); ok {
+func (d *typeVarDetector) EnterType(t type_system.Type) type_system.EnterResult {
+	if tv, ok := t.(*type_system.TypeVarType); ok && tv.Instance == nil {
 		d.found = true
+		return type_system.EnterResult{SkipChildren: true}
 	}
-	return t
+	return type_system.EnterResult{}
 }
 func (d *typeVarDetector) ExitType(t type_system.Type) type_system.Type { return t }
 
@@ -216,7 +218,7 @@ func (v *TypeExpansionVisitor) resolveTypeOfQualIdent(ident type_system.QualIden
 	}
 }
 
-func (v *TypeExpansionVisitor) EnterType(t type_system.Type) type_system.Type {
+func (v *TypeExpansionVisitor) EnterType(t type_system.Type) type_system.EnterResult {
 	switch t := t.(type) {
 	case *type_system.FuncType:
 		v.skipTypeRefsCount++ // don't expand type refs inside function types
@@ -238,7 +240,7 @@ func (v *TypeExpansionVisitor) EnterType(t type_system.Type) type_system.Type {
 
 		maps.Copy(inferSubs, groupSubs)
 
-		return type_system.NewCondType(
+		return type_system.EnterResult{Type: type_system.NewCondType(
 			t.Provenance(),
 			t.Check,
 			extendsType,
@@ -247,10 +249,10 @@ func (v *TypeExpansionVisitor) EnterType(t type_system.Type) type_system.Type {
 			// type didn't have any InferTypes in it, so we don't need to
 			// replace them with fresh type variables.
 			SubstituteTypeParams(t.Else, inferSubs),
-		)
+		)}
 	}
 
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
@@ -2024,9 +2026,9 @@ type InferTypeFinder struct {
 	inferVars map[string]type_system.Type
 }
 
-func (v *InferTypeFinder) EnterType(t type_system.Type) type_system.Type {
+func (v *InferTypeFinder) EnterType(t type_system.Type) type_system.EnterResult {
 	// No-op - just for traversal
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *InferTypeFinder) ExitType(t type_system.Type) type_system.Type {
@@ -2061,9 +2063,9 @@ type InferTypeReplacer struct {
 	inferMapping map[string]type_system.Type
 }
 
-func (v *InferTypeReplacer) EnterType(t type_system.Type) type_system.Type {
+func (v *InferTypeReplacer) EnterType(t type_system.Type) type_system.EnterResult {
 	// No-op - just for traversal
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *InferTypeReplacer) ExitType(t type_system.Type) type_system.Type {

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -39,6 +39,26 @@ type expandSeenKey struct {
 // A non-nil value is the cached expansion result (re-encounter = reuse).
 type expandSeen map[expandSeenKey]type_system.Type
 
+// typeVarDetector is a TypeVisitor that detects unresolved type variables.
+// TypeVarType.Accept prunes first, so EnterType only sees unresolved vars.
+type typeVarDetector struct{ found bool }
+
+func (d *typeVarDetector) EnterType(t type_system.Type) type_system.Type {
+	if _, ok := t.(*type_system.TypeVarType); ok {
+		d.found = true
+	}
+	return t
+}
+func (d *typeVarDetector) ExitType(t type_system.Type) type_system.Type { return t }
+
+// containsTypeVar returns true if the type contains any unresolved type variables.
+// Uses the Accept visitor to walk all nested types exhaustively.
+func containsTypeVar(t type_system.Type) bool {
+	d := &typeVarDetector{}
+	t.Accept(d)
+	return d.found
+}
+
 // isSymbolIndexKey returns true if the given MemberAccessKey is an IndexKey
 // whose underlying type is a UniqueSymbolType (e.g. Symbol.iterator).
 func isSymbolIndexKey(key MemberAccessKey) bool {
@@ -590,6 +610,31 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 
 	objType = type_system.Prune(objType)
 
+	// Check the cross-call expansion cache for TypeRefTypes with fully-concrete
+	// type args. This avoids redundant ExpandType calls when the same concrete
+	// TypeRefType is accessed multiple times (e.g. obj.x, obj.y on the same type). (#453)
+	var cacheKey *expandSeenKey
+	if tref, ok := objType.(*type_system.TypeRefType); ok && tref.TypeAlias != nil {
+		concrete := true
+		for _, arg := range tref.TypeArgs {
+			if containsTypeVar(arg) {
+				concrete = false
+				break
+			}
+		}
+		if concrete {
+			k := expandSeenKey{
+				alias:    unsafe.Pointer(tref.TypeAlias),
+				typeArgs: typeArgKey(tref.TypeArgs),
+			}
+			if cached, exists := c.expandCache[k]; exists {
+				objType = cached
+			} else {
+				cacheKey = &k
+			}
+		}
+	}
+
 	// Repeatedly expand objType until it's either an ObjectType, NamespaceType,
 	// IntersectionType, or can't be expanded any further
 	for {
@@ -626,6 +671,11 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 		}
 
 		objType = expandedType
+	}
+
+	// Store the expanded result in the cross-call cache
+	if cacheKey != nil {
+		c.expandCache[*cacheKey] = objType
 	}
 
 	switch t := objType.(type) {

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -625,9 +625,15 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 			}
 		}
 		if concrete {
+			// insideKeyOf is explicitly false: getMemberType never operates inside
+			// a keyof context, so this cache only stores non-keyof expansions.
+			// This avoids collisions with the per-pass expandSeen cache used by
+			// expandTypeWithConfig, which keys on insideKeyOfTarget > 0.
+			// See TODO(#455) on expandSeenKey for potential removal of insideKeyOf.
 			k := expandSeenKey{
-				alias:    unsafe.Pointer(tref.TypeAlias),
-				typeArgs: typeArgKey(tref.TypeArgs),
+				alias:       unsafe.Pointer(tref.TypeAlias),
+				typeArgs:    typeArgKey(tref.TypeArgs),
+				insideKeyOf: false,
 			}
 			if cached, exists := c.expandCache[k]; exists {
 				objType = cached

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1352,6 +1352,7 @@ const DEBUG = false
 // order.
 // TODO: all interface declarations in a namespace to shadow previous ones.
 func (c *Checker) InferModule(ctx Context, m *ast.Module) []Error {
+	clear(c.expandCache) // Reset cross-call expansion cache for this inference pass
 	errors := []Error{}
 
 	// Phase 1: Create file scopes and process imports for each file.

--- a/internal/checker/infer_script.go
+++ b/internal/checker/infer_script.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (c *Checker) InferScript(ctx Context, m *ast.Script) (*Scope, []Error) {
+	clear(c.expandCache) // Reset cross-call expansion cache for this inference pass
 	errors := []Error{}
 	ctx = ctx.WithNewScope()
 

--- a/internal/checker/regex.go
+++ b/internal/checker/regex.go
@@ -20,9 +20,9 @@ type NamedCaptureGroupExtractor struct {
 	namedGroups map[string]type_system.Type
 }
 
-func (v *NamedCaptureGroupExtractor) EnterType(t type_system.Type) type_system.Type {
+func (v *NamedCaptureGroupExtractor) EnterType(t type_system.Type) type_system.EnterResult {
 	// No-op - just for traversal
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *NamedCaptureGroupExtractor) ExitType(t type_system.Type) type_system.Type {
@@ -62,9 +62,9 @@ type RegexTypeReplacer struct {
 	substitutions map[string]type_system.Type
 }
 
-func (v *RegexTypeReplacer) EnterType(t type_system.Type) type_system.Type {
+func (v *RegexTypeReplacer) EnterType(t type_system.Type) type_system.EnterResult {
 	// No-op - just for traversal
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *RegexTypeReplacer) ExitType(t type_system.Type) type_system.Type {

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -29,7 +29,7 @@ func (v *TypeParamSubstitutionVisitor) SubstituteType(t type_system.Type) type_s
 	return t.Accept(v)
 }
 
-func (v *TypeParamSubstitutionVisitor) EnterType(t type_system.Type) type_system.Type {
+func (v *TypeParamSubstitutionVisitor) EnterType(t type_system.Type) type_system.EnterResult {
 	// When entering a FuncType with type parameters, push shadowed parameters onto stack
 	if funcType, ok := t.(*type_system.FuncType); ok && len(funcType.TypeParams) > 0 {
 		shadows := make(map[string]bool)
@@ -38,7 +38,7 @@ func (v *TypeParamSubstitutionVisitor) EnterType(t type_system.Type) type_system
 		}
 		v.shadowStack = append(v.shadowStack, shadows)
 	}
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.Type {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -2057,9 +2057,9 @@ type OccursInVisitor struct {
 	t1     type_system.Type
 }
 
-func (v *OccursInVisitor) EnterType(t type_system.Type) type_system.Type {
+func (v *OccursInVisitor) EnterType(t type_system.Type) type_system.EnterResult {
 	// No-op for entry
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *OccursInVisitor) ExitType(t type_system.Type) type_system.Type {
@@ -2265,9 +2265,9 @@ func copyObjTypeElems(elems []type_system.ObjTypeElem) []type_system.ObjTypeElem
 
 type RemoveUncertainMutabilityVisitor struct{}
 
-func (v *RemoveUncertainMutabilityVisitor) EnterType(t type_system.Type) type_system.Type {
+func (v *RemoveUncertainMutabilityVisitor) EnterType(t type_system.Type) type_system.EnterResult {
 	// No-op for entry
-	return nil
+	return type_system.EnterResult{}
 }
 
 func (v *RemoveUncertainMutabilityVisitor) ExitType(t type_system.Type) type_system.Type {

--- a/internal/codegen/self_type_utils.go
+++ b/internal/codegen/self_type_utils.go
@@ -20,13 +20,14 @@ type selfTypeRefVisitor struct {
 	found bool
 }
 
-func (v *selfTypeRefVisitor) EnterType(t type_system.Type) type_system.Type {
+func (v *selfTypeRefVisitor) EnterType(t type_system.Type) type_system.EnterResult {
 	if tref, ok := type_system.Prune(t).(*type_system.TypeRefType); ok {
 		if type_system.QualIdentToString(tref.Name) == "Self" {
 			v.found = true
+			return type_system.EnterResult{SkipChildren: true}
 		}
 	}
-	return nil // continue traversal
+	return type_system.EnterResult{}
 }
 
 // replaceSelfWithThis returns a copy of the type with all TypeRefType 'Self' replaced by a TypeScript 'this' type using TypeVisitor.
@@ -37,8 +38,8 @@ func replaceSelfWithThis(t type_system.Type) type_system.Type {
 
 type selfReplaceVisitor struct{}
 
-func (v *selfReplaceVisitor) EnterType(t type_system.Type) type_system.Type {
-	return nil // continue traversal
+func (v *selfReplaceVisitor) EnterType(t type_system.Type) type_system.EnterResult {
+	return type_system.EnterResult{}
 }
 
 func (v *selfReplaceVisitor) ExitType(t type_system.Type) type_system.Type {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -212,18 +212,25 @@ func NewTypeVarType(provenance Provenance, id int) *TypeVarType {
 }
 
 func (t *TypeVarType) Accept(v TypeVisitor) Type {
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*TypeVarType)
+	}
+	if enter.SkipChildren {
+		if result := v.ExitType(t); result != nil {
+			return result
+		}
+		return t
+	}
+
 	prunedType := Prune(t)
 	if prunedType != t {
 		return prunedType.Accept(v) // Accept on the pruned type
 	}
 
-	if result := v.EnterType(prunedType); result != nil {
-		t = result.(*TypeVarType)
-	}
-	if result := v.ExitType(prunedType); result != nil {
+	if result := v.ExitType(t); result != nil {
 		return result
 	}
-
 	return t
 }
 func (t *TypeVarType) Equals(other Type) bool {
@@ -291,13 +298,26 @@ func NewTypeRefTypeFromQualIdent(provenance Provenance, name QualIdent, typeAlia
 	}
 }
 func (t *TypeRefType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		switch result := result.(type) {
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		switch r := enter.Type.(type) {
 		case *TypeRefType:
-			t = result
+			t = r
 		default:
-			return result.Accept(v)
+			if enter.SkipChildren {
+				if visitResult := v.ExitType(r); visitResult != nil {
+					return visitResult
+				}
+				return r
+			}
+			return r.Accept(v)
 		}
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false
@@ -422,8 +442,9 @@ func NewBigIntPrimType(provenance Provenance) *PrimType {
 	}
 }
 func (t *PrimType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*PrimType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*PrimType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -489,8 +510,9 @@ func NewRegexTypeWithPatternString(provenance Provenance, pattern string) (Type,
 	return NewRegexType(provenance, regex, groups), nil
 }
 func (t *RegexType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*RegexType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*RegexType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -562,8 +584,9 @@ func NewBigIntLitType(provenance Provenance, value big.Int) *LitType {
 }
 
 func (t *LitType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*LitType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*LitType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -609,8 +632,9 @@ func NewUniqueSymbolType(provenance Provenance, value int) *UniqueSymbolType {
 }
 
 func (t *UniqueSymbolType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*UniqueSymbolType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*UniqueSymbolType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -633,8 +657,9 @@ type UnknownType struct {
 }
 
 func (t *UnknownType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*UnknownType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*UnknownType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -657,8 +682,9 @@ type NeverType struct {
 }
 
 func (t *NeverType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*NeverType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*NeverType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -690,8 +716,9 @@ type ErrorType struct {
 }
 
 func (t *ErrorType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*ErrorType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*ErrorType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -714,8 +741,9 @@ type VoidType struct {
 }
 
 func (t *VoidType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*VoidType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*VoidType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -738,8 +766,9 @@ type AnyType struct {
 }
 
 func (t *AnyType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*AnyType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*AnyType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -762,8 +791,9 @@ type GlobalThisType struct {
 }
 
 func (t *GlobalThisType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*GlobalThisType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*GlobalThisType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -854,8 +884,15 @@ func NewFuncType(provenance Provenance, typeParams []*TypeParam, params []*FuncP
 	}
 }
 func (t *FuncType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*FuncType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*FuncType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false
@@ -1430,8 +1467,15 @@ func NewNominalObjectType(provenance Provenance, elems []ObjTypeElem) *ObjectTyp
 }
 
 func (t *ObjectType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*ObjectType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*ObjectType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false
@@ -1694,8 +1738,15 @@ func NewTupleType(provenance Provenance, elems ...Type) *TupleType {
 	}
 }
 func (t *TupleType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*TupleType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*TupleType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false
@@ -1781,8 +1832,15 @@ func NewRestSpreadType(provenance Provenance, typ Type) *RestSpreadType {
 	}
 }
 func (t *RestSpreadType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*RestSpreadType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*RestSpreadType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	newType := t.Type.Accept(v)
@@ -1922,8 +1980,15 @@ func NewUnionType(provenance Provenance, types ...Type) Type {
 	}
 }
 func (t *UnionType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*UnionType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*UnionType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false
@@ -2129,8 +2194,15 @@ func NewIntersectionType(provenance Provenance, types ...Type) Type {
 }
 
 func (t *IntersectionType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*IntersectionType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*IntersectionType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false
@@ -2195,8 +2267,15 @@ func NewKeyOfType(provenance Provenance, typ Type) *KeyOfType {
 	}
 }
 func (t *KeyOfType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*KeyOfType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*KeyOfType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	newType := t.Type.Accept(v)
@@ -2236,8 +2315,9 @@ func NewTypeOfType(provenance Provenance, ident QualIdent) *TypeOfType {
 }
 
 func (t *TypeOfType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*TypeOfType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*TypeOfType)
 	}
 
 	if visitResult := v.ExitType(t); visitResult != nil {
@@ -2271,8 +2351,15 @@ func NewIndexType(provenance Provenance, target Type, index Type) *IndexType {
 	}
 }
 func (t *IndexType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*IndexType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*IndexType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	newTarget := t.Target.Accept(v)
@@ -2307,8 +2394,15 @@ type CondType struct {
 }
 
 func (t *CondType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*CondType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*CondType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	newCheck := t.Check.Accept(v)
@@ -2360,8 +2454,9 @@ type InferType struct {
 }
 
 func (t *InferType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*InferType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*InferType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -2400,8 +2495,15 @@ type MutabilityType struct {
 }
 
 func (t *MutabilityType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*MutabilityType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*MutabilityType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	newType := t.Type.Accept(v)
@@ -2455,8 +2557,9 @@ func NewWildcardType(provenance Provenance) *WildcardType {
 	}
 }
 func (t *WildcardType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*WildcardType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*WildcardType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -2486,8 +2589,15 @@ func NewExtractorType(provenance Provenance, extractor Type, args ...Type) *Extr
 	}
 }
 func (t *ExtractorType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*ExtractorType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*ExtractorType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	newExtractor := t.Extractor.Accept(v)
@@ -2562,8 +2672,15 @@ func NewTemplateLitType(provenance Provenance, quasis []*Quasi, types []Type) *T
 	}
 }
 func (t *TemplateLitType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*TemplateLitType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*TemplateLitType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false
@@ -2628,8 +2745,9 @@ type IntrinsicType struct {
 }
 
 func (t *IntrinsicType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*IntrinsicType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*IntrinsicType)
 	}
 	if result := v.ExitType(t); result != nil {
 		return result
@@ -2721,8 +2839,15 @@ func NewNamespaceType(provenance Provenance, ns *Namespace) *NamespaceType {
 	}
 }
 func (t *NamespaceType) Accept(v TypeVisitor) Type {
-	if result := v.EnterType(t); result != nil {
-		t = result.(*NamespaceType)
+	enter := v.EnterType(t)
+	if enter.Type != nil {
+		t = enter.Type.(*NamespaceType)
+	}
+	if enter.SkipChildren {
+		if visitResult := v.ExitType(t); visitResult != nil {
+			return visitResult
+		}
+		return t
 	}
 
 	changed := false

--- a/internal/type_system/visitor.go
+++ b/internal/type_system/visitor.go
@@ -1,6 +1,12 @@
 package type_system
 
+// EnterResult controls traversal after EnterType.
+type EnterResult struct {
+	Type         Type // nil = don't replace the node
+	SkipChildren bool // true = skip child traversal, go straight to ExitType
+}
+
 type TypeVisitor interface {
-	EnterType(t Type) Type
+	EnterType(t Type) EnterResult
 	ExitType(t Type) Type
 }

--- a/internal/type_system/visitor_test.go
+++ b/internal/type_system/visitor_test.go
@@ -10,9 +10,9 @@ import (
 // meaning it doesn't transform any types but allows traversal
 type IdentityVisitor struct{}
 
-func (v *IdentityVisitor) EnterType(t Type) Type {
+func (v *IdentityVisitor) EnterType(t Type) EnterResult {
 	// No-op for entry
-	return nil
+	return EnterResult{}
 }
 
 func (v *IdentityVisitor) ExitType(t Type) Type {
@@ -28,9 +28,9 @@ func NewTypeReplacementVisitor(replacements map[Type]Type) *TypeReplacementVisit
 	return &TypeReplacementVisitor{replacements: replacements}
 }
 
-func (v *TypeReplacementVisitor) EnterType(t Type) Type {
+func (v *TypeReplacementVisitor) EnterType(t Type) EnterResult {
 	// No-op for entry
-	return nil
+	return EnterResult{}
 }
 
 func (v *TypeReplacementVisitor) ExitType(t Type) Type {
@@ -53,9 +53,9 @@ func NewTrackingVisitor() *TrackingVisitor {
 	}
 }
 
-func (v *TrackingVisitor) EnterType(t Type) Type {
+func (v *TrackingVisitor) EnterType(t Type) EnterResult {
 	v.enteredTypes = append(v.enteredTypes, t)
-	return nil
+	return EnterResult{}
 }
 
 func (v *TrackingVisitor) ExitType(t Type) Type {
@@ -85,11 +85,11 @@ func NewSameKindReplacementVisitor(replacements map[Type]Type) *SameKindReplacem
 	return &SameKindReplacementVisitor{replacements: replacements}
 }
 
-func (v *SameKindReplacementVisitor) EnterType(t Type) Type {
+func (v *SameKindReplacementVisitor) EnterType(t Type) EnterResult {
 	if replacement, found := v.replacements[t]; found {
-		return replacement
+		return EnterResult{Type: replacement}
 	}
-	return nil
+	return EnterResult{}
 }
 
 func (v *SameKindReplacementVisitor) ExitType(t Type) Type {
@@ -1137,9 +1137,9 @@ type TransformingTrackingVisitor struct {
 	newType      Type
 }
 
-func (v *TransformingTrackingVisitor) EnterType(t Type) Type {
+func (v *TransformingTrackingVisitor) EnterType(t Type) EnterResult {
 	v.enteredTypes = append(v.enteredTypes, t)
-	return nil
+	return EnterResult{}
 }
 
 func (v *TransformingTrackingVisitor) ExitType(t Type) Type {
@@ -1211,9 +1211,9 @@ type OrderTrackingVisitor struct {
 	exitFunc  func(Type) Type
 }
 
-func (v *OrderTrackingVisitor) EnterType(t Type) Type {
+func (v *OrderTrackingVisitor) EnterType(t Type) EnterResult {
 	v.enterFunc(t)
-	return nil
+	return EnterResult{}
 }
 
 func (v *OrderTrackingVisitor) ExitType(t Type) Type {


### PR DESCRIPTION
## Summary
- Adds a cross-call `expandCache` (`map[expandSeenKey]Type`) on the `Checker` struct to memoize the expansion loop result in `getMemberType`
- Only caches fully-concrete `TypeRefType`s (no unresolved type variables in type args), so unification cannot invalidate entries
- Uses the `Accept` visitor for exhaustive type-variable detection via `containsTypeVar`
- Updates `TypeVisitor.EnterType` to return `EnterResult{Type, SkipChildren}` struct, enabling early traversal termination
- Reorders `TypeVarType.Accept` to call `EnterType` before pruning, consistent with all other `Accept` methods

Closes #453

## Benchmark results

Targeted benchmarks from #460 (8 iterations each):

| Benchmark | main (ns/op) | fix-453 (ns/op) | Delta |
|---|---|---|---|
| RepeatedGenericPropertyAccess | ~1,675,000 | ~1,675,000 | ~0% |
| MultipleGenericTypes | ~455,800 | ~467,000 | ~noise |
| UnionMemberAccess | ~2,544,000 | ~2,281,000 | **-10%** |
| GenericPropertyAccessModule | ~46,200 | ~41,800 | **-10%** |

No regressions on existing benchmarks.

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Targeted benchmarks from #460 show improvement for union member access and generic property access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type expansion caching to prevent inconsistent behavior across multiple type inference passes, addressing type resolution issues.

* **Refactor**
  * Enhanced type system visitor pattern to support improved type traversal control, resulting in more efficient type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->