### PR TITLE
Fix expandMappedElems panic on infinite key types (#456)

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -396,6 +396,9 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 					// For mapped types, return the constraint type
 					// e.g., keyof {[K]: T[K] for K in Keys} -> Keys
 					return e.TypeParam.Constraint
+				case *type_system.IndexSignatureElem:
+					// keyof {[key: string]: T} -> string
+					keys = append(keys, e.KeyType)
 				case *type_system.RestSpreadElem:
 					// For rest spread, recursively get keyof the spread type
 					spreadKeys, _ := v.checker.ExpandType(v.ctx, type_system.NewKeyOfType(nil, e.Value), -1)
@@ -1067,6 +1070,18 @@ func (c *Checker) lazyMemberLookup(ctx Context, t *type_system.TypeRefType, name
 		}
 	}
 
+	// If not found by name, check for a matching index signature.
+	if memberType == nil {
+		for _, elem := range objType.Elems {
+			if idxSig, ok := elem.(*type_system.IndexSignatureElem); ok {
+				if prim, ok := idxSig.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.StrPrim {
+					memberType = idxSig.Value
+					break
+				}
+			}
+		}
+	}
+
 	if memberType == nil {
 		// Not found in direct Elems; fall back so the full expansion can
 		// check Extends, RestSpreadElem, etc.
@@ -1120,6 +1135,10 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					if len(spreadErrors) == 0 {
 						return spreadType, errors
 					}
+				}
+			case *type_system.IndexSignatureElem:
+				if prim, ok := elem.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.StrPrim {
+					return elem.Value, errors
 				}
 			case *type_system.MappedElem:
 				panic("MappedElems should have been expanded before property access")
@@ -1206,6 +1225,10 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						if elem.Name == targetKey && mode == AccessWrite {
 							return elem.Fn.Params[0].Type, errors
 						}
+					case *type_system.IndexSignatureElem:
+						if prim, ok := elem.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.StrPrim {
+							return elem.Value, errors
+						}
 					case *type_system.RestSpreadElem:
 						if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
 							spreadType, spreadErrors := c.getObjectAccess(resolvedObj, key, mode, nil)
@@ -1252,6 +1275,10 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				case *type_system.SetterElem:
 					if elem.Name == symKey && mode == AccessWrite {
 						return elem.Fn.Params[0].Type, errors
+					}
+				case *type_system.IndexSignatureElem:
+					if prim, ok := elem.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.SymbolPrim {
+						return elem.Value, errors
 					}
 				case *type_system.RestSpreadElem:
 					if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
@@ -1739,11 +1766,8 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 
 // expandMappedElems expands MappedElem elements in an ObjectType into concrete properties.
 // For example, {[P in "foo" | "bar"]: string} becomes {foo: string, bar: string}.
-//
-// TODO(#456): This function only handles finite, enumerable key sets (string/number
-// literals, symbols). It panics when the constraint is a primitive type like `string`
-// or `number` (e.g. Record<string, T> which expands to {[P in string]: T}). Supporting
-// infinite key types requires adding an index signature representation to the type system.
+// When the constraint is a primitive type like `string` or `number` (e.g. Record<string, T>),
+// an IndexSignatureElem is emitted instead of enumerating keys.
 func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType) *type_system.ObjectType {
 	// Check if there are any MappedElem elements to expand
 	hasMappedElems := false
@@ -1774,9 +1798,34 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 				keys = []type_system.Type{constraint}
 			}
 
-			// For each key in the constraint, create a property
+			// For each key in the constraint, create a property or index signature
 			for _, keyType := range keys {
 				keyType = type_system.Prune(keyType)
+
+				// If the key type is a primitive (string, number, symbol), emit an
+				// IndexSignatureElem — we cannot enumerate an infinite key space.
+				if primType, ok := keyType.(*type_system.PrimType); ok {
+					switch primType.Prim {
+					case type_system.StrPrim, type_system.NumPrim, type_system.SymbolPrim:
+						propValue := SubstituteTypeParams(mappedElem.Value, map[string]type_system.Type{
+							mappedElem.TypeParam.Name: keyType,
+						})
+						// Note: we intentionally do NOT call ExpandType on propValue here.
+						// For recursive types like Json = ... | Record<string, Json>,
+						// expanding would trigger infinite recursion. The value type
+						// will be expanded lazily when accessed.
+						readonly := false
+						if mappedElem.Readonly != nil && *mappedElem.Readonly == type_system.MMAdd {
+							readonly = true
+						}
+						expandedElems = append(expandedElems, &type_system.IndexSignatureElem{
+							KeyType:  keyType,
+							Value:    propValue,
+							Readonly: readonly,
+						})
+						continue
+					}
+				}
 
 				// Substitute the type parameter with the key type
 				keySubs := map[string]type_system.Type{

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1256,6 +1256,8 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					return indexSigFallback, errors
 				}
 			}
+
+			// Handle numeric literal keys (e.g. m[n] where n: 5).
 			if numLit, ok := indexLit.Lit.(*type_system.NumLit); ok {
 				// Numeric literal index — check for numeric-keyed properties and
 				// numeric index signatures, falling back to string index signatures
@@ -1300,8 +1302,12 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				}
 			}
 		}
+
 		// Handle numeric primitive keys (e.g. m[n] where n: number).
+		// Prefer the numeric index signature; fall back to string (TypeScript
+		// coerces numeric keys to strings, so a string sig also applies).
 		if primType, ok := keyType.(*type_system.PrimType); ok && primType.Prim == type_system.NumPrim {
+			var strSigFallback type_system.Type
 			for _, elem := range objType.Elems {
 				if sig, ok := elem.(*type_system.IndexSignatureElem); ok {
 					if prim, ok := sig.KeyType.(*type_system.PrimType); ok {
@@ -1309,12 +1315,16 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 							return sig.Value, errors
 						}
 						if prim.Prim == type_system.StrPrim {
-							return sig.Value, errors
+							strSigFallback = sig.Value
 						}
 					}
 				}
 			}
+			if strSigFallback != nil {
+				return strSigFallback, errors
+			}
 		}
+
 		// Handle string primitive keys (e.g. m[s] where s: string).
 		if primType, ok := keyType.(*type_system.PrimType); ok && primType.Prim == type_system.StrPrim {
 			for _, elem := range objType.Elems {
@@ -1325,6 +1335,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				}
 			}
 		}
+
 		// Handle unique symbol keys (e.g. Symbol.iterator).
 		// Search in reverse order for override semantics, and check
 		// RestSpreadElems so that symbol-keyed properties from spread

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1107,6 +1107,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		// earlier ones. This respects JavaScript spread semantics where
 		// {a: 1, ...{a: 2}} yields a=2 and {...{a: 1}, a: 2} yields a=2.
 		targetKey := type_system.NewStrKey(k.Name)
+		var indexSigFallback type_system.Type
 		for i := len(objType.Elems) - 1; i >= 0; i-- {
 			switch elem := objType.Elems[i].(type) {
 			case *type_system.PropertyElem:
@@ -1138,7 +1139,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				}
 			case *type_system.IndexSignatureElem:
 				if prim, ok := elem.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.StrPrim {
-					return elem.Value, errors
+					indexSigFallback = elem.Value
 				}
 			case *type_system.MappedElem:
 				panic("MappedElems should have been expanded before property access")
@@ -1148,6 +1149,11 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 			default:
 				panic(fmt.Sprintf("Unknown object type element: %#v", elem))
 			}
+		}
+
+		// If no explicit member matched but an index signature did, return it.
+		if indexSigFallback != nil {
+			return indexSigFallback, errors
 		}
 
 		// Check the Extends field if property not found.
