### PR TITLE
Optimize SubstituteTypeParams to reduce allocations (#461)

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -17,6 +17,8 @@ type Checker struct {
 	GlobalScope           *Scope                     // Explicit reference to global scope (contains globals like Array, Promise, etc.)
 	FileScopes            map[int]*Scope             // Populated by InferModule: SourceID → file-specific scope
 	expandCache           expandSeen                 // Cross-call cache for getMemberType's expansion loop (#453)
+	substCache            expandSeen                 // Cross-call cache for expandTypeRef's SubstituteTypeParams (#461)
+	memberCache           memberCache                // Per-property cache for lazy member substitution (#461)
 }
 
 func NewChecker() *Checker {
@@ -29,6 +31,8 @@ func NewChecker() *Checker {
 		PackageRegistry:       NewPackageRegistry(),
 		GlobalScope:           nil, // Will be set by initializeGlobalScope() during prelude loading
 		expandCache:           make(expandSeen),
+		substCache:            make(expandSeen),
+		memberCache:           make(memberCache),
 	}
 }
 

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -39,6 +39,17 @@ type expandSeenKey struct {
 // A non-nil value is the cached expansion result (re-encounter = reuse).
 type expandSeen map[expandSeenKey]type_system.Type
 
+// memberCacheKey identifies a specific property on a specific instantiation of
+// a generic type alias. Used by lazyMemberLookup to cache per-property
+// substitution results (#461).
+type memberCacheKey struct {
+	alias    unsafe.Pointer // TypeAlias pointer
+	typeArgs string         // typeArgKey(typeArgs)
+	member   string         // property name
+}
+
+type memberCache map[memberCacheKey]type_system.Type
+
 // typeVarDetector is a TypeVisitor that detects unresolved type variables.
 // Only unresolved TypeVarTypes (Instance == nil) are flagged; resolved ones
 // are pruned through by Accept and their instances are visited normally.
@@ -698,7 +709,18 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 			return t.TypeArgs[0], errors
 		}
 
-		// Try to expand the type alias and call getAccessType recursively
+		// Lazy substitution (#461): for generic TypeRefTypes resolving to
+		// ObjectTypes, find the property on the unsubstituted ObjectType and
+		// substitute only that property's type. This turns the cost from
+		// O(all methods) into O(1) for single property lookups.
+		if propKey, ok := key.(PropertyKey); ok {
+			if memberType, found := c.lazyMemberLookup(ctx, t, propKey.Name, mode); found {
+				return memberType, errors
+			}
+		}
+
+		// Fallback: full expansion for index access, extends properties,
+		// symbol keys, or non-ObjectType aliases.
 		expandType, expandErrors := c.expandTypeRef(ctx, t)
 		accessType, accessErrors := c.getMemberType(ctx, expandType, key, mode)
 
@@ -974,6 +996,84 @@ func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
 		}
 	}
 	return nil
+}
+
+// lazyMemberLookup performs property lookup on a generic TypeRefType without
+// substituting the entire ObjectType. It finds the property on the raw
+// (unsubstituted) ObjectType and substitutes only that property's type.
+// Results are cached per (TypeAlias, typeArgs, memberName) so repeated
+// accesses to the same property are free after the first lookup.
+// Returns (memberType, true) if the property was found, or (nil, false)
+// to signal the caller should fall back to full expansion.
+func (c *Checker) lazyMemberLookup(ctx Context, t *type_system.TypeRefType, name string, mode AccessMode) (type_system.Type, bool) {
+	typeAlias := t.TypeAlias
+	if typeAlias == nil {
+		typeAlias = resolveQualifiedTypeAlias(ctx, t.Name)
+	}
+	if typeAlias == nil {
+		return nil, false
+	}
+
+	aliasType := type_system.Prune(typeAlias.Type)
+	objType, ok := aliasType.(*type_system.ObjectType)
+	if !ok {
+		return nil, false
+	}
+
+	// Check per-member cache first.
+	cacheKey := memberCacheKey{
+		alias:    unsafe.Pointer(typeAlias),
+		typeArgs: typeArgKey(t.TypeArgs),
+		member:   name,
+	}
+	if cached, exists := c.memberCache[cacheKey]; exists {
+		return cached, true
+	}
+
+	// Search the unsubstituted ObjectType for the property.
+	targetKey := type_system.NewStrKey(name)
+	var memberType type_system.Type
+	for i := len(objType.Elems) - 1; i >= 0; i-- {
+		switch elem := objType.Elems[i].(type) {
+		case *type_system.PropertyElem:
+			if elem.Name == targetKey {
+				memberType = elem.Value
+				if elem.Optional {
+					memberType = type_system.NewUnionType(nil, memberType, type_system.NewUndefinedType(nil))
+				}
+			}
+		case *type_system.MethodElem:
+			if elem.Name == targetKey {
+				memberType = elem.Fn
+			}
+		case *type_system.GetterElem:
+			if elem.Name == targetKey && mode == AccessRead {
+				memberType = elem.Fn.Return
+			}
+		case *type_system.SetterElem:
+			if elem.Name == targetKey && mode == AccessWrite {
+				memberType = elem.Fn.Params[0].Type
+			}
+		}
+		if memberType != nil {
+			break
+		}
+	}
+
+	if memberType == nil {
+		// Not found in direct Elems; fall back so the full expansion can
+		// check Extends, RestSpreadElem, etc.
+		return nil, false
+	}
+
+	// Substitute only this member's type instead of the whole ObjectType.
+	if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
+		substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
+		memberType = SubstituteTypeParams(memberType, substitutions)
+	}
+
+	c.memberCache[cacheKey] = memberType
+	return memberType, true
 }
 
 // getObjectAccess handles property and index access on ObjectType.
