### PR TITLE
Alias tracking (local) & Transition checking

### DIFF
--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -71,6 +71,12 @@ func (c *Checker) checkMutabilityTransition(
 
 	var conflicting []string
 
+	// Note: the loop intentionally does NOT skip sourceVarID. The source
+	// variable is itself a member of the alias set, and if it is still live
+	// after the transition point, it IS a conflicting alias. For example,
+	// when creating an immutable alias `snapshot` from a mutable `items`,
+	// `items` being live means mutations can still occur through it — that
+	// is the conflict we want to report.
 	aliasSets := ctx.Aliases.GetAliasSets(sourceVarID)
 	for _, aliasSet := range aliasSets {
 		for varID, aliasMut := range aliasSet.Members {
@@ -154,14 +160,7 @@ func (c *Checker) trackAliasesForVarDecl(
 		// Check mutability transition
 		stmtRef, hasRef := ctx.StmtToRef[enclosingStmt]
 		if hasRef {
-			// Determine the source's mutability from its alias set
-			sourceMut := false
-			for _, set := range ctx.Aliases.GetAliasSets(sourceVarID) {
-				if m, exists := set.Members[sourceVarID]; exists {
-					sourceMut = m == liveness.AliasMutable
-					break
-				}
-			}
+			sourceMut := isSourceMutable(ctx, sourceVarID)
 
 			return c.checkMutabilityTransition(
 				ctx,
@@ -210,13 +209,7 @@ func (c *Checker) trackAliasesForAssignment(
 		// Check mutability transition before reassigning
 		stmtRef, hasRef := ctx.StmtToRef[ctx.CurrentStmt]
 		if hasRef {
-			sourceMut := false
-			for _, set := range ctx.Aliases.GetAliasSets(sourceVarID) {
-				if m, exists := set.Members[sourceVarID]; exists {
-					sourceMut = m == liveness.AliasMutable
-					break
-				}
-			}
+			sourceMut := isSourceMutable(ctx, sourceVarID)
 
 			transErrors := c.checkMutabilityTransition(
 				ctx,
@@ -243,6 +236,17 @@ func (c *Checker) trackAliasesForAssignment(
 	}
 
 	return nil
+}
+
+// isSourceMutable checks whether a source variable is registered as mutable
+// in its alias sets. Returns true if the source holds a mutable reference.
+func isSourceMutable(ctx Context, sourceVarID liveness.VarID) bool {
+	for _, set := range ctx.Aliases.GetAliasSets(sourceVarID) {
+		if m, exists := set.Members[sourceVarID]; exists {
+			return m == liveness.AliasMutable
+		}
+	}
+	return false
 }
 
 // varIDToName resolves a VarID back to a variable name for error messages.

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -191,6 +191,9 @@ func (c *Checker) trackAliasesForAssignment(
 	rhs ast.Expr,
 	targetType type_system.Type,
 ) []Error {
+	if target.VarID <= 0 {
+		return nil
+	}
 	targetVarID := liveness.VarID(target.VarID)
 	targetMut := isMutableType(targetType)
 	var aliasMut liveness.AliasMutability

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -52,12 +52,10 @@ func (e MutabilityTransitionError) Message() string {
 // while an immutable alias assumes it is unchanged.
 //
 // Rule 1 (mut → immutable): No live mutable aliases may exist after this point,
-//
-//	provided the target (immutable) alias is also live.
+// provided the target (immutable) alias is also live.
 //
 // Rule 2 (immutable → mut): No live immutable aliases may exist after this point,
-//
-//	provided the target (mutable) alias is also live.
+// provided the target (mutable) alias is also live.
 //
 // Rule 3: Multiple mutable aliases are always allowed (mut → mut is not a transition).
 func (c *Checker) checkMutabilityTransition(
@@ -147,7 +145,10 @@ func (c *Checker) trackAliasesForVarDecl(
 	bindings map[string]*type_system.Binding,
 	enclosingStmt ast.Stmt,
 ) []Error {
-	// Only handle simple identifier patterns for now
+	// Only handle simple identifier patterns for now.
+	// VarID 0 means unset (rename pass didn't run), and negative VarIDs are
+	// outer/non-local bindings — only positive VarIDs are local variables
+	// with liveness info.
 	identPat, ok := decl.Pattern.(*ast.IdentPat)
 	if !ok || identPat.VarID <= 0 {
 		return nil

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -47,12 +47,23 @@ func (e MutabilityTransitionError) Message() string {
 // at the given program point. Returns an error if conflicting live aliases
 // exist.
 //
-// Rule 1 (mut → immutable): No live mutable aliases may exist after this point.
-// Rule 2 (immutable → mut): No live immutable aliases may exist after this point.
+// A transition is only dangerous when both sides are live simultaneously
+// after the transition point — i.e. a mutable alias could mutate the value
+// while an immutable alias assumes it is unchanged.
+//
+// Rule 1 (mut → immutable): No live mutable aliases may exist after this point,
+//
+//	provided the target (immutable) alias is also live.
+//
+// Rule 2 (immutable → mut): No live immutable aliases may exist after this point,
+//
+//	provided the target (mutable) alias is also live.
+//
 // Rule 3: Multiple mutable aliases are always allowed (mut → mut is not a transition).
 func (c *Checker) checkMutabilityTransition(
 	ctx Context,
 	sourceVarID liveness.VarID,
+	targetVarID liveness.VarID,
 	sourceVarName string,
 	targetVarName string,
 	sourceMut bool,
@@ -66,6 +77,12 @@ func (c *Checker) checkMutabilityTransition(
 	}
 
 	if ctx.Liveness == nil || ctx.Aliases == nil {
+		return nil
+	}
+
+	// If the target alias is dead immediately after the transition, there is
+	// no window where both sides are live simultaneously, so it's safe.
+	if !ctx.Liveness.IsLiveAfter(assignRef, targetVarID) {
 		return nil
 	}
 
@@ -165,6 +182,7 @@ func (c *Checker) trackAliasesForVarDecl(
 			return c.checkMutabilityTransition(
 				ctx,
 				sourceVarID,
+				targetVarID,
 				c.varIDToName(ctx, sourceVarID),
 				identPat.Name,
 				sourceMut,
@@ -217,6 +235,7 @@ func (c *Checker) trackAliasesForAssignment(
 			transErrors := c.checkMutabilityTransition(
 				ctx,
 				sourceVarID,
+				targetVarID,
 				c.varIDToName(ctx, sourceVarID),
 				target.Name,
 				sourceMut,

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -1,0 +1,257 @@
+package checker
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// MutabilityTransitionError is reported when a mutability transition
+// (mut→immutable or immutable→mut) is attempted while conflicting live
+// aliases exist.
+type MutabilityTransitionError struct {
+	// SourceVar is the variable being aliased.
+	SourceVar string
+	// TargetVar is the variable being created/assigned.
+	TargetVar string
+	// ConflictingVars lists the names of live aliases that conflict.
+	ConflictingVars []string
+	// MutToImmutable is true for Rule 1 (mut→immutable), false for Rule 2 (immutable→mut).
+	MutToImmutable bool
+	span           ast.Span
+}
+
+func (e MutabilityTransitionError) isError() {}
+func (e MutabilityTransitionError) Span() ast.Span {
+	return e.span
+}
+func (e MutabilityTransitionError) IsWarning() bool {
+	return false
+}
+func (e MutabilityTransitionError) Message() string {
+	if e.MutToImmutable {
+		return fmt.Sprintf(
+			"cannot transition '%s' from mutable to immutable: conflicting live mutable alias(es): %v",
+			e.SourceVar, e.ConflictingVars,
+		)
+	}
+	return fmt.Sprintf(
+		"cannot transition '%s' from immutable to mutable: conflicting live immutable alias(es): %v",
+		e.SourceVar, e.ConflictingVars,
+	)
+}
+
+// checkMutabilityTransition verifies that a mutability transition is safe
+// at the given program point. Returns an error if conflicting live aliases
+// exist.
+//
+// Rule 1 (mut → immutable): No live mutable aliases may exist after this point.
+// Rule 2 (immutable → mut): No live immutable aliases may exist after this point.
+// Rule 3: Multiple mutable aliases are always allowed (mut → mut is not a transition).
+func (c *Checker) checkMutabilityTransition(
+	ctx Context,
+	sourceVarID liveness.VarID,
+	sourceVarName string,
+	targetVarName string,
+	sourceMut bool,
+	targetMut bool,
+	assignRef liveness.StmtRef,
+	span ast.Span,
+) []Error {
+	// Same mutability — no transition (Rule 3 for mut→mut)
+	if sourceMut == targetMut {
+		return nil
+	}
+
+	if ctx.Liveness == nil || ctx.Aliases == nil {
+		return nil
+	}
+
+	var conflicting []string
+
+	aliasSets := ctx.Aliases.GetAliasSets(sourceVarID)
+	for _, aliasSet := range aliasSets {
+		for varID, aliasMut := range aliasSet.Members {
+			if !ctx.Liveness.IsLiveAfter(assignRef, varID) {
+				continue
+			}
+			if sourceMut && !targetMut {
+				// Rule 1: mut → immutable — error if any live mutable alias exists
+				if aliasMut == liveness.AliasMutable {
+					conflicting = append(conflicting, c.varIDToName(ctx, varID))
+				}
+			} else {
+				// Rule 2: immutable → mut — error if any live immutable alias exists
+				if aliasMut == liveness.AliasImmutable {
+					conflicting = append(conflicting, c.varIDToName(ctx, varID))
+				}
+			}
+		}
+	}
+
+	if len(conflicting) == 0 {
+		return nil
+	}
+
+	return []Error{&MutabilityTransitionError{
+		SourceVar:       sourceVarName,
+		TargetVar:       targetVarName,
+		ConflictingVars: conflicting,
+		MutToImmutable:  sourceMut && !targetMut,
+		span:            span,
+	}}
+}
+
+// isMutableType checks whether a type has a mutable wrapper (MutabilityType
+// with MutabilityMutable). This determines how a variable accesses the
+// shared value for alias tracking purposes.
+func isMutableType(t type_system.Type) bool {
+	pruned := type_system.Prune(t)
+	if mut, ok := pruned.(*type_system.MutabilityType); ok {
+		return mut.Mutability == type_system.MutabilityMutable
+	}
+	return false
+}
+
+// trackAliasesForVarDecl updates the alias tracker and checks mutability
+// transitions for a variable declaration with an initializer.
+// Only handles simple IdentPat bindings for now (Phase 5-6).
+func (c *Checker) trackAliasesForVarDecl(
+	ctx Context,
+	decl *ast.VarDecl,
+	bindings map[string]*type_system.Binding,
+	enclosingStmt ast.Stmt,
+) []Error {
+	// Only handle simple identifier patterns for now
+	identPat, ok := decl.Pattern.(*ast.IdentPat)
+	if !ok || identPat.VarID <= 0 {
+		return nil
+	}
+
+	targetVarID := liveness.VarID(identPat.VarID)
+	binding := bindings[identPat.Name]
+	if binding == nil {
+		return nil
+	}
+
+	targetMut := isMutableType(binding.Type)
+	var aliasMut liveness.AliasMutability
+	if targetMut {
+		aliasMut = liveness.AliasMutable
+	} else {
+		aliasMut = liveness.AliasImmutable
+	}
+
+	source := liveness.DetermineAliasSource(decl.Init)
+
+	switch source.Kind {
+	case liveness.AliasSourceVariable:
+		sourceVarID := source.VarIDs[0]
+		ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
+
+		// Check mutability transition
+		stmtRef, hasRef := ctx.StmtToRef[enclosingStmt]
+		if hasRef {
+			// Determine the source's mutability from its alias set
+			sourceMut := false
+			for _, set := range ctx.Aliases.GetAliasSets(sourceVarID) {
+				if m, exists := set.Members[sourceVarID]; exists {
+					sourceMut = m == liveness.AliasMutable
+					break
+				}
+			}
+
+			return c.checkMutabilityTransition(
+				ctx,
+				sourceVarID,
+				c.varIDToName(ctx, sourceVarID),
+				identPat.Name,
+				sourceMut,
+				targetMut,
+				stmtRef,
+				decl.Span(),
+			)
+		}
+	case liveness.AliasSourceFresh:
+		ctx.Aliases.NewValue(targetVarID, aliasMut)
+	default:
+		// Unknown or multiple — create a fresh value conservatively
+		ctx.Aliases.NewValue(targetVarID, aliasMut)
+	}
+
+	return nil
+}
+
+// trackAliasesForAssignment updates the alias tracker and checks mutability
+// transitions for a variable reassignment (e.g. `b = expr`).
+func (c *Checker) trackAliasesForAssignment(
+	ctx Context,
+	target *ast.IdentExpr,
+	rhs ast.Expr,
+	targetType type_system.Type,
+) []Error {
+	targetVarID := liveness.VarID(target.VarID)
+	targetMut := isMutableType(targetType)
+	var aliasMut liveness.AliasMutability
+	if targetMut {
+		aliasMut = liveness.AliasMutable
+	} else {
+		aliasMut = liveness.AliasImmutable
+	}
+
+	source := liveness.DetermineAliasSource(rhs)
+
+	switch source.Kind {
+	case liveness.AliasSourceVariable:
+		sourceVarID := source.VarIDs[0]
+
+		// Check mutability transition before reassigning
+		stmtRef, hasRef := ctx.StmtToRef[ctx.CurrentStmt]
+		if hasRef {
+			sourceMut := false
+			for _, set := range ctx.Aliases.GetAliasSets(sourceVarID) {
+				if m, exists := set.Members[sourceVarID]; exists {
+					sourceMut = m == liveness.AliasMutable
+					break
+				}
+			}
+
+			transErrors := c.checkMutabilityTransition(
+				ctx,
+				sourceVarID,
+				c.varIDToName(ctx, sourceVarID),
+				target.Name,
+				sourceMut,
+				targetMut,
+				stmtRef,
+				target.Span(),
+			)
+			if len(transErrors) > 0 {
+				// Still perform reassignment so alias state stays consistent
+				ctx.Aliases.Reassign(targetVarID, &sourceVarID, aliasMut)
+				return transErrors
+			}
+		}
+
+		ctx.Aliases.Reassign(targetVarID, &sourceVarID, aliasMut)
+	case liveness.AliasSourceFresh:
+		ctx.Aliases.Reassign(targetVarID, nil, aliasMut)
+	default:
+		ctx.Aliases.Reassign(targetVarID, nil, aliasMut)
+	}
+
+	return nil
+}
+
+// varIDToName resolves a VarID back to a variable name for error messages.
+// It searches the VarID-to-name mapping built during the rename pass.
+func (c *Checker) varIDToName(ctx Context, id liveness.VarID) string {
+	if ctx.VarIDNames != nil {
+		if name, ok := ctx.VarIDNames[id]; ok {
+			return name
+		}
+	}
+	return fmt.Sprintf("var#%d", id)
+}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -164,6 +164,14 @@ type Context struct {
 	// StmtToRef maps AST statement nodes to their position in the CFG,
 	// enabling lookup of liveness information for a given statement.
 	StmtToRef map[ast.Stmt]liveness.StmtRef
+
+	// VarIDNames maps each local VarID to the variable name, for error messages.
+	VarIDNames map[liveness.VarID]string
+
+	// CurrentStmt is the enclosing statement currently being type-checked.
+	// Set by inferStmt so that nested expression inference can look up the
+	// StmtRef for alias tracking and mutability transition checking.
+	CurrentStmt ast.Stmt
 }
 
 func (ctx *Context) AddYieldedType(t type_system.Type) {
@@ -191,6 +199,7 @@ func (ctx *Context) WithNewScope() Context {
 		Liveness:               ctx.Liveness,
 		Aliases:                ctx.Aliases,
 		StmtToRef:              ctx.StmtToRef,
+		VarIDNames:             ctx.VarIDNames,
 	}
 }
 
@@ -214,6 +223,7 @@ func (ctx *Context) WithNewScopeAndNamespace(ns *type_system.Namespace) Context 
 		Liveness:          ctx.Liveness,
 		Aliases:           ctx.Aliases,
 		StmtToRef:         ctx.StmtToRef,
+		VarIDNames:        ctx.VarIDNames,
 	}
 }
 
@@ -237,6 +247,7 @@ func (ctx *Context) WithScope(scope *Scope) Context {
 		Liveness:               ctx.Liveness,
 		Aliases:                ctx.Aliases,
 		StmtToRef:              ctx.StmtToRef,
+		VarIDNames:             ctx.VarIDNames,
 	}
 }
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -200,6 +200,7 @@ func (ctx *Context) WithNewScope() Context {
 		Aliases:                ctx.Aliases,
 		StmtToRef:              ctx.StmtToRef,
 		VarIDNames:             ctx.VarIDNames,
+		CurrentStmt:            ctx.CurrentStmt,
 	}
 }
 
@@ -224,6 +225,7 @@ func (ctx *Context) WithNewScopeAndNamespace(ns *type_system.Namespace) Context 
 		Aliases:           ctx.Aliases,
 		StmtToRef:         ctx.StmtToRef,
 		VarIDNames:        ctx.VarIDNames,
+		CurrentStmt:       ctx.CurrentStmt,
 	}
 }
 
@@ -248,6 +250,7 @@ func (ctx *Context) WithScope(scope *Scope) Context {
 		Aliases:                ctx.Aliases,
 		StmtToRef:              ctx.StmtToRef,
 		VarIDNames:             ctx.VarIDNames,
+		CurrentStmt:            ctx.CurrentStmt,
 	}
 }
 

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -137,8 +137,11 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			errors = slices.Concat(errors, unifyErrors)
 
 			// Alias tracking for variable reassignment (Phase 6.3)
-			// Only run when typing succeeded — incorrect types could cause
-			// false positive transition errors.
+			// Only run when unification succeeded — incorrect types could cause
+			// false positive transition errors. We intentionally check only for
+			// new errors from unification (not len(errors) == 0) because prior
+			// errors from LHS/RHS inference (e.g. readonly checks, member access
+			// errors) don't invalidate the types used for alias tracking.
 			if ctx.Aliases != nil && len(errors) == errorsBefore {
 				if identExpr, ok := expr.Left.(*ast.IdentExpr); ok && identExpr.VarID > 0 {
 					transErrors := c.trackAliasesForAssignment(ctx, identExpr, expr.Right, leftType)

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -132,11 +132,14 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			}
 
 			// RHS must be a subtype of LHS because we're assigning RHS to LHS
+			errorsBefore := len(errors)
 			unifyErrors := c.Unify(ctx, rightType, leftType)
 			errors = slices.Concat(errors, unifyErrors)
 
 			// Alias tracking for variable reassignment (Phase 6.3)
-			if ctx.Aliases != nil {
+			// Only run when typing succeeded — incorrect types could cause
+			// false positive transition errors.
+			if ctx.Aliases != nil && len(errors) == errorsBefore {
 				if identExpr, ok := expr.Left.(*ast.IdentExpr); ok && identExpr.VarID > 0 {
 					transErrors := c.trackAliasesForAssignment(ctx, identExpr, expr.Right, leftType)
 					errors = slices.Concat(errors, transErrors)
@@ -795,13 +798,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			newNamespace.Values[name] = binding
 		}
 		newScope := ctx.Scope.WithNewScopeAndNamespace(newNamespace)
-		newCtx := Context{
-			Scope:                  newScope,
-			IsAsync:                ctx.IsAsync,
-			IsPatMatch:             ctx.IsPatMatch,
-			AllowUndefinedTypeRefs: ctx.AllowUndefinedTypeRefs,
-			TypeRefsToUpdate:       ctx.TypeRefsToUpdate,
-		}
+		newCtx := ctx.WithScope(newScope)
 
 		// Infer the type of the consequent block with the new context
 		consType, consErrors := c.inferBlock(newCtx, &expr.Cons, type_system.NewNeverType(nil))

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -135,6 +135,14 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			unifyErrors := c.Unify(ctx, rightType, leftType)
 			errors = slices.Concat(errors, unifyErrors)
 
+			// Alias tracking for variable reassignment (Phase 6.3)
+			if ctx.Aliases != nil {
+				if identExpr, ok := expr.Left.(*ast.IdentExpr); ok && identExpr.VarID > 0 {
+					transErrors := c.trackAliasesForAssignment(ctx, identExpr, expr.Right, leftType)
+					errors = slices.Concat(errors, transErrors)
+				}
+			}
+
 			exprType = neverType
 		} else {
 			opBinding := ctx.Scope.GetValue(string(expr.Op))
@@ -473,7 +481,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				}
 
 				inferErrors := c.inferFuncBodyWithFuncSigType(
-					methodCtx, methodType, paramBindings, methodExpr.Fn.Body, methodExpr.Fn.Async)
+					methodCtx, methodType, paramBindings, methodExpr.Fn.Params, methodExpr.Fn.Body, methodExpr.Fn.Async)
 				errors = slices.Concat(errors, inferErrors)
 
 			case *ast.GetterExpr:
@@ -487,7 +495,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 
 				getterExpr := elem
 				inferErrors := c.inferFuncBodyWithFuncSigType(
-					objCtx, funcType, paramBindings, getterExpr.Fn.Body, getterExpr.Fn.Async)
+					objCtx, funcType, paramBindings, getterExpr.Fn.Params, getterExpr.Fn.Body, getterExpr.Fn.Async)
 				errors = slices.Concat(errors, inferErrors)
 
 			case *ast.SetterExpr:
@@ -501,7 +509,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 
 				setterExpr := elem
 				inferErrors := c.inferFuncBodyWithFuncSigType(
-					objCtx, funcType, paramBindings, setterExpr.Fn.Body, setterExpr.Fn.Async)
+					objCtx, funcType, paramBindings, setterExpr.Fn.Params, setterExpr.Fn.Body, setterExpr.Fn.Async)
 				errors = slices.Concat(errors, inferErrors)
 			case *ast.ObjSpreadExpr:
 				// Already handled in the first loop — nothing to do here.
@@ -527,7 +535,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			funcCtx.CallSiteTypeVars = &callSiteTypeVars
 		}
 
-		inferErrors := c.inferFuncBodyWithFuncSigType(funcCtx, funcType, paramBindings, expr.Body, expr.FuncSig.Async)
+		inferErrors := c.inferFuncBodyWithFuncSigType(funcCtx, funcType, paramBindings, expr.FuncSig.Params, expr.Body, expr.FuncSig.Async)
 		errors = slices.Concat(errors, inferErrors)
 
 		// Only generalize top-level FuncExprs. Nested FuncExprs (inside function

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -271,7 +271,7 @@ func (c *Checker) inferFuncBody(
 
 	// Liveness pre-pass: resolve names, build CFG, compute liveness,
 	// and initialize alias tracker for mutability transition checking.
-	c.runLivenessPrePass(&ctx, astParams, body)
+	c.runLivenessPrePass(&ctx, astParams, bindings, body)
 
 	errors := []Error{}
 	for _, stmt := range body.Stmts {

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -171,6 +171,7 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 	ctx Context,
 	funcSigType *type_system.FuncType,
 	paramBindings map[string]*type_system.Binding,
+	astParams []*ast.Param,
 	body *ast.Block,
 	isAsync bool,
 ) []Error {
@@ -194,7 +195,7 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 		bodyCtx.AwaitThrowTypes = &awaitThrowTypes
 	}
 
-	returnType, inferredThrowType, bodyErrors := c.inferFuncBody(bodyCtx, paramBindings, body)
+	returnType, inferredThrowType, bodyErrors := c.inferFuncBody(bodyCtx, paramBindings, astParams, body)
 	errors = slices.Concat(errors, bodyErrors)
 
 	// Check if this function is a generator (contains yield)
@@ -261,11 +262,16 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 func (c *Checker) inferFuncBody(
 	ctx Context,
 	bindings map[string]*type_system.Binding,
+	astParams []*ast.Param,
 	body *ast.Block,
 ) (type_system.Type, type_system.Type, []Error) {
 
 	ctx = ctx.WithNewScope()
 	maps.Copy(ctx.Scope.Namespace.Values, bindings)
+
+	// Liveness pre-pass: resolve names, build CFG, compute liveness,
+	// and initialize alias tracker for mutability transition checking.
+	c.runLivenessPrePass(&ctx, astParams, body)
 
 	errors := []Error{}
 	for _, stmt := range body.Stmts {

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -736,7 +736,7 @@ func (c *Checker) InferComponent(
 					declCtx.CallSiteTypeVars = &callSiteTypeVars
 
 					inferErrors := c.inferFuncBodyWithFuncSigType(
-						declCtx, funcType, paramBindings, decl.Body, decl.FuncSig.Async)
+						declCtx, funcType, paramBindings, decl.FuncSig.Params, decl.Body, decl.FuncSig.Async)
 					errors = slices.Concat(errors, inferErrors)
 				}
 
@@ -1106,7 +1106,7 @@ func (c *Checker) InferComponent(
 							}
 
 							methodCtx := methodCtxForElem[classMethodCtxKey{decl: decl, elemIndex: i}]
-							bodyErrors := c.inferFuncBodyWithFuncSigType(methodCtx, methodType.Fn, paramBindings, bodyElem.Fn.Body, false)
+							bodyErrors := c.inferFuncBodyWithFuncSigType(methodCtx, methodType.Fn, paramBindings, bodyElem.Fn.Params, bodyElem.Fn.Body, false)
 							errors = slices.Concat(errors, bodyErrors)
 						}
 
@@ -1166,7 +1166,7 @@ func (c *Checker) InferComponent(
 							}
 
 							if bodyElem.Fn.Body != nil {
-								bodyErrors := c.inferFuncBodyWithFuncSigType(bodyCtx, getterType.Fn, paramBindings, bodyElem.Fn.Body, false)
+								bodyErrors := c.inferFuncBodyWithFuncSigType(bodyCtx, getterType.Fn, paramBindings, bodyElem.Fn.Params, bodyElem.Fn.Body, false)
 								errors = slices.Concat(errors, bodyErrors)
 							}
 						}
@@ -1229,7 +1229,7 @@ func (c *Checker) InferComponent(
 							}
 
 							if bodyElem.Fn.Body != nil {
-								bodyErrors := c.inferFuncBodyWithFuncSigType(bodyCtx, setterType.Fn, paramBindings, bodyElem.Fn.Body, false)
+								bodyErrors := c.inferFuncBodyWithFuncSigType(bodyCtx, setterType.Fn, paramBindings, bodyElem.Fn.Params, bodyElem.Fn.Body, false)
 								errors = slices.Concat(errors, bodyErrors)
 							}
 						}

--- a/internal/checker/infer_script.go
+++ b/internal/checker/infer_script.go
@@ -14,6 +14,12 @@ func (c *Checker) InferScript(ctx Context, m *ast.Script) (scope *Scope, errors 
 	ctx = ctx.WithNewScope()
 	scope = ctx.Scope
 
+	// Run the liveness pre-pass on top-level script code so that alias
+	// tracking and mutability transition checking work the same as inside
+	// function bodies.
+	scriptBody := &ast.Block{Stmts: m.Stmts, Span: m.Span()}
+	c.runLivenessPrePass(&ctx, nil, nil, scriptBody)
+
 	for _, stmt := range m.Stmts {
 		c.checkTimeout()
 		stmtErrors := c.inferStmt(ctx, stmt)

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -11,12 +11,13 @@ import (
 )
 
 func (c *Checker) inferStmt(ctx Context, stmt ast.Stmt) []Error {
+	ctx.CurrentStmt = stmt
 	switch stmt := stmt.(type) {
 	case *ast.ExprStmt:
 		_, errors := c.inferExpr(ctx, stmt.Expr)
 		return errors
 	case *ast.DeclStmt:
-		return c.inferDecl(ctx, stmt.Decl)
+		return c.inferDecl(ctx, stmt.Decl, stmt)
 	case *ast.ReturnStmt:
 		errors := []Error{}
 		if stmt.Expr != nil {
@@ -39,7 +40,7 @@ func (c *Checker) inferStmt(ctx Context, stmt ast.Stmt) []Error {
 	}
 }
 
-func (c *Checker) inferDecl(ctx Context, decl ast.Decl) []Error {
+func (c *Checker) inferDecl(ctx Context, decl ast.Decl, enclosingStmt ast.Stmt) []Error {
 	switch decl := decl.(type) {
 	case *ast.FuncDecl:
 		// Handle incomplete function declarations
@@ -48,7 +49,7 @@ func (c *Checker) inferDecl(ctx Context, decl ast.Decl) []Error {
 		}
 		return c.inferFuncDecl(ctx, decl)
 	case *ast.VarDecl:
-		bindings, errors := c.inferVarDecl(ctx, decl)
+		bindings, errors := c.inferVarDecl(ctx, decl, enclosingStmt)
 		maps.Copy(ctx.Scope.Namespace.Values, bindings)
 		return errors
 	case *ast.TypeDecl:
@@ -75,6 +76,7 @@ func (c *Checker) inferDecl(ctx Context, decl ast.Decl) []Error {
 func (c *Checker) inferVarDecl(
 	ctx Context,
 	decl *ast.VarDecl,
+	enclosingStmt ast.Stmt,
 ) (map[string]*type_system.Binding, []Error) {
 	errors := []Error{}
 
@@ -114,6 +116,12 @@ func (c *Checker) inferVarDecl(
 
 		unifyErrors := c.Unify(ctx, initType, patType)
 		errors = slices.Concat(errors, unifyErrors)
+	}
+
+	// Alias tracking and mutability transition checking (Phase 5-6)
+	if ctx.Aliases != nil && decl.Init != nil {
+		transErrors := c.trackAliasesForVarDecl(ctx, decl, bindings, enclosingStmt)
+		errors = slices.Concat(errors, transErrors)
 	}
 
 	return bindings, errors
@@ -166,7 +174,7 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 		ctx.CallSiteTypeVars = &callSiteTypeVars
 
 		inferErrors := c.inferFuncBodyWithFuncSigType(
-			ctx, funcType, paramBindings, decl.Body, decl.FuncSig.Async)
+			ctx, funcType, paramBindings, decl.FuncSig.Params, decl.Body, decl.FuncSig.Async)
 		errors = slices.Concat(errors, inferErrors)
 	}
 

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -161,11 +161,7 @@ func (c *Checker) inferTypeAnn(
 				condScope.SetTypeAlias(name, inferTypeAlias)
 			}
 
-			condCtx = Context{
-				Scope:      condScope,
-				IsAsync:    ctx.IsAsync,
-				IsPatMatch: ctx.IsPatMatch,
-			}
+			condCtx = ctx.WithScope(condScope)
 		}
 
 		thenType, thenErrors := c.inferTypeAnn(condCtx, typeAnn.Then)
@@ -397,11 +393,7 @@ func (c *Checker) inferObjectTypeAnn(
 				}
 				mappedScope.SetTypeAlias(elem.TypeParam.Name, typeParamAlias)
 
-				mappedCtx = Context{
-					Scope:      mappedScope,
-					IsAsync:    ctx.IsAsync,
-					IsPatMatch: ctx.IsPatMatch,
-				}
+				mappedCtx = ctx.WithScope(mappedScope)
 			}
 
 			// Infer the value type with the type parameter in scope

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -46,6 +46,10 @@ func collectOuterBindings(scope *Scope) map[string]liveness.VarID {
 	bindings := make(map[string]liveness.VarID)
 	nextID := liveness.VarID(-1)
 
+	// Note: the loop starts from the current scope, which includes parameter
+	// bindings that were already added. This is intentional — the rename pass's
+	// define() overwrites the negative VarID with a positive one when it
+	// processes the parameter, so the shadowing is handled correctly.
 	for s := scope; s != nil; s = s.Parent {
 		for name := range s.Namespace.Values {
 			if _, exists := bindings[name]; !exists {

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
 // runLivenessPrePass runs name resolution, CFG construction, and liveness
@@ -12,15 +13,31 @@ import (
 // This must be called after bindings have been added to the scope (so that
 // outer-scope names can be resolved) but before statements are walked for
 // type checking.
-func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, body *ast.Block) {
+func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, paramBindings map[string]*type_system.Binding, body *ast.Block) {
 	// Build outer bindings from the scope chain. Every value binding
 	// accessible from the current scope (excluding local params, which the
 	// rename pass handles separately) gets a negative VarID so the rename
 	// pass can distinguish local from non-local variables.
 	outerBindings := collectOuterBindings(ctx.Scope)
 
+	// Compute extra param names: bindings in paramBindings that are not in
+	// astParams (e.g. implicit 'self' in methods). These need positive VarIDs
+	// so their uses in the body are tracked as local variables.
+	astParamNames := make(map[string]bool, len(astParams))
+	for _, p := range astParams {
+		if identPat, ok := p.Pattern.(*ast.IdentPat); ok {
+			astParamNames[identPat.Name] = true
+		}
+	}
+	var extraParamNames []string
+	for name := range paramBindings {
+		if !astParamNames[name] {
+			extraParamNames = append(extraParamNames, name)
+		}
+	}
+
 	// Phase 2: Resolve names → VarIDs
-	renameResult := liveness.Rename(astParams, *body, outerBindings)
+	renameResult := liveness.Rename(astParams, *body, outerBindings, extraParamNames...)
 
 	// Phase 3-4: Build CFG and run backward liveness analysis
 	cfg := liveness.BuildCFG(*body)
@@ -29,8 +46,38 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, body 
 	// Build StmtToRef lookup
 	stmtToRef := liveness.BuildStmtToRef(cfg)
 
-	// Initialize alias tracker
+	// Initialize alias tracker and seed parameters so that aliases from
+	// parameters are tracked and mutability transitions are detected.
 	aliases := liveness.NewAliasTracker()
+	for _, param := range astParams {
+		if identPat, ok := param.Pattern.(*ast.IdentPat); ok && identPat.VarID > 0 {
+			varID := liveness.VarID(identPat.VarID)
+			// Determine mutability from the parameter's type binding in scope.
+			mut := liveness.AliasImmutable
+			if binding := ctx.Scope.Namespace.Values[identPat.Name]; binding != nil {
+				if isMutableType(binding.Type) {
+					mut = liveness.AliasMutable
+				}
+			}
+			aliases.NewValue(varID, mut)
+		}
+	}
+	// Seed extra params (e.g. 'self') into the alias tracker.
+	for _, name := range extraParamNames {
+		// Reverse-lookup: find the VarID assigned to this name.
+		for varID, varName := range renameResult.VarIDNames {
+			if varName == name {
+				mut := liveness.AliasImmutable
+				if binding := paramBindings[name]; binding != nil {
+					if isMutableType(binding.Type) {
+						mut = liveness.AliasMutable
+					}
+				}
+				aliases.NewValue(varID, mut)
+				break
+			}
+		}
+	}
 
 	// Set context fields
 	ctx.Liveness = livenessInfo

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -64,20 +64,14 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, param
 		}
 	}
 	// Seed extra params (e.g. 'self') into the alias tracker.
-	for _, name := range extraParamNames {
-		// Reverse-lookup: find the VarID assigned to this name.
-		for varID, varName := range renameResult.VarIDNames {
-			if varName == name {
-				mut := liveness.AliasImmutable
-				if binding := paramBindings[name]; binding != nil {
-					if isMutableType(binding.Type) {
-						mut = liveness.AliasMutable
-					}
-				}
-				aliases.NewValue(varID, mut)
-				break
+	for name, varID := range renameResult.ExtraParamVarIDs {
+		mut := liveness.AliasImmutable
+		if binding := paramBindings[name]; binding != nil {
+			if isMutableType(binding.Type) {
+				mut = liveness.AliasMutable
 			}
 		}
+		aliases.NewValue(varID, mut)
 	}
 
 	// Set context fields

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -1,0 +1,59 @@
+package checker
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+)
+
+// runLivenessPrePass runs name resolution, CFG construction, and liveness
+// analysis on a function body. It sets up the Context fields needed for
+// alias tracking and mutability transition checking during type inference.
+//
+// This must be called after bindings have been added to the scope (so that
+// outer-scope names can be resolved) but before statements are walked for
+// type checking.
+func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, body *ast.Block) {
+	// Build outer bindings from the scope chain. Every value binding
+	// accessible from the current scope (excluding local params, which the
+	// rename pass handles separately) gets a negative VarID so the rename
+	// pass can distinguish local from non-local variables.
+	outerBindings := collectOuterBindings(ctx.Scope)
+
+	// Phase 2: Resolve names → VarIDs
+	renameResult := liveness.Rename(astParams, *body, outerBindings)
+
+	// Phase 3-4: Build CFG and run backward liveness analysis
+	cfg := liveness.BuildCFG(*body)
+	livenessInfo := liveness.AnalyzeFunction(cfg)
+
+	// Build StmtToRef lookup
+	stmtToRef := liveness.BuildStmtToRef(cfg)
+
+	// Initialize alias tracker
+	aliases := liveness.NewAliasTracker()
+
+	// Set context fields
+	ctx.Liveness = livenessInfo
+	ctx.Aliases = aliases
+	ctx.StmtToRef = stmtToRef
+	ctx.VarIDNames = renameResult.VarIDNames
+}
+
+// collectOuterBindings walks the scope chain and collects all value binding
+// names, assigning each a unique negative VarID. These are used by the
+// rename pass to distinguish non-local references from unresolved names.
+func collectOuterBindings(scope *Scope) map[string]liveness.VarID {
+	bindings := make(map[string]liveness.VarID)
+	nextID := liveness.VarID(-1)
+
+	for s := scope; s != nil; s = s.Parent {
+		for name := range s.Namespace.Values {
+			if _, exists := bindings[name]; !exists {
+				bindings[name] = nextID
+				nextID--
+			}
+		}
+	}
+
+	return bindings
+}

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -23,23 +24,23 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, param
 	// Compute extra param names: bindings in paramBindings that are not in
 	// astParams (e.g. implicit 'self' in methods). These need positive VarIDs
 	// so their uses in the body are tracked as local variables.
-	astParamNames := make(map[string]bool, len(astParams))
+	astParamNames := set.NewSet[string]()
 	for _, p := range astParams {
 		if identPat, ok := p.Pattern.(*ast.IdentPat); ok {
-			astParamNames[identPat.Name] = true
+			astParamNames.Add(identPat.Name)
 		}
 	}
 	var extraParamNames []string
 	for name := range paramBindings {
-		if !astParamNames[name] {
+		if !astParamNames.Contains(name) {
 			extraParamNames = append(extraParamNames, name)
 		}
 	}
 
-	// Phase 2: Resolve names → VarIDs
+	// Resolve names → VarIDs
 	renameResult := liveness.Rename(astParams, *body, outerBindings, extraParamNames...)
 
-	// Phase 3-4: Build CFG and run backward liveness analysis
+	// Build CFG and run backward liveness analysis
 	cfg := liveness.BuildCFG(*body)
 	livenessInfo := liveness.AnalyzeFunction(cfg)
 
@@ -89,6 +90,10 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, param
 // collectOuterBindings walks the scope chain and collects all value binding
 // names, assigning each a unique negative VarID. These are used by the
 // rename pass to distinguish non-local references from unresolved names.
+//
+// TODO(Phase 15.1): This re-walks the entire scope chain (including the
+// prelude) on every call. Cache the flattened bindings at the parent scope
+// level so that only the current scope's bindings need to be added each time.
 func collectOuterBindings(scope *Scope) map[string]liveness.VarID {
 	bindings := make(map[string]liveness.VarID)
 	nextID := liveness.VarID(-1)

--- a/internal/checker/tests/transition_test.go
+++ b/internal/checker/tests/transition_test.go
@@ -9,12 +9,20 @@ import (
 	. "github.com/escalier-lang/escalier/internal/checker"
 	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type expectedTransitionError struct {
+	SourceVar       string
+	TargetVar       string
+	ConflictingVars []string
+	MutToImmutable  bool
+}
 
 func TestMutabilityTransitions(t *testing.T) {
 	tests := map[string]struct {
-		input        string
-		expectErrors bool
+		input          string
+		expectedErrors []expectedTransitionError
 	}{
 		// Rule 1: mut → immutable — OK when source is dead
 		"MutToImmutable_SourceDead_OK": {
@@ -26,7 +34,6 @@ func TestMutabilityTransitions(t *testing.T) {
 					snapshot
 				}
 			`,
-			expectErrors: false,
 		},
 		// Rule 1: mut → immutable — ERROR when source is live
 		"MutToImmutable_SourceLive_Error": {
@@ -38,7 +45,12 @@ func TestMutabilityTransitions(t *testing.T) {
 					snapshot
 				}
 			`,
-			expectErrors: true,
+			expectedErrors: []expectedTransitionError{{
+				SourceVar:       "items",
+				TargetVar:       "snapshot",
+				ConflictingVars: []string{"items"},
+				MutToImmutable:  true,
+			}},
 		},
 		// Rule 2: immutable → mut — OK when source is dead
 		"ImmutableToMut_SourceDead_OK": {
@@ -50,7 +62,6 @@ func TestMutabilityTransitions(t *testing.T) {
 					mutableConfig.host = "0.0.0.0"
 				}
 			`,
-			expectErrors: false,
 		},
 		// Rule 2: immutable → mut — ERROR when source is live
 		"ImmutableToMut_SourceLive_Error": {
@@ -62,7 +73,12 @@ func TestMutabilityTransitions(t *testing.T) {
 					config
 				}
 			`,
-			expectErrors: true,
+			expectedErrors: []expectedTransitionError{{
+				SourceVar:       "config",
+				TargetVar:       "mutableConfig",
+				ConflictingVars: []string{"config"},
+				MutToImmutable:  false,
+			}},
 		},
 		// Rule 3: multiple mutable aliases — always OK
 		"MultipleMutableAliases_OK": {
@@ -74,10 +90,9 @@ func TestMutabilityTransitions(t *testing.T) {
 					a.x
 				}
 			`,
-			expectErrors: false,
 		},
-		// Alias tracking: transitive alias conflict
-		"TransitiveAlias_MutToImmutable_Error": {
+		// Alias tracking: transitive alias — OK when immutable target is dead
+		"TransitiveAlias_MutToImmutable_TargetDead_OK": {
 			input: `
 				fn test() {
 					val p: mut {x: number} = {x: 0}
@@ -86,7 +101,24 @@ func TestMutabilityTransitions(t *testing.T) {
 					r.x = 5
 				}
 			`,
-			expectErrors: true,
+		},
+		// Alias tracking: transitive alias — ERROR when immutable target is live
+		"TransitiveAlias_MutToImmutable_TargetLive_Error": {
+			input: `
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					val r: mut {x: number} = p
+					val q: {x: number} = p
+					r.x = 5
+					q
+				}
+			`,
+			expectedErrors: []expectedTransitionError{{
+				SourceVar:       "p",
+				TargetVar:       "q",
+				ConflictingVars: []string{"r"},
+				MutToImmutable:  true,
+			}},
 		},
 		// Fresh value — no alias, no transition check
 		"FreshValue_NoTransition": {
@@ -98,10 +130,20 @@ func TestMutabilityTransitions(t *testing.T) {
 					b
 				}
 			`,
-			expectErrors: false,
 		},
-		// Chain aliasing: val b = a; val c = b — a is still live and mutable
-		"ChainAlias_MutToImmutable_Error": {
+		// Chain aliasing: val b = a; val c = b — OK when immutable target c is dead
+		"ChainAlias_MutToImmutable_TargetDead_OK": {
+			input: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: mut {x: number} = a
+					val c: {x: number} = b
+					a.x = 2
+				}
+			`,
+		},
+		// Chain aliasing: val b = a; val c = b — ERROR when immutable target c is live
+		"ChainAlias_MutToImmutable_TargetLive_Error": {
 			input: `
 				fn test() {
 					val a: mut {x: number} = {x: 1}
@@ -111,7 +153,12 @@ func TestMutabilityTransitions(t *testing.T) {
 					c
 				}
 			`,
-			expectErrors: true,
+			expectedErrors: []expectedTransitionError{{
+				SourceVar:       "b",
+				TargetVar:       "c",
+				ConflictingVars: []string{"a"},
+				MutToImmutable:  true,
+			}},
 		},
 		// Parameter alias: mut param → immutable — ERROR when param is still live
 		"ParamAlias_MutToImmutable_SourceLive_Error": {
@@ -122,7 +169,12 @@ func TestMutabilityTransitions(t *testing.T) {
 					snapshot
 				}
 			`,
-			expectErrors: true,
+			expectedErrors: []expectedTransitionError{{
+				SourceVar:       "items",
+				TargetVar:       "snapshot",
+				ConflictingVars: []string{"items"},
+				MutToImmutable:  true,
+			}},
 		},
 		// Parameter alias: mut param → immutable — OK when param is dead
 		"ParamAlias_MutToImmutable_SourceDead_OK": {
@@ -133,7 +185,6 @@ func TestMutabilityTransitions(t *testing.T) {
 					snapshot
 				}
 			`,
-			expectErrors: false,
 		},
 		// Chain aliasing: val b = a; val c = b — a is dead after transition
 		"ChainAlias_MutToImmutable_OK_WhenDead": {
@@ -146,14 +197,13 @@ func TestMutabilityTransitions(t *testing.T) {
 					c
 				}
 			`,
-			expectErrors: false,
 		},
 	}
 
 	// Top-level script code (no wrapping function) — same rules apply.
 	tests["TopLevel_MutToImmutable_Error"] = struct {
-		input        string
-		expectErrors bool
+		input          string
+		expectedErrors []expectedTransitionError
 	}{
 		input: `
 			val items: mut {x: number} = {x: 1}
@@ -161,11 +211,16 @@ func TestMutabilityTransitions(t *testing.T) {
 			items.x = 2
 			snapshot
 		`,
-		expectErrors: true,
+		expectedErrors: []expectedTransitionError{{
+			SourceVar:       "items",
+			TargetVar:       "snapshot",
+			ConflictingVars: []string{"items"},
+			MutToImmutable:  true,
+		}},
 	}
 	tests["TopLevel_MutToImmutable_OK"] = struct {
-		input        string
-		expectErrors bool
+		input          string
+		expectedErrors []expectedTransitionError
 	}{
 		input: `
 			val items: mut {x: number} = {x: 1}
@@ -173,7 +228,6 @@ func TestMutabilityTransitions(t *testing.T) {
 			val snapshot: {x: number} = items
 			snapshot
 		`,
-		expectErrors: false,
 	}
 
 	for name, test := range tests {
@@ -190,7 +244,7 @@ func TestMutabilityTransitions(t *testing.T) {
 			p := parser.NewParser(ctx, source)
 			script, parseErrors := p.ParseScript()
 
-			assert.Len(t, parseErrors, 0, "Expected no parse errors")
+			require.Empty(t, parseErrors, "Expected no parse errors")
 
 			c := NewChecker(ctx)
 			inferCtx := Context{
@@ -200,26 +254,23 @@ func TestMutabilityTransitions(t *testing.T) {
 			}
 			_, inferErrors := c.InferScript(inferCtx, script)
 
-			hasMutErr := false
+			var mutErrors []*MutabilityTransitionError
 			for _, err := range inferErrors {
-				if _, ok := err.(*MutabilityTransitionError); ok {
-					hasMutErr = true
-					break
+				if mutErr, ok := err.(*MutabilityTransitionError); ok {
+					mutErrors = append(mutErrors, mutErr)
 				}
 			}
 
-			if test.expectErrors {
-				assert.True(t, hasMutErr, "Expected MutabilityTransitionError for %s, got: %v", name, inferErrors)
-				// Print the errors to help debugging
-				for i, err := range inferErrors {
-					t.Logf("Error[%d]: %s", i, err.Message())
-				}
+			if len(test.expectedErrors) == 0 {
+				assert.Empty(t, mutErrors, "Expected no MutabilityTransitionError")
 			} else {
-				assert.False(t, hasMutErr, "Unexpected MutabilityTransitionError for %s", name)
-				if len(inferErrors) > 0 {
-					for i, err := range inferErrors {
-						t.Logf("Unexpected Error[%d]: %s", i, err.Message())
-					}
+				require.Len(t, mutErrors, len(test.expectedErrors), "Wrong number of MutabilityTransitionErrors")
+				for i, expected := range test.expectedErrors {
+					actual := mutErrors[i]
+					assert.Equal(t, expected.SourceVar, actual.SourceVar, "SourceVar mismatch")
+					assert.Equal(t, expected.TargetVar, actual.TargetVar, "TargetVar mismatch")
+					assert.Equal(t, expected.ConflictingVars, actual.ConflictingVars, "ConflictingVars mismatch")
+					assert.Equal(t, expected.MutToImmutable, actual.MutToImmutable, "MutToImmutable mismatch")
 				}
 			}
 		})

--- a/internal/checker/tests/transition_test.go
+++ b/internal/checker/tests/transition_test.go
@@ -150,6 +150,32 @@ func TestMutabilityTransitions(t *testing.T) {
 		},
 	}
 
+	// Top-level script code (no wrapping function) — same rules apply.
+	tests["TopLevel_MutToImmutable_Error"] = struct {
+		input        string
+		expectErrors bool
+	}{
+		input: `
+			val items: mut {x: number} = {x: 1}
+			val snapshot: {x: number} = items
+			items.x = 2
+			snapshot
+		`,
+		expectErrors: true,
+	}
+	tests["TopLevel_MutToImmutable_OK"] = struct {
+		input        string
+		expectErrors bool
+	}{
+		input: `
+			val items: mut {x: number} = {x: 1}
+			items.x = 2
+			val snapshot: {x: number} = items
+			snapshot
+		`,
+		expectErrors: false,
+	}
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/checker/tests/transition_test.go
+++ b/internal/checker/tests/transition_test.go
@@ -1,0 +1,171 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	. "github.com/escalier-lang/escalier/internal/checker"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMutabilityTransitions(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		expectErrors bool
+	}{
+		// Rule 1: mut → immutable — OK when source is dead
+		"MutToImmutable_SourceDead_OK": {
+			input: `
+				fn test() {
+					val items: mut {x: number} = {x: 1}
+					items.x = 2
+					val snapshot: {x: number} = items
+					snapshot
+				}
+			`,
+			expectErrors: false,
+		},
+		// Rule 1: mut → immutable — ERROR when source is live
+		"MutToImmutable_SourceLive_Error": {
+			input: `
+				fn test() {
+					val items: mut {x: number} = {x: 1}
+					val snapshot: {x: number} = items
+					items.x = 2
+					snapshot
+				}
+			`,
+			expectErrors: true,
+		},
+		// Rule 2: immutable → mut — OK when source is dead
+		"ImmutableToMut_SourceDead_OK": {
+			input: `
+				fn test() {
+					val config: {host: string} = {host: "localhost"}
+					config
+					val mutableConfig: mut {host: string} = config
+					mutableConfig.host = "0.0.0.0"
+				}
+			`,
+			expectErrors: false,
+		},
+		// Rule 2: immutable → mut — ERROR when source is live
+		"ImmutableToMut_SourceLive_Error": {
+			input: `
+				fn test() {
+					val config: {host: string} = {host: "localhost"}
+					val mutableConfig: mut {host: string} = config
+					mutableConfig.host = "0.0.0.0"
+					config
+				}
+			`,
+			expectErrors: true,
+		},
+		// Rule 3: multiple mutable aliases — always OK
+		"MultipleMutableAliases_OK": {
+			input: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: mut {x: number} = a
+					b.x = 2
+					a.x
+				}
+			`,
+			expectErrors: false,
+		},
+		// Alias tracking: transitive alias conflict
+		"TransitiveAlias_MutToImmutable_Error": {
+			input: `
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					val r: mut {x: number} = p
+					val q: {x: number} = p
+					r.x = 5
+				}
+			`,
+			expectErrors: true,
+		},
+		// Fresh value — no alias, no transition check
+		"FreshValue_NoTransition": {
+			input: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: {x: number} = {x: 2}
+					a.x = 3
+					b
+				}
+			`,
+			expectErrors: false,
+		},
+		// Chain aliasing: val b = a; val c = b — a is still live and mutable
+		"ChainAlias_MutToImmutable_Error": {
+			input: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: mut {x: number} = a
+					val c: {x: number} = b
+					a.x = 2
+					c
+				}
+			`,
+			expectErrors: true,
+		},
+		// Chain aliasing: val b = a; val c = b — a is dead after transition
+		"ChainAlias_MutToImmutable_OK_WhenDead": {
+			input: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: mut {x: number} = a
+					a.x = 2
+					val c: {x: number} = b
+					c
+				}
+			`,
+			expectErrors: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := &ast.Source{
+				ID:       0,
+				Path:     "input.esc",
+				Contents: test.input,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			p := parser.NewParser(ctx, source)
+			script, parseErrors := p.ParseScript()
+
+			assert.Len(t, parseErrors, 0, "Expected no parse errors")
+
+			c := NewChecker(ctx)
+			inferCtx := Context{
+				Scope:      Prelude(c),
+				IsAsync:    false,
+				IsPatMatch: false,
+			}
+			_, inferErrors := c.InferScript(inferCtx, script)
+
+			if test.expectErrors {
+				assert.NotEmpty(t, inferErrors, "Expected inference errors for %s", name)
+				// Print the errors to help debugging
+				for i, err := range inferErrors {
+					t.Logf("Error[%d]: %s", i, err.Message())
+				}
+			} else {
+				if len(inferErrors) > 0 {
+					for i, err := range inferErrors {
+						t.Logf("Unexpected Error[%d]: %s", i, err.Message())
+					}
+				}
+				assert.Empty(t, inferErrors, "Expected no inference errors for %s", name)
+			}
+		})
+	}
+}

--- a/internal/checker/tests/transition_test.go
+++ b/internal/checker/tests/transition_test.go
@@ -113,6 +113,28 @@ func TestMutabilityTransitions(t *testing.T) {
 			`,
 			expectErrors: true,
 		},
+		// Parameter alias: mut param → immutable — ERROR when param is still live
+		"ParamAlias_MutToImmutable_SourceLive_Error": {
+			input: `
+				fn test(items: mut {x: number}) {
+					val snapshot: {x: number} = items
+					items.x = 2
+					snapshot
+				}
+			`,
+			expectErrors: true,
+		},
+		// Parameter alias: mut param → immutable — OK when param is dead
+		"ParamAlias_MutToImmutable_SourceDead_OK": {
+			input: `
+				fn test(items: mut {x: number}) {
+					items.x = 2
+					val snapshot: {x: number} = items
+					snapshot
+				}
+			`,
+			expectErrors: false,
+		},
 		// Chain aliasing: val b = a; val c = b — a is dead after transition
 		"ChainAlias_MutToImmutable_OK_WhenDead": {
 			input: `
@@ -152,19 +174,27 @@ func TestMutabilityTransitions(t *testing.T) {
 			}
 			_, inferErrors := c.InferScript(inferCtx, script)
 
+			hasMutErr := false
+			for _, err := range inferErrors {
+				if _, ok := err.(*MutabilityTransitionError); ok {
+					hasMutErr = true
+					break
+				}
+			}
+
 			if test.expectErrors {
-				assert.NotEmpty(t, inferErrors, "Expected inference errors for %s", name)
+				assert.True(t, hasMutErr, "Expected MutabilityTransitionError for %s, got: %v", name, inferErrors)
 				// Print the errors to help debugging
 				for i, err := range inferErrors {
 					t.Logf("Error[%d]: %s", i, err.Message())
 				}
 			} else {
+				assert.False(t, hasMutErr, "Unexpected MutabilityTransitionError for %s", name)
 				if len(inferErrors) > 0 {
 					for i, err := range inferErrors {
 						t.Logf("Unexpected Error[%d]: %s", i, err.Message())
 					}
 				}
-				assert.Empty(t, inferErrors, "Expected no inference errors for %s", name)
 			}
 		})
 	}

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -1,0 +1,109 @@
+package liveness
+
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// AliasSourceKind describes the kind of alias source an expression represents.
+type AliasSourceKind int
+
+const (
+	AliasSourceFresh    AliasSourceKind = iota // new value, no alias
+	AliasSourceVariable                        // aliases a specific variable
+	AliasSourceMultiple                        // aliases one of several variables (conditional)
+	AliasSourceUnknown                         // cannot determine statically
+)
+
+// AliasSource describes where a value comes from for alias tracking purposes.
+type AliasSource struct {
+	Kind   AliasSourceKind
+	VarIDs []VarID // empty for Fresh/Unknown, one for Variable, multiple for Multiple
+}
+
+// DetermineAliasSource examines an expression and returns its alias source.
+// When the expression is an IdentExpr, the VarID is read directly from the
+// node (set by the rename pass in Phase 2).
+func DetermineAliasSource(expr ast.Expr) AliasSource {
+	switch e := expr.(type) {
+	case *ast.IdentExpr:
+		if e.VarID > 0 {
+			return AliasSource{Kind: AliasSourceVariable, VarIDs: []VarID{VarID(e.VarID)}}
+		}
+		// Non-local variable (VarID <= 0) — treat as unknown since we
+		// can't track aliases across function boundaries.
+		return AliasSource{Kind: AliasSourceUnknown}
+
+	// Fresh values: literals, object/array construction, function expressions
+	case *ast.LiteralExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.ObjectExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.TupleExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.FuncExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.TemplateLitExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.TaggedTemplateLitExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.JSXElementExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.JSXFragmentExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+
+	// Function calls: treat as fresh for now (Phase 8 adds lifetime-based tracking)
+	case *ast.CallExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+
+	// Unary/binary operations produce fresh primitive values
+	case *ast.UnaryExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.BinaryExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+
+	// Type cast: the alias source is the inner expression
+	case *ast.TypeCastExpr:
+		return DetermineAliasSource(e.Expr)
+
+	// Await: the alias source is the inner expression
+	case *ast.AwaitExpr:
+		return DetermineAliasSource(e.Arg)
+
+	// Property access: aliases the property's source (Phase 7);
+	// for now treat as unknown
+	case *ast.MemberExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+	case *ast.IndexExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+
+	// Conditionals: aliases all branches (Phase 7);
+	// for now treat as unknown
+	case *ast.IfElseExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+	case *ast.IfLetExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+	case *ast.MatchExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+
+	// Do expressions, try-catch: complex control flow, treat as unknown
+	case *ast.DoExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+	case *ast.TryCatchExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+
+	// Throw/yield don't produce values that get assigned
+	case *ast.ThrowExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+	case *ast.YieldExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+
+	// Array spread
+	case *ast.ArraySpreadExpr:
+		return AliasSource{Kind: AliasSourceFresh}
+
+	// Error expression
+	case *ast.ErrorExpr:
+		return AliasSource{Kind: AliasSourceUnknown}
+
+	default:
+		return AliasSource{Kind: AliasSourceUnknown}
+	}
+}

--- a/internal/liveness/alias_analysis_test.go
+++ b/internal/liveness/alias_analysis_test.go
@@ -1,0 +1,251 @@
+package liveness
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineAliasSource_Identifier(t *testing.T) {
+	ident := ast.NewIdent("x", ast.Span{})
+	ident.VarID = 1
+
+	source := DetermineAliasSource(ident)
+
+	require.Equal(t, AliasSourceVariable, source.Kind)
+	require.Equal(t, []VarID{1}, source.VarIDs)
+}
+
+func TestDetermineAliasSource_NonLocalIdentifier(t *testing.T) {
+	ident := ast.NewIdent("x", ast.Span{})
+	ident.VarID = -1
+
+	source := DetermineAliasSource(ident)
+
+	require.Equal(t, AliasSourceUnknown, source.Kind)
+}
+
+func TestDetermineAliasSource_UnsetIdentifier(t *testing.T) {
+	ident := ast.NewIdent("x", ast.Span{})
+	// VarID defaults to 0
+
+	source := DetermineAliasSource(ident)
+
+	require.Equal(t, AliasSourceUnknown, source.Kind)
+}
+
+func TestDetermineAliasSource_Literal(t *testing.T) {
+	lit := ast.NewLitExpr(ast.NewNumber(42, ast.Span{}))
+
+	source := DetermineAliasSource(lit)
+
+	require.Equal(t, AliasSourceFresh, source.Kind)
+	require.Empty(t, source.VarIDs)
+}
+
+func TestDetermineAliasSource_ObjectExpr(t *testing.T) {
+	obj := ast.NewObject(nil, ast.Span{})
+
+	source := DetermineAliasSource(obj)
+
+	require.Equal(t, AliasSourceFresh, source.Kind)
+}
+
+func TestDetermineAliasSource_TupleExpr(t *testing.T) {
+	tuple := ast.NewArray(nil, ast.Span{})
+
+	source := DetermineAliasSource(tuple)
+
+	require.Equal(t, AliasSourceFresh, source.Kind)
+}
+
+func TestDetermineAliasSource_CallExpr(t *testing.T) {
+	call := ast.NewCall(ast.NewIdent("foo", ast.Span{}), nil, false, ast.Span{})
+
+	source := DetermineAliasSource(call)
+
+	require.Equal(t, AliasSourceFresh, source.Kind)
+}
+
+func TestDetermineAliasSource_BinaryExpr(t *testing.T) {
+	bin := ast.NewBinary(
+		ast.NewLitExpr(ast.NewNumber(1, ast.Span{})),
+		ast.NewLitExpr(ast.NewNumber(2, ast.Span{})),
+		ast.Plus,
+		ast.Span{},
+	)
+
+	source := DetermineAliasSource(bin)
+
+	require.Equal(t, AliasSourceFresh, source.Kind)
+}
+
+func TestDetermineAliasSource_MemberExpr(t *testing.T) {
+	member := ast.NewMember(
+		ast.NewIdent("obj", ast.Span{}),
+		ast.NewIdentifier("field", ast.Span{}),
+		false,
+		ast.Span{},
+	)
+
+	source := DetermineAliasSource(member)
+
+	require.Equal(t, AliasSourceUnknown, source.Kind)
+}
+
+func TestDetermineAliasSource_TypeCast(t *testing.T) {
+	ident := ast.NewIdent("x", ast.Span{})
+	ident.VarID = 3
+	cast := ast.NewTypeCast(ident, nil, ast.Span{})
+
+	source := DetermineAliasSource(cast)
+
+	require.Equal(t, AliasSourceVariable, source.Kind)
+	require.Equal(t, []VarID{3}, source.VarIDs)
+}
+
+// Integration tests: alias tracking with DetermineAliasSource
+
+func TestAliasTracking_ValBEqualsA(t *testing.T) {
+	// val a = {x: 1}; val b = a → a and b in same alias set
+	tracker := NewAliasTracker()
+	var a VarID = 1
+	var b VarID = 2
+
+	tracker.NewValue(a, AliasImmutable)
+	tracker.AddAlias(b, a, AliasImmutable)
+
+	aSets := tracker.GetAliasSets(a)
+	bSets := tracker.GetAliasSets(b)
+	require.Len(t, aSets, 1)
+	require.Len(t, bSets, 1)
+	require.Equal(t, aSets[0].ID, bSets[0].ID)
+	require.Len(t, aSets[0].Members, 2)
+}
+
+func TestAliasTracking_FreshValue(t *testing.T) {
+	// val b = {x: 1} → b gets a fresh alias set
+	tracker := NewAliasTracker()
+	var b VarID = 1
+
+	tracker.NewValue(b, AliasImmutable)
+
+	sets := tracker.GetAliasSets(b)
+	require.Len(t, sets, 1)
+	require.Equal(t, b, sets[0].Origin)
+	require.Len(t, sets[0].Members, 1)
+}
+
+func TestAliasTracking_ReassignToFresh(t *testing.T) {
+	// var b = a; b = {x: 1} → b leaves a's set after reassignment
+	tracker := NewAliasTracker()
+	var a VarID = 1
+	var b VarID = 2
+
+	tracker.NewValue(a, AliasImmutable)
+	tracker.AddAlias(b, a, AliasImmutable)
+
+	// Verify they start in the same set
+	require.Equal(t,
+		tracker.GetAliasSets(a)[0].ID,
+		tracker.GetAliasSets(b)[0].ID,
+	)
+
+	// Reassign b to a fresh value
+	tracker.Reassign(b, nil, AliasImmutable)
+
+	// b should have its own set now
+	aSets := tracker.GetAliasSets(a)
+	bSets := tracker.GetAliasSets(b)
+	require.Len(t, aSets, 1)
+	require.Len(t, bSets, 1)
+	require.NotEqual(t, aSets[0].ID, bSets[0].ID)
+	require.NotContains(t, aSets[0].Members, b)
+}
+
+func TestAliasTracking_ReassignToOtherVar(t *testing.T) {
+	// var b = a; b = c → b leaves a's set and joins c's set
+	tracker := NewAliasTracker()
+	var a VarID = 1
+	var b VarID = 2
+	var c VarID = 3
+
+	tracker.NewValue(a, AliasImmutable)
+	tracker.AddAlias(b, a, AliasImmutable)
+	tracker.NewValue(c, AliasImmutable)
+
+	// Reassign b to c
+	tracker.Reassign(b, &c, AliasImmutable)
+
+	aSets := tracker.GetAliasSets(a)
+	bSets := tracker.GetAliasSets(b)
+	cSets := tracker.GetAliasSets(c)
+
+	require.NotContains(t, aSets[0].Members, b, "b should not be in a's set")
+	require.Equal(t, bSets[0].ID, cSets[0].ID, "b should be in c's set")
+}
+
+func TestAliasTracking_MultipleAliases(t *testing.T) {
+	// val b = a; val c = a → a, b, c all in same set
+	tracker := NewAliasTracker()
+	var a VarID = 1
+	var b VarID = 2
+	var c VarID = 3
+
+	tracker.NewValue(a, AliasImmutable)
+	tracker.AddAlias(b, a, AliasImmutable)
+	tracker.AddAlias(c, a, AliasImmutable)
+
+	sets := tracker.GetAliasSets(a)
+	require.Len(t, sets, 1)
+	require.Len(t, sets[0].Members, 3)
+	require.Contains(t, sets[0].Members, a)
+	require.Contains(t, sets[0].Members, b)
+	require.Contains(t, sets[0].Members, c)
+}
+
+func TestAliasTracking_Chain(t *testing.T) {
+	// val b = a; val c = b → a, b, c all in same set
+	tracker := NewAliasTracker()
+	var a VarID = 1
+	var b VarID = 2
+	var c VarID = 3
+
+	tracker.NewValue(a, AliasImmutable)
+	tracker.AddAlias(b, a, AliasImmutable)
+	tracker.AddAlias(c, b, AliasImmutable)
+
+	aSets := tracker.GetAliasSets(a)
+	require.Len(t, aSets, 1)
+	require.Len(t, aSets[0].Members, 3)
+	require.Contains(t, aSets[0].Members, a)
+	require.Contains(t, aSets[0].Members, b)
+	require.Contains(t, aSets[0].Members, c)
+}
+
+func TestAliasTracking_Shadowing(t *testing.T) {
+	// val x = a; val x = {y: 1}
+	// With distinct VarIDs: first x (VarID=2) stays in a's set,
+	// second x (VarID=3) gets a fresh set.
+	tracker := NewAliasTracker()
+	var a VarID = 1
+	var x1 VarID = 2 // first x
+	var x2 VarID = 3 // second x (shadow)
+
+	tracker.NewValue(a, AliasImmutable)
+	tracker.AddAlias(x1, a, AliasImmutable)
+	tracker.NewValue(x2, AliasImmutable)
+
+	// x1 should still be in a's set
+	aSets := tracker.GetAliasSets(a)
+	require.Len(t, aSets, 1)
+	require.Contains(t, aSets[0].Members, x1)
+	require.NotContains(t, aSets[0].Members, x2)
+
+	// x2 should have its own set
+	x2Sets := tracker.GetAliasSets(x2)
+	require.Len(t, x2Sets, 1)
+	require.Equal(t, x2, x2Sets[0].Origin)
+	require.NotContains(t, x2Sets[0].Members, x1)
+}

--- a/internal/liveness/cfg.go
+++ b/internal/liveness/cfg.go
@@ -42,6 +42,19 @@ func BuildCFG(body ast.Block) *CFG {
 	return &CFG{Entry: entry, Exit: exit, Blocks: b.blocks}
 }
 
+// BuildStmtToRef constructs a mapping from AST statement nodes to their
+// position in the CFG. This enables O(1) lookup of liveness information
+// for a given statement during type checking.
+func BuildStmtToRef(cfg *CFG) map[ast.Stmt]StmtRef {
+	result := make(map[ast.Stmt]StmtRef)
+	for _, block := range cfg.Blocks {
+		for i, stmt := range block.Stmts {
+			result[stmt] = StmtRef{BlockID: block.ID, StmtIdx: i}
+		}
+	}
+	return result
+}
+
 // cfgBuilder accumulates basic blocks while walking the AST.
 type cfgBuilder struct {
 	blocks []*BasicBlock

--- a/internal/liveness/rename.go
+++ b/internal/liveness/rename.go
@@ -38,6 +38,11 @@ type RenameResult struct {
 	// Used for error messages in later phases (e.g. mutability transition errors).
 	VarIDNames map[VarID]string
 
+	// ExtraParamVarIDs maps each extra parameter name (e.g. implicit 'self')
+	// to the VarID assigned by the rename pass. Only populated when extra
+	// parameter names are passed to Rename().
+	ExtraParamVarIDs map[string]VarID
+
 	// Errors contains any unresolved variable references found during
 	// the rename pass.
 	Errors []RenameError
@@ -129,17 +134,22 @@ func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID,
 
 	// Define extra parameter names (e.g. implicit 'self' in methods) that are
 	// not present in the AST params but should be treated as local bindings.
-	for _, name := range extraParamNames {
-		r.define(name)
+	var extraParamVarIDs map[string]VarID
+	if len(extraParamNames) > 0 {
+		extraParamVarIDs = make(map[string]VarID, len(extraParamNames))
+		for _, name := range extraParamNames {
+			extraParamVarIDs[name] = r.define(name)
+		}
 	}
 
 	// Process the function body.
 	r.renameBlock(body)
 
 	return &RenameResult{
-		UniqueVarCount: int(r.nextID) - 1, // count of local variables assigned
-		VarIDNames:     r.varIDNames,
-		Errors:         r.errors,
+		UniqueVarCount:   int(r.nextID) - 1, // count of local variables assigned
+		VarIDNames:       r.varIDNames,
+		ExtraParamVarIDs: extraParamVarIDs,
+		Errors:           r.errors,
 	}
 }
 

--- a/internal/liveness/rename.go
+++ b/internal/liveness/rename.go
@@ -34,6 +34,10 @@ type RenameResult struct {
 	// data structures in later phases).
 	UniqueVarCount int
 
+	// VarIDNames maps each local VarID to the variable name it was assigned from.
+	// Used for error messages in later phases (e.g. mutability transition errors).
+	VarIDNames map[VarID]string
+
 	// Errors contains any unresolved variable references found during
 	// the rename pass.
 	Errors []RenameError
@@ -48,17 +52,19 @@ type RenameError struct {
 
 // renamer holds the mutable state of the rename pass.
 type renamer struct {
-	nextID VarID
-	scope  *scope
-	errors []RenameError
+	nextID     VarID
+	scope      *scope
+	errors     []RenameError
+	varIDNames map[VarID]string
 }
 
 func newRenamer(outerBindings map[string]VarID) *renamer {
 	s := newScope(nil)
 	maps.Copy(s.bindings, outerBindings)
 	return &renamer{
-		nextID: 1, // local VarIDs start at 1
-		scope:  s,
+		nextID:     1, // local VarIDs start at 1
+		scope:      s,
+		varIDNames: make(map[VarID]string),
 	}
 }
 
@@ -80,6 +86,7 @@ func (r *renamer) popScope() {
 func (r *renamer) define(name string) VarID {
 	id := r.freshID()
 	r.scope.bindings[name] = id
+	r.varIDNames[id] = name
 	return id
 }
 
@@ -125,6 +132,7 @@ func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID)
 
 	return &RenameResult{
 		UniqueVarCount: int(r.nextID) - 1, // count of local variables assigned
+		VarIDNames:     r.varIDNames,
 		Errors:         r.errors,
 	}
 }

--- a/internal/liveness/rename.go
+++ b/internal/liveness/rename.go
@@ -116,7 +116,7 @@ func (r *renamer) resolve(name string, span ast.Span) VarID {
 //
 // After this function returns, the internal scope stack is discarded.
 // All downstream phases read VarIDs directly from AST nodes.
-func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID) *RenameResult {
+func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID, extraParamNames ...string) *RenameResult {
 	r := newRenamer(outerBindings)
 
 	// Process function parameters — they are in scope for the entire body.
@@ -125,6 +125,12 @@ func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID)
 	// positive IDs (assigned by define()), outer bindings have negative IDs.
 	for _, param := range params {
 		r.renamePat(param.Pattern)
+	}
+
+	// Define extra parameter names (e.g. implicit 'self' in methods) that are
+	// not present in the AST params but should be treated as local bindings.
+	for _, name := range extraParamNames {
+		r.define(name)
 	}
 
 	// Process the function body.

--- a/internal/liveness/rename_test.go
+++ b/internal/liveness/rename_test.go
@@ -552,6 +552,54 @@ func TestIfElseShadowing(t *testing.T) {
 	require.Equal(t, outerX.VarID, outerXRef.VarID)
 }
 
+func TestExtraParamNames(t *testing.T) {
+	// Simulates a method body with an implicit 'self' parameter:
+	// fn method(a) { print(self); print(a) }
+	// where 'self' is passed as an extra param name, not an AST param.
+	a := identPat("a")
+	aRef := ident("a")
+	selfRef := ident("self")
+
+	params := []*ast.Param{
+		{Pattern: a, Optional: false},
+	}
+	body := block(
+		exprStmt(call(ident("print"), selfRef)),
+		exprStmt(call(ident("print"), aRef)),
+	)
+
+	result := Rename(params, body, map[string]VarID{"print": -1}, "self")
+
+	require.Empty(t, result.Errors)
+	require.Equal(t, 2, result.UniqueVarCount) // a, self
+
+	// ExtraParamVarIDs should contain 'self' with a positive VarID.
+	require.Len(t, result.ExtraParamVarIDs, 1)
+	selfVarID, ok := result.ExtraParamVarIDs["self"]
+	require.True(t, ok, "ExtraParamVarIDs should contain 'self'")
+	require.Greater(t, int(selfVarID), 0, "extra param should get a positive VarID")
+
+	// The reference to 'self' in the body should resolve to the extra param's VarID.
+	require.Equal(t, int(selfVarID), selfRef.VarID)
+
+	// Regular param still works.
+	require.Equal(t, a.VarID, aRef.VarID)
+
+	// Extra param VarID should also appear in VarIDNames.
+	require.Equal(t, "self", result.VarIDNames[selfVarID])
+}
+
+func TestExtraParamNamesEmpty(t *testing.T) {
+	// When no extra param names are passed, ExtraParamVarIDs should be nil.
+	body := block(
+		exprStmt(numLit(1)),
+	)
+
+	result := Rename(nil, body, map[string]VarID{})
+
+	require.Nil(t, result.ExtraParamVarIDs)
+}
+
 func TestJSXExpressions(t *testing.T) {
 	// val name = "world"
 	// val el = <div class={name}>{name}</div>

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -885,14 +885,18 @@ mutability, check the alias set and liveness:
 ```go
 // CheckMutabilityTransition verifies that a mutability transition is safe
 // at the given program point. Returns an error if conflicting live aliases
-// exist.
+// exist AND the target alias is itself live (a dead target cannot observe
+// violations, so the transition is safe).
 //
-// Rule 1 (mut → immutable): No live mutable aliases may exist after this point.
-// Rule 2 (immutable → mut): No live immutable aliases may exist after this point.
+// Rule 1 (mut → immutable): No live mutable aliases may exist after this point,
+//     provided the target (immutable) alias is also live.
+// Rule 2 (immutable → mut): No live immutable aliases may exist after this point,
+//     provided the target (mutable) alias is also live.
 // Rule 3: Multiple mutable aliases are always allowed.
 func (c *Checker) CheckMutabilityTransition(
     ctx Context,
     sourceVar VarID,
+    targetVar VarID,
     sourceMut bool,     // mutability of the source
     targetMut bool,     // mutability of the target
     assignRef liveness.StmtRef,
@@ -901,16 +905,18 @@ func (c *Checker) CheckMutabilityTransition(
 
 The algorithm:
 1. If `sourceMut == targetMut`, no transition — always OK (Rule 3 for mut→mut)
-2. Get **all** alias sets of `sourceVar` via `GetAliasSets(sourceVar)` (a
+2. If `targetVar` is **not live** after `assignRef`, the transition is safe —
+   a dead target alias can never observe a conflicting mutation. Return early.
+3. Get **all** alias sets of `sourceVar` via `GetAliasSets(sourceVar)` (a
    variable may belong to multiple sets due to conditional aliasing)
-3. For each alias set that `sourceVar` belongs to:
+4. For each alias set that `sourceVar` belongs to:
    - For each variable `v` in that alias set (including `sourceVar`):
      - Check if `v` is live after `assignRef` (using `LivenessInfo.IsLiveAfter`)
      - If `sourceMut && !targetMut` (Rule 1): error if `v` has mutable
        access and is live
      - If `!sourceMut && targetMut` (Rule 2): error if `v` has immutable
        access and is live
-4. Union all conflicting live aliases across all sets into the error report
+5. Union all conflicting live aliases across all sets into the error report
 
 ### 6.2 Integration with `inferVarDecl`
 
@@ -1017,10 +1023,17 @@ print(a.x)
 
 **Alias tracking:**
 ```esc
-// ERROR: r is a live mutable alias of p
+// ERROR: r is a live mutable alias of p, and q is live (used below)
 val p: mut Point = {x: 0, y: 0}
 val r: mut Point = p
-val q: Point = p  // ERROR: r is live and mutable
+val q: Point = p  // ERROR: r is live and mutable, q is live
+r.x = 5
+print(q.x)
+
+// OK: q is dead (never used after assignment), so no conflict
+val p: mut Point = {x: 0, y: 0}
+val r: mut Point = p
+val q: Point = p  // OK: q is never used
 r.x = 5
 ```
 

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -22,6 +22,7 @@ into phases that build incrementally, each producing a testable milestone.
 |    12 | Error messages                                       | 6–11       |        |
 |    13 | Remove `mut?`                                        | 6–12       |        |
 |    14 | PrintType and display                                | 13         |        |
+|    15 | Performance optimizations                            | 6          |        |
 
 ---
 
@@ -2478,6 +2479,35 @@ for specific functions referenced in the error, not globally.
   - `'a Array<T>`
   - `Array<'a T>`
   - `fn<'a>(p: mut 'a Point) -> mut 'a Point`
+
+---
+
+## Phase 15: Performance Optimizations
+
+**Goal:** Reduce redundant work in the liveness pre-pass and related analyses
+without changing observable behavior.
+
+### 15.1 Cache `collectOuterBindings` Results
+
+`collectOuterBindings` walks the entire scope chain — including the prelude —
+on every call to `runLivenessPrePass`. For a module with many functions, this
+re-traverses the same parent scopes repeatedly.
+
+**File:** `internal/checker/liveness_prepass.go`
+
+Cache the flattened outer-bindings map at the parent scope level. When
+computing outer bindings for a function, check if the parent scope already
+has a cached result. If so, copy it and add only the current scope's
+bindings. The parent scope is stable by the time we enter a function body,
+so the cache is valid.
+
+Considerations:
+- The current scope itself cannot be cached because parameter bindings are
+  copied into it (`maps.Copy`) before `runLivenessPrePass` runs.
+- The module scope grows as declarations are processed, so its cache must
+  be invalidated or built lazily.
+- The prelude scope never changes and is the largest — caching it alone
+  may capture most of the benefit.
 
 ---
 

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -13,7 +13,7 @@ into phases that build incrementally, each producing a testable milestone.
 |     3 | Liveness analysis (straight-line code)               | 2          | Done   |
 |     4 | Liveness analysis (control flow)                     | 3          | Done   |
 |     5 | Alias tracking (local variables)                     | 3          | Done   |
-|     6 | Mutability transition checking                       | 4, 5       |        |
+|     6 | Mutability transition checking                       | 4, 5       | Done   |
 |     7 | Alias tracking (properties, closures, destructuring) | 5, 6       |        |
 |     8 | Lifetime annotations and inference                   | 6, 7       |        |
 |     9 | Lifetime unification                                 | 8          |        |
@@ -2523,9 +2523,9 @@ implementation is stable. These are explicitly **not part of Phases 1–14**:
 └── 2. Name resolution & VarID assignment ✅
     └── 3. Liveness (linear) ✅
         ├── 4. Liveness (control flow) ✅
-        │   └── 6. Transition checking ←── (also depends on 5)
+        │   └── 6. Transition checking ←── (also depends on 5) ✅
         └── 5. Alias tracking (local) ✅
-            ├── 6. Transition checking
+            ├── 6. Transition checking ✅
             │   └── 7. Advanced alias tracking (properties, closures, destructuring)
             │       └── 8. Lifetime annotations, inference, & constructors
             │           └── 9. Lifetime unification ('static, conflict detection,

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -12,7 +12,7 @@ into phases that build incrementally, each producing a testable milestone.
 |     2 | Name resolution and VarID assignment                 | 1          | Done   |
 |     3 | Liveness analysis (straight-line code)               | 2          | Done   |
 |     4 | Liveness analysis (control flow)                     | 3          | Done   |
-|     5 | Alias tracking (local variables)                     | 3          |        |
+|     5 | Alias tracking (local variables)                     | 3          | Done   |
 |     6 | Mutability transition checking                       | 4, 5       |        |
 |     7 | Alias tracking (properties, closures, destructuring) | 5, 6       |        |
 |     8 | Lifetime annotations and inference                   | 6, 7       |        |
@@ -2524,7 +2524,7 @@ implementation is stable. These are explicitly **not part of Phases 1–14**:
     └── 3. Liveness (linear) ✅
         ├── 4. Liveness (control flow) ✅
         │   └── 6. Transition checking ←── (also depends on 5)
-        └── 5. Alias tracking (local)
+        └── 5. Alias tracking (local) ✅
             ├── 6. Transition checking
             │   └── 7. Advanced alias tracking (properties, closures, destructuring)
             │       └── 8. Lifetime annotations, inference, & constructors

--- a/planning/lifetimes/requirements.md
+++ b/planning/lifetimes/requirements.md
@@ -172,9 +172,11 @@ This is useful for:
 ### Rule 1: Mutable-to-Immutable Transition
 
 A mutable value can be assigned to a variable with an immutable type when **no
-live mutable references** to that value exist after the assignment point. This
-includes aliases created through other variables, object properties, or function
-return values.
+live mutable references** to that value exist after the assignment point, **or**
+when the immutable target itself is dead (never used after the assignment). The
+transition is only dangerous when both a mutable alias and the immutable alias
+are live simultaneously — only then can a mutation through the mutable alias
+violate the immutable alias's stability guarantee.
 
 ```esc
 val items: mut Array<number> = [1, 2, 3]
@@ -198,10 +200,22 @@ items.push(4)                        // this mutation would violate `snapshot`'s
 print(snapshot.length)
 ```
 
+**OK — target is dead:**
+
+```esc
+val items: mut Array<number> = [1, 2, 3]
+val snapshot: Array<number> = items  // OK: `snapshot` is never used
+items.push(4)                        // no immutable alias observes this
+```
+
 ### Rule 2: Immutable-to-Mutable Transition
 
 An immutable value can be assigned to a variable with a mutable type when **no
-live immutable references** to that value exist after the assignment point.
+live immutable references** to that value exist after the assignment point, **or**
+when the mutable target itself is dead (never used after the assignment). The
+transition is only dangerous when both an immutable alias and the mutable alias
+are live simultaneously — only then can a mutation through the mutable alias
+violate the immutable alias's stability guarantee.
 
 ```esc
 val config: {host: string} = {host: "localhost"}
@@ -221,6 +235,14 @@ val config: {host: string} = {host: "localhost"}
 val mutableConfig: mut {host: string} = config  // ERROR: `config` used below
 mutableConfig.host = "example.com"
 print(config.host)  // would see mutated value since mutableConfig.host was changed
+```
+
+**OK — target is dead:**
+
+```esc
+val config: {host: string} = {host: "localhost"}
+val mutableConfig: mut {host: string} = config  // OK: `mutableConfig` is never used
+print(config.host)                               // no mutable alias exists to cause mutation
 ```
 
 ### Rule 3: Multiple Mutable References to the Same Value Are Allowed
@@ -251,10 +273,15 @@ of an alias set, not just the variable being assigned.
 ```esc
 val p: mut Point = {x: 0, y: 0}
 val r: mut Point = p        // r and p are in the same alias set
-val q: Point = p             // ERROR: r is a live mutable alias of p
+val q: Point = p             // ERROR: r is a live mutable alias of p,
+                             //        and q is live (used below)
 r.x = 5
 print(q.x)
 ```
+
+If the immutable alias `q` were never used after the assignment, no error
+would occur — both sides must be live simultaneously for the transition to
+be dangerous.
 
 ### Object Properties
 


### PR DESCRIPTION
- **Lifetimes 5: Alias tracking (local)**
- **Lifetimes 6: Transition checking**
- **dedupe mutability lookup, propagate CurrentStmt in With* methods in checker.go**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced mutability-transition checks when variables switch between mutable/immutable, using alias tracking and a liveness pre-pass for both top-level code and function bodies.
  * Added alias-source analysis and a statement→position mapping to support safer reassignment checks.

* **Refactor**
  * Inference and context flow updated to preserve scope/statement metadata and pass explicit parameter info into body inference.

* **Tests**
  * New tests covering alias analysis and mutability-transition scenarios.

* **Documentation**
  * Updated lifetime rules and examples clarifying when transitions are allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->