@@ -1203,6 +1209,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 			if strLit, ok := indexLit.Lit.(*type_system.StrLit); ok {
 				// Search in reverse order for override semantics (same as PropertyKey).
 				targetKey := type_system.NewStrKey(strLit.Value)
+				var indexSigFallback type_system.Type
 				for i := len(objType.Elems) - 1; i >= 0; i-- {
 					switch elem := objType.Elems[i].(type) {
 					case *type_system.PropertyElem:
@@ -1227,7 +1234,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						}
 					case *type_system.IndexSignatureElem:
 						if prim, ok := elem.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.StrPrim {
-							return elem.Value, errors
+							indexSigFallback = elem.Value
 						}
 					case *type_system.RestSpreadElem:
 						if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
@@ -1245,6 +1252,77 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						panic(fmt.Sprintf("Unknown object type element: %#v", elem))
 					}
 				}
+				if indexSigFallback != nil {
+					return indexSigFallback, errors
+				}
+			}
+			if numLit, ok := indexLit.Lit.(*type_system.NumLit); ok {
+				// Numeric literal index — check for numeric-keyed properties and
+				// numeric index signatures, falling back to string index signatures
+				// per TypeScript's numeric-to-string coercion rules.
+				targetKey := type_system.NewNumKey(numLit.Value)
+				var numSigFallback type_system.Type
+				var strSigFallback type_system.Type
+				for i := len(objType.Elems) - 1; i >= 0; i-- {
+					switch elem := objType.Elems[i].(type) {
+					case *type_system.PropertyElem:
+						if elem.Name == targetKey {
+							propType := elem.Value
+							if elem.Optional {
+								propType = type_system.NewUnionType(nil, propType, type_system.NewUndefinedType(nil))
+							}
+							return propType, errors
+						}
+					case *type_system.IndexSignatureElem:
+						if prim, ok := elem.KeyType.(*type_system.PrimType); ok {
+							if prim.Prim == type_system.NumPrim {
+								numSigFallback = elem.Value
+							} else if prim.Prim == type_system.StrPrim {
+								strSigFallback = elem.Value
+							}
+						}
+					case *type_system.RestSpreadElem:
+						if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
+							spreadType, spreadErrors := c.getObjectAccess(resolvedObj, key, mode, nil)
+							if len(spreadErrors) == 0 {
+								return spreadType, errors
+							}
+						}
+					default:
+						continue
+					}
+				}
+				if numSigFallback != nil {
+					return numSigFallback, errors
+				}
+				if strSigFallback != nil {
+					return strSigFallback, errors
+				}
+			}
+		}
+		// Handle numeric primitive keys (e.g. m[n] where n: number).
+		if primType, ok := keyType.(*type_system.PrimType); ok && primType.Prim == type_system.NumPrim {
+			for _, elem := range objType.Elems {
+				if sig, ok := elem.(*type_system.IndexSignatureElem); ok {
+					if prim, ok := sig.KeyType.(*type_system.PrimType); ok {
+						if prim.Prim == type_system.NumPrim {
+							return sig.Value, errors
+						}
+						if prim.Prim == type_system.StrPrim {
+							return sig.Value, errors
+						}
+					}
+				}
+			}
+		}
+		// Handle string primitive keys (e.g. m[s] where s: string).
+		if primType, ok := keyType.(*type_system.PrimType); ok && primType.Prim == type_system.StrPrim {
+			for _, elem := range objType.Elems {
+				if sig, ok := elem.(*type_system.IndexSignatureElem); ok {
+					if prim, ok := sig.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.StrPrim {
+						return sig.Value, errors
+					}
+				}
 			}
 		}
 		// Handle unique symbol keys (e.g. Symbol.iterator).
@@ -1254,6 +1332,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		// are found.
 		if symType, ok := keyType.(*type_system.UniqueSymbolType); ok {
 			symKey := type_system.NewSymKey(symType.Value)
+			var indexSigFallback type_system.Type
 			for i := len(objType.Elems) - 1; i >= 0; i-- {
 				switch elem := objType.Elems[i].(type) {
 				case *type_system.PropertyElem:
@@ -1278,7 +1357,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					}
 				case *type_system.IndexSignatureElem:
 					if prim, ok := elem.KeyType.(*type_system.PrimType); ok && prim.Prim == type_system.SymbolPrim {
-						return elem.Value, errors
+						indexSigFallback = elem.Value
 					}
 				case *type_system.RestSpreadElem:
 					if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
@@ -1294,6 +1373,9 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				default:
 					continue
 				}
+			}
+			if indexSigFallback != nil {
+				return indexSigFallback, errors
 			}
 		}
 
@@ -1818,11 +1900,9 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 						if mappedElem.Readonly != nil && *mappedElem.Readonly == type_system.MMAdd {
 							readonly = true
 						}
-						expandedElems = append(expandedElems, &type_system.IndexSignatureElem{
-							KeyType:  keyType,
-							Value:    propValue,
-							Readonly: readonly,
-						})
+						expandedElems = append(expandedElems, type_system.NewIndexSignatureElem(
+							keyType, propValue, readonly,
+						))
 						continue
 					}
 				}

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -285,11 +285,11 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 					Extends:   c.deepCloneType(e.Extends, varMapping),
 				}
 			case *type_system.IndexSignatureElem:
-				elems[i] = &type_system.IndexSignatureElem{
-					KeyType:  c.deepCloneType(e.KeyType, varMapping),
-					Value:    c.deepCloneType(e.Value, varMapping),
-					Readonly: e.Readonly,
-				}
+				elems[i] = type_system.NewIndexSignatureElem(
+					c.deepCloneType(e.KeyType, varMapping),
+					c.deepCloneType(e.Value, varMapping),
+					e.Readonly,
+				)
 			default:
 				elems[i] = elem
 			}

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -77,6 +77,9 @@ func collectUnresolvedTypeVars(
 				if e.TypeParam != nil {
 					collectUnresolvedTypeVars(e.TypeParam.Constraint, vars, order)
 				}
+			case *type_system.IndexSignatureElem:
+				collectUnresolvedTypeVars(e.KeyType, vars, order)
+				collectUnresolvedTypeVars(e.Value, vars, order)
 			}
 		}
 	case *type_system.TupleType:
@@ -280,6 +283,12 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 					Readonly:  e.Readonly,
 					Check:     c.deepCloneType(e.Check, varMapping),
 					Extends:   c.deepCloneType(e.Extends, varMapping),
+				}
+			case *type_system.IndexSignatureElem:
+				elems[i] = &type_system.IndexSignatureElem{
+					KeyType:  c.deepCloneType(e.KeyType, varMapping),
+					Value:    c.deepCloneType(e.Value, varMapping),
+					Readonly: e.Readonly,
 				}
 			default:
 				elems[i] = elem

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1642,6 +1642,30 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"x": "number",
 			},
 		},
