### PR TITLE
Dedupe copy-on-write code in types.go

### DIFF
--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -65,21 +65,7 @@ func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.
 
 		// Handle type arguments if they exist
 		if len(t.TypeArgs) > 0 {
-			var newTypeArgs []type_system.Type
-			for i, arg := range t.TypeArgs {
-				newArg := arg.Accept(v)
-				if newArg != arg {
-					if newTypeArgs == nil {
-						newTypeArgs = make([]type_system.Type, len(t.TypeArgs))
-						copy(newTypeArgs[:i], t.TypeArgs[:i])
-					}
-				}
-				if newTypeArgs != nil {
-					newTypeArgs[i] = newArg
-				}
-			}
-
-			if newTypeArgs != nil {
+			if newTypeArgs, changed := type_system.CowAcceptTypes(t.TypeArgs, v); changed {
 				return type_system.NewTypeRefTypeFromQualIdent(t.Provenance(), t.Name, t.TypeAlias, newTypeArgs...)
 			}
 		}

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -63,12 +63,8 @@ func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.
 			return substitute
 		}
 
-		// Handle type arguments if they exist
-		if len(t.TypeArgs) > 0 {
-			if newTypeArgs, changed := type_system.CowAcceptTypes(t.TypeArgs, v); changed {
-				return type_system.NewTypeRefTypeFromQualIdent(t.Provenance(), t.Name, t.TypeAlias, newTypeArgs...)
-			}
-		}
+		// TypeArgs are already visited by TypeRefType.Accept via CowAcceptTypes
+		// before ExitType is called, so no need to re-traverse them here.
 	}
 	// For all other types, return nil to let Accept handle the traversal
 	return nil