@@ -1801,8 +1901,19 @@ func (c *Checker) expandTypeRef(ctx Context, t *type_system.TypeRefType) (type_s
 
 	// Handle type parameter substitution if the type is generic
 	if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
+		// Check substitution cache to avoid redundant SubstituteTypeParams calls
+		// for the same type alias + type args combination (#461).
+		key := expandSeenKey{
+			alias:       unsafe.Pointer(typeAlias),
+			typeArgs:    typeArgKey(t.TypeArgs),
+			insideKeyOf: false,
+		}
+		if cached, exists := c.substCache[key]; exists {
+			return cached, []Error{}
+		}
 		substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
 		expandedType = SubstituteTypeParams(typeAlias.Type, substitutions)
+		c.substCache[key] = expandedType
 	}
 
 	return expandedType, []Error{}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -41,11 +41,13 @@ type expandSeen map[expandSeenKey]type_system.Type
 
 // memberCacheKey identifies a specific property on a specific instantiation of
 // a generic type alias. Used by lazyMemberLookup to cache per-property
-// substitution results (#461).
+// substitution results (#461). The mode field separates getter-read results
+// from setter-write results so they are never confused.
 type memberCacheKey struct {
 	alias    unsafe.Pointer // TypeAlias pointer
 	typeArgs string         // typeArgKey(typeArgs)
 	member   string         // property name
+	mode     AccessMode     // read vs write (getter vs setter)
 }
 
 type memberCache map[memberCacheKey]type_system.Type
@@ -623,6 +625,27 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 
 	objType = type_system.Prune(objType)
 
+	// Fast path for TypeRefTypes: try O(1) per-member lazy lookup before
+	// the expansion loop which would substitute the entire ObjectType (#461).
+	// This handles both nominal types (which the expansion loop can't expand)
+	// and non-nominal generic aliases (avoiding full expansion entirely).
+	if tref, ok := objType.(*type_system.TypeRefType); ok {
+		// Handle Array numeric index access (skip symbol keys like Symbol.iterator)
+		if indexKey, ok := key.(IndexKey); ok && type_system.QualIdentToString(tref.Name) == "Array" && !isSymbolIndexKey(key) {
+			unifyErrors := c.Unify(ctx, indexKey.Type, type_system.NewNumPrimType(nil))
+			errors = slices.Concat(errors, unifyErrors)
+			return tref.TypeArgs[0], errors
+		}
+
+		// Lazy substitution: find the property on the unsubstituted ObjectType
+		// and substitute only that property's type.
+		if propKey, ok := key.(PropertyKey); ok {
+			if memberType, found := c.lazyMemberLookup(ctx, tref, propKey.Name, mode); found {
+				return memberType, errors
+			}
+		}
+	}
+
 	// Check the cross-call expansion cache for TypeRefTypes with fully-concrete
 	// type args. This avoids redundant ExpandType calls when the same concrete
 	// TypeRefType is accessed multiple times (e.g. obj.x, obj.y on the same type). (#453)
@@ -702,25 +725,8 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 		// For mutable types, get the access from the inner type
 		return c.getMemberType(ctx, t.Type, key, mode)
 	case *type_system.TypeRefType:
-		// Handle Array numeric index access (skip symbol keys like Symbol.iterator)
-		if indexKey, ok := key.(IndexKey); ok && type_system.QualIdentToString(t.Name) == "Array" && !isSymbolIndexKey(key) {
-			unifyErrors := c.Unify(ctx, indexKey.Type, type_system.NewNumPrimType(nil))
-			errors = slices.Concat(errors, unifyErrors)
-			return t.TypeArgs[0], errors
-		}
-
-		// Lazy substitution (#461): for generic TypeRefTypes resolving to
-		// ObjectTypes, find the property on the unsubstituted ObjectType and
-		// substitute only that property's type. This turns the cost from
-		// O(all methods) into O(1) for single property lookups.
-		if propKey, ok := key.(PropertyKey); ok {
-			if memberType, found := c.lazyMemberLookup(ctx, t, propKey.Name, mode); found {
-				return memberType, errors
-			}
-		}
-
-		// Fallback: full expansion for index access, extends properties,
-		// symbol keys, or non-ObjectType aliases.
+		// Fallback for TypeRefTypes that the lazy path couldn't handle
+		// (index access, extends properties, symbol keys, non-ObjectType aliases).
 		expandType, expandErrors := c.expandTypeRef(ctx, t)
 		accessType, accessErrors := c.getMemberType(ctx, expandType, key, mode)
 