+		"RecordNumberTypeWithNumericPrimKey": {
+			input: `
+				type NumberMap = Record<number, number>
+				declare val m: NumberMap
+				declare val n: number
+				val x = m[n]
+			`,
+			expectedTypes: map[string]string{
+				"m": "NumberMap",
+				"x": "number",
+			},
+		},
+		"RecordStringTypeWithNumericPrimKey": {
+			input: `
+				type StringMap = Record<string, number>
+				declare val m: StringMap
+				declare val n: number
+				val x = m[n]
+			`,
+			expectedTypes: map[string]string{
+				"m": "StringMap",
+				"x": "number",
+			},
+		},
 		"RecordSymbolType": {
 			input: `
 				type SymbolMap = Record<symbol, number>

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1594,19 +1594,22 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"b":  "B",
 			},
 		},
-		// TODO(#456): Record<string, Json> panics in expandMappedElems because
-		// it can't enumerate keys from the `string` primitive type. Once #456
-		// is fixed, add Record<string, Json> back to the Json union and include
-		// object literal values like { name: "test", scores: [1, 2, 3] }.
 		"RecursiveJsonLikeType": {
 			input: `
-				type Json = string | number | boolean | null | Array<Json>
+				type Json = string | number | boolean | null | Array<Json> | Record<string, Json>
 				val j: Json = "hello"
 				val j2: Json = 42
 				val j3: Json = true
 				val j4: Json = null
 				val j5: Json = [1, 2, 3]
 				val j6: Json = ["nested", [1, [true, [null, ["deep"]]]]]
+				// TODO(#463): object literals against recursive unions hang due to
+				// infinite expansion of recursive type args in expandSeen. The
+				// typeArgKey grows unboundedly (Array<R> → Array<string|Array<R>>
+				// → ...) so cycle detection never triggers. This affects any
+				// recursive type alias with generic members (e.g. Array<Json>),
+				// not just Record. See json_unify_debug_test.go for analysis.
+				// val j7: Json = { names: ["alice", "bob"], scores: [1, 2, 3] }
 			`,
 			expectedTypes: map[string]string{
 				"j":  "Json",
@@ -1615,6 +1618,17 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"j4": "Json",
 				"j5": "Json",
 				"j6": "Json",
+			},
+		},
+		"RecordStringType": {
+			input: `
+				type StringMap = Record<string, number>
+				declare val m: StringMap
+				val x = m.foo
+			`,
+			expectedTypes: map[string]string{
+				"m": "StringMap",
+				"x": "number",
 			},
 		},
 		"CycleDetectionSameTypeAssignment": {

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1631,6 +1631,29 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"x": "number",
 			},
 		},
+		"RecordNumberType": {
+			input: `
+				type NumberMap = Record<number, number>
+				declare val m: NumberMap
+				val x = m[1]
+			`,
+			expectedTypes: map[string]string{
+				"m": "NumberMap",
+				"x": "number",
+			},
+		},
+		"RecordSymbolType": {
+			input: `
+				type SymbolMap = Record<symbol, number>
+				declare val m: SymbolMap
+				declare val s: unique symbol
+				val x = m[s]
+			`,
+			expectedTypes: map[string]string{
+				"m": "SymbolMap",
+				"x": "number",
+			},
+		},
 		"CycleDetectionSameTypeAssignment": {
 			input: `
 				type List<T> = { head: T, tail: List<T> | null }

--- a/internal/checker/tests/unify_test.go
+++ b/internal/checker/tests/unify_test.go
@@ -894,9 +894,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(ctx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		resolved := type_system.Prune(tv)
-		assert.IsType(t, &type_system.PrimType{}, resolved)
-		assert.Equal(t, type_system.NumPrim, resolved.(*type_system.PrimType).Prim,
+		assert.Equal(t, "number", type_system.Prune(tv).String(),
 			"numeric key should resolve to number via numeric index signature")
 	})
 
@@ -917,9 +915,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(ctx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		resolved := type_system.Prune(tv)
-		assert.IsType(t, &type_system.PrimType{}, resolved)
-		assert.Equal(t, type_system.NumPrim, resolved.(*type_system.PrimType).Prim,
+		assert.Equal(t, "number", type_system.Prune(tv).String(),
 			"numeric key should resolve to number regardless of signature declaration order")
 	})
 
@@ -939,9 +935,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(ctx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		resolved := type_system.Prune(tv)
-		assert.IsType(t, &type_system.PrimType{}, resolved)
-		assert.Equal(t, type_system.NumPrim, resolved.(*type_system.PrimType).Prim,
+		assert.Equal(t, "number", type_system.Prune(tv).String(),
 			"string key should match string index signature")
 	})
 
@@ -960,9 +954,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(ctx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		resolved := type_system.Prune(tv)
-		assert.IsType(t, &type_system.PrimType{}, resolved)
-		assert.Equal(t, type_system.StrPrim, resolved.(*type_system.PrimType).Prim,
+		assert.Equal(t, "string", type_system.Prune(tv).String(),
 			"numeric key should fall back to string index signature when no numeric sig exists")
 	})
 

--- a/internal/checker/tests/unify_test.go
+++ b/internal/checker/tests/unify_test.go
@@ -747,10 +747,8 @@ func TestUnifyOpenClosedIndexSignatureDedup(t *testing.T) {
 	ctx := Context{Scope: Prelude(checker), IsAsync: false, IsPatMatch: false}
 
 	t.Run("duplicate string index signatures are unified not duplicated", func(t *testing.T) {
-		// Escalier:
-		//   type Open = Record<string, T>   // open, T is a type variable
-		//   type Closed = Record<string, number>
-		//   val x: Open = ... as Closed
+		// openObj:   {[key: string]: T}       (open, T is a type variable)
+		// closedObj: {[key: string]: number}
 		tv := type_system.NewTypeVarType(nil, 0)
 		openObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			type_system.NewIndexSignatureElem(
@@ -789,10 +787,8 @@ func TestUnifyOpenClosedIndexSignatureDedup(t *testing.T) {
 	})
 
 	t.Run("compatible numeric and string index sigs are copied", func(t *testing.T) {
-		// Escalier:
-		//   type Open = Record<string, number>      // open
-		//   type Closed = Record<number, number>
-		//   val x: Open = ... as Closed
+		// openObj:   {[key: string]: number}   (open)
+		// closedObj: {[index: number]: number}
 		//
 		// TypeScript requires that when both [key: string] and [index: number]
 		// exist, the numeric value type must be a subtype of the string value
@@ -829,10 +825,8 @@ func TestUnifyOpenClosedIndexSignatureDedup(t *testing.T) {
 	})
 
 	t.Run("closed-vs-open direction also deduplicates", func(t *testing.T) {
-		// Escalier:
-		//   type Closed = Record<string, number>
-		//   type Open = Record<string, T>   // open, T is a type variable
-		//   val x: Closed = ... as Open
+		// closedObj: {[key: string]: number}
+		// openObj:   {[key: string]: T}       (open, T is a type variable)
 		closedObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			type_system.NewIndexSignatureElem(
 				type_system.NewStrPrimType(nil),
@@ -884,9 +878,9 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 	ctx := Context{Scope: Prelude(checker), IsAsync: false, IsPatMatch: false}
 
 	t.Run("numeric key matches when num sig declared first", func(t *testing.T) {
-		// num sig declared first in the elems list, e.g.
-		//   val obj1: {0: T} = ...
-		//   val obj2: Record<number, number> & Record<string, number> = ...
+		// obj1: {0: T}
+		// obj2: {[index: number]: number, [key: string]: number}
+		//   (num sig declared first in the elems list)
 		tv := type_system.NewTypeVarType(nil, 0)
 		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
@@ -907,9 +901,9 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 	})
 
 	t.Run("numeric key matches when str sig declared first", func(t *testing.T) {
-		// str sig declared first in the elems list (reversed order)
-		//   val obj1: {0: T} = ...
-		//   val obj2: Record<string, number> & Record<number, number> = ...
+		// obj1: {0: T}
+		// obj2: {[key: string]: number, [index: number]: number}
+		//   (str sig declared first in the elems list)
 		tv := type_system.NewTypeVarType(nil, 0)
 		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
@@ -930,8 +924,8 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 	})
 
 	t.Run("string key matches string sig", func(t *testing.T) {
-		//   val obj1: {foo: T} = ...
-		//   val obj2: Record<number, number> & Record<string, number> = ...
+		// obj1: {foo: T}
+		// obj2: {[index: number]: number, [key: string]: number}
 		tv := type_system.NewTypeVarType(nil, 0)
 		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			type_system.NewPropertyElem(type_system.NewStrKey("foo"), tv),
@@ -952,9 +946,8 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 	})
 
 	t.Run("numeric key falls back to string sig when no numeric sig", func(t *testing.T) {
-		//   val obj1: {0: T} = ...
-		//   type Obj2 = Record<string, string>
-		//   val obj2: Obj2 = ...
+		// obj1: {0: T}
+		// obj2: {[key: string]: string}
 		tv := type_system.NewTypeVarType(nil, 0)
 		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
@@ -974,11 +967,12 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 	})
 
 	t.Run("incompatible dual index signatures produce error", func(t *testing.T) {
+		// obj1: {0: T}
+		// obj2: {[index: number]: boolean, [key: string]: string}
+		//
 		// TypeScript forbids this combination because boolean is not a subtype
 		// of string. Since obj[1] === obj["1"] in JavaScript, both signatures
 		// apply to numeric keys and their value types must be compatible.
-		//   val obj1: {0: T} = ...
-		//   val obj2: Record<number, boolean> & Record<string, string> = ...
 		tv := type_system.NewTypeVarType(nil, 0)
 		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
@@ -991,5 +985,60 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 
 		errors := checker.Unify(ctx, obj1, obj2)
 		assert.NotEmpty(t, errors, "incompatible dual index signatures should produce an error for numeric keys")
+	})
+
+	t.Run("cross-object incompatible numeric and string sigs produce error", func(t *testing.T) {
+		// obj1: {[index: number]: boolean}
+		// obj2: {[key: string]: string}
+		//
+		// The numeric sig is on obj1 and the string sig is on obj2.
+		// Even though neither object individually has both, the cross-object
+		// check should still enforce that the numeric value (boolean) is
+		// compatible with the string value (string).
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewNumPrimType(nil), type_system.NewBoolPrimType(nil), false),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewStrPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.NotEmpty(t, errors, "cross-object incompatible numeric/string index signatures should produce an error")
+	})
+
+	t.Run("cross-object compatible numeric and string sigs succeed", func(t *testing.T) {
+		// obj1: {[index: number]: number}
+		// obj2: {[key: string]: number}
+		//
+		// The numeric sig is on obj1 and the string sig is on obj2, but
+		// their value types are compatible (both number).
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewNumPrimType(nil), type_system.NewNumPrimType(nil), false),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewNumPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.Empty(t, errors, "cross-object compatible numeric/string index signatures should succeed")
+	})
+
+	t.Run("cross-object reversed direction also checked", func(t *testing.T) {
+		// obj1: {[key: string]: string}
+		// obj2: {[index: number]: boolean}
+		//
+		// String sig on obj1, numeric sig on obj2, incompatible values.
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewStrPrimType(nil), false),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewNumPrimType(nil), type_system.NewBoolPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.NotEmpty(t, errors, "cross-object check should work regardless of which side has the numeric sig")
 	})
 }

--- a/internal/checker/tests/unify_test.go
+++ b/internal/checker/tests/unify_test.go
@@ -741,3 +741,255 @@ func TestUnifyTypeVarNotCorruptedByFailedIntersectionTrial(t *testing.T) {
 		assert.Equal(t, type_system.StrPrim, prim.Prim, "TypeVar should be bound to string, not number")
 	})
 }
+
+func TestUnifyOpenClosedIndexSignatureDedup(t *testing.T) {
+	checker := NewChecker()
+	ctx := Context{Scope: Prelude(checker), IsAsync: false, IsPatMatch: false}
+
+	t.Run("duplicate string index signatures are unified not duplicated", func(t *testing.T) {
+		// Escalier:
+		//   type Open = Record<string, T>   // open, T is a type variable
+		//   type Closed = Record<string, number>
+		//   val x: Open = ... as Closed
+		tv := type_system.NewTypeVarType(nil, 0)
+		openObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(
+				type_system.NewStrPrimType(nil),
+				tv,
+				false,
+			),
+		})
+		openObj.Open = true
+
+		closedObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(
+				type_system.NewStrPrimType(nil),
+				type_system.NewNumPrimType(nil),
+				false,
+			),
+		})
+
+		errors := checker.Unify(ctx, openObj, closedObj)
+		assert.Empty(t, errors, "unifying matching index signatures should not produce errors")
+
+		// The type variable should be bound to number
+		resolved := type_system.Prune(tv)
+		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to number")
+		prim := resolved.(*type_system.PrimType)
+		assert.Equal(t, type_system.NumPrim, prim.Prim)
+
+		// The open object should NOT have a duplicate index signature appended
+		indexSigCount := 0
+		for _, elem := range openObj.Elems {
+			if _, ok := elem.(*type_system.IndexSignatureElem); ok {
+				indexSigCount++
+			}
+		}
+		assert.Equal(t, 1, indexSigCount, "open object should have exactly one index signature, not a duplicate")
+	})
+
+	t.Run("compatible numeric and string index sigs are copied", func(t *testing.T) {
+		// Escalier:
+		//   type Open = Record<string, number>      // open
+		//   type Closed = Record<number, number>
+		//   val x: Open = ... as Closed
+		//
+		// TypeScript requires that when both [key: string] and [index: number]
+		// exist, the numeric value type must be a subtype of the string value
+		// type (since obj[1] === obj["1"]). Here we use number for both which
+		// is valid.
+		openObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(
+				type_system.NewStrPrimType(nil),
+				type_system.NewNumPrimType(nil),
+				false,
+			),
+		})
+		openObj.Open = true
+
+		closedObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(
+				type_system.NewNumPrimType(nil),
+				type_system.NewNumPrimType(nil),
+				false,
+			),
+		})
+
+		errors := checker.Unify(ctx, openObj, closedObj)
+		assert.Empty(t, errors, "compatible index signature key kinds should not conflict")
+
+		// The open object should now have both index signatures
+		indexSigCount := 0
+		for _, elem := range openObj.Elems {
+			if _, ok := elem.(*type_system.IndexSignatureElem); ok {
+				indexSigCount++
+			}
+		}
+		assert.Equal(t, 2, indexSigCount, "open object should have both string and number index signatures")
+	})
+
+	t.Run("closed-vs-open direction also deduplicates", func(t *testing.T) {
+		// Escalier:
+		//   type Closed = Record<string, number>
+		//   type Open = Record<string, T>   // open, T is a type variable
+		//   val x: Closed = ... as Open
+		closedObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(
+				type_system.NewStrPrimType(nil),
+				type_system.NewNumPrimType(nil),
+				false,
+			),
+		})
+
+		tv := type_system.NewTypeVarType(nil, 0)
+		openObj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(
+				type_system.NewStrPrimType(nil),
+				tv,
+				false,
+			),
+		})
+		openObj.Open = true
+
+		errors := checker.Unify(ctx, closedObj, openObj)
+		assert.Empty(t, errors, "unifying matching index signatures should not produce errors")
+
+		// The type variable should be bound to number
+		resolved := type_system.Prune(tv)
+		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to number")
+		prim := resolved.(*type_system.PrimType)
+		assert.Equal(t, type_system.NumPrim, prim.Prim)
+
+		// The open object should NOT have a duplicate index signature
+		indexSigCount := 0
+		for _, elem := range openObj.Elems {
+			if _, ok := elem.(*type_system.IndexSignatureElem); ok {
+				indexSigCount++
+			}
+		}
+		assert.Equal(t, 1, indexSigCount, "open object should have exactly one index signature")
+	})
+}
+
+func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
+	// These tests exercise findIndexSignatureForKey indirectly through Unify.
+	//
+	// TypeScript requires that when both [key: string]: S and [index: number]: N
+	// exist, N must be a subtype of S (since obj[1] === obj["1"]). We use
+	// number for both value types here so the combination is valid, and
+	// distinguish them by binding a type variable against each signature
+	// independently to confirm which one was matched.
+
+	checker := NewChecker()
+	ctx := Context{Scope: Prelude(checker), IsAsync: false, IsPatMatch: false}
+
+	t.Run("numeric key matches when num sig declared first", func(t *testing.T) {
+		// num sig declared first in the elems list, e.g.
+		//   val obj1: {0: T} = ...
+		//   val obj2: Record<number, number> & Record<string, number> = ...
+		tv := type_system.NewTypeVarType(nil, 0)
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewNumPrimType(nil), type_system.NewNumPrimType(nil), false),
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewNumPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.Empty(t, errors)
+
+		resolved := type_system.Prune(tv)
+		assert.IsType(t, &type_system.PrimType{}, resolved)
+		assert.Equal(t, type_system.NumPrim, resolved.(*type_system.PrimType).Prim,
+			"numeric key should resolve to number via numeric index signature")
+	})
+
+	t.Run("numeric key matches when str sig declared first", func(t *testing.T) {
+		// str sig declared first in the elems list (reversed order)
+		//   val obj1: {0: T} = ...
+		//   val obj2: Record<string, number> & Record<number, number> = ...
+		tv := type_system.NewTypeVarType(nil, 0)
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewNumPrimType(nil), false),
+			type_system.NewIndexSignatureElem(type_system.NewNumPrimType(nil), type_system.NewNumPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.Empty(t, errors)
+
+		resolved := type_system.Prune(tv)
+		assert.IsType(t, &type_system.PrimType{}, resolved)
+		assert.Equal(t, type_system.NumPrim, resolved.(*type_system.PrimType).Prim,
+			"numeric key should resolve to number regardless of signature declaration order")
+	})
+
+	t.Run("string key matches string sig", func(t *testing.T) {
+		//   val obj1: {foo: T} = ...
+		//   val obj2: Record<number, number> & Record<string, number> = ...
+		tv := type_system.NewTypeVarType(nil, 0)
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewPropertyElem(type_system.NewStrKey("foo"), tv),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewNumPrimType(nil), type_system.NewNumPrimType(nil), false),
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewNumPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.Empty(t, errors)
+
+		resolved := type_system.Prune(tv)
+		assert.IsType(t, &type_system.PrimType{}, resolved)
+		assert.Equal(t, type_system.NumPrim, resolved.(*type_system.PrimType).Prim,
+			"string key should match string index signature")
+	})
+
+	t.Run("numeric key falls back to string sig when no numeric sig", func(t *testing.T) {
+		//   val obj1: {0: T} = ...
+		//   type Obj2 = Record<string, string>
+		//   val obj2: Obj2 = ...
+		tv := type_system.NewTypeVarType(nil, 0)
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewStrPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.Empty(t, errors)
+
+		resolved := type_system.Prune(tv)
+		assert.IsType(t, &type_system.PrimType{}, resolved)
+		assert.Equal(t, type_system.StrPrim, resolved.(*type_system.PrimType).Prim,
+			"numeric key should fall back to string index signature when no numeric sig exists")
+	})
+
+	t.Run("incompatible dual index signatures produce error", func(t *testing.T) {
+		// TypeScript forbids this combination because boolean is not a subtype
+		// of string. Since obj[1] === obj["1"] in JavaScript, both signatures
+		// apply to numeric keys and their value types must be compatible.
+		//   val obj1: {0: T} = ...
+		//   val obj2: Record<number, boolean> & Record<string, string> = ...
+		tv := type_system.NewTypeVarType(nil, 0)
+		obj1 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewPropertyElem(type_system.NewNumKey(0), tv),
+		})
+
+		obj2 := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+			type_system.NewIndexSignatureElem(type_system.NewNumPrimType(nil), type_system.NewBoolPrimType(nil), false),
+			type_system.NewIndexSignatureElem(type_system.NewStrPrimType(nil), type_system.NewStrPrimType(nil), false),
+		})
+
+		errors := checker.Unify(ctx, obj1, obj2)
+		assert.NotEmpty(t, errors, "incompatible dual index signatures should produce an error for numeric keys")
+	})
+}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -958,11 +958,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 				}
 				// Copy index signatures from closed to open
 				for _, sig := range collected2.IndexSignatures {
-					obj1.Elems = append(obj1.Elems, &type_system.IndexSignatureElem{
-						KeyType:  sig.KeyType,
-						Value:    sig.Value,
-						Readonly: sig.Readonly,
-					})
+					obj1.Elems = append(obj1.Elems, copyObjTypeElem(sig))
 				}
 				return errors
 			}