--- a/internal/type_system/cow_accept_test.go
+++ b/internal/type_system/cow_accept_test.go
@@ -1,0 +1,204 @@
+package type_system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// countingSubstitutionVisitor mimics TypeParamSubstitutionVisitor but also
+// counts how many times EnterType is called. This lets us detect double
+// traversal of TypeArgs when ExitType redundantly calls CowAcceptTypes.
+type countingSubstitutionVisitor struct {
+	substitutions map[string]Type
+	enterCount    int
+}
+
+func (v *countingSubstitutionVisitor) EnterType(t Type) EnterResult {
+	v.enterCount++
+	return EnterResult{}
+}
+
+func (v *countingSubstitutionVisitor) ExitType(t Type) Type {
+	if tref, ok := t.(*TypeRefType); ok {
+		typeName := QualIdentToString(tref.Name)
+		if sub, found := v.substitutions[typeName]; found {
+			return sub
+		}
+		// TypeArgs are already visited by TypeRefType.Accept via CowAcceptTypes
+		// before ExitType is called, so no need to re-traverse them here.
+	}
+	return nil
+}
+
+// TestSubstitutionVisitorDoubleTraversal verifies that a substitution visitor
+// does not re-traverse TypeArgs in ExitType when Accept already visited them.
+// With the redundant CowAcceptTypes call in ExitType, Array<T> with T→number
+// causes 3 EnterType calls (Array<T>, T, then number from the re-traversal).
+// Without the redundant call, it should be only 2 (Array<T>, T).
+func TestSubstitutionVisitorDoubleTraversal(t *testing.T) {
+	// Array<T> — one TypeRefType with one type arg
+	typeRef := NewTypeRefType(nil, "Array", nil, NewTypeRefType(nil, "T", nil))
+
+	v := &countingSubstitutionVisitor{
+		substitutions: map[string]Type{
+			"T": NewNumPrimType(nil),
+		},
+	}
+
+	result := typeRef.Accept(v)
+
+	// Correctness: substitution should work regardless
+	assert.Equal(t, "Array<number>", result.String())
+
+	// Performance: TypeArgs should be visited exactly once.
+	// Accept visits: Array<T> (1) + T (2) = 2 EnterType calls.
+	// With the redundant CowAcceptTypes in ExitType, there's an extra
+	// visit of the already-substituted 'number', making it 3.
+	assert.Equal(t, 2, v.enterCount,
+		"ExitType should not re-traverse TypeArgs that Accept already visited")
+}
+
+func TestCowAcceptTypes(t *testing.T) {
+	t.Run("returns same slice when nothing changes", func(t *testing.T) {
+		items := []Type{
+			NewNumPrimType(nil),
+			NewStrPrimType(nil),
+		}
+
+		result, changed := CowAcceptTypes(items, &IdentityVisitor{})
+
+		assert.False(t, changed)
+		assert.Same(t, &items[0], &result[0], "should return the same slice, not a copy")
+	})
+
+	t.Run("returns new slice when an element changes", func(t *testing.T) {
+		numType := NewNumPrimType(nil)
+		strType := NewStrPrimType(nil)
+		boolType := NewBoolPrimType(nil)
+		items := []Type{numType, strType}
+
+		visitor := NewTypeReplacementVisitor(map[Type]Type{
+			strType: boolType,
+		})
+		result, changed := CowAcceptTypes(items, visitor)
+
+		assert.True(t, changed)
+		assert.NotSame(t, &items[0], &result[0], "should return a new slice")
+		// Unchanged element is preserved
+		assert.Same(t, items[0], result[0])
+		// Changed element is the replacement
+		assert.Same(t, boolType, result[1])
+	})
+
+	t.Run("handles empty slice", func(t *testing.T) {
+		items := []Type{}
+
+		result, changed := CowAcceptTypes(items, &IdentityVisitor{})
+
+		assert.False(t, changed)
+		assert.Equal(t, 0, len(result))
+	})
+
+	t.Run("preserves elements before the first change", func(t *testing.T) {
+		num := NewNumPrimType(nil)
+		str := NewStrPrimType(nil)
+		boolType := NewBoolPrimType(nil)
+		replacement := NewNumPrimType(nil)
+
+		// Only the last element changes
+		items := []Type{num, str, boolType}
+		visitor := NewTypeReplacementVisitor(map[Type]Type{
+			boolType: replacement,
+		})
+
+		result, changed := CowAcceptTypes(items, visitor)
+
+		assert.True(t, changed)
+		// First two elements are copied from original
+		assert.Same(t, num, result[0])
+		assert.Same(t, str, result[1])
+		assert.Same(t, replacement, result[2])
+	})
+}
+
+func TestCowAcceptElems(t *testing.T) {
+	t.Run("returns same slice when nothing changes", func(t *testing.T) {
+		items := []ObjTypeElem{
+			&PropertyElem{Name: NewStrKey("x"), Value: NewNumPrimType(nil)},
+			&PropertyElem{Name: NewStrKey("y"), Value: NewStrPrimType(nil)},
+		}
+
+		result, changed := CowAcceptElems(items, &IdentityVisitor{})
+
+		assert.False(t, changed)
+		assert.Same(t, &items[0], &result[0])
+	})
+
+	t.Run("returns new slice when an element changes", func(t *testing.T) {
+		numType := NewNumPrimType(nil)
+		strType := NewStrPrimType(nil)
+		boolType := NewBoolPrimType(nil)
+
+		items := []ObjTypeElem{
+			&PropertyElem{Name: NewStrKey("x"), Value: numType},
+			&PropertyElem{Name: NewStrKey("y"), Value: strType},
+		}
+
+		// Replace strType with boolType — this will cause the second PropertyElem to change
+		visitor := NewTypeReplacementVisitor(map[Type]Type{
+			strType: boolType,
+		})
+		result, changed := CowAcceptElems(items, visitor)
+
+		assert.True(t, changed)
+		// First element unchanged
+		assert.Same(t, items[0], result[0])
+		// Second element changed (new PropertyElem with boolType)
+		prop := result[1].(*PropertyElem)
+		assert.Same(t, boolType, prop.Value)
+	})
+}
+
+func TestCowAcceptTypeRefs(t *testing.T) {
+	t.Run("returns same slice when nothing changes", func(t *testing.T) {
+		items := []*TypeRefType{
+			NewTypeRefType(nil, "Foo", nil),
+			NewTypeRefType(nil, "Bar", nil),
+		}
+
+		result, changed := CowAcceptTypeRefs(items, &IdentityVisitor{})
+
+		assert.False(t, changed)
+		assert.Same(t, &items[0], &result[0])
+	})
+
+	t.Run("preserves nil entries", func(t *testing.T) {
+		ref := NewTypeRefType(nil, "Foo", nil)
+		items := []*TypeRefType{nil, ref, nil}
+
+		result, changed := CowAcceptTypeRefs(items, &IdentityVisitor{})
+
+		assert.False(t, changed)
+		// Same slice returned
+		assert.Same(t, &items[0], &result[0])
+	})
+
+	t.Run("preserves nil entries when another element changes", func(t *testing.T) {
+		numType := NewNumPrimType(nil)
+		strType := NewStrPrimType(nil)
+
+		refWithArg := NewTypeRefType(nil, "Foo", nil, numType)
+		items := []*TypeRefType{nil, refWithArg}
+
+		// Replace numType with strType — this changes the TypeArg inside refWithArg
+		visitor := NewTypeReplacementVisitor(map[Type]Type{
+			numType: strType,
+		})
+		result, changed := CowAcceptTypeRefs(items, visitor)
+
+		assert.True(t, changed)
+		assert.Nil(t, result[0])
+		assert.Equal(t, "Foo<string>", result[1].String())
+	})
+}

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -320,21 +320,7 @@ func (t *TypeRefType) Accept(v TypeVisitor) Type {
 		return t
 	}
 
