### PR TITLE
Fix infinite expansion of recursive type args (#463)

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -237,6 +237,16 @@ func (v *TypeExpansionVisitor) EnterType(t type_system.Type) type_system.EnterRe
 		v.skipTypeRefsCount++ // don't expand type refs inside function types
 	case *type_system.ObjectType:
 		v.skipTypeRefsCount++ // don't expand type refs inside object types
+	case *type_system.TypeRefType:
+		// Skip child traversal for TypeRefTypes that will be expanded.
+		// TypeRefType.Accept normally visits TypeArgs before ExitType, but
+		// this expands recursive type args (e.g. Json → string|...|Array<Json>),
+		// creating ever-growing TypeArgs that defeat cycle detection (#463).
+		// ExitType handles TypeArgs expansion explicitly with cycle detection.
+		_ = t
+		if v.skipTypeRefsCount == 0 && v.expandTypeRefsCount != 0 {
+			return type_system.EnterResult{SkipChildren: true}
+		}
 	case *type_system.CondType:
 		// We need to expand the CondType's extends type on entering so that
 		// we can replace InferTypes in the extends type with fresh type variables
@@ -529,6 +539,22 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 		// - ensure that the number of type args matches the number of type params
 		// - handle type params with defaults
 		if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
+			// Expand TypeArgs before substitution. EnterType sets SkipChildren
+			// for expandable TypeRefTypes to prevent the visitor from expanding
+			// TypeArgs (which defeats cycle detection for recursive types, #463).
+			// We expand them here explicitly using the same `seen` map so that
+			// recursive args (e.g. Json in Array<Json>) are detected as cycles
+			// and left unexpanded, while non-recursive args (e.g. NumberContainer
+			// in Container<NumberContainer>) are expanded normally.
+			expandedArgs := make([]type_system.Type, len(t.TypeArgs))
+			for i, arg := range t.TypeArgs {
+				exp, _ := v.checker.expandTypeWithConfig(v.ctx, arg, v.expandTypeRefsCount, v.insideKeyOfTarget, v.seen)
+				if exp != nil {
+					expandedArgs[i] = exp
+				} else {
+					expandedArgs[i] = arg
+				}
+			}
 
 			// TODO:
 			// Handle case such as:
@@ -538,7 +564,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 			// of any other type.
 			switch prunedType := type_system.Prune(expandedType).(type) {
 			case *type_system.CondType:
-				substitutionSets, subSetErrors := v.checker.generateSubstitutionSets(v.ctx, typeAlias.TypeParams, t.TypeArgs)
+				substitutionSets, subSetErrors := v.checker.generateSubstitutionSets(v.ctx, typeAlias.TypeParams, expandedArgs)
 				if len(subSetErrors) > 0 {
 					v.errors = slices.Concat(v.errors, subSetErrors)
 				}
@@ -553,16 +579,16 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 					// Create a union type of all expanded types
 					expandedType = type_system.NewUnionType(nil, expandedTypes...)
 				} else {
-					substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
+					substitutions := createTypeParamSubstitutions(expandedArgs, typeAlias.TypeParams)
 					expandedType = SubstituteTypeParams(prunedType, substitutions)
 				}
 			case *type_system.ObjectType:
 				// Expand any MappedElem elements in the object type
-				substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
+				substitutions := createTypeParamSubstitutions(expandedArgs, typeAlias.TypeParams)
 				objType := SubstituteTypeParams(prunedType, substitutions)
 				expandedType = v.expandMappedElems(objType)
 			default:
-				substitutions := createTypeParamSubstitutions(t.TypeArgs, typeAlias.TypeParams)
+				substitutions := createTypeParamSubstitutions(expandedArgs, typeAlias.TypeParams)
 				expandedType = SubstituteTypeParams(prunedType, substitutions)
 			}
 		} else if len(typeAlias.TypeParams) == 0 && len(t.TypeArgs) == 0 {

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1603,13 +1603,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				val j4: Json = null
 				val j5: Json = [1, 2, 3]
 				val j6: Json = ["nested", [1, [true, [null, ["deep"]]]]]
-				// TODO(#463): object literals against recursive unions hang due to
-				// infinite expansion of recursive type args in expandSeen. The
-				// typeArgKey grows unboundedly (Array<R> → Array<string|Array<R>>
-				// → ...) so cycle detection never triggers. This affects any
-				// recursive type alias with generic members (e.g. Array<Json>),
-				// not just Record. See json_unify_debug_test.go for analysis.
-				// val j7: Json = { names: ["alice", "bob"], scores: [1, 2, 3] }
+				val j7: Json = {names: ["alice", "bob"], scores: [1, 2, 3]}
 			`,
 			expectedTypes: map[string]string{
 				"j":  "Json",
@@ -1618,6 +1612,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				"j4": "Json",
 				"j5": "Json",
 				"j6": "Json",
+				"j7": "Json",
 			},
 		},
 		"RecordStringType": {

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -76,6 +76,11 @@ func typeArgKey(args []type_system.Type) string {
 // its structural expansion. This prevents unbounded key growth when
 // recursive type aliases are expanded (e.g. Json → string|Array<Json>
 // produces the same key regardless of how deeply Json has been unfolded).
+//
+// TODO(#467): Replace with PrintType(t, StableKeyConfig) once the
+// configurable printType function is available. This will extend stable-key
+// handling to all compound types (CondType, MutabilityType, FuncType, etc.)
+// without duplicating the String() logic.
 func typeKey(t type_system.Type) string {
 	switch v := t.(type) {
 	case *type_system.TypeVarType:

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -57,28 +57,58 @@ func interfaceDataPointer(t type_system.Type) unsafe.Pointer {
 
 // typeArgKey produces a stable, deterministic string key for type arguments.
 // For TypeVarType, it uses TypeVar.ID (stable regardless of binding state).
+// For TypeRefType with a resolved TypeAlias, it uses the alias pointer address
+// plus the recursive typeArgKey of its own type args. This prevents unbounded
+// key growth for recursive type aliases (e.g. Array<Json> where
+// Json = string | ... | Array<Json>) — see #463.
 // For all other types, it uses fmt.Sprint (structural comparison).
-//
-// Known limitation: this only handles TypeVarType at the top level of a type
-// arg. If a type arg is a structural type containing an embedded TypeVar
-// (e.g. {x: TypeVar#42, y: string}), fmt.Sprint will print the TypeVar's
-// bound value, which could change mid-pass during unification. This would
-// require a type arg like List<{x: T}> where T gets bound between two
-// encounters of the same TypeRefType. If the key proves unstable, this
-// function should be made recursive: walk the full type structure using the
-// visitor pattern, emitting TypeVar.ID for any TypeVarType at any depth and
-// structural representation for everything else. See the "KNOWN LIMITATION"
-// section in planning/taming_recursion/plan_b_visited_set.md Step 4.
 func typeArgKey(args []type_system.Type) string {
 	parts := make([]string, len(args))
 	for i, arg := range args {
-		if tv, ok := arg.(*type_system.TypeVarType); ok {
-			parts[i] = fmt.Sprintf("$%d", tv.ID)
-		} else {
-			parts[i] = fmt.Sprint(arg)
-		}
+		parts[i] = typeKey(arg)
 	}
 	return strings.Join(parts, ",")
+}
+
+// typeKey produces a stable string key for a single type.
+// It recurses into container types (unions, intersections, tuples) so that
+// any embedded TypeRefType is represented by its TypeAlias pointer, not by
+// its structural expansion. This prevents unbounded key growth when
+// recursive type aliases are expanded (e.g. Json → string|Array<Json>
+// produces the same key regardless of how deeply Json has been unfolded).
+func typeKey(t type_system.Type) string {
+	switch v := t.(type) {
+	case *type_system.TypeVarType:
+		return fmt.Sprintf("$%d", v.ID)
+	case *type_system.TypeRefType:
+		if v.TypeAlias != nil {
+			if len(v.TypeArgs) == 0 {
+				return fmt.Sprintf("@%p", v.TypeAlias)
+			}
+			return fmt.Sprintf("@%p<%s>", v.TypeAlias, typeArgKey(v.TypeArgs))
+		}
+		return fmt.Sprint(v)
+	case *type_system.UnionType:
+		parts := make([]string, len(v.Types))
+		for i, u := range v.Types {
+			parts[i] = typeKey(u)
+		}
+		return "(" + strings.Join(parts, " | ") + ")"
+	case *type_system.IntersectionType:
+		parts := make([]string, len(v.Types))
+		for i, u := range v.Types {
+			parts[i] = typeKey(u)
+		}
+		return "(" + strings.Join(parts, " & ") + ")"
+	case *type_system.TupleType:
+		parts := make([]string, len(v.Elems))
+		for i, u := range v.Elems {
+			parts[i] = typeKey(u)
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+	default:
+		return fmt.Sprint(t)
+	}
 }
 
 // noMatchError is a sentinel error indicating that no case in unifyMatched


### PR DESCRIPTION
## Summary

- Fix infinite recursion when type-checking object literals against recursive union type aliases (e.g. `type Json = string | number | boolean | null | Array<Json> | Record<string, Json>`)
- Root cause: `TypeRefType.Accept()` visits TypeArgs before `ExitType`, expanding recursive args into ever-growing keys that defeat `expandSeen` cycle detection
- Skip child traversal for expandable TypeRefTypes in `EnterType`, then explicitly expand TypeArgs in `ExitType` using the same `seen` map so recursive args are detected as cycles
- Make `typeArgKey` recursive via `typeKey` so embedded TypeRefTypes use stable alias-pointer keys regardless of expansion depth

## Test plan

- [x] Uncommented previously-disabled `val j7: Json = { names: ["alice", "bob"], scores: [1, 2, 3] }` test case — now passes
- [x] `NestedGenericTypes` and `ComplexGenericNesting` tests pass (no regression in non-recursive generic expansion)
- [x] Full test suite passes (`go test ./...`)

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of recursive and complex type expansions to prevent incorrect type inference in nested scenarios.
  * Enhanced type unification to provide more stable and accurate type resolution for recursive and parameterized types.

* **Tests**
  * Added test coverage for recursive type patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->