@@ -991,11 +987,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 				}
 				// Copy index signatures from closed to open
 				for _, sig := range collected1.IndexSignatures {
-					obj2.Elems = append(obj2.Elems, &type_system.IndexSignatureElem{
-						KeyType:  sig.KeyType,
-						Value:    sig.Value,
-						Readonly: sig.Readonly,
-					})
+					obj2.Elems = append(obj2.Elems, copyObjTypeElem(sig))
 				}
 				return errors
 			}
@@ -2296,6 +2288,9 @@ func copyObjTypeElem(elem type_system.ObjTypeElem) type_system.ObjTypeElem {
 	case *type_system.SetterElem:
 		cp := *e
 		return &cp
+	case *type_system.IndexSignatureElem:
+		cp := *e
+		return &cp
 	default:
 		return elem
 	}
@@ -3004,7 +2999,9 @@ func findIndexSignatureForKey(key type_system.ObjTypeKey, indexSigs []*type_syst
 		if prim, ok := sig.KeyType.(*type_system.PrimType); ok {
 			switch prim.Prim {
 			case type_system.StrPrim:
-				if key.Kind == type_system.StrObjTypeKeyKind {
+				// String index signatures accept both string and numeric keys
+				// (TypeScript coerces numeric keys to strings).
+				if key.Kind == type_system.StrObjTypeKeyKind || key.Kind == type_system.NumObjTypeKeyKind {
 					return sig.Value
 				}
 			case type_system.NumPrim:

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -956,6 +956,14 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 						}
 					}
 				}
+				// Copy index signatures from closed to open
+				for _, sig := range collected2.IndexSignatures {
+					obj1.Elems = append(obj1.Elems, &type_system.IndexSignatureElem{
+						KeyType:  sig.KeyType,
+						Value:    sig.Value,
+						Readonly: sig.Readonly,
+					})
+				}
 				return errors
 			}
 