-	changed := false
-	var newTypeArgs []Type
-	for i, arg := range t.TypeArgs {
-		newArg := arg.Accept(v)
-		if newArg != arg {
-			if newTypeArgs == nil {
-				newTypeArgs = make([]Type, len(t.TypeArgs))
-				copy(newTypeArgs[:i], t.TypeArgs[:i])
-			}
-			changed = true
-		}
-		if newTypeArgs != nil {
-			newTypeArgs[i] = newArg
-		}
-	}
+	newTypeArgs, changed := CowAcceptTypes(t.TypeArgs, v)
 
 	var result Type = t
 	if changed {
@@ -1533,87 +1519,22 @@ func (t *ObjectType) Accept(v TypeVisitor) Type {
 		return t
 	}
 
-	changed := false
-	var newElems []ObjTypeElem
-	for i, elem := range t.Elems {
-		newElem := elem.Accept(v)
-		if newElem != elem {
-			if newElems == nil {
-				newElems = make([]ObjTypeElem, len(t.Elems))
-				copy(newElems[:i], t.Elems[:i])
-			}
-			changed = true
-		}
-		if newElems != nil {
-			newElems[i] = newElem
-		}
-	}
-
-	var newExtends []*TypeRefType
-	for i, ext := range t.Extends {
-		if ext == nil {
-			if newExtends != nil {
-				newExtends[i] = nil
-			}
-			continue
-		}
-		newExt := ext.Accept(v).(*TypeRefType)
-		if newExt != ext {
-			if newExtends == nil {
-				newExtends = make([]*TypeRefType, len(t.Extends))
-				copy(newExtends[:i], t.Extends[:i])
-			}
-			changed = true
-		}
-		if newExtends != nil {
-			newExtends[i] = newExt
-		}
-	}
-
-	var newImplements []*TypeRefType
-	for i, impl := range t.Implements {
-		if impl == nil {
-			if newImplements != nil {
-				newImplements[i] = nil
-			}
-			continue
-		}
-		newImpl := impl.Accept(v).(*TypeRefType)
-		if newImpl != impl {
-			if newImplements == nil {
-				newImplements = make([]*TypeRefType, len(t.Implements))
-				copy(newImplements[:i], t.Implements[:i])
-			}
-			changed = true
-		}
-		if newImplements != nil {
-			newImplements[i] = newImpl
-		}
-	}
+	newElems, elemsChanged := CowAcceptElems(t.Elems, v)
+	newExtends, extendsChanged := CowAcceptTypeRefs(t.Extends, v)
+	newImplements, implementsChanged := CowAcceptTypeRefs(t.Implements, v)
+	changed := elemsChanged || extendsChanged || implementsChanged
 
 	var result *ObjectType = t
 	if changed {
-		elems := t.Elems
-		if newElems != nil {
-			elems = newElems
-		}
-		extends := t.Extends
-		if newExtends != nil {
-			extends = newExtends
-		}
-		implements := t.Implements
-		if newImplements != nil {
-			implements = newImplements
-		}
-		result = NewObjectType(t.provenance, elems)
+		result = NewObjectType(t.provenance, newElems)
 		result.ID = t.ID
 		result.Exact = t.Exact
 		result.Immutable = t.Immutable
 		result.Mutable = t.Mutable
 		result.Nominal = t.Nominal
 		result.Interface = t.Interface
-		result.Extends = extends
-		result.Implements = implements
+		result.Extends = newExtends
+		result.Implements = newImplements
 		result.SymbolKeyMap = t.SymbolKeyMap
 		result.Open = t.Open
 		result.MatchedUnionMembers = t.MatchedUnionMembers
@@ -1843,21 +1764,7 @@ func (t *TupleType) Accept(v TypeVisitor) Type {
 		return t
 	}
 
-	changed := false
-	var newElems []Type
-	for i, elem := range t.Elems {
-		newElem := elem.Accept(v)
-		if newElem != elem {
-			if newElems == nil {
-				newElems = make([]Type, len(t.Elems))
-				copy(newElems[:i], t.Elems[:i])
-			}
-			changed = true
-		}
-		if newElems != nil {
-			newElems[i] = newElem
-		}
-	}
+	newElems, changed := CowAcceptTypes(t.Elems, v)
 
 	var result Type = t
 	if changed {
@@ -2091,21 +1998,7 @@ func (t *UnionType) Accept(v TypeVisitor) Type {
 		return t
 	}
 
-	changed := false
-	var newTypes []Type
-	for i, typ := range t.Types {
-		newType := typ.Accept(v)
-		if newType != typ {
-			if newTypes == nil {
-				newTypes = make([]Type, len(t.Types))
-				copy(newTypes[:i], t.Types[:i])
-			}
-			changed = true
-		}
-		if newTypes != nil {
-			newTypes[i] = newType
-		}
-	}
+	newTypes, changed := CowAcceptTypes(t.Types, v)
 
 	var result Type = t
 	if changed {
@@ -2311,21 +2204,7 @@ func (t *IntersectionType) Accept(v TypeVisitor) Type {
 		return t
 	}
 
-	changed := false
-	var newTypes []Type
-	for i, typ := range t.Types {
-		newType := typ.Accept(v)
-		if newType != typ {
-			if newTypes == nil {
-				newTypes = make([]Type, len(t.Types))
-				copy(newTypes[:i], t.Types[:i])
-			}
-			changed = true
-		}
-		if newTypes != nil {
-			newTypes[i] = newType
-		}
-	}
+	newTypes, changed := CowAcceptTypes(t.Types, v)
 
 	var result Type = t
 	if changed {
@@ -2713,29 +2592,12 @@ func (t *ExtractorType) Accept(v TypeVisitor) Type {
 	}
 
 	newExtractor := t.Extractor.Accept(v)
-	changed := newExtractor != t.Extractor
-	var newArgs []Type
-	for i, arg := range t.Args {
-		newArg := arg.Accept(v)
-		if newArg != arg {
-			if newArgs == nil {
-				newArgs = make([]Type, len(t.Args))
-				copy(newArgs[:i], t.Args[:i])
-			}
-			changed = true
-		}
-		if newArgs != nil {
-			newArgs[i] = newArg
-		}
-	}
+	newArgs, argsChanged := CowAcceptTypes(t.Args, v)
+	changed := newExtractor != t.Extractor || argsChanged
 
 	var result Type = t
 	if changed {
-		args := t.Args
-		if newArgs != nil {
-			args = newArgs
-		}
-		result = NewExtractorType(t.provenance, newExtractor, args...)
+		result = NewExtractorType(t.provenance, newExtractor, newArgs...)
 	}
 
 	if visitResult := v.ExitType(result); visitResult != nil {
@@ -2805,29 +2667,11 @@ func (t *TemplateLitType) Accept(v TypeVisitor) Type {
 		return t
 	}
 
-	changed := false
-	var newTypes []Type
-	for i, typ := range t.Types {
-		newType := typ.Accept(v)
-		if newType != typ {
-			if newTypes == nil {
-				newTypes = make([]Type, len(t.Types))
-				copy(newTypes[:i], t.Types[:i])
-			}
-			changed = true
-		}
-		if newTypes != nil {
-			newTypes[i] = newType
-		}
-	}
+	newTypes, changed := CowAcceptTypes(t.Types, v)
 
 	var result Type = t
 	if changed {
-		types := t.Types
-		if newTypes != nil {
-			types = newTypes
-		}
-		result = NewTemplateLitType(t.provenance, t.Quasis, types)
+		result = NewTemplateLitType(t.provenance, t.Quasis, newTypes)
 	}
 
 	if visitResult := v.ExitType(result); visitResult != nil {
@@ -3220,4 +3064,85 @@ func namespaceEquals(n1, n2 *Namespace) bool {
 // Equals is a convenience function that delegates to the Equals method
 func Equals(t1 Type, t2 Type) bool {
 	return equals(t1, t2)
+}
+
+// CowAcceptTypes applies a TypeVisitor to each element of a []Type slice.
+// It is used inside Accept methods on composite types (UnionType, TupleType, etc.)
+// to visit child type slices. It uses copy-on-write semantics so that no slice
+// allocation occurs when the visitor leaves all elements unchanged — which is the
+// common case during type walks. This matters because Accept is called recursively
+// on every node in every type tree during inference, and most visits are no-op
+// traversals. Returns the (possibly new) slice and whether any element changed.
+func CowAcceptTypes(items []Type, v TypeVisitor) ([]Type, bool) {
+	var result []Type
+	for i, item := range items {
+		newItem := item.Accept(v)
+		if newItem != item {
+			if result == nil {
+				result = make([]Type, len(items))
+				copy(result[:i], items[:i])
+			}
+		}
+		if result != nil {
+			result[i] = newItem
+		}
+	}
+	if result != nil {
+		return result, true
+	}
+	return items, false
+}
+
+// CowAcceptElems applies a TypeVisitor to each element of a []ObjTypeElem slice.
+// It is used inside ObjectType.Accept to visit the Elems slice. Like CowAcceptTypes,
+// it uses copy-on-write semantics to avoid allocating a new slice when no elements
+// change.
+func CowAcceptElems(items []ObjTypeElem, v TypeVisitor) ([]ObjTypeElem, bool) {
+	var result []ObjTypeElem
+	for i, item := range items {
+		newItem := item.Accept(v)
+		if newItem != item {
+			if result == nil {
+				result = make([]ObjTypeElem, len(items))
+				copy(result[:i], items[:i])
+			}
+		}
+		if result != nil {
+			result[i] = newItem
+		}
+	}
+	if result != nil {
+		return result, true
+	}
+	return items, false
+}
+
+// CowAcceptTypeRefs applies a TypeVisitor to each element of a []*TypeRefType slice.
+// It is used inside ObjectType.Accept to visit the Extends and Implements slices.
+// Like CowAcceptTypes, it uses copy-on-write semantics to avoid allocating a new
+// slice when no elements change. Nil elements are preserved as-is.
+func CowAcceptTypeRefs(items []*TypeRefType, v TypeVisitor) ([]*TypeRefType, bool) {
+	var result []*TypeRefType
+	for i, item := range items {
+		if item == nil {
+			if result != nil {
+				result[i] = nil
+			}
+			continue
+		}
+		newItem := item.Accept(v).(*TypeRefType)
+		if newItem != item {
+			if result == nil {
+				result = make([]*TypeRefType, len(items))
+				copy(result[:i], items[:i])
+			}
+		}
+		if result != nil {
+			result[i] = newItem
+		}
+	}
+	if result != nil {
+		return result, true
+	}
+	return items, false
 }

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -3073,6 +3073,12 @@ func Equals(t1 Type, t2 Type) bool {
 // common case during type walks. This matters because Accept is called recursively
 // on every node in every type tree during inference, and most visits are no-op
 // traversals. Returns the (possibly new) slice and whether any element changed.
+//
+// Note: unlike CowAcceptTypeRefs, this function does not check for nil elements.
+// All []Type slices in the type system (TypeArgs, Elems, Types, Args) are
+// constructed with non-nil entries, and the rest of the codebase (String, Equals,
+// Accept methods) calls methods on elements without nil guards. If a nil element
+// were present, it would panic here and in many other places.
 func CowAcceptTypes(items []Type, v TypeVisitor) ([]Type, bool) {
 	var result []Type
 	for i, item := range items {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated type-checking implementation by refactoring duplicate visitor traversal patterns into reusable helper functions, reducing code duplication and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->