@@ -1025,6 +1031,7 @@ func (c *Checker) lazyMemberLookup(ctx Context, t *type_system.TypeRefType, name
 		alias:    unsafe.Pointer(typeAlias),
 		typeArgs: typeArgKey(t.TypeArgs),
 		member:   name,
+		mode:     mode,
 	}
 	if cached, exists := c.memberCache[cacheKey]; exists {
 		return cached, true

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1353,6 +1353,8 @@ const DEBUG = false
 // TODO: all interface declarations in a namespace to shadow previous ones.
 func (c *Checker) InferModule(ctx Context, m *ast.Module) []Error {
 	clear(c.expandCache) // Reset cross-call expansion cache for this inference pass
+	clear(c.substCache)  // Reset substitution cache for this inference pass
+	clear(c.memberCache) // Reset per-member substitution cache for this inference pass
 	errors := []Error{}
 
 	// Phase 1: Create file scopes and process imports for each file.

--- a/internal/checker/infer_script.go
+++ b/internal/checker/infer_script.go
@@ -8,6 +8,8 @@ import (
 
 func (c *Checker) InferScript(ctx Context, m *ast.Script) (*Scope, []Error) {
 	clear(c.expandCache) // Reset cross-call expansion cache for this inference pass
+	clear(c.substCache)  // Reset substitution cache for this inference pass
+	clear(c.memberCache) // Reset per-member substitution cache for this inference pass
 	errors := []Error{}
 	ctx = ctx.WithNewScope()
 

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -65,17 +65,21 @@ func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.
 
 		// Handle type arguments if they exist
 		if len(t.TypeArgs) > 0 {
-			newTypeArgs := make([]type_system.Type, len(t.TypeArgs))
-			changed := false
+			var newTypeArgs []type_system.Type
 			for i, arg := range t.TypeArgs {
 				newArg := arg.Accept(v)
-				newTypeArgs[i] = newArg
 				if newArg != arg {
-					changed = true
+					if newTypeArgs == nil {
+						newTypeArgs = make([]type_system.Type, len(t.TypeArgs))
+						copy(newTypeArgs[:i], t.TypeArgs[:i])
+					}
+				}
+				if newTypeArgs != nil {
+					newTypeArgs[i] = newArg
 				}
 			}
 
-			if changed {
+			if newTypeArgs != nil {
 				return type_system.NewTypeRefType(t.Provenance(), typeName, t.TypeAlias, newTypeArgs...)
 			}
 		}

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -80,7 +80,7 @@ func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.
 			}
 
 			if newTypeArgs != nil {
-				return type_system.NewTypeRefType(t.Provenance(), typeName, t.TypeAlias, newTypeArgs...)
+				return type_system.NewTypeRefTypeFromQualIdent(t.Provenance(), t.Name, t.TypeAlias, newTypeArgs...)
 			}
 		}
 	}

--- a/internal/checker/tests/benchmark_test.go
+++ b/internal/checker/tests/benchmark_test.go
@@ -681,3 +681,48 @@ func BenchmarkComplexProject(b *testing.B) {
 		_ = c.InferModule(inferCtx, module)
 	}
 }
+
+// TestArrayTypeStructure verifies where Array's properties live (Elems vs Extends)
+// to inform lazy member lookup optimization decisions (#461).
+func TestArrayTypeStructure(t *testing.T) {
+	c := NewChecker()
+	scope := Prelude(c)
+	alias := scope.GetTypeAlias("Array")
+	if alias == nil {
+		t.Fatal("Array type alias not found")
+	}
+	objType, ok := type_system.Prune(alias.Type).(*type_system.ObjectType)
+	if !ok {
+		t.Fatalf("Array type is %T, not ObjectType", type_system.Prune(alias.Type))
+	}
+
+	// Array should be a nominal interface with many elements and no Extends.
+	if !objType.Nominal || !objType.Interface {
+		t.Errorf("expected Nominal=true, Interface=true; got Nominal=%v, Interface=%v",
+			objType.Nominal, objType.Interface)
+	}
+	if len(objType.Elems) == 0 {
+		t.Error("expected Array to have elements")
+	}
+
+	// Verify common properties are findable in direct Elems.
+	for _, name := range []string{"length", "indexOf", "join", "slice"} {
+		key := type_system.NewStrKey(name)
+		found := false
+		for _, elem := range objType.Elems {
+			switch e := elem.(type) {
+			case *type_system.PropertyElem:
+				if e.Name == key {
+					found = true
+				}
+			case *type_system.MethodElem:
+				if e.Name == key {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in Array's direct Elems", name)
+		}
+	}
+}

--- a/internal/checker/tests/getter_setter_test.go
+++ b/internal/checker/tests/getter_setter_test.go
@@ -191,6 +191,49 @@ func TestGetterSetterAccess(t *testing.T) {
 				"Unknown property 's' in object type A | B",
 			},
 		},
+		// Verify that the per-member lazy substitution cache (#461) separates
+		// read (getter) and write (setter) results. Without AccessMode in the
+		// cache key, reading a getter-only property could pollute the cache so
+		// that a subsequent write incorrectly succeeds (or vice versa).
+		"GenericClassGetterThenSetterCacheIsolation": {
+			input: `
+				class Box<T>(value: T) {
+					value,
+					get contents(self) -> T {
+						return self.value
+					},
+					set contents(mut self, v: T) {
+						self.value = v
+					},
+				}
+				val b: mut Box<number> = Box(1)
+				val c = b.contents
+				fn main() {
+					b.contents = 42
+				}
+			`,
+			expectedErrors: nil,
+		},
+		// The reverse order: write first, then read.
+		"GenericClassSetterThenGetterCacheIsolation": {
+			input: `
+				class Box<T>(value: T) {
+					value,
+					get contents(self) -> T {
+						return self.value
+					},
+					set contents(mut self, v: T) {
+						self.value = v
+					},
+				}
+				val b: mut Box<string> = Box("hello")
+				fn main() {
+					b.contents = "world"
+				}
+				val c: string = b.contents
+			`,
+			expectedErrors: nil,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -321,13 +321,19 @@ func (t *TypeRefType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
-	newTypeArgs := make([]Type, len(t.TypeArgs))
+	var newTypeArgs []Type
 	for i, arg := range t.TypeArgs {
 		newArg := arg.Accept(v)
 		if newArg != arg {
+			if newTypeArgs == nil {
+				newTypeArgs = make([]Type, len(t.TypeArgs))
+				copy(newTypeArgs[:i], t.TypeArgs[:i])
+			}
 			changed = true
 		}
-		newTypeArgs[i] = newArg
+		if newTypeArgs != nil {
+			newTypeArgs[i] = newArg
+		}
 	}
 
 	var result Type = t
@@ -896,17 +902,21 @@ func (t *FuncType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
-	newParams := make([]*FuncParam, len(t.Params))
+	var newParams []*FuncParam
 	for i, param := range t.Params {
 		newType := param.Type.Accept(v)
 		if newType != param.Type {
+			if newParams == nil {
+				newParams = make([]*FuncParam, len(t.Params))
+				copy(newParams[:i], t.Params[:i])
+			}
 			changed = true
 			newParams[i] = &FuncParam{
 				Pattern:  param.Pattern,
 				Type:     newType,
 				Optional: param.Optional,
 			}
-		} else {
+		} else if newParams != nil {
 			newParams[i] = param
 		}
 	}
@@ -929,10 +939,14 @@ func (t *FuncType) Accept(v TypeVisitor) Type {
 
 	var result Type = t
 	if changed {
+		params := t.Params
+		if newParams != nil {
+			params = newParams
+		}
 		result = NewFuncType(
 			t.provenance,
 			t.TypeParams,
-			newParams,
+			params,
 			newReturn,
 			newThrows,
 		)
@@ -1479,52 +1493,86 @@ func (t *ObjectType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
-	newElems := make([]ObjTypeElem, len(t.Elems))
+	var newElems []ObjTypeElem
 	for i, elem := range t.Elems {
 		newElem := elem.Accept(v)
 		if newElem != elem {
+			if newElems == nil {
+				newElems = make([]ObjTypeElem, len(t.Elems))
+				copy(newElems[:i], t.Elems[:i])
+			}
 			changed = true
 		}
-		newElems[i] = newElem
+		if newElems != nil {
+			newElems[i] = newElem
+		}
 	}
 
-	newExtends := make([]*TypeRefType, len(t.Extends))
+	var newExtends []*TypeRefType
 	for i, ext := range t.Extends {
 		if ext == nil {
-			newExtends[i] = nil
+			if newExtends != nil {
+				newExtends[i] = nil
+			}
 			continue
 		}
 		newExt := ext.Accept(v).(*TypeRefType)
 		if newExt != ext {
+			if newExtends == nil {
+				newExtends = make([]*TypeRefType, len(t.Extends))
+				copy(newExtends[:i], t.Extends[:i])
+			}
 			changed = true
 		}
-		newExtends[i] = newExt
+		if newExtends != nil {
+			newExtends[i] = newExt
+		}
 	}
 
-	newImplements := make([]*TypeRefType, len(t.Implements))
+	var newImplements []*TypeRefType
 	for i, impl := range t.Implements {
 		if impl == nil {
-			newImplements[i] = nil
+			if newImplements != nil {
+				newImplements[i] = nil
+			}
 			continue
 		}
 		newImpl := impl.Accept(v).(*TypeRefType)
 		if newImpl != impl {
+			if newImplements == nil {
+				newImplements = make([]*TypeRefType, len(t.Implements))
+				copy(newImplements[:i], t.Implements[:i])
+			}
 			changed = true
 		}
-		newImplements[i] = newImpl
+		if newImplements != nil {
+			newImplements[i] = newImpl
+		}
 	}
 
 	var result *ObjectType = t
 	if changed {
-		result = NewObjectType(t.provenance, newElems)
+		elems := t.Elems
+		if newElems != nil {
+			elems = newElems
+		}
+		extends := t.Extends
+		if newExtends != nil {
+			extends = newExtends
+		}
+		implements := t.Implements
+		if newImplements != nil {
+			implements = newImplements
+		}
+		result = NewObjectType(t.provenance, elems)
 		result.ID = t.ID
 		result.Exact = t.Exact
 		result.Immutable = t.Immutable
 		result.Mutable = t.Mutable
 		result.Nominal = t.Nominal
 		result.Interface = t.Interface
-		result.Extends = newExtends
-		result.Implements = newImplements
+		result.Extends = extends
+		result.Implements = implements
 		result.SymbolKeyMap = t.SymbolKeyMap
 		result.Open = t.Open
 		result.MatchedUnionMembers = t.MatchedUnionMembers
@@ -1750,13 +1798,19 @@ func (t *TupleType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
-	newElems := make([]Type, len(t.Elems))
+	var newElems []Type
 	for i, elem := range t.Elems {
 		newElem := elem.Accept(v)
 		if newElem != elem {
+			if newElems == nil {
+				newElems = make([]Type, len(t.Elems))
+				copy(newElems[:i], t.Elems[:i])
+			}
 			changed = true
 		}
-		newElems[i] = newElem
+		if newElems != nil {
+			newElems[i] = newElem
+		}
 	}
 
 	var result Type = t
@@ -1992,13 +2046,19 @@ func (t *UnionType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
-	newTypes := make([]Type, len(t.Types))
+	var newTypes []Type
 	for i, typ := range t.Types {
 		newType := typ.Accept(v)
 		if newType != typ {
+			if newTypes == nil {
+				newTypes = make([]Type, len(t.Types))
+				copy(newTypes[:i], t.Types[:i])
+			}
 			changed = true
 		}
-		newTypes[i] = newType
+		if newTypes != nil {
+			newTypes[i] = newType
+		}
 	}
 
 	var result Type = t
@@ -2206,13 +2266,19 @@ func (t *IntersectionType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
-	newTypes := make([]Type, len(t.Types))
+	var newTypes []Type
 	for i, typ := range t.Types {
 		newType := typ.Accept(v)
 		if newType != typ {
+			if newTypes == nil {
+				newTypes = make([]Type, len(t.Types))
+				copy(newTypes[:i], t.Types[:i])
+			}
 			changed = true
 		}
-		newTypes[i] = newType
+		if newTypes != nil {
+			newTypes[i] = newType
+		}
 	}
 
 	var result Type = t
@@ -2602,18 +2668,28 @@ func (t *ExtractorType) Accept(v TypeVisitor) Type {
 
 	newExtractor := t.Extractor.Accept(v)
 	changed := newExtractor != t.Extractor
-	newArgs := make([]Type, len(t.Args))
+	var newArgs []Type
 	for i, arg := range t.Args {
 		newArg := arg.Accept(v)
 		if newArg != arg {
+			if newArgs == nil {
+				newArgs = make([]Type, len(t.Args))
+				copy(newArgs[:i], t.Args[:i])
+			}
 			changed = true
 		}
-		newArgs[i] = newArg
+		if newArgs != nil {
+			newArgs[i] = newArg
+		}
 	}
 
 	var result Type = t
 	if changed {
-		result = NewExtractorType(t.provenance, newExtractor, newArgs...)
+		args := t.Args
+		if newArgs != nil {
+			args = newArgs
+		}
+		result = NewExtractorType(t.provenance, newExtractor, args...)
 	}
 
 	if visitResult := v.ExitType(result); visitResult != nil {
@@ -2684,18 +2760,28 @@ func (t *TemplateLitType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
-	newTypes := make([]Type, len(t.Types))
+	var newTypes []Type
 	for i, typ := range t.Types {
 		newType := typ.Accept(v)
 		if newType != typ {
+			if newTypes == nil {
+				newTypes = make([]Type, len(t.Types))
+				copy(newTypes[:i], t.Types[:i])
+			}
 			changed = true
 		}
-		newTypes[i] = newType
+		if newTypes != nil {
+			newTypes[i] = newType
+		}
 	}
 
 	var result Type = t
 	if changed {
-		result = NewTemplateLitType(t.provenance, t.Quasis, newTypes)
+		types := t.Types
+		if newTypes != nil {
+			types = newTypes
+		}
+		result = NewTemplateLitType(t.provenance, t.Quasis, types)
 	}
 
 	if visitResult := v.ExitType(result); visitResult != nil {


### PR DESCRIPTION
## Summary

- **Optimization 1 — Substitution cache**: Cache `SubstituteTypeParams` results in `expandTypeRef` keyed on `(TypeAlias pointer, type args)`, eliminating redundant full-ObjectType substitutions for the same generic instantiation across an inference pass
- **Optimization 2 — Lazy per-member substitution**: `lazyMemberLookup` finds the property on the *unsubstituted* ObjectType and substitutes only that member's type, turning property access from O(all methods) to O(1). Results are cached in a per-member `memberCache` for repeated accesses
- **Optimization 3 — Deferred allocations in Accept**: All composite `Accept` methods (`FuncType`, `ObjectType`, `TypeRefType`, `TupleType`, `UnionType`, `IntersectionType`, `ExtractorType`, `TemplateLitType`) now use copy-on-write — slices are only allocated when a child actually changes

### Benchmark results (`BenchmarkRepeatedGenericPropertyAccess`)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| ns/op | 1,667,000 | ~140,000 | **~12x faster** |
| B/op | 1,879,381 | ~144,600 | **~13x less memory** |
| allocs/op | 37,262 | ~2,654 | **~14x fewer allocations** |

## Test plan

- [x] All 18 packages pass (`go test ./...`)
- [x] Benchmark confirms performance improvement
- [x] `TestArrayTypeStructure` validates lazy lookup assumptions about Array's type structure

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Added caching for type parameter substitutions to reduce redundant computations.
  * Implemented lazy member lookups for generic type aliases.
  * Optimized memory allocation in type argument handling.

* **Bug Fixes**
  * Improved type argument substitution handling in type reference processing.

* **Tests**
  * Added validation test for type structure verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->