@@ -980,6 +988,14 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 							obj2.Elems = append(obj2.Elems, copyObjTypeElem(we))
 						}
 					}
+				}
+				// Copy index signatures from closed to open
+				for _, sig := range collected1.IndexSignatures {
+					obj2.Elems = append(obj2.Elems, &type_system.IndexSignatureElem{
+						KeyType:  sig.KeyType,
+						Value:    sig.Value,
+						Readonly: sig.Readonly,
+					})
 				}
 				return errors
 			}
@@ -1070,6 +1086,10 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 							}
 						}
 						errors = slices.Concat(errors, unifyErrors)
+					} else if idxValType := findIndexSignatureForKey(key2, collected1.IndexSignatures); idxValType != nil {
+						// obj1 has an index signature matching this key — unify value types
+						unifyErrors := c.unifyWithDepth(ctx, idxValType, value2, depth, seen)
+						errors = slices.Concat(errors, unifyErrors)
 					} else {
 						knfErr := &KeyNotFoundError{
 							Object: obj1,
@@ -1088,6 +1108,34 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 						// reported the KeyNotFoundError above.
 						undefinedType := type_system.NewUndefinedType(nil)
 						c.unifyWithDepth(ctx, value2, undefinedType, depth, seen)
+					}
+				}
+
+				// Check keys in obj1 not in obj2 against obj2's index signatures
+				if len(collected2.IndexSignatures) > 0 {
+					for _, key1 := range keys1 {
+						if _, has := namedElems2[key1]; !has {
+							if value1, ok := namedElems1[key1]; ok {
+								if idxValType := findIndexSignatureForKey(key1, collected2.IndexSignatures); idxValType != nil {
+									unifyErrors := c.unifyWithDepth(ctx, value1, idxValType, depth, seen)
+									errors = slices.Concat(errors, unifyErrors)
+								}
+							}
+						}
+					}
+				}
+
+				// Unify matching index signatures from both sides
+				for _, sig1 := range collected1.IndexSignatures {
+					for _, sig2 := range collected2.IndexSignatures {
+						if prim1, ok1 := sig1.KeyType.(*type_system.PrimType); ok1 {
+							if prim2, ok2 := sig2.KeyType.(*type_system.PrimType); ok2 {
+								if prim1.Prim == prim2.Prim {
+									unifyErrors := c.unifyWithDepth(ctx, sig1.Value, sig2.Value, depth, seen)
+									errors = slices.Concat(errors, unifyErrors)
+								}
+							}
+						}
 					}
 				}
 			}
@@ -2872,12 +2920,13 @@ func (c *Checker) unifyVariadicVsVariadic(
 //   - GetterElem populates Read only
 //   - SetterElem populates Write only
 type collectedElemTypes struct {
-	Read      map[type_system.ObjTypeKey]type_system.Type        // readable types (Property, Method, Getter)
-	Write     map[type_system.ObjTypeKey]type_system.Type        // writable types (Property, Setter)
-	Keys      []type_system.ObjTypeKey                           // all names, deduplicated, in insertion order
-	OrigRead  map[type_system.ObjTypeKey]type_system.ObjTypeElem // original readable elem; nil if not requested
-	OrigWrite map[type_system.ObjTypeKey]type_system.ObjTypeElem // original writable elem; nil if not requested
-	RestTypes []type_system.Type
+	Read            map[type_system.ObjTypeKey]type_system.Type        // readable types (Property, Method, Getter)
+	Write           map[type_system.ObjTypeKey]type_system.Type        // writable types (Property, Setter)
+	Keys            []type_system.ObjTypeKey                           // all names, deduplicated, in insertion order
+	OrigRead        map[type_system.ObjTypeKey]type_system.ObjTypeElem // original readable elem; nil if not requested
+	OrigWrite       map[type_system.ObjTypeKey]type_system.ObjTypeElem // original writable elem; nil if not requested
+	RestTypes       []type_system.Type
+	IndexSignatures []*type_system.IndexSignatureElem // index signatures (e.g. [key: string]: T)
 }
 
 // collectObjElemTypes extracts named property types from an ObjectType into
@@ -2937,6 +2986,8 @@ func collectObjElemTypes(obj *type_system.ObjectType, collectOrigElems bool) col
 			if collectOrigElems {
 				result.OrigWrite[elem.Name] = elem
 			}
+		case *type_system.IndexSignatureElem:
+			result.IndexSignatures = append(result.IndexSignatures, elem)
 		case *type_system.RestSpreadElem:
 			result.RestTypes = append(result.RestTypes, elem.Value)
 		default:
@@ -2944,6 +2995,30 @@ func collectObjElemTypes(obj *type_system.ObjectType, collectOrigElems bool) col
 		}
 	}
 	return result
+}
+
+// findIndexSignatureForKey returns the value type of the first index signature
+// whose key type is compatible with the given property key, or nil if none match.
+func findIndexSignatureForKey(key type_system.ObjTypeKey, indexSigs []*type_system.IndexSignatureElem) type_system.Type {
+	for _, sig := range indexSigs {
+		if prim, ok := sig.KeyType.(*type_system.PrimType); ok {
+			switch prim.Prim {
+			case type_system.StrPrim:
+				if key.Kind == type_system.StrObjTypeKeyKind {
+					return sig.Value
+				}
+			case type_system.NumPrim:
+				if key.Kind == type_system.NumObjTypeKeyKind {
+					return sig.Value
+				}
+			case type_system.SymbolPrim:
+				if key.Kind == type_system.SymObjTypeKeyKind {
+					return sig.Value
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Checker) unifyPatternWithUnion(

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1130,15 +1130,9 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 
 				// Unify matching index signatures from both sides
 				for _, sig1 := range collected1.IndexSignatures {
-					for _, sig2 := range collected2.IndexSignatures {
-						if prim1, ok1 := sig1.KeyType.(*type_system.PrimType); ok1 {
-							if prim2, ok2 := sig2.KeyType.(*type_system.PrimType); ok2 {
-								if prim1.Prim == prim2.Prim {
-									unifyErrors := c.unifyWithDepth(ctx, sig1.Value, sig2.Value, depth, seen)
-									errors = slices.Concat(errors, unifyErrors)
-								}
-							}
-						}
+					if match := findMatchingIndexSignature(sig1, collected2.IndexSignatures); match != nil {
+						unifyErrors := c.unifyWithDepth(ctx, sig1.Value, match.Value, depth, seen)
+						errors = slices.Concat(errors, unifyErrors)
 					}
 				}
 
@@ -1146,8 +1140,32 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 				// when an object has both [key: string]: S and [index: number]: N,
 				// N must be compatible with S because JavaScript coerces numeric
 				// keys to strings (obj[1] === obj["1"]).
+				// Check within each object and across objects.
 				errors = slices.Concat(errors, c.unifyNumericWithStringIndexSigs(ctx, collected1.IndexSignatures, depth, seen))
 				errors = slices.Concat(errors, c.unifyNumericWithStringIndexSigs(ctx, collected2.IndexSignatures, depth, seen))
+
+				// Cross-object check: if one side has a numeric sig and the other
+				// has a string sig, their value types must also be compatible.
+				for _, s1 := range collected1.IndexSignatures {
+					p1, ok := s1.KeyType.(*type_system.PrimType)
+					if !ok {
+						continue
+					}
+					for _, s2 := range collected2.IndexSignatures {
+						p2, ok := s2.KeyType.(*type_system.PrimType)
+						if !ok {
+							continue
+						}
+						if p1.Prim == type_system.NumPrim && p2.Prim == type_system.StrPrim {
+							errors = slices.Concat(errors, c.unifyWithDepth(ctx, s1.Value, s2.Value, depth, seen))
+						} else if p1.Prim == type_system.StrPrim && p2.Prim == type_system.NumPrim {
+							// Args are swapped so the numeric value is always t1 and the
+							// string value is always t2, matching the within-object check
+							// in unifyNumericWithStringIndexSigs(numVal, strVal).
+							errors = slices.Concat(errors, c.unifyWithDepth(ctx, s2.Value, s1.Value, depth, seen))
+						}
+					}
+				}
 			}
 
 			return errors

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -956,9 +956,15 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 						}
 					}
 				}
-				// Copy index signatures from closed to open
+				// Copy or unify index signatures from closed to open.
 				for _, sig := range collected2.IndexSignatures {
-					obj1.Elems = append(obj1.Elems, copyObjTypeElem(sig))
+					if existing := findMatchingIndexSignature(sig, collected1.IndexSignatures); existing != nil {
+						// Both sides have the same key-kind — unify their value types.
+						unifyErrors := c.unifyWithDepth(ctx, existing.Value, sig.Value, depth, seen)
+						errors = slices.Concat(errors, unifyErrors)
+					} else {
+						obj1.Elems = append(obj1.Elems, copyObjTypeElem(sig))
+					}
 				}
 				return errors
 			}
@@ -985,9 +991,14 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 						}
 					}
 				}
-				// Copy index signatures from closed to open
+				// Copy or unify index signatures from closed to open.
 				for _, sig := range collected1.IndexSignatures {
-					obj2.Elems = append(obj2.Elems, copyObjTypeElem(sig))
+					if existing := findMatchingIndexSignature(sig, collected2.IndexSignatures); existing != nil {
+						unifyErrors := c.unifyWithDepth(ctx, existing.Value, sig.Value, depth, seen)
+						errors = slices.Concat(errors, unifyErrors)
+					} else {
+						obj2.Elems = append(obj2.Elems, copyObjTypeElem(sig))
+					}
 				}
 				return errors
 			}
@@ -1130,6 +1141,13 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, depth int, 
 						}
 					}
 				}
+
+				// Enforce TypeScript numeric/string index signature compatibility:
+				// when an object has both [key: string]: S and [index: number]: N,
+				// N must be compatible with S because JavaScript coerces numeric
+				// keys to strings (obj[1] === obj["1"]).
+				errors = slices.Concat(errors, c.unifyNumericWithStringIndexSigs(ctx, collected1.IndexSignatures, depth, seen))
+				errors = slices.Concat(errors, c.unifyNumericWithStringIndexSigs(ctx, collected2.IndexSignatures, depth, seen))
 			}
 
 			return errors
@@ -2992,20 +3010,35 @@ func collectObjElemTypes(obj *type_system.ObjectType, collectOrigElems bool) col
 	return result
 }
 
-// findIndexSignatureForKey returns the value type of the first index signature
+// findIndexSignatureForKey returns the value type of the index signature
 // whose key type is compatible with the given property key, or nil if none match.
+// For numeric keys, a numeric index signature is preferred over a string one
+// so the result is order-independent.
 func findIndexSignatureForKey(key type_system.ObjTypeKey, indexSigs []*type_system.IndexSignatureElem) type_system.Type {
+	// For numeric keys, prefer the numeric index signature over the string
+	// fallback so that iteration order doesn't affect the result.
+	if key.Kind == type_system.NumObjTypeKeyKind {
+		var strFallback type_system.Type
+		for _, sig := range indexSigs {
+			if prim, ok := sig.KeyType.(*type_system.PrimType); ok {
+				switch prim.Prim {
+				case type_system.NumPrim:
+					return sig.Value
+				case type_system.StrPrim:
+					if strFallback == nil {
+						strFallback = sig.Value
+					}
+				}
+			}
+		}
+		return strFallback
+	}
+
 	for _, sig := range indexSigs {
 		if prim, ok := sig.KeyType.(*type_system.PrimType); ok {
 			switch prim.Prim {
 			case type_system.StrPrim:
-				// String index signatures accept both string and numeric keys
-				// (TypeScript coerces numeric keys to strings).
-				if key.Kind == type_system.StrObjTypeKeyKind || key.Kind == type_system.NumObjTypeKeyKind {
-					return sig.Value
-				}
-			case type_system.NumPrim:
-				if key.Kind == type_system.NumObjTypeKeyKind {
+				if key.Kind == type_system.StrObjTypeKeyKind {
 					return sig.Value
 				}
 			case type_system.SymbolPrim:
@@ -3014,6 +3047,42 @@ func findIndexSignatureForKey(key type_system.ObjTypeKey, indexSigs []*type_syst
 				}
 			}
 		}
+	}
+	return nil
+}
+
+// findMatchingIndexSignature returns the first index signature in existing
+// whose KeyType PrimType matches sig's KeyType PrimType, or nil if none match.
+func findMatchingIndexSignature(sig *type_system.IndexSignatureElem, existing []*type_system.IndexSignatureElem) *type_system.IndexSignatureElem {
+	sigPrim, ok := sig.KeyType.(*type_system.PrimType)
+	if !ok {
+		return nil
+	}
+	for _, e := range existing {
+		if ePrim, ok := e.KeyType.(*type_system.PrimType); ok && ePrim.Prim == sigPrim.Prim {
+			return e
+		}
+	}
+	return nil
+}
+
+// unifyNumericWithStringIndexSigs enforces the TypeScript rule that when an
+// object has both [key: string]: S and [index: number]: N, N must be compatible
+// with S (because JavaScript coerces numeric keys to strings: obj[1] === obj["1"]).
+func (c *Checker) unifyNumericWithStringIndexSigs(ctx Context, sigs []*type_system.IndexSignatureElem, depth int, seen unifySeen) []Error {
+	var numVal, strVal type_system.Type
+	for _, sig := range sigs {
+		if prim, ok := sig.KeyType.(*type_system.PrimType); ok {
+			switch prim.Prim {
+			case type_system.NumPrim:
+				numVal = sig.Value
+			case type_system.StrPrim:
+				strVal = sig.Value
+			}
+		}
+	}
+	if numVal != nil && strVal != nil {
+		return c.unifyWithDepth(ctx, numVal, strVal, depth, seen)
 	}
 	return nil
 }

--- a/internal/codegen/builder_test.go
+++ b/internal/codegen/builder_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dep_graph"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -913,6 +914,59 @@ company.project.module.submodule.utils.constant = company__project__module__subm
 			}
 
 			assert.Equal(t, test.expected, printer.Output, "Generated module should match expected output")
+		})
+	}
+}
+
+func TestBuildIndexSignatureKeyName(t *testing.T) {
+	tests := map[string]struct {
+		keyType  type_system.Type
+		value    type_system.Type
+		readonly bool
+		expected string
+	}{
+		"StringIndexSignature": {
+			keyType:  type_system.NewStrPrimType(nil),
+			value:    type_system.NewNumPrimType(nil),
+			readonly: false,
+			expected: "[key: string]: number",
+		},
+		"NumberIndexSignature": {
+			keyType:  type_system.NewNumPrimType(nil),
+			value:    type_system.NewStrPrimType(nil),
+			readonly: false,
+			expected: "[index: number]: string",
+		},
+		"SymbolIndexSignature": {
+			keyType:  type_system.NewSymPrimType(nil),
+			value:    type_system.NewNumPrimType(nil),
+			readonly: false,
+			expected: "[sym: symbol]: number",
+		},
+		"ReadonlyStringIndexSignature": {
+			keyType:  type_system.NewStrPrimType(nil),
+			value:    type_system.NewNumPrimType(nil),
+			readonly: true,
+			expected: "readonly [key: string]: number",
+		},
+		"ReadonlyNumberIndexSignature": {
+			keyType:  type_system.NewNumPrimType(nil),
+			value:    type_system.NewStrPrimType(nil),
+			readonly: true,
+			expected: "readonly [index: number]: string",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := &Builder{tempId: 0, depGraph: nil}
+			elem := type_system.NewIndexSignatureElem(test.keyType, test.value, test.readonly)
+			ann := builder.buildObjTypeAnnElem(elem, nil)
+
+			printer := NewPrinter()
+			printer.printObjTypeAnnElem(ann)
+
+			assert.Equal(t, test.expected, printer.Output)
 		})
 	}
 }

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -921,8 +921,17 @@ func (b *Builder) buildObjTypeAnnElem(elem type_sys.ObjTypeElem, symbolExprMap m
 			ReadOnly:  mapMappedModifier(elem.Readonly),
 		}
 	case *type_sys.IndexSignatureElem:
+		keyName := "key"
+		if prim, ok := elem.KeyType.(*type_sys.PrimType); ok {
+			switch prim.Prim {
+			case type_sys.NumPrim:
+				keyName = "index"
+			case type_sys.SymbolPrim:
+				keyName = "sym"
+			}
+		}
 		return &IndexSignatureTypeAnn{
-			KeyName:  "key",
+			KeyName:  keyName,
 			KeyType:  b.buildTypeAnn(elem.KeyType),
 			Value:    b.buildTypeAnn(elem.Value),
 			Readonly: elem.Readonly,

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -920,6 +920,13 @@ func (b *Builder) buildObjTypeAnnElem(elem type_sys.ObjTypeElem, symbolExprMap m
 			Optional:  mapMappedModifier(elem.Optional),
 			ReadOnly:  mapMappedModifier(elem.Readonly),
 		}
+	case *type_sys.IndexSignatureElem:
+		return &IndexSignatureTypeAnn{
+			KeyName:  "key",
+			KeyType:  b.buildTypeAnn(elem.KeyType),
+			Value:    b.buildTypeAnn(elem.Value),
+			Readonly: elem.Readonly,
+		}
 	case *type_sys.RestSpreadElem:
 		return &RestSpreadTypeAnn{
 			Value: b.buildTypeAnn(elem.Value),

--- a/internal/codegen/printer.go
+++ b/internal/codegen/printer.go
@@ -452,6 +452,16 @@ func (p *Printer) printObjTypeAnnElem(elem ObjTypeAnnElem) {
 		}
 		p.print(": ")
 		p.PrintTypeAnn(elem.Value)
+	case *IndexSignatureTypeAnn:
+		if elem.Readonly {
+			p.print("readonly ")
+		}
+		p.print("[")
+		p.print(elem.KeyName)
+		p.print(": ")
+		p.PrintTypeAnn(elem.KeyType)
+		p.print("]: ")
+		p.PrintTypeAnn(elem.Value)
 	case *RestSpreadTypeAnn:
 		p.print("...")
 		p.PrintTypeAnn(elem.Value)

--- a/internal/codegen/type_ann.go
+++ b/internal/codegen/type_ann.go
@@ -191,7 +191,8 @@ func (*GetterTypeAnn) isObjTypeAnnElem()      {}
 func (*SetterTypeAnn) isObjTypeAnnElem()      {}
 func (*PropertyTypeAnn) isObjTypeAnnElem()    {}
 func (*MappedTypeAnn) isObjTypeAnnElem()      {}
-func (*RestSpreadTypeAnn) isObjTypeAnnElem()  {}
+func (*IndexSignatureTypeAnn) isObjTypeAnnElem() {}
+func (*RestSpreadTypeAnn) isObjTypeAnnElem()     {}
 
 type CallableTypeAnn struct{ Fn FuncTypeAnn }
 type ConstructorTypeAnn struct{ Fn FuncTypeAnn }
@@ -235,6 +236,13 @@ type MappedTypeAnn struct {
 type IndexParamTypeAnn struct {
 	Name       string
 	Constraint TypeAnn
+}
+
+type IndexSignatureTypeAnn struct {
+	KeyName  string  // e.g. "key"
+	KeyType  TypeAnn // e.g. string, number
+	Value    TypeAnn
+	Readonly bool
 }
 
 type RestSpreadTypeAnn struct {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1298,6 +1298,26 @@ type IndexSignatureElem struct {
 	Value    Type
 	Readonly bool
 }
+// NewIndexSignatureElem creates an IndexSignatureElem, panicking if keyType is
+// not a *PrimType with Prim in {StrPrim, NumPrim, SymbolPrim}.
+func NewIndexSignatureElem(keyType Type, value Type, readonly bool) *IndexSignatureElem {
+	prim, ok := keyType.(*PrimType)
+	if !ok {
+		panic(fmt.Sprintf("IndexSignatureElem keyType must be a *PrimType, got %T", keyType))
+	}
+	switch prim.Prim {
+	case StrPrim, NumPrim, SymbolPrim:
+		// valid
+	default:
+		panic(fmt.Sprintf("IndexSignatureElem keyType must be string, number, or symbol, got %v", prim.Prim))
+	}
+	return &IndexSignatureElem{
+		KeyType:  keyType,
+		Value:    value,
+		Readonly: readonly,
+	}
+}
+
 type RestSpreadElem struct{ Value Type }
 
 func NewRestSpreadElem(value Type) *RestSpreadElem {
@@ -1429,11 +1449,7 @@ func (idx *IndexSignatureElem) Accept(v TypeVisitor) ObjTypeElem {
 		changed = true
 	}
 	if changed {
-		return &IndexSignatureElem{
-			KeyType:  newKeyType,
-			Value:    newValue,
-			Readonly: idx.Readonly,
-		}
+		return NewIndexSignatureElem(newKeyType, newValue, idx.Readonly)
 	}
 	return idx
 }
@@ -3125,6 +3141,12 @@ func objTypeElemEquals(e1, e2 ObjTypeElem) bool {
 	case *RestSpreadElem:
 		if e2, ok := e2.(*RestSpreadElem); ok {
 			return equals(e1.Value, e2.Value)
+		}
+	case *IndexSignatureElem:
+		if e2, ok := e2.(*IndexSignatureElem); ok {
+			return e1.Readonly == e2.Readonly &&
+				equals(e1.KeyType, e2.KeyType) &&
+				equals(e1.Value, e2.Value)
 		}
 	}
 	return false

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1293,6 +1293,11 @@ type IndexParam struct {
 	Name       string
 	Constraint Type
 }
+type IndexSignatureElem struct {
+	KeyType  Type // must be a PrimType (string, number, symbol)
+	Value    Type
+	Readonly bool
+}
 type RestSpreadElem struct{ Value Type }
 
 func NewRestSpreadElem(value Type) *RestSpreadElem {
@@ -1307,8 +1312,9 @@ func (*MethodElem) isObjTypeElem()      {}
 func (*GetterElem) isObjTypeElem()      {}
 func (*SetterElem) isObjTypeElem()      {}
 func (*PropertyElem) isObjTypeElem()    {}
-func (*MappedElem) isObjTypeElem()      {}
-func (*RestSpreadElem) isObjTypeElem()  {}
+func (*MappedElem) isObjTypeElem()          {}
+func (*IndexSignatureElem) isObjTypeElem()  {}
+func (*RestSpreadElem) isObjTypeElem()      {}
 
 func (c *CallableElem) Accept(v TypeVisitor) ObjTypeElem {
 	newFn := c.Fn.Accept(v).(*FuncType)
@@ -1411,6 +1417,25 @@ func (m *MappedElem) Accept(v TypeVisitor) ObjTypeElem {
 		}
 	}
 	return m
+}
+func (idx *IndexSignatureElem) Accept(v TypeVisitor) ObjTypeElem {
+	changed := false
+	newKeyType := idx.KeyType.Accept(v)
+	if newKeyType != idx.KeyType {
+		changed = true
+	}
+	newValue := idx.Value.Accept(v)
+	if newValue != idx.Value {
+		changed = true
+	}
+	if changed {
+		return &IndexSignatureElem{
+			KeyType:  newKeyType,
+			Value:    newValue,
+			Readonly: idx.Readonly,
+		}
+	}
+	return idx
 }
 func (r *RestSpreadElem) Accept(v TypeVisitor) ObjTypeElem {
 	newValue := r.Value.Accept(v)
@@ -1763,6 +1788,11 @@ func (t *ObjectType) String() string {
 				// TODO: handle optional and readonly
 				result += "[" + elem.TypeParam.Name + " in " + elem.TypeParam.Constraint.String() + "]"
 				result += ": " + elem.Value.String()
+			case *IndexSignatureElem:
+				if elem.Readonly {
+					result += "readonly "
+				}
+				result += "[key: " + elem.KeyType.String() + "]: " + elem.Value.String()
 			case *RestSpreadElem:
 				result += "..." + elem.Value.String()
 			default:


### PR DESCRIPTION
## Summary

- Add `IndexSignatureElem` to the type system so that mapped types with primitive constraints (`string`, `number`, `symbol`) expand to index signatures instead of panicking
- Update unification to match properties against index signatures when a named property isn't found
- Update codegen to emit `[key: string]: T` syntax in `.d.ts` output
- Update all ObjTypeElem switch sites (generalize, expand_type property access, etc.)

## What works after this change

- `Record<string, T>` no longer panics — it expands to `{[key: string]: T}`
- Property access on index-signature types: `m.foo` on `Record<string, number>` infers `number`
- Recursive unions with `Record`: `type Json = string | ... | Record<string, Json>` type-checks correctly for primitive and array values
- `keyof` on index-signature types returns the key primitive

## Known limitation

Object literal assignment to recursive unions containing generic members (`Array<Json>`) hangs due to a pre-existing bug in expansion cycle detection — filed as #463. This is not caused by this PR.

## Test plan

- [x] `RecursiveJsonLikeType` — `Json` union with `Record<string, Json>`, primitive and array assignments
- [x] `RecordStringType` — property access on `Record<string, number>`
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full index-signature support: string, number and symbol index keys are represented and emitted in type annotations (including readonly index signatures).

* **Bug Fixes**
  * Property/index access now falls back to compatible index signatures (numeric→string coercion honored); keyof and mapped-type expansion account for index-signature keys and avoid eager recursion.

* **Tests**
  * Added/extended tests for Record/indexed access, unified index-signature unification, and mapped-record scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->