### PR TITLE
Lifetimes 8.2: per-leaf lifetimes, escape detection, mutual-recursion convergence

### DIFF
--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -231,6 +231,11 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 		}
 		funcSigType.Throws = type_system.NewNeverType(nil)
 		c.closeOpenParams(funcSigType)
+
+		// Phase 8.3: infer lifetimes for generator yields. Yields aliasing
+		// parameters propagate the lifetime to T inside Generator<T, ...>.
+		c.InferLifetimes(astParams, body, funcSigType)
+
 		return errors
 	}
 

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -234,7 +234,7 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 
 		// Phase 8.3: infer lifetimes for generator yields. Yields aliasing
 		// parameters propagate the lifetime to T inside Generator<T, ...>.
-		c.InferLifetimes(astParams, body, funcSigType)
+		c.InferLifetimes(astParams, body, funcSigType, isAsync)
 
 		return errors
 	}
@@ -263,7 +263,7 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 	// Infer lifetime parameters from the body. This must run after returnType
 	// has been unified into funcSigType.Return so that the lifetime is attached
 	// to the same type the caller will see.
-	c.InferLifetimes(astParams, body, funcSigType)
+	c.InferLifetimes(astParams, body, funcSigType, isAsync)
 
 	return errors
 }

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -250,10 +250,10 @@ type paramLeaf struct {
 // collectParamLeaves walks each function parameter's pattern in lockstep
 // with the parameter's inferred type, producing an ordered list of
 // (VarID, leafType) pairs for every leaf binding that has a positive
-// VarID set by the rename pass.
-//
-// Object-destructured params are not yet walked — see Phase 8.6 deferred
-// items in implementation_plan.md.
+// VarID set by the rename pass. Tuple-, object-, and rest-destructuring
+// patterns are supported; for object patterns, leaf positions are
+// resolved by string-key lookup against the corresponding ObjectType's
+// PropertyElems.
 func collectParamLeaves(
 	astParams []*ast.Param,
 	funcParams []*type_system.FuncParam,
@@ -291,6 +291,56 @@ func walkPatternForLeaves(pat ast.Pat, t type_system.Type, into *[]paramLeaf) {
 				break
 			}
 			walkPatternForLeaves(elem, tt.Elems[i], into)
+		}
+	case *ast.ObjectPat:
+		ot, ok := pt.(*type_system.ObjectType)
+		if !ok {
+			return
+		}
+		// Build a key→Type map for the object type's properties so each
+		// pattern element can resolve its corresponding sub-position.
+		propTypes := make(map[string]type_system.Type)
+		for _, elem := range ot.Elems {
+			if prop, ok := elem.(*type_system.PropertyElem); ok &&
+				prop.Name.Kind == type_system.StrObjTypeKeyKind {
+				propTypes[prop.Name.Str] = prop.Value
+			}
+		}
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjKeyValuePat:
+				// `{ key: value-pat }` — recurse into value-pat with
+				// the property's type. The property name is the lookup
+				// key.
+				if e.Key == nil {
+					continue
+				}
+				if propType, exists := propTypes[e.Key.Name]; exists {
+					walkPatternForLeaves(e.Value, propType, into)
+				}
+			case *ast.ObjShorthandPat:
+				// `{ key }` (or `{ key: TypeAnn }`, `{ key = default }`)
+				// — the leaf binding has the same name as the property.
+				if e.Key == nil || e.VarID <= 0 {
+					continue
+				}
+				propType, exists := propTypes[e.Key.Name]
+				if !exists {
+					continue
+				}
+				*into = append(*into, paramLeaf{
+					varID:    liveness.VarID(e.VarID),
+					leafType: propType,
+				})
+			case *ast.ObjRestPat:
+				// `{ ...rest }` — the rest pattern collects remaining
+				// properties into a fresh object. Like a function rest
+				// param's container, this is freshly assembled per
+				// call, so attaching a container-level lifetime would
+				// be wrong. Per-property element lifetimes for object
+				// rest are deferred (would require synthesizing a
+				// per-call object type).
+			}
 		}
 	case *ast.RestPat:
 		// `...args: T[]` — the lifetime-bearing position is the

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -196,24 +196,33 @@ func setLifetimeOnType(t type_system.Type, lt type_system.Lifetime) {
 }
 
 // InferConstructorLifetimes analyzes a class declaration to determine
-// which constructor parameters are stored as fields, attaches a fresh
-// LifetimeVar to each such parameter and to the constructor's return
-// type, and records the lifetime parameters and default mutability on
-// the class TypeAlias.
+// which constructor parameters are stored as fields (or implicitly
+// captured by method bodies), attaches a fresh LifetimeVar to each such
+// parameter and to the constructor's return type, and records the
+// lifetime parameters and default mutability on the class TypeAlias.
 //
-// Detected storage patterns (Phase 8.6 foundational subset):
+// Detected storage / capture patterns (Phase 8.6):
 //   - Shorthand field referring to a constructor parameter by name,
 //     with or without a default:
 //     `class C(p: mut Point) { p, }`
 //     `class C(p: mut Point) { p = fallback, }`
-//   - Explicit field whose value is an IdentExpr to a constructor
-//     parameter: `class C(p: mut Point) { p: p, }`
+//   - Explicit field whose value references a constructor parameter,
+//     directly or through composite/projection expressions:
+//     `class C(p: mut Point) { x: p, }`
+//     `class C(p: mut Point) { x: p.inner, }`
+//     `class C(p: mut Point) { x: {inner: p}, }`
+//     `class C(p: mut Point) { x: [p, p], }`
+//   - Implicit capture: a method body references a constructor parameter
+//     by name (Escalier allows methods to see constructor params without
+//     going through `self`):
+//     `class C(p: mut Point) { foo(self) { return p } }`
 //
 // Deferred (see implementation_plan.md Phase 8 status):
-//   - Storage through nested expressions (`x: f(p)`).
-//   - Storage into nested object/array literals.
-//   - Lifetime inference for explicit field-initializer expressions
-//     that depend on parameters in non-identity ways.
+//   - Inference of method-side return-type lifetimes when a method
+//     captures a constructor param (the constructor gets the lifetime,
+//     but the method's return type does not yet inherit it).
+//   - Storage through function-call results (`x: f(p)`) — calls are
+//     conservatively treated as fresh by the field walker.
 func (c *Checker) InferConstructorLifetimes(
 	classDecl *ast.ClassDecl,
 	typeAlias *type_system.TypeAlias,
@@ -246,7 +255,12 @@ func (c *Checker) InferConstructorLifetimes(
 	}
 
 	// For each constructor param that is a reference type AND is stored
-	// as a field, allocate a fresh LifetimeVar.
+	// as a field (or captured by a method), allocate a fresh LifetimeVar.
+	//
+	// Note: matching is by *name* rather than VarID because
+	// InferConstructorLifetimes runs during the namespace placeholder phase,
+	// before the rename pass has populated VarIDs on identifiers in field
+	// initializers or method bodies.
 	paramNameToIndex := make(map[string]int)
 	for i, p := range classDecl.Params {
 		if identPat, ok := p.Pattern.(*ast.IdentPat); ok {
@@ -255,33 +269,17 @@ func (c *Checker) InferConstructorLifetimes(
 	}
 
 	storedParams := set.NewSet[int]()
+
 	for _, elem := range classDecl.Body {
-		fieldElem, ok := elem.(*ast.FieldElem)
-		if !ok {
-			continue
-		}
-		// Field name must be a plain identifier for our patterns.
-		fieldNameIdent, ok := fieldElem.Name.(*ast.IdentExpr)
-		if !ok {
-			continue
-		}
-
-		// Shorthand: name only, no value. A default may still be present
-		// (`p = somePoint`) — when the caller passes `p`, the field stores
-		// the param, so the param's lifetime matters regardless of whether
-		// a default is provided.
-		if fieldElem.Value == nil {
-			if idx, ok := paramNameToIndex[fieldNameIdent.Name]; ok {
-				storedParams.Add(idx)
+		switch elem := elem.(type) {
+		case *ast.FieldElem:
+			collectFieldStorageParams(elem, paramNameToIndex, storedParams)
+		case *ast.MethodElem:
+			// Static methods can't access instance state implicitly.
+			if elem.Static || elem.Fn == nil || elem.Fn.Body == nil {
+				continue
 			}
-			continue
-		}
-
-		// Explicit: `name: <ident>` where ident is a constructor param.
-		if valIdent, ok := fieldElem.Value.(*ast.IdentExpr); ok {
-			if idx, ok := paramNameToIndex[valIdent.Name]; ok {
-				storedParams.Add(idx)
-			}
+			collectMethodBodyCaptures(elem.Fn, paramNameToIndex, storedParams)
 		}
 	}
 
@@ -328,6 +326,282 @@ func (c *Checker) InferConstructorLifetimes(
 		lifetimeArgs[i] = lv
 	}
 	setLifetimeArgsOnType(ctorFn.Return, lifetimeArgs)
+}
+
+// collectFieldStorageParams inspects a single class field-element and adds
+// the indices of any constructor parameters whose value is captured by the
+// field's initializer to storedParams.
+//
+// The cases handled here mirror the storage shapes documented on
+// InferConstructorLifetimes: shorthand fields, identity initializers, and
+// composite or projection initializers (object/tuple literals, member or
+// index access into a param). Function-call initializers are not analyzed —
+// liveness.DetermineAliasSource treats calls as fresh, and a checker-aware
+// alternative would need lifetime info from callees that may not yet be
+// resolved at this point in inference.
+func collectFieldStorageParams(
+	fieldElem *ast.FieldElem,
+	paramNameToIndex map[string]int,
+	storedParams set.Set[int],
+) {
+	// Field name must be a plain identifier for the shorthand pattern.
+	fieldNameIdent, ok := fieldElem.Name.(*ast.IdentExpr)
+
+	// Shorthand: `{ p, }` or `{ p = fallback, }`. A default does not change
+	// the conclusion: when the caller passes `p`, the field stores the
+	// param, so the param's lifetime matters.
+	if ok && fieldElem.Value == nil {
+		if idx, ok := paramNameToIndex[fieldNameIdent.Name]; ok {
+			storedParams.Add(idx)
+		}
+		return
+	}
+
+	if fieldElem.Value == nil {
+		return
+	}
+
+	// Explicit `name: <expr>` — walk the initializer for any captured params.
+	for _, idx := range findCapturedParamsInExpr(fieldElem.Value, paramNameToIndex) {
+		storedParams.Add(idx)
+	}
+}
+
+// findCapturedParamsInExpr walks a field-initializer expression looking
+// for references to constructor parameters by name. Returns the parameter
+// indices in first-seen order. Recurses into composite literals
+// (object/tuple) and into spread elements; projection expressions
+// (member/index access, type cast, await) fall through to
+// liveness.DetermineAliasSource which already walks past those.
+//
+// Function calls and other complex expressions whose result might capture
+// arguments are NOT analyzed — they are treated as fresh.
+func findCapturedParamsInExpr(
+	expr ast.Expr,
+	paramNameToIndex map[string]int,
+) []int {
+	seen := set.NewSet[int]()
+	var result []int
+
+	addByName := func(name string) {
+		if idx, ok := paramNameToIndex[name]; ok && !seen.Contains(idx) {
+			seen.Add(idx)
+			result = append(result, idx)
+		}
+	}
+
+	var visit func(e ast.Expr)
+	visit = func(e ast.Expr) {
+		if e == nil {
+			return
+		}
+		switch ex := e.(type) {
+		case *ast.ObjectExpr:
+			for _, elem := range ex.Elems {
+				switch el := elem.(type) {
+				case *ast.PropertyExpr:
+					if el.Value != nil {
+						visit(el.Value)
+						continue
+					}
+					// Object shorthand: `{ p }` — the property name doubles
+					// as a value reference.
+					if name, ok := el.Name.(*ast.IdentExpr); ok {
+						addByName(name.Name)
+					}
+				case *ast.ObjSpreadExpr:
+					visit(el.Value)
+				}
+			}
+		case *ast.TupleExpr:
+			for _, sub := range ex.Elems {
+				visit(sub)
+			}
+		case *ast.ArraySpreadExpr:
+			visit(ex.Value)
+		case *ast.IdentExpr:
+			addByName(ex.Name)
+		case *ast.MemberExpr:
+			visit(ex.Object)
+		case *ast.IndexExpr:
+			visit(ex.Object)
+		case *ast.TypeCastExpr:
+			visit(ex.Expr)
+		case *ast.AwaitExpr:
+			visit(ex.Arg)
+		case *ast.IfElseExpr:
+			// Conditional that yields a value: both branches may
+			// contribute captures. Use the existing helper to find each
+			// branch's result expression.
+			cons := blockResultExpr(ex.Cons)
+			if cons != nil {
+				visit(cons)
+			}
+			if ex.Alt != nil {
+				if ex.Alt.Expr != nil {
+					visit(ex.Alt.Expr)
+				} else if ex.Alt.Block != nil {
+					if alt := blockResultExpr(*ex.Alt.Block); alt != nil {
+						visit(alt)
+					}
+				}
+			}
+		}
+	}
+	visit(expr)
+	return result
+}
+
+// blockResultExpr returns the result expression of a block (the last
+// statement if it's an ExprStmt), or nil if the block is empty or ends
+// with a non-expression statement. Mirrors the helper of the same name in
+// the liveness package, duplicated here to avoid an import cycle.
+func blockResultExpr(b ast.Block) ast.Expr {
+	if len(b.Stmts) == 0 {
+		return nil
+	}
+	if exprStmt, ok := b.Stmts[len(b.Stmts)-1].(*ast.ExprStmt); ok {
+		return exprStmt.Expr
+	}
+	return nil
+}
+
+// collectMethodBodyCaptures walks a method body looking for IdentExpr
+// references whose name matches a constructor parameter, and adds the
+// matching parameter indices to storedParams. Tracks shadowing introduced
+// by inner FuncExpr params so that names rebound by nested functions are
+// not counted as captures.
+//
+// This closes the soundness gap where a method body references a
+// constructor param by name (Escalier allows this) without any
+// corresponding `self.field` projection — see the example in
+// implementation_plan.md Phase 8.6 implicit-captures discussion.
+func collectMethodBodyCaptures(
+	fn *ast.FuncExpr,
+	paramNameToIndex map[string]int,
+	storedParams set.Set[int],
+) {
+	// Names shadowed in the current scope (and all enclosing scopes within
+	// the method) are tracked as a stack: each entry is the set of names
+	// bound by a single FuncExpr's parameters.
+	v := &methodCaptureVisitor{
+		paramNameToIndex: paramNameToIndex,
+		storedParams:     storedParams,
+	}
+	// The method's own params shadow constructor params with the same name.
+	v.pushScope(fn.Params)
+	if fn.Body != nil {
+		fn.Body.Accept(v)
+	}
+	v.popScope()
+}
+
+type methodCaptureVisitor struct {
+	ast.DefaultVisitor
+	paramNameToIndex map[string]int
+	storedParams     set.Set[int]
+	shadowed         []set.Set[string]
+}
+
+func (v *methodCaptureVisitor) pushScope(params []*ast.Param) {
+	scope := set.NewSet[string]()
+	for _, p := range params {
+		collectPatternBindingNames(p.Pattern, scope)
+	}
+	v.shadowed = append(v.shadowed, scope)
+}
+
+func (v *methodCaptureVisitor) popScope() {
+	v.shadowed = v.shadowed[:len(v.shadowed)-1]
+}
+
+func (v *methodCaptureVisitor) isShadowed(name string) bool {
+	for _, s := range v.shadowed {
+		if s.Contains(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *methodCaptureVisitor) EnterExpr(e ast.Expr) bool {
+	switch ex := e.(type) {
+	case *ast.IdentExpr:
+		if v.isShadowed(ex.Name) {
+			return true
+		}
+		if idx, ok := v.paramNameToIndex[ex.Name]; ok {
+			v.storedParams.Add(idx)
+		}
+	case *ast.FuncExpr:
+		// Nested function: its params introduce new shadows for the
+		// duration of its body. Manually descend so we control scope.
+		v.pushScope(ex.Params)
+		if ex.Body != nil {
+			ex.Body.Accept(v)
+		}
+		v.popScope()
+		return false
+	}
+	return true
+}
+
+func (v *methodCaptureVisitor) EnterDecl(d ast.Decl) bool {
+	switch dd := d.(type) {
+	case *ast.VarDecl:
+		// `let p = ...` (or `var p = ...`) shadows the constructor's `p`
+		// from this point onward in the enclosing block. Record the
+		// pattern's bound names in the current scope.
+		if len(v.shadowed) > 0 {
+			collectPatternBindingNames(dd.Pattern, v.shadowed[len(v.shadowed)-1])
+		}
+	case *ast.FuncDecl:
+		// Nested function declaration: similar to FuncExpr, its params
+		// shadow outer names within its body.
+		if dd.Body == nil {
+			return false
+		}
+		v.pushScope(dd.Params)
+		dd.Body.Accept(v)
+		v.popScope()
+		return false
+	case *ast.ClassDecl:
+		// Skip nested classes — their constructor param names introduce
+		// a fresh shadow scope that's outside the analysis we care about.
+		return false
+	}
+	return true
+}
+
+// collectPatternBindingNames adds every identifier name introduced by a
+// pattern (recursively) to the provided set.
+func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
+	if p == nil {
+		return
+	}
+	switch pp := p.(type) {
+	case *ast.IdentPat:
+		into.Add(pp.Name)
+	case *ast.TuplePat:
+		for _, sub := range pp.Elems {
+			collectPatternBindingNames(sub, into)
+		}
+	case *ast.ObjectPat:
+		for _, elem := range pp.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjKeyValuePat:
+				collectPatternBindingNames(e.Value, into)
+			case *ast.ObjShorthandPat:
+				if e.Key != nil {
+					into.Add(e.Key.Name)
+				}
+			case *ast.ObjRestPat:
+				collectPatternBindingNames(e.Pattern, into)
+			}
+		}
+	case *ast.RestPat:
+		collectPatternBindingNames(pp.Pattern, into)
+	}
 }
 
 // typeCarriesLifetime reports whether the given type can carry a lifetime.

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -896,6 +896,13 @@ func collectMethodBodyCaptures(
 		paramNameToIndex: paramNameToIndex,
 		storedParams:     storedParams,
 	}
+	// Visit parameter defaults BEFORE pushing the method's own scope:
+	// defaults evaluate against the enclosing (constructor) scope where
+	// `paramNameToIndex` is keyed, so an unshadowed `p` in a default
+	// captures the constructor's `p`.
+	for _, p := range fn.Params {
+		v.visitParamDefaults(p.Pattern)
+	}
 	// The method's own params shadow constructor params with the same name.
 	v.pushScope()
 	for _, p := range fn.Params {
@@ -940,6 +947,44 @@ func (v *methodCaptureVisitor) addBindings(pat ast.Pat) {
 	collectPatternBindingNames(pat, v.shadowed[len(v.shadowed)-1])
 }
 
+// visitParamDefaults visits the default expression of every leaf in a
+// parameter pattern (IdentPat.Default, ObjShorthandPat.Default), recursing
+// through container patterns. Defaults evaluate in the *enclosing* scope
+// at call time, so this must be called BEFORE the param's own bindings
+// are added to the shadow stack — otherwise a default like `q = p` would
+// incorrectly resolve `p` against the freshly-shadowed inner binding
+// instead of the outer (constructor) scope.
+func (v *methodCaptureVisitor) visitParamDefaults(pat ast.Pat) {
+	if pat == nil {
+		return
+	}
+	switch p := pat.(type) {
+	case *ast.IdentPat:
+		if p.Default != nil {
+			p.Default.Accept(v)
+		}
+	case *ast.TuplePat:
+		for _, elem := range p.Elems {
+			v.visitParamDefaults(elem)
+		}
+	case *ast.ObjectPat:
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjKeyValuePat:
+				v.visitParamDefaults(e.Value)
+			case *ast.ObjShorthandPat:
+				if e.Default != nil {
+					e.Default.Accept(v)
+				}
+			case *ast.ObjRestPat:
+				v.visitParamDefaults(e.Pattern)
+			}
+		}
+	case *ast.RestPat:
+		v.visitParamDefaults(p.Pattern)
+	}
+}
+
 func (v *methodCaptureVisitor) isShadowed(name string) bool {
 	for _, s := range v.shadowed {
 		if s.Contains(name) {
@@ -972,6 +1017,12 @@ func (v *methodCaptureVisitor) EnterExpr(e ast.Expr) bool {
 		// duration of its body. Drive the body traversal manually so
 		// the param-scope wraps the body's own block scope; return
 		// false to suppress the framework's default child recursion.
+		// Param defaults must be visited BEFORE pushing the new scope —
+		// they resolve against the enclosing scope, not the
+		// freshly-shadowed inner one.
+		for _, p := range ex.Params {
+			v.visitParamDefaults(p.Pattern)
+		}
 		v.pushScope()
 		for _, p := range ex.Params {
 			v.addBindings(p.Pattern)
@@ -1000,9 +1051,14 @@ func (v *methodCaptureVisitor) EnterDecl(d ast.Decl) bool {
 		return false
 	case *ast.FuncDecl:
 		// Nested function declaration: similar to FuncExpr, its params
-		// shadow outer names within its body.
+		// shadow outer names within its body. Param defaults resolve
+		// against the enclosing scope and must be visited BEFORE the
+		// new param scope is pushed.
 		if dd.Body == nil {
 			return false
+		}
+		for _, p := range dd.Params {
+			v.visitParamDefaults(p.Pattern)
 		}
 		v.pushScope()
 		for _, p := range dd.Params {

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -38,7 +38,7 @@ func lifetimeParamName(i int) string {
 //   - Multiple returns aliasing different parameters: emits a
 //     LifetimeUnion on the return type.
 //   - Parameters stored into module-level (non-local) state: assigned
-//     'static directly. See DetectEscapingRefs.
+//     'static directly. See detectEscapingLeafIndices.
 //   - Yields aliasing parameters (generators): the lifetime is attached
 //     to the yield type T inside Generator<T, TReturn, TNext> rather than
 //     to the Generator container itself, so each yielded value carries
@@ -190,6 +190,15 @@ func (c *Checker) inferLifetimesCore(
 		}
 	}
 
+	// Skip the alias-source walk entirely when the result type cannot
+	// carry a lifetime (e.g. it's a TypeVar, primitive, or
+	// union/intersection without a common lifetime-bearing structure).
+	// Without a place to attach the lifetime on the result side, the
+	// lifetime parameter would be unused noise in the signature.
+	if !typeCarriesLifetime(resultType) {
+		return
+	}
+
 	// Determine which leaves are aliased across all alias-source
 	// expressions. Use insertion order so the resulting LifetimeParams
 	// list is deterministic.
@@ -231,15 +240,6 @@ func (c *Checker) inferLifetimesCore(
 		return
 	}
 
-	// Skip lifetime inference entirely when the result type cannot carry
-	// a lifetime (e.g. it's a TypeVar, primitive, or union/intersection
-	// without a common lifetime-bearing structure). Without a place to
-	// attach the lifetime on the result side, the lifetime parameter
-	// would be unused noise in the signature.
-	if !typeCarriesLifetime(resultType) {
-		return
-	}
-
 	// Walk the aliased leaves. For each, either:
 	//   (a) Reuse the leaf's existing lifetime (set by a prior pass —
 	//       the LifetimeVar is pointer-shared, already in
@@ -268,17 +268,17 @@ func (c *Checker) inferLifetimesCore(
 		// Reuse an already-inferred LifetimeVar on the leaf so the
 		// signature stays stable across re-runs and pointer identity
 		// is preserved with anything that already references it.
-		if existing, ok := type_system.PruneLifetime(type_system.GetLifetime(leaf.leafType)).(*type_system.LifetimeVar); ok && existing != nil {
-			returnLifetimeMembers = append(returnLifetimeMembers, existing)
+		if existingLV, ok := type_system.PruneLifetime(type_system.GetLifetime(leaf.leafType)).(*type_system.LifetimeVar); ok && existingLV != nil {
+			returnLifetimeMembers = append(returnLifetimeMembers, existingLV)
 			continue
 		}
 		nameIdx := len(funcType.LifetimeParams) + len(newLifetimeParams)
-		lv := c.FreshLifetimeVar(lifetimeParamName(nameIdx))
-		newLifetimeParams = append(newLifetimeParams, lv)
-		returnLifetimeMembers = append(returnLifetimeMembers, lv)
+		newLV := c.FreshLifetimeVar(lifetimeParamName(nameIdx))
+		newLifetimeParams = append(newLifetimeParams, newLV)
+		returnLifetimeMembers = append(returnLifetimeMembers, newLV)
 
 		// Attach the lifetime to the leaf's type position.
-		setLifetimeOnType(leaf.leafType, lv)
+		setLifetimeOnType(leaf.leafType, newLV)
 	}
 
 	if len(returnLifetimeMembers) == 0 && !returnHasStatic {
@@ -343,6 +343,18 @@ func collectParamLeaves(
 	return leaves
 }
 
+// walkPatternForLeaves recurses through a destructuring pattern in
+// lockstep with its inferred type, appending a paramLeaf for every
+// leaf binding (IdentPat or ObjShorthandPat) with a positive VarID.
+//
+// We don't use the ast.Visitor interface here because the visitor only
+// carries pattern context — it has no notion of a parallel type tree.
+// Each container pattern (TuplePat, ObjectPat, RestPat) needs to pick
+// the matching sub-type (tuple element, property value, array element)
+// before descending, which would force a visitor implementation to
+// maintain a side stack of types pushed/popped on EnterPat/ExitPat and
+// to repeat the same type-shape switching done here. With one caller
+// and one purpose, a self-contained recursive walk is simpler.
 func walkPatternForLeaves(pat ast.Pat, t type_system.Type, into *[]paramLeaf) {
 	if pat == nil || t == nil {
 		return
@@ -465,11 +477,13 @@ func arrayElemType(t type_system.Type) type_system.Type {
 	return tref.TypeArgs[0]
 }
 
-// DetectEscapingRefs walks a function body looking for assignments that
-// store one of the function's parameters into a non-local location
-// (module-level variable, prelude binding, or any other binding looked
-// up through the function's enclosing scope chain). Returns the set of
-// parameter indices whose value escapes.
+// detectEscapingLeafIndices walks a function body looking for
+// assignments that store one of the function's parameter leaves into a
+// non-local location (module-level variable, prelude binding, or any
+// other binding looked up through the function's enclosing scope
+// chain). leafIndex maps a leaf binding's VarID to its position in the
+// leaves list; the returned set contains the indices of leaves whose
+// value escapes.
 //
 // Detection is by VarID: the rename pass assigns positive VarIDs to
 // locals and negative VarIDs to outer-scope references. An assignment
@@ -484,17 +498,6 @@ func arrayElemType(t type_system.Type) type_system.Type {
 //     borrow-checker tolerates this (it's sound, just imprecise).
 //   - Stores via property assignment whose root is a local but is
 //     itself stored elsewhere: not tracked here.
-func DetectEscapingRefs(
-	body *ast.Block,
-	paramIndex map[liveness.VarID]int,
-) set.Set[int] {
-	return detectEscapingLeafIndices(body, paramIndex)
-}
-
-// detectEscapingLeafIndices is the leaf-aware version of
-// DetectEscapingRefs: leafIndex maps a leaf binding's VarID to its
-// position in the leaves list, and the returned set contains the
-// indices of leaves whose value escapes.
 func detectEscapingLeafIndices(
 	body *ast.Block,
 	leafIndex map[liveness.VarID]int,
@@ -553,19 +556,10 @@ func (v *escapingRefsVisitor) EnterDecl(d ast.Decl) bool {
 // isNonLocalLValue returns true if the given assignment-target expression's
 // root identifier resolves to a non-local binding (VarID <= 0). Walks
 // through MemberExpr/IndexExpr chains to find the root identifier.
+// rootObjectVarID returns 0 when the root is non-local (or not a simple
+// ident chain), which matches what we want to flag as escaping.
 func isNonLocalLValue(expr ast.Expr) bool {
-	for {
-		switch e := expr.(type) {
-		case *ast.IdentExpr:
-			return e.VarID <= 0
-		case *ast.MemberExpr:
-			expr = e.Object
-		case *ast.IndexExpr:
-			expr = e.Object
-		default:
-			return false
-		}
-	}
+	return rootObjectVarID(expr) == 0
 }
 
 // setLifetimeOnType attaches a lifetime to a type's Lifetime field, walking
@@ -650,7 +644,10 @@ func (c *Checker) InferConstructorLifetimes(
 	// Note: matching is by *name* rather than VarID because
 	// InferConstructorLifetimes runs during the namespace placeholder phase,
 	// before the rename pass has populated VarIDs on identifiers in field
-	// initializers or method bodies.
+	// initializers or method bodies. We must run this early so the class's
+	// TypeAlias advertises its LifetimeParams (and DefaultMutable) before
+	// any consumer — function param annotations, var decls, constructor
+	// call sites — resolves the class by name during the body phase.
 	paramNameToIndex := make(map[string]int)
 	for i, p := range classDecl.Params {
 		if identPat, ok := p.Pattern.(*ast.IdentPat); ok {

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -26,9 +26,10 @@ func lifetimeParamName(i int) string {
 }
 
 // InferLifetimes analyzes a function body to determine which parameters
-// are aliased by the return value (or escape into module-level state),
-// attaches the appropriate lifetime to each such parameter and to the
-// return type, and records the lifetime parameters on the FuncType.
+// are aliased by the return value (or yielded value, for generators), or
+// escape into module-level state, and attaches the appropriate lifetime
+// to each such parameter and to the return / yield type, recording
+// lifetime parameters on the FuncType.
 //
 // This is the foundational case of Phase 8.3 + 8.4. The algorithm
 // handles:
@@ -38,11 +39,16 @@ func lifetimeParamName(i int) string {
 //     LifetimeUnion on the return type.
 //   - Parameters stored into module-level (non-local) state: assigned
 //     'static directly. See DetectEscapingRefs.
+//   - Yields aliasing parameters (generators): the lifetime is attached
+//     to the yield type T inside Generator<T, TReturn, TNext> rather than
+//     to the Generator container itself, so each yielded value carries
+//     the lifetime.
 //
 // Deferred (see implementation_plan.md Phase 8 status):
 //   - Element-level lifetimes (Array<'a T>) for fresh containers whose
 //     elements alias a parameter.
-//   - Generator yields (yield treated as fresh).
+//   - `yield from` (delegate yield) propagation from the inner iterator's
+//     element type.
 //   - Propagating lifetimes through nested calls into other functions.
 //
 // astParams is the list of parameter ASTs (used to map their VarIDs to
@@ -98,22 +104,51 @@ func (c *Checker) InferLifetimes(
 		})
 	}
 
-	// Walk the body to collect every return statement's expression.
+	// Determine the *result type* — the position to which the
+	// per-source lifetime is attached. For generators, the result is
+	// the yield type T inside Generator<T, TReturn, TNext>; for plain
+	// functions, it's the return type itself.
+	resultType := funcType.Return
+	yieldTargetType := generatorYieldType(funcType.Return)
+	if yieldTargetType != nil {
+		resultType = yieldTargetType
+	}
+
+	// Walk the body to collect alias-source expressions: every return
+	// statement's expression for plain functions, plus every yield
+	// expression's value for generators (the yielded value is what
+	// callers see via Iterator.next()).
 	v := &returnExprVisitor{}
 	for _, stmt := range body.Stmts {
 		stmt.Accept(v)
 	}
-	if len(v.exprs) == 0 {
+	yields := collectYieldExprs(body)
+	if len(v.exprs) == 0 && len(yields) == 0 {
 		return
 	}
 
-	// Determine which leaves are aliased across all return expressions.
-	// Use insertion order so the resulting LifetimeParams list is
-	// deterministic.
+	// Determine which leaves are aliased across all alias-source
+	// expressions. Use insertion order so the resulting LifetimeParams
+	// list is deterministic.
+	sourceExprs := make([]ast.Expr, 0, len(v.exprs)+len(yields))
+	if yieldTargetType != nil {
+		// Generator: yields are the lifetime-bearing source.
+		// The function's `return` (if any) sets TReturn — that lifetime
+		// position is not yet inferred (deferred).
+		sourceExprs = append(sourceExprs, yields...)
+	} else {
+		sourceExprs = append(sourceExprs, v.exprs...)
+	}
 	seen := set.NewSet[int]()
 	var orderedLeaves []int
-	for _, re := range v.exprs {
-		src := liveness.DetermineAliasSource(re)
+	for _, re := range sourceExprs {
+		// Use the checker-aware variant so call expressions whose callee
+		// has inferred lifetime parameters propagate the relevant
+		// argument's alias source through to the result. This is what
+		// makes Phase 8.7's mutual-recursion fixed-point pass actually
+		// converge: on the second pass, peers' lifetimes are visible
+		// here.
+		src := determineCheckerAliasSource(re)
 		switch src.Kind {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 			for _, vid := range src.VarIDs {
@@ -133,12 +168,12 @@ func (c *Checker) InferLifetimes(
 		return
 	}
 
-	// Skip lifetime inference entirely when the return type cannot carry
+	// Skip lifetime inference entirely when the result type cannot carry
 	// a lifetime (e.g. it's a TypeVar, primitive, or union/intersection
 	// without a common lifetime-bearing structure). Without a place to
-	// attach the lifetime on the return side, the lifetime parameter
+	// attach the lifetime on the result side, the lifetime parameter
 	// would be unused noise in the signature.
-	if !typeCarriesLifetime(funcType.Return) {
+	if !typeCarriesLifetime(resultType) {
 		return
 	}
 
@@ -193,7 +228,7 @@ func (c *Checker) InferLifetimes(
 	} else {
 		returnLifetime = &type_system.LifetimeUnion{Lifetimes: returnLifetimeMembers}
 	}
-	setLifetimeOnType(funcType.Return, returnLifetime)
+	setLifetimeOnType(resultType, returnLifetime)
 
 	if len(lifetimeParams) > 0 {
 		funcType.LifetimeParams = lifetimeParams
@@ -870,9 +905,15 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 
 	calleeType := callExpr.Callee.InferredType()
 	fnType := extractFuncType(calleeType)
-	if fnType == nil || len(fnType.LifetimeParams) == 0 {
+	if fnType == nil {
 		return liveness.DetermineAliasSource(expr)
 	}
+	// Don't gate on fnType.LifetimeParams here: by the time the call is
+	// type-checked, callee-side instantiation may have cleared
+	// LifetimeParams while leaving the LifetimeVars themselves attached
+	// to the param/return type positions. The presence of a lifetime on
+	// the return type is the authoritative signal that this call carries
+	// alias information.
 
 	retLifetime := type_system.PruneLifetime(type_system.GetLifetime(fnType.Return))
 	if retLifetime == nil {
@@ -1018,6 +1059,66 @@ func (v *returnExprVisitor) EnterExpr(expr ast.Expr) bool {
 }
 
 func (v *returnExprVisitor) EnterDecl(decl ast.Decl) bool {
+	if _, ok := decl.(*ast.FuncDecl); ok {
+		return false
+	}
+	return true
+}
+
+// generatorYieldType returns the yield type T of a Generator<T, TReturn,
+// TNext> or AsyncGenerator<T, TReturn, TNext> reference, walking past
+// mutability wrappers. Returns nil if t is not a generator reference or
+// has no type args.
+func generatorYieldType(t type_system.Type) type_system.Type {
+	pt := stripMutabilityWrapper(type_system.Prune(t))
+	tref, ok := pt.(*type_system.TypeRefType)
+	if !ok {
+		return nil
+	}
+	name := type_system.QualIdentToString(tref.Name)
+	if name != "Generator" && name != "AsyncGenerator" {
+		return nil
+	}
+	if len(tref.TypeArgs) == 0 {
+		return nil
+	}
+	return tref.TypeArgs[0]
+}
+
+// collectYieldExprs walks a function body collecting the value
+// expressions of every (non-delegate) yield expression. Delegate yields
+// (`yield from iter`) are skipped — propagating lifetimes from the
+// inner iterator's element type is deferred. Bare `yield` (with no
+// value) is also skipped because there is no value to alias.
+func collectYieldExprs(body *ast.Block) []ast.Expr {
+	v := &yieldExprVisitor{}
+	for _, stmt := range body.Stmts {
+		stmt.Accept(v)
+	}
+	return v.exprs
+}
+
+type yieldExprVisitor struct {
+	ast.DefaultVisitor
+	exprs []ast.Expr
+}
+
+func (v *yieldExprVisitor) EnterExpr(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.YieldExpr:
+		if e.Value != nil && !e.IsDelegate {
+			v.exprs = append(v.exprs, e.Value)
+		}
+		return true
+	case *ast.FuncExpr:
+		// Skip nested function bodies — their yields belong to the
+		// inner generator (if any), not ours.
+		return false
+	}
+	return true
+}
+
+func (v *yieldExprVisitor) EnterDecl(decl ast.Decl) bool {
 	if _, ok := decl.(*ast.FuncDecl); ok {
 		return false
 	}

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -52,13 +52,18 @@ func lifetimeParamName(i int) string {
 //   - Propagating lifetimes through nested calls into other functions.
 //
 // astParams is the list of parameter ASTs (used to map their VarIDs to
-// parameter indices). funcType is mutated in place.
+// parameter indices). funcType is mutated in place. isAsync reports
+// whether the function was declared `async` — together with the
+// presence of `yield` in the body it determines whether the return
+// type should be unwrapped to its inner T (Promise<T,_>'s value or
+// Generator<T,_,_>'s yield) or treated as the direct result.
 func (c *Checker) InferLifetimes(
 	astParams []*ast.Param,
 	body *ast.Block,
 	funcType *type_system.FuncType,
+	isAsync bool,
 ) {
-	c.inferLifetimesCore(astParams, body, funcType, false)
+	c.inferLifetimesCore(astParams, body, funcType, isAsync, false)
 }
 
 // ReinferLifetimes re-runs lifetime inference on a function whose first
@@ -74,8 +79,9 @@ func (c *Checker) ReinferLifetimes(
 	astParams []*ast.Param,
 	body *ast.Block,
 	funcType *type_system.FuncType,
+	isAsync bool,
 ) {
-	c.inferLifetimesCore(astParams, body, funcType, true)
+	c.inferLifetimesCore(astParams, body, funcType, isAsync, true)
 }
 
 // inferLifetimesCore is the shared body of InferLifetimes and
@@ -89,6 +95,7 @@ func (c *Checker) inferLifetimesCore(
 	astParams []*ast.Param,
 	body *ast.Block,
 	funcType *type_system.FuncType,
+	isAsync bool,
 	reinfer bool,
 ) {
 	if body == nil || funcType == nil {
@@ -142,21 +149,6 @@ func (c *Checker) inferLifetimesCore(
 		})
 	}
 
-	// Determine the *result type* — the position to which the
-	// per-source lifetime is attached. For generators, the result is
-	// the yield type T inside Generator<T, TReturn, TNext>; for async
-	// functions, the result is the resolved type T inside
-	// Promise<T, E>; for plain functions, it's the return type itself.
-	// In each wrapper case the container is freshly assembled per call
-	// and has no caller-provided lifetime — only its inner T does.
-	resultType := funcType.Return
-	yieldTargetType := generatorYieldType(funcType.Return)
-	if yieldTargetType != nil {
-		resultType = yieldTargetType
-	} else if pvt := promiseValueType(funcType.Return); pvt != nil {
-		resultType = pvt
-	}
-
 	// Walk the body to collect alias-source expressions: every return
 	// statement's expression for plain functions, plus every yield
 	// expression's value for generators (the yielded value is what
@@ -170,11 +162,39 @@ func (c *Checker) inferLifetimesCore(
 		return
 	}
 
+	// A function is a generator when its body actually contains `yield`,
+	// not merely when its return type happens to be Generator<...>. A
+	// plain function that forwards a Generator<T> parameter (e.g.
+	// `return g`) is NOT a generator and the return type carries the
+	// lifetime as a whole, not just its inner yield T.
+	isGenerator := len(yields) > 0
+
+	// Determine the *result type* — the position to which the
+	// per-source lifetime is attached. For generators, the result is
+	// the yield type T inside Generator<T, TReturn, TNext>; for async
+	// functions, the result is the resolved type T inside
+	// Promise<T, E>; for plain functions, it's the return type itself.
+	// In the generator/async cases the container is freshly assembled
+	// per call and has no caller-provided lifetime — only its inner T
+	// does. When the function is neither (so the Promise<T>/Generator<T>
+	// in its signature is the user's actual result, not a wrapper the
+	// compiler synthesized), the lifetime must attach to that container.
+	resultType := funcType.Return
+	if isGenerator {
+		if t := generatorYieldType(funcType.Return); t != nil {
+			resultType = t
+		}
+	} else if isAsync {
+		if t := promiseValueType(funcType.Return); t != nil {
+			resultType = t
+		}
+	}
+
 	// Determine which leaves are aliased across all alias-source
 	// expressions. Use insertion order so the resulting LifetimeParams
 	// list is deterministic.
 	sourceExprs := make([]ast.Expr, 0, len(v.exprs)+len(yields))
-	if yieldTargetType != nil {
+	if isGenerator {
 		// Generator: yields are the lifetime-bearing source.
 		// The function's `return` (if any) sets TReturn — that lifetime
 		// position is not yet inferred (deferred).
@@ -345,7 +365,16 @@ func walkPatternForLeaves(pat ast.Pat, t type_system.Type, into *[]paramLeaf) {
 			if i >= len(tt.Elems) {
 				break
 			}
-			walkPatternForLeaves(elem, tt.Elems[i], into)
+			elemType := tt.Elems[i]
+			// Tuple rest spreads (`[T, ...Array<U>]`) carry a
+			// RestSpreadType in the tuple's Elems slot. The pattern's
+			// matching RestPat expects to receive the *array* type so
+			// its inner pattern can be walked against the element type.
+			// Unwrap the spread here so RestPat sees Array<U> directly.
+			if rest, ok := elemType.(*type_system.RestSpreadType); ok {
+				elemType = rest.Type
+			}
+			walkPatternForLeaves(elem, elemType, into)
 		}
 	case *ast.ObjectPat:
 		ot, ok := pt.(*type_system.ObjectType)

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -63,42 +63,36 @@ func (c *Checker) InferLifetimes(
 		return
 	}
 
-	// Build VarID → param index map for the simple identifier-pattern case.
-	// Destructuring-pattern params don't get lifetimes in this pass.
-	paramIndex := make(map[liveness.VarID]int)
-	for i, p := range astParams {
-		switch pat := p.Pattern.(type) {
-		case *ast.IdentPat:
-			if pat.VarID > 0 {
-				paramIndex[liveness.VarID(pat.VarID)] = i
-			}
-		case *ast.RestPat:
-			// Rest params are skipped here: the lifetime-bearing position
-			// for `...args: T[]` is the *element* type, not the container
-			// variable. Attaching a container-level lifetime to `args`
-			// would be incorrect (the array is freshly assembled per
-			// call), and element-level lifetimes are deferred — see the
-			// file-level docstring's "Element-level lifetimes" bullet.
-		}
-	}
-	if len(paramIndex) == 0 {
+	// Build an ordered list of param "leaves": for IdentPat params, the
+	// leaf is the param itself; for tuple-destructured params (TuplePat),
+	// each leaf IdentPat becomes its own leaf with a Type position
+	// pointing at the corresponding sub-position of the param's type;
+	// for RestPat (`...args: T[]`), the inner pattern's leaf points at
+	// the *element* type Array<T>'s TypeArgs[0], not the array container
+	// — the container is freshly assembled per call and has no
+	// caller-provided lifetime.
+	//
+	// Object-destructured params are not yet walked (Phase 8.6 deferred).
+	leaves := collectParamLeaves(astParams, funcType.Params)
+	if len(leaves) == 0 {
 		return
+	}
+	leafIndex := make(map[liveness.VarID]int)
+	for i, l := range leaves {
+		leafIndex[l.varID] = i
 	}
 
 	// Phase 8.4: detect parameters that escape into module-level state and
 	// assign them 'static directly. This must run before the return-alias
 	// pass so that an escaping param gets 'static rather than a fresh 'a
 	// even when it is also returned by some path.
-	escapingParams := DetectEscapingRefs(body, paramIndex)
-	for idx := range escapingParams {
-		if idx >= len(funcType.Params) {
+	escapingLeaves := detectEscapingLeafIndices(body, leafIndex)
+	for idx := range escapingLeaves {
+		leaf := leaves[idx]
+		if !typeCarriesLifetime(leaf.leafType) {
 			continue
 		}
-		paramType := funcType.Params[idx].Type
-		if !typeCarriesLifetime(paramType) {
-			continue
-		}
-		setLifetimeOnType(paramType, &type_system.LifetimeValue{
+		setLifetimeOnType(leaf.leafType, &type_system.LifetimeValue{
 			Name:     "static",
 			IsStatic: true,
 		})
@@ -113,29 +107,29 @@ func (c *Checker) InferLifetimes(
 		return
 	}
 
-	// Determine which parameters are aliased across all return expressions.
-	// Use insertion order of parameter indices so that the resulting
-	// LifetimeParams list is deterministic.
+	// Determine which leaves are aliased across all return expressions.
+	// Use insertion order so the resulting LifetimeParams list is
+	// deterministic.
 	seen := set.NewSet[int]()
-	var orderedParams []int
+	var orderedLeaves []int
 	for _, re := range v.exprs {
 		src := liveness.DetermineAliasSource(re)
 		switch src.Kind {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 			for _, vid := range src.VarIDs {
-				idx, ok := paramIndex[vid]
+				idx, ok := leafIndex[vid]
 				if !ok {
 					continue
 				}
 				if !seen.Contains(idx) {
 					seen.Add(idx)
-					orderedParams = append(orderedParams, idx)
+					orderedLeaves = append(orderedLeaves, idx)
 				}
 			}
 		}
 	}
 
-	if len(orderedParams) == 0 {
+	if len(orderedLeaves) == 0 {
 		return
 	}
 
@@ -148,39 +142,33 @@ func (c *Checker) InferLifetimes(
 		return
 	}
 
-	// Allocate one fresh LifetimeVar per aliased parameter whose param
-	// type can also carry a lifetime — same reasoning as above for the
-	// param side. Escaping params are handled separately: their param
-	// type already carries 'static, and the return type (if it aliases
-	// them) inherits 'static too.
-	lifetimeParams := make([]*type_system.LifetimeVar, 0, len(orderedParams))
+	// Allocate one fresh LifetimeVar per aliased leaf whose leaf type
+	// can also carry a lifetime — same reasoning as above for the param
+	// side. Escaping leaves are handled separately: their leaf type
+	// already carries 'static, and the return type (if it aliases them)
+	// inherits 'static too.
+	lifetimeParams := make([]*type_system.LifetimeVar, 0, len(orderedLeaves))
 	returnHasStatic := false
 	var returnLifetimeMembers []type_system.Lifetime
-	for _, idx := range orderedParams {
-		if idx >= len(funcType.Params) {
+	for _, idx := range orderedLeaves {
+		leaf := leaves[idx]
+		if !typeCarriesLifetime(leaf.leafType) {
 			continue
 		}
-		paramType := funcType.Params[idx].Type
-		if !typeCarriesLifetime(paramType) {
-			continue
-		}
-		if escapingParams.Contains(idx) {
-			// Param already carries 'static. Record that the return
+		if escapingLeaves.Contains(idx) {
+			// Leaf already carries 'static. Record that the return
 			// shares this 'static lifetime, but don't allocate a 'a for
-			// it (since the param's lifetime is a concrete value, not a
+			// it (since the leaf's lifetime is a concrete value, not a
 			// variable).
 			returnHasStatic = true
 			continue
 		}
-		// paramIndex (above) was populated only from IdentPat params, so
-		// astParams[idx].Pattern is guaranteed to be *ast.IdentPat.
-		_ = astParams[idx].Pattern.(*ast.IdentPat)
 		lv := c.FreshLifetimeVar(lifetimeParamName(len(lifetimeParams)))
 		lifetimeParams = append(lifetimeParams, lv)
 		returnLifetimeMembers = append(returnLifetimeMembers, lv)
 
-		// Attach the lifetime to the parameter's type.
-		setLifetimeOnType(paramType, lv)
+		// Attach the lifetime to the leaf's type position.
+		setLifetimeOnType(leaf.leafType, lv)
 	}
 
 	if len(returnLifetimeMembers) == 0 && !returnHasStatic {
@@ -212,6 +200,102 @@ func (c *Checker) InferLifetimes(
 	}
 }
 
+// paramLeaf represents a leaf binding within a function-parameter pattern,
+// paired with the Type position to which a lifetime should be attached.
+// For a simple identifier param `p: T`, leafType is the param's full type;
+// for a tuple-destructured param `[a, b]: [T, U]`, each leaf points at the
+// corresponding tuple element type; for a rest param `...args: T[]`, the
+// leaf points at the *element* type T (the array container is freshly
+// assembled per call and has no caller-provided lifetime).
+type paramLeaf struct {
+	varID    liveness.VarID
+	leafType type_system.Type
+}
+
+// collectParamLeaves walks each function parameter's pattern in lockstep
+// with the parameter's inferred type, producing an ordered list of
+// (VarID, leafType) pairs for every leaf binding that has a positive
+// VarID set by the rename pass.
+//
+// Object-destructured params are not yet walked — see Phase 8.6 deferred
+// items in implementation_plan.md.
+func collectParamLeaves(
+	astParams []*ast.Param,
+	funcParams []*type_system.FuncParam,
+) []paramLeaf {
+	var leaves []paramLeaf
+	for i, p := range astParams {
+		if i >= len(funcParams) {
+			continue
+		}
+		walkPatternForLeaves(p.Pattern, funcParams[i].Type, &leaves)
+	}
+	return leaves
+}
+
+func walkPatternForLeaves(pat ast.Pat, t type_system.Type, into *[]paramLeaf) {
+	if pat == nil || t == nil {
+		return
+	}
+	pt := stripMutabilityWrapper(type_system.Prune(t))
+	switch p := pat.(type) {
+	case *ast.IdentPat:
+		if p.VarID > 0 {
+			*into = append(*into, paramLeaf{
+				varID:    liveness.VarID(p.VarID),
+				leafType: t,
+			})
+		}
+	case *ast.TuplePat:
+		tt, ok := pt.(*type_system.TupleType)
+		if !ok {
+			return
+		}
+		for i, elem := range p.Elems {
+			if i >= len(tt.Elems) {
+				break
+			}
+			walkPatternForLeaves(elem, tt.Elems[i], into)
+		}
+	case *ast.RestPat:
+		// `...args: T[]` — the lifetime-bearing position is the
+		// *element* type, not the array container. Descend into the
+		// inner pattern with the element type.
+		elem := arrayElemType(t)
+		if elem == nil {
+			return
+		}
+		walkPatternForLeaves(p.Pattern, elem, into)
+	}
+}
+
+// stripMutabilityWrapper strips a MutabilityType wrapper (any kind:
+// explicit `mut`, immutable, or uncertain `mut?`) so callers can match
+// the underlying structural type. Returns the input unchanged if not
+// wrapped. Distinct from the more selective `unwrapMutability` in
+// unify.go which only strips uncertain wrappers — here we want the
+// underlying structural type regardless of mutability annotation.
+func stripMutabilityWrapper(t type_system.Type) type_system.Type {
+	if mt, ok := t.(*type_system.MutabilityType); ok {
+		return type_system.Prune(mt.Type)
+	}
+	return t
+}
+
+// arrayElemType returns the element type T of an Array<T> reference,
+// walking past mutability wrappers. Returns nil if t is not an Array.
+func arrayElemType(t type_system.Type) type_system.Type {
+	pt := stripMutabilityWrapper(type_system.Prune(t))
+	tref, ok := pt.(*type_system.TypeRefType)
+	if !ok {
+		return nil
+	}
+	if type_system.QualIdentToString(tref.Name) != "Array" || len(tref.TypeArgs) != 1 {
+		return nil
+	}
+	return tref.TypeArgs[0]
+}
+
 // DetectEscapingRefs walks a function body looking for assignments that
 // store one of the function's parameters into a non-local location
 // (module-level variable, prelude binding, or any other binding looked
@@ -235,13 +319,24 @@ func DetectEscapingRefs(
 	body *ast.Block,
 	paramIndex map[liveness.VarID]int,
 ) set.Set[int] {
+	return detectEscapingLeafIndices(body, paramIndex)
+}
+
+// detectEscapingLeafIndices is the leaf-aware version of
+// DetectEscapingRefs: leafIndex maps a leaf binding's VarID to its
+// position in the leaves list, and the returned set contains the
+// indices of leaves whose value escapes.
+func detectEscapingLeafIndices(
+	body *ast.Block,
+	leafIndex map[liveness.VarID]int,
+) set.Set[int] {
 	escaped := set.NewSet[int]()
-	if body == nil || len(paramIndex) == 0 {
+	if body == nil || len(leafIndex) == 0 {
 		return escaped
 	}
 	v := &escapingRefsVisitor{
-		paramIndex: paramIndex,
-		escaped:    escaped,
+		leafIndex: leafIndex,
+		escaped:   escaped,
 	}
 	body.Accept(v)
 	return escaped
@@ -249,8 +344,8 @@ func DetectEscapingRefs(
 
 type escapingRefsVisitor struct {
 	ast.DefaultVisitor
-	paramIndex map[liveness.VarID]int
-	escaped    set.Set[int]
+	leafIndex map[liveness.VarID]int
+	escaped   set.Set[int]
 }
 
 func (v *escapingRefsVisitor) EnterExpr(e ast.Expr) bool {
@@ -260,7 +355,7 @@ func (v *escapingRefsVisitor) EnterExpr(e ast.Expr) bool {
 			switch src.Kind {
 			case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 				for _, vid := range src.VarIDs {
-					if idx, ok := v.paramIndex[vid]; ok {
+					if idx, ok := v.leafIndex[vid]; ok {
 						v.escaped.Add(idx)
 					}
 				}

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -58,14 +58,48 @@ func (c *Checker) InferLifetimes(
 	body *ast.Block,
 	funcType *type_system.FuncType,
 ) {
+	c.inferLifetimesCore(astParams, body, funcType, false)
+}
+
+// ReinferLifetimes re-runs lifetime inference on a function whose first
+// pass has already completed. Intended for the SCC re-run in
+// InferComponent: peers in the same SCC may have gained inferred
+// lifetimes after this function's first pass, in which case
+// `determineCheckerAliasSource` can now reach through their call
+// expressions and reveal additional aliased leaves. Unlike
+// InferLifetimes, this entry point bypasses the user-explicit guard,
+// so callers must ensure they don't invoke it on a function whose
+// LifetimeParams were declared explicitly by the user.
+func (c *Checker) ReinferLifetimes(
+	astParams []*ast.Param,
+	body *ast.Block,
+	funcType *type_system.FuncType,
+) {
+	c.inferLifetimesCore(astParams, body, funcType, true)
+}
+
+// inferLifetimesCore is the shared body of InferLifetimes and
+// ReinferLifetimes. The reinfer flag controls whether the function may
+// extend an already-inferred set of lifetime params: when false, the
+// function bails out as soon as it sees existing LifetimeParams (the
+// historical behavior protecting user-explicit lifetimes); when true,
+// it walks the leaves and *appends* new lifetime params for any leaves
+// that became visible via newly-resolved peer signatures.
+func (c *Checker) inferLifetimesCore(
+	astParams []*ast.Param,
+	body *ast.Block,
+	funcType *type_system.FuncType,
+	reinfer bool,
+) {
 	if body == nil || funcType == nil {
 		return
 	}
 	// If the user already declared explicit lifetime parameters on the
 	// signature, don't second-guess them. (Resolution of those annotated
 	// lifetimes during type-checking is a separate concern handled by
-	// the type-annotation inference path.)
-	if len(funcType.LifetimeParams) > 0 {
+	// the type-annotation inference path.) The reinfer path skips this
+	// guard so the SCC re-run can extend a previously-inferred result.
+	if !reinfer && len(funcType.LifetimeParams) > 0 {
 		return
 	}
 
@@ -91,11 +125,15 @@ func (c *Checker) InferLifetimes(
 	// Phase 8.4: detect parameters that escape into module-level state and
 	// assign them 'static directly. This must run before the return-alias
 	// pass so that an escaping param gets 'static rather than a fresh 'a
-	// even when it is also returned by some path.
+	// even when it is also returned by some path. Already-set 'static
+	// (from a prior pass) is a no-op.
 	escapingLeaves := detectEscapingLeafIndices(body, leafIndex)
 	for idx := range escapingLeaves {
 		leaf := leaves[idx]
 		if !typeCarriesLifetime(leaf.leafType) {
+			continue
+		}
+		if existing, ok := type_system.PruneLifetime(type_system.GetLifetime(leaf.leafType)).(*type_system.LifetimeValue); ok && existing.IsStatic {
 			continue
 		}
 		setLifetimeOnType(leaf.leafType, &type_system.LifetimeValue{
@@ -106,12 +144,17 @@ func (c *Checker) InferLifetimes(
 
 	// Determine the *result type* — the position to which the
 	// per-source lifetime is attached. For generators, the result is
-	// the yield type T inside Generator<T, TReturn, TNext>; for plain
-	// functions, it's the return type itself.
+	// the yield type T inside Generator<T, TReturn, TNext>; for async
+	// functions, the result is the resolved type T inside
+	// Promise<T, E>; for plain functions, it's the return type itself.
+	// In each wrapper case the container is freshly assembled per call
+	// and has no caller-provided lifetime — only its inner T does.
 	resultType := funcType.Return
 	yieldTargetType := generatorYieldType(funcType.Return)
 	if yieldTargetType != nil {
 		resultType = yieldTargetType
+	} else if pvt := promiseValueType(funcType.Return); pvt != nil {
+		resultType = pvt
 	}
 
 	// Walk the body to collect alias-source expressions: every return
@@ -177,12 +220,16 @@ func (c *Checker) InferLifetimes(
 		return
 	}
 
-	// Allocate one fresh LifetimeVar per aliased leaf whose leaf type
-	// can also carry a lifetime — same reasoning as above for the param
-	// side. Escaping leaves are handled separately: their leaf type
-	// already carries 'static, and the return type (if it aliases them)
-	// inherits 'static too.
-	lifetimeParams := make([]*type_system.LifetimeVar, 0, len(orderedLeaves))
+	// Walk the aliased leaves. For each, either:
+	//   (a) Reuse the leaf's existing lifetime (set by a prior pass —
+	//       the LifetimeVar is pointer-shared, already in
+	//       funcType.LifetimeParams).
+	//   (b) Treat as escaping — contribute 'static to the return.
+	//   (c) Allocate a fresh LifetimeVar — append it to LifetimeParams.
+	// returnLifetimeMembers accumulates ALL lifetimes contributed to
+	// the return, so that on a re-run we can rebuild the union over
+	// both pre-existing and newly-discovered leaves.
+	var newLifetimeParams []*type_system.LifetimeVar
 	returnHasStatic := false
 	var returnLifetimeMembers []type_system.Lifetime
 	for _, idx := range orderedLeaves {
@@ -198,8 +245,16 @@ func (c *Checker) InferLifetimes(
 			returnHasStatic = true
 			continue
 		}
-		lv := c.FreshLifetimeVar(lifetimeParamName(len(lifetimeParams)))
-		lifetimeParams = append(lifetimeParams, lv)
+		// Reuse an already-inferred LifetimeVar on the leaf so the
+		// signature stays stable across re-runs and pointer identity
+		// is preserved with anything that already references it.
+		if existing, ok := type_system.PruneLifetime(type_system.GetLifetime(leaf.leafType)).(*type_system.LifetimeVar); ok && existing != nil {
+			returnLifetimeMembers = append(returnLifetimeMembers, existing)
+			continue
+		}
+		nameIdx := len(funcType.LifetimeParams) + len(newLifetimeParams)
+		lv := c.FreshLifetimeVar(lifetimeParamName(nameIdx))
+		newLifetimeParams = append(newLifetimeParams, lv)
 		returnLifetimeMembers = append(returnLifetimeMembers, lv)
 
 		// Attach the lifetime to the leaf's type position.
@@ -230,8 +285,8 @@ func (c *Checker) InferLifetimes(
 	}
 	setLifetimeOnType(resultType, returnLifetime)
 
-	if len(lifetimeParams) > 0 {
-		funcType.LifetimeParams = lifetimeParams
+	if len(newLifetimeParams) > 0 {
+		funcType.LifetimeParams = append(funcType.LifetimeParams, newLifetimeParams...)
 	}
 }
 
@@ -436,7 +491,10 @@ type escapingRefsVisitor struct {
 func (v *escapingRefsVisitor) EnterExpr(e ast.Expr) bool {
 	if be, ok := e.(*ast.BinaryExpr); ok && be.Op == ast.Assign {
 		if isNonLocalLValue(be.Left) {
-			src := liveness.DetermineAliasSource(be.Right)
+			// Use the checker-aware variant so a parameter that flows
+			// through a call whose callee returns its argument
+			// (`cache = wrap(p)`) is still detected as escaping.
+			src := determineCheckerAliasSource(be.Right)
 			switch src.Kind {
 			case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 				for _, vid := range src.VarIDs {
@@ -579,6 +637,20 @@ func (c *Checker) InferConstructorLifetimes(
 			collectFieldStorageParams(elem, paramNameToIndex, storedParams)
 		case *ast.MethodElem:
 			// Static methods can't access instance state implicitly.
+			if elem.Static || elem.Fn == nil || elem.Fn.Body == nil {
+				continue
+			}
+			collectMethodBodyCaptures(elem.Fn, paramNameToIndex, storedParams)
+		case *ast.GetterElem:
+			// Getters are instance accessors that can implicitly
+			// reference constructor params, just like methods.
+			if elem.Static || elem.Fn == nil || elem.Fn.Body == nil {
+				continue
+			}
+			collectMethodBodyCaptures(elem.Fn, paramNameToIndex, storedParams)
+		case *ast.SetterElem:
+			// Setters likewise — the body may both read and assign
+			// constructor params.
 			if elem.Static || elem.Fn == nil || elem.Fn.Body == nil {
 				continue
 			}
@@ -772,8 +844,8 @@ func blockResultExpr(b ast.Block) ast.Expr {
 // collectMethodBodyCaptures walks a method body looking for IdentExpr
 // references whose name matches a constructor parameter, and adds the
 // matching parameter indices to storedParams. Tracks shadowing introduced
-// by inner FuncExpr params so that names rebound by nested functions are
-// not counted as captures.
+// by inner function params and by `var`/`val`/`let` bindings within
+// blocks so that names rebound locally are not counted as captures.
 //
 // This closes the soundness gap where a method body references a
 // constructor param by name (Escalier allows this) without any
@@ -784,38 +856,43 @@ func collectMethodBodyCaptures(
 	paramNameToIndex map[string]int,
 	storedParams set.Set[int],
 ) {
-	// Names shadowed in the current scope (and all enclosing scopes within
-	// the method) are tracked as a stack: each entry is the set of names
-	// bound by a single FuncExpr's parameters.
 	v := &methodCaptureVisitor{
 		paramNameToIndex: paramNameToIndex,
 		storedParams:     storedParams,
 	}
 	// The method's own params shadow constructor params with the same name.
-	v.pushScope(fn.Params)
+	v.pushScope()
+	for _, p := range fn.Params {
+		v.addBindings(p.Pattern)
+	}
 	if fn.Body != nil {
-		fn.Body.Accept(v)
+		v.walkBlock(fn.Body)
 	}
 	v.popScope()
 }
 
 type methodCaptureVisitor struct {
-	ast.DefaultVisitor
 	paramNameToIndex map[string]int
 	storedParams     set.Set[int]
-	shadowed         []set.Set[string]
+	// shadowed is a stack of block/function scopes. Each entry is the set
+	// of names bound in that scope. A name is considered shadowed if it
+	// appears in any active scope.
+	shadowed []set.Set[string]
 }
 
-func (v *methodCaptureVisitor) pushScope(params []*ast.Param) {
-	scope := set.NewSet[string]()
-	for _, p := range params {
-		collectPatternBindingNames(p.Pattern, scope)
-	}
-	v.shadowed = append(v.shadowed, scope)
+func (v *methodCaptureVisitor) pushScope() {
+	v.shadowed = append(v.shadowed, set.NewSet[string]())
 }
 
 func (v *methodCaptureVisitor) popScope() {
 	v.shadowed = v.shadowed[:len(v.shadowed)-1]
+}
+
+func (v *methodCaptureVisitor) addBindings(pat ast.Pat) {
+	if len(v.shadowed) == 0 {
+		return
+	}
+	collectPatternBindingNames(pat, v.shadowed[len(v.shadowed)-1])
 }
 
 func (v *methodCaptureVisitor) isShadowed(name string) bool {
@@ -827,50 +904,131 @@ func (v *methodCaptureVisitor) isShadowed(name string) bool {
 	return false
 }
 
-func (v *methodCaptureVisitor) EnterExpr(e ast.Expr) bool {
+func (v *methodCaptureVisitor) walkBlock(b *ast.Block) {
+	if b == nil {
+		return
+	}
+	v.pushScope()
+	for _, stmt := range b.Stmts {
+		v.walkStmt(stmt)
+	}
+	v.popScope()
+}
+
+func (v *methodCaptureVisitor) walkStmt(s ast.Stmt) {
+	if s == nil {
+		return
+	}
+	switch ss := s.(type) {
+	case *ast.ExprStmt:
+		v.walkExpr(ss.Expr)
+	case *ast.ReturnStmt:
+		v.walkExpr(ss.Expr)
+	case *ast.DeclStmt:
+		v.walkDecl(ss.Decl)
+	}
+}
+
+func (v *methodCaptureVisitor) walkDecl(d ast.Decl) {
+	if d == nil {
+		return
+	}
+	switch dd := d.(type) {
+	case *ast.VarDecl:
+		// Visit the initializer BEFORE adding the new binding to the
+		// current scope. This prevents `var p = p` from incorrectly
+		// treating the RHS `p` as the freshly-shadowed inner binding —
+		// it should resolve against the enclosing scope (potentially
+		// the constructor's param).
+		if dd.Init != nil {
+			v.walkExpr(dd.Init)
+		}
+		v.addBindings(dd.Pattern)
+	case *ast.FuncDecl:
+		// Nested function declaration: similar to FuncExpr, its params
+		// shadow outer names within its body.
+		if dd.Body == nil {
+			return
+		}
+		v.pushScope()
+		for _, p := range dd.Params {
+			v.addBindings(p.Pattern)
+		}
+		v.walkBlock(dd.Body)
+		v.popScope()
+	case *ast.ClassDecl:
+		// Skip nested classes — their constructor param names introduce
+		// a fresh shadow scope that's outside the analysis we care about.
+	}
+}
+
+func (v *methodCaptureVisitor) walkExpr(e ast.Expr) {
+	if e == nil {
+		return
+	}
 	switch ex := e.(type) {
 	case *ast.IdentExpr:
 		if v.isShadowed(ex.Name) {
-			return true
+			return
 		}
 		if idx, ok := v.paramNameToIndex[ex.Name]; ok {
 			v.storedParams.Add(idx)
 		}
 	case *ast.FuncExpr:
 		// Nested function: its params introduce new shadows for the
-		// duration of its body. Manually descend so we control scope.
-		v.pushScope(ex.Params)
-		if ex.Body != nil {
-			ex.Body.Accept(v)
+		// duration of its body.
+		v.pushScope()
+		for _, p := range ex.Params {
+			v.addBindings(p.Pattern)
 		}
+		v.walkBlock(ex.Body)
 		v.popScope()
+	default:
+		// Walk through other expression shapes by visiting their child
+		// expressions / blocks directly. We use an inner ast Visitor that
+		// re-enters our walk for IdentExpr, FuncExpr, blocks, and decls
+		// so scope tracking stays consistent.
+		ex.Accept(&methodCaptureSubVisitor{outer: v})
+	}
+}
+
+// methodCaptureSubVisitor handles traversal of expression subtrees that
+// don't introduce a new scope themselves. It delegates back to the outer
+// methodCaptureVisitor for IdentExpr lookups and for nodes that DO start
+// a new scope (FuncExpr, FuncDecl, blocks, var decls), so that scope
+// push/pop remains in lockstep with the source structure.
+type methodCaptureSubVisitor struct {
+	ast.DefaultVisitor
+	outer *methodCaptureVisitor
+}
+
+func (v *methodCaptureSubVisitor) EnterExpr(e ast.Expr) bool {
+	switch e.(type) {
+	case *ast.IdentExpr, *ast.FuncExpr:
+		v.outer.walkExpr(e)
 		return false
 	}
 	return true
 }
 
-func (v *methodCaptureVisitor) EnterDecl(d ast.Decl) bool {
-	switch dd := d.(type) {
-	case *ast.VarDecl:
-		// `let p = ...` (or `var p = ...`) shadows the constructor's `p`
-		// from this point onward in the enclosing block. Record the
-		// pattern's bound names in the current scope.
-		if len(v.shadowed) > 0 {
-			collectPatternBindingNames(dd.Pattern, v.shadowed[len(v.shadowed)-1])
-		}
-	case *ast.FuncDecl:
-		// Nested function declaration: similar to FuncExpr, its params
-		// shadow outer names within its body.
-		if dd.Body == nil {
-			return false
-		}
-		v.pushScope(dd.Params)
-		dd.Body.Accept(v)
-		v.popScope()
+func (v *methodCaptureSubVisitor) EnterStmt(s ast.Stmt) bool {
+	switch s.(type) {
+	case *ast.DeclStmt:
+		v.outer.walkStmt(s)
 		return false
-	case *ast.ClassDecl:
-		// Skip nested classes — their constructor param names introduce
-		// a fresh shadow scope that's outside the analysis we care about.
+	}
+	return true
+}
+
+func (v *methodCaptureSubVisitor) EnterBlock(b ast.Block) bool {
+	v.outer.walkBlock(&b)
+	return false
+}
+
+func (v *methodCaptureSubVisitor) EnterDecl(d ast.Decl) bool {
+	switch d.(type) {
+	case *ast.VarDecl, *ast.FuncDecl, *ast.ClassDecl:
+		v.outer.walkDecl(d)
 		return false
 	}
 	return true
@@ -1127,6 +1285,24 @@ func generatorYieldType(t type_system.Type) type_system.Type {
 	}
 	name := type_system.QualIdentToString(tref.Name)
 	if name != "Generator" && name != "AsyncGenerator" {
+		return nil
+	}
+	if len(tref.TypeArgs) == 0 {
+		return nil
+	}
+	return tref.TypeArgs[0]
+}
+
+// promiseValueType returns the resolved value type T of a
+// Promise<T, E> reference, walking past mutability wrappers. Returns
+// nil if t is not a Promise reference or has no type args.
+func promiseValueType(t type_system.Type) type_system.Type {
+	pt := stripMutabilityWrapper(type_system.Prune(t))
+	tref, ok := pt.(*type_system.TypeRefType)
+	if !ok {
+		return nil
+	}
+	if type_system.QualIdentToString(tref.Name) != "Promise" {
 		return nil
 	}
 	if len(tref.TypeArgs) == 0 {

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -26,21 +26,23 @@ func lifetimeParamName(i int) string {
 }
 
 // InferLifetimes analyzes a function body to determine which parameters
-// are aliased by the return value, attaches a fresh LifetimeVar to each
-// such parameter and to the return type, and records the lifetime
-// parameters on the FuncType.
+// are aliased by the return value (or escape into module-level state),
+// attaches the appropriate lifetime to each such parameter and to the
+// return type, and records the lifetime parameters on the FuncType.
 //
-// This is the foundational case of Phase 8.3. The algorithm only handles:
+// This is the foundational case of Phase 8.3 + 8.4. The algorithm
+// handles:
 //   - Returns of a parameter (or property/index access of a parameter):
 //     produces a container-level lifetime on the parameter and return type.
 //   - Multiple returns aliasing different parameters: emits a
 //     LifetimeUnion on the return type.
+//   - Parameters stored into module-level (non-local) state: assigned
+//     'static directly. See DetectEscapingRefs.
 //
 // Deferred (see implementation_plan.md Phase 8 status):
 //   - Element-level lifetimes (Array<'a T>) for fresh containers whose
 //     elements alias a parameter.
 //   - Generator yields (yield treated as fresh).
-//   - Escaping references to module-level state ('static).
 //   - Propagating lifetimes through nested calls into other functions.
 //
 // astParams is the list of parameter ASTs (used to map their VarIDs to
@@ -81,6 +83,25 @@ func (c *Checker) InferLifetimes(
 	}
 	if len(paramIndex) == 0 {
 		return
+	}
+
+	// Phase 8.4: detect parameters that escape into module-level state and
+	// assign them 'static directly. This must run before the return-alias
+	// pass so that an escaping param gets 'static rather than a fresh 'a
+	// even when it is also returned by some path.
+	escapingParams := DetectEscapingRefs(body, paramIndex)
+	for idx := range escapingParams {
+		if idx >= len(funcType.Params) {
+			continue
+		}
+		paramType := funcType.Params[idx].Type
+		if !typeCarriesLifetime(paramType) {
+			continue
+		}
+		setLifetimeOnType(paramType, &type_system.LifetimeValue{
+			Name:     "static",
+			IsStatic: true,
+		})
 	}
 
 	// Walk the body to collect every return statement's expression.
@@ -129,8 +150,12 @@ func (c *Checker) InferLifetimes(
 
 	// Allocate one fresh LifetimeVar per aliased parameter whose param
 	// type can also carry a lifetime — same reasoning as above for the
-	// param side.
+	// param side. Escaping params are handled separately: their param
+	// type already carries 'static, and the return type (if it aliases
+	// them) inherits 'static too.
 	lifetimeParams := make([]*type_system.LifetimeVar, 0, len(orderedParams))
+	returnHasStatic := false
+	var returnLifetimeMembers []type_system.Lifetime
 	for _, idx := range orderedParams {
 		if idx >= len(funcType.Params) {
 			continue
@@ -139,43 +164,141 @@ func (c *Checker) InferLifetimes(
 		if !typeCarriesLifetime(paramType) {
 			continue
 		}
+		if escapingParams.Contains(idx) {
+			// Param already carries 'static. Record that the return
+			// shares this 'static lifetime, but don't allocate a 'a for
+			// it (since the param's lifetime is a concrete value, not a
+			// variable).
+			returnHasStatic = true
+			continue
+		}
 		// paramIndex (above) was populated only from IdentPat params, so
 		// astParams[idx].Pattern is guaranteed to be *ast.IdentPat.
 		_ = astParams[idx].Pattern.(*ast.IdentPat)
 		lv := c.FreshLifetimeVar(lifetimeParamName(len(lifetimeParams)))
 		lifetimeParams = append(lifetimeParams, lv)
+		returnLifetimeMembers = append(returnLifetimeMembers, lv)
 
 		// Attach the lifetime to the parameter's type.
 		setLifetimeOnType(paramType, lv)
 	}
 
-	if len(lifetimeParams) == 0 {
+	if len(returnLifetimeMembers) == 0 && !returnHasStatic {
 		return
 	}
 
-	// Construct the lifetime to attach to the return type. Only include
-	// parameters that actually got lifetime variables (i.e. param types
-	// that could carry one). By construction of orderedParams above,
-	// every entry in lifetimeParams is guaranteed to be a possible source
-	// for the return value on at least one code path — DetermineAliasSource
-	// in the body walk only added a param to orderedParams if some return
-	// expression aliased it. The union therefore expresses "the result
-	// could have come from any of these params, depending on which branch
-	// ran"; the caller treats the result as bounded by the shortest of
-	// the listed lifetimes.
+	// Construct the lifetime to attach to the return type. The members
+	// include any fresh LifetimeVars allocated above plus a 'static value
+	// when the return aliases an escaping param. The union expresses
+	// "the result could have come from any of these sources, depending on
+	// which branch ran"; the caller treats the result as bounded by the
+	// shortest of the listed lifetimes (and 'static is unbounded).
+	if returnHasStatic {
+		returnLifetimeMembers = append(returnLifetimeMembers, &type_system.LifetimeValue{
+			Name:     "static",
+			IsStatic: true,
+		})
+	}
 	var returnLifetime type_system.Lifetime
-	if len(lifetimeParams) == 1 {
-		returnLifetime = lifetimeParams[0]
+	if len(returnLifetimeMembers) == 1 {
+		returnLifetime = returnLifetimeMembers[0]
 	} else {
-		members := make([]type_system.Lifetime, len(lifetimeParams))
-		for i, lv := range lifetimeParams {
-			members[i] = lv
-		}
-		returnLifetime = &type_system.LifetimeUnion{Lifetimes: members}
+		returnLifetime = &type_system.LifetimeUnion{Lifetimes: returnLifetimeMembers}
 	}
 	setLifetimeOnType(funcType.Return, returnLifetime)
 
-	funcType.LifetimeParams = lifetimeParams
+	if len(lifetimeParams) > 0 {
+		funcType.LifetimeParams = lifetimeParams
+	}
+}
+
+// DetectEscapingRefs walks a function body looking for assignments that
+// store one of the function's parameters into a non-local location
+// (module-level variable, prelude binding, or any other binding looked
+// up through the function's enclosing scope chain). Returns the set of
+// parameter indices whose value escapes.
+//
+// Detection is by VarID: the rename pass assigns positive VarIDs to
+// locals and negative VarIDs to outer-scope references. An assignment
+// whose lvalue root is a non-local identifier (VarID <= 0) is treated
+// as a store into outer-lived state. Stores into locals don't escape
+// because the local's lifetime is bounded by the function body.
+//
+// Limitations:
+//   - Closures over a *nested* function's local: inner functions whose
+//     body assigns to an outer function's local will mark that param as
+//     'static, which is more conservative than necessary. The
+//     borrow-checker tolerates this (it's sound, just imprecise).
+//   - Stores via property assignment whose root is a local but is
+//     itself stored elsewhere: not tracked here.
+func DetectEscapingRefs(
+	body *ast.Block,
+	paramIndex map[liveness.VarID]int,
+) set.Set[int] {
+	escaped := set.NewSet[int]()
+	if body == nil || len(paramIndex) == 0 {
+		return escaped
+	}
+	v := &escapingRefsVisitor{
+		paramIndex: paramIndex,
+		escaped:    escaped,
+	}
+	body.Accept(v)
+	return escaped
+}
+
+type escapingRefsVisitor struct {
+	ast.DefaultVisitor
+	paramIndex map[liveness.VarID]int
+	escaped    set.Set[int]
+}
+
+func (v *escapingRefsVisitor) EnterExpr(e ast.Expr) bool {
+	if be, ok := e.(*ast.BinaryExpr); ok && be.Op == ast.Assign {
+		if isNonLocalLValue(be.Left) {
+			src := liveness.DetermineAliasSource(be.Right)
+			switch src.Kind {
+			case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
+				for _, vid := range src.VarIDs {
+					if idx, ok := v.paramIndex[vid]; ok {
+						v.escaped.Add(idx)
+					}
+				}
+			}
+		}
+	}
+	// Don't descend into nested function bodies — their assignments
+	// concern their own params, not ours.
+	if _, ok := e.(*ast.FuncExpr); ok {
+		return false
+	}
+	return true
+}
+
+func (v *escapingRefsVisitor) EnterDecl(d ast.Decl) bool {
+	switch d.(type) {
+	case *ast.FuncDecl, *ast.ClassDecl:
+		return false
+	}
+	return true
+}
+
+// isNonLocalLValue returns true if the given assignment-target expression's
+// root identifier resolves to a non-local binding (VarID <= 0). Walks
+// through MemberExpr/IndexExpr chains to find the root identifier.
+func isNonLocalLValue(expr ast.Expr) bool {
+	for {
+		switch e := expr.(type) {
+		case *ast.IdentExpr:
+			return e.VarID <= 0
+		case *ast.MemberExpr:
+			expr = e.Object
+		case *ast.IndexExpr:
+			expr = e.Object
+		default:
+			return false
+		}
+	}
 }
 
 // setLifetimeOnType attaches a lifetime to a type's Lifetime field, walking

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -31,8 +31,8 @@ func lifetimeParamName(i int) string {
 // to each such parameter and to the return / yield type, recording
 // lifetime parameters on the FuncType.
 //
-// This is the foundational case of Phase 8.3 + 8.4. The algorithm
-// handles:
+// This is the entry point for the body-side of Phase 8.3 + 8.4 + 8.7.
+// The algorithm handles:
 //   - Returns of a parameter (or property/index access of a parameter):
 //     produces a container-level lifetime on the parameter and return type.
 //   - Multiple returns aliasing different parameters: emits a
@@ -43,6 +43,16 @@ func lifetimeParamName(i int) string {
 //     to the yield type T inside Generator<T, TReturn, TNext> rather than
 //     to the Generator container itself, so each yielded value carries
 //     the lifetime.
+//   - Per-leaf lifetimes for tuple-, object-, and rest-destructured
+//     parameters: walkPatternForLeaves walks each parameter's pattern in
+//     lockstep with its inferred type, producing one (VarID, leafType)
+//     entry per leaf binding so that each destructured leaf can receive
+//     its own lifetime variable.
+//
+// For SCC re-runs in mutual recursion (Phase 8.7), see ReinferLifetimes,
+// which forwards to inferLifetimesCore with reinfer=true so that
+// previously-inferred LifetimeParams can be extended once peers' signatures
+// become resolvable on the second pass.
 //
 // Deferred (see implementation_plan.md Phase 8 status):
 //   - Element-level lifetimes (Array<'a T>) for fresh containers whose
@@ -1010,35 +1020,54 @@ func (v *methodCaptureVisitor) EnterDecl(d ast.Decl) bool {
 	return true
 }
 
-// collectPatternBindingNames adds every identifier name introduced by a
-// pattern (recursively) to the provided set.
-func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
-	if p == nil {
+// forEachLeafBinding invokes fn for every identifier-binding leaf
+// introduced by a pattern, walking through Tuple/Object/Rest containers.
+// Leaves are IdentPat (the pattern's own Name+VarID) and ObjShorthandPat
+// (the property's Key.Name plus the shorthand's own VarID). ObjRestPat,
+// RestPat, and ObjKeyValuePat are container-only; this helper recurses
+// through them.
+//
+// Note: walkPatternForLeaves cannot use this helper because it walks the
+// pattern in *lockstep with the parameter's type* (slicing tuple/object/
+// array sub-positions to compute each leaf's leafType) and intentionally
+// skips ObjRestPat (a freshly-assembled container has no
+// caller-provided lifetime). The two name-only walkers below share this
+// traversal; lifetime walking does not.
+func forEachLeafBinding(pat ast.Pat, fn func(name string, varID int)) {
+	if pat == nil {
 		return
 	}
-	switch pp := p.(type) {
+	switch p := pat.(type) {
 	case *ast.IdentPat:
-		into.Add(pp.Name)
+		fn(p.Name, p.VarID)
 	case *ast.TuplePat:
-		for _, sub := range pp.Elems {
-			collectPatternBindingNames(sub, into)
+		for _, sub := range p.Elems {
+			forEachLeafBinding(sub, fn)
 		}
 	case *ast.ObjectPat:
-		for _, elem := range pp.Elems {
+		for _, elem := range p.Elems {
 			switch e := elem.(type) {
 			case *ast.ObjKeyValuePat:
-				collectPatternBindingNames(e.Value, into)
+				forEachLeafBinding(e.Value, fn)
 			case *ast.ObjShorthandPat:
 				if e.Key != nil {
-					into.Add(e.Key.Name)
+					fn(e.Key.Name, e.VarID)
 				}
 			case *ast.ObjRestPat:
-				collectPatternBindingNames(e.Pattern, into)
+				forEachLeafBinding(e.Pattern, fn)
 			}
 		}
 	case *ast.RestPat:
-		collectPatternBindingNames(pp.Pattern, into)
+		forEachLeafBinding(p.Pattern, fn)
 	}
+}
+
+// collectPatternBindingNames adds every identifier name introduced by a
+// pattern (recursively) to the provided set.
+func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
+	forEachLeafBinding(p, func(name string, _ int) {
+		into.Add(name)
+	})
 }
 
 // typeCarriesLifetime reports whether the given type can carry a lifetime.

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -892,12 +892,21 @@ func collectMethodBodyCaptures(
 		v.addBindings(p.Pattern)
 	}
 	if fn.Body != nil {
-		v.walkBlock(fn.Body)
+		fn.Body.Accept(v)
 	}
 	v.popScope()
 }
 
+// methodCaptureVisitor walks a method body looking for identifier
+// references whose name matches a constructor parameter, while tracking
+// the lexical scopes that shadow such names. It implements ast.Visitor
+// directly: EnterBlock/ExitBlock maintain the shadow stack for ordinary
+// blocks; EnterExpr/EnterDecl handle the cases that need bespoke
+// ordering (FuncExpr/FuncDecl push their own scope around the body;
+// VarDecl visits its initializer BEFORE adding the new binding so that
+// `var p = p` resolves the RHS against the outer scope).
 type methodCaptureVisitor struct {
+	ast.DefaultVisitor
 	paramNameToIndex map[string]int
 	storedParams     set.Set[int]
 	// shadowed is a stack of block/function scopes. Each entry is the set
@@ -930,35 +939,43 @@ func (v *methodCaptureVisitor) isShadowed(name string) bool {
 	return false
 }
 
-func (v *methodCaptureVisitor) walkBlock(b *ast.Block) {
-	if b == nil {
-		return
-	}
+func (v *methodCaptureVisitor) EnterBlock(b ast.Block) bool {
 	v.pushScope()
-	for _, stmt := range b.Stmts {
-		v.walkStmt(stmt)
-	}
+	return true
+}
+
+func (v *methodCaptureVisitor) ExitBlock(b ast.Block) {
 	v.popScope()
 }
 
-func (v *methodCaptureVisitor) walkStmt(s ast.Stmt) {
-	if s == nil {
-		return
+func (v *methodCaptureVisitor) EnterExpr(e ast.Expr) bool {
+	switch ex := e.(type) {
+	case *ast.IdentExpr:
+		if !v.isShadowed(ex.Name) {
+			if idx, ok := v.paramNameToIndex[ex.Name]; ok {
+				v.storedParams.Add(idx)
+			}
+		}
+		return false
+	case *ast.FuncExpr:
+		// Nested function: its params introduce new shadows for the
+		// duration of its body. Drive the body traversal manually so
+		// the param-scope wraps the body's own block scope; return
+		// false to suppress the framework's default child recursion.
+		v.pushScope()
+		for _, p := range ex.Params {
+			v.addBindings(p.Pattern)
+		}
+		if ex.Body != nil {
+			ex.Body.Accept(v)
+		}
+		v.popScope()
+		return false
 	}
-	switch ss := s.(type) {
-	case *ast.ExprStmt:
-		v.walkExpr(ss.Expr)
-	case *ast.ReturnStmt:
-		v.walkExpr(ss.Expr)
-	case *ast.DeclStmt:
-		v.walkDecl(ss.Decl)
-	}
+	return true
 }
 
-func (v *methodCaptureVisitor) walkDecl(d ast.Decl) {
-	if d == nil {
-		return
-	}
+func (v *methodCaptureVisitor) EnterDecl(d ast.Decl) bool {
 	switch dd := d.(type) {
 	case *ast.VarDecl:
 		// Visit the initializer BEFORE adding the new binding to the
@@ -967,94 +984,27 @@ func (v *methodCaptureVisitor) walkDecl(d ast.Decl) {
 		// it should resolve against the enclosing scope (potentially
 		// the constructor's param).
 		if dd.Init != nil {
-			v.walkExpr(dd.Init)
+			dd.Init.Accept(v)
 		}
 		v.addBindings(dd.Pattern)
+		return false
 	case *ast.FuncDecl:
 		// Nested function declaration: similar to FuncExpr, its params
 		// shadow outer names within its body.
 		if dd.Body == nil {
-			return
+			return false
 		}
 		v.pushScope()
 		for _, p := range dd.Params {
 			v.addBindings(p.Pattern)
 		}
-		v.walkBlock(dd.Body)
+		dd.Body.Accept(v)
 		v.popScope()
+		return false
 	case *ast.ClassDecl:
 		// Skip nested classes — their constructor param names introduce
 		// a fresh shadow scope that's outside the analysis we care about.
-	}
-}
-
-func (v *methodCaptureVisitor) walkExpr(e ast.Expr) {
-	if e == nil {
-		return
-	}
-	switch ex := e.(type) {
-	case *ast.IdentExpr:
-		if v.isShadowed(ex.Name) {
-			return
-		}
-		if idx, ok := v.paramNameToIndex[ex.Name]; ok {
-			v.storedParams.Add(idx)
-		}
-	case *ast.FuncExpr:
-		// Nested function: its params introduce new shadows for the
-		// duration of its body.
-		v.pushScope()
-		for _, p := range ex.Params {
-			v.addBindings(p.Pattern)
-		}
-		v.walkBlock(ex.Body)
-		v.popScope()
-	default:
-		// Walk through other expression shapes by visiting their child
-		// expressions / blocks directly. We use an inner ast Visitor that
-		// re-enters our walk for IdentExpr, FuncExpr, blocks, and decls
-		// so scope tracking stays consistent.
-		ex.Accept(&methodCaptureSubVisitor{outer: v})
-	}
-}
-
-// methodCaptureSubVisitor handles traversal of expression subtrees that
-// don't introduce a new scope themselves. It delegates back to the outer
-// methodCaptureVisitor for IdentExpr lookups and for nodes that DO start
-// a new scope (FuncExpr, FuncDecl, blocks, var decls), so that scope
-// push/pop remains in lockstep with the source structure.
-type methodCaptureSubVisitor struct {
-	ast.DefaultVisitor
-	outer *methodCaptureVisitor
-}
-
-func (v *methodCaptureSubVisitor) EnterExpr(e ast.Expr) bool {
-	switch e.(type) {
-	case *ast.IdentExpr, *ast.FuncExpr:
-		v.outer.walkExpr(e)
-		return false
-	}
-	return true
-}
-
-func (v *methodCaptureSubVisitor) EnterStmt(s ast.Stmt) bool {
-	switch s.(type) {
-	case *ast.DeclStmt:
-		v.outer.walkStmt(s)
-		return false
-	}
-	return true
-}
-
-func (v *methodCaptureSubVisitor) EnterBlock(b ast.Block) bool {
-	v.outer.walkBlock(&b)
-	return false
-}
-
-func (v *methodCaptureSubVisitor) EnterDecl(d ast.Decl) bool {
-	switch d.(type) {
-	case *ast.VarDecl, *ast.FuncDecl, *ast.ClassDecl:
-		v.outer.walkDecl(d)
+		_ = dd
 		return false
 	}
 	return true

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1276,7 +1276,7 @@ func (c *Checker) InferComponent(
 				if len(fd.FuncSig.LifetimeParams) > 0 {
 					continue
 				}
-				c.ReinferLifetimes(fd.FuncSig.Params, fd.Body, ft)
+				c.ReinferLifetimes(fd.FuncSig.Params, fd.Body, ft, fd.FuncSig.Async)
 			}
 		}
 	}

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1249,14 +1249,19 @@ func (c *Checker) InferComponent(
 	// FuncDecls. The re-run picks up lifetimes for any function that
 	// didn't infer them on its first pass — its peers may now have
 	// lifetime info via determineCheckerAliasSource that wasn't
-	// available the first time. Functions that DID infer lifetimes on
-	// the first pass are skipped by InferLifetimes' early-return guard.
+	// available the first time. The re-run uses ReinferLifetimes
+	// (instead of InferLifetimes) so that functions whose first pass
+	// already inferred SOME lifetimes can still pick up additional ones
+	// via newly-resolved peer signatures (e.g. a return path through a
+	// peer call whose lifetime wasn't yet known on the first pass).
+	// User-explicit lifetimes (declared in the AST) are preserved by
+	// skipping the reinfer entry point for those decls.
 	//
 	// This is a one-pass re-run, not a true fixed-point — chains
 	// requiring 3+ iterations still won't converge fully. In practice
-	// most mutual-recursion cases need at most one re-run because at
-	// least one function in the cycle has a base case that determines
-	// its lifetime independent of the recursive calls.
+	// most mutual-recursion cases need at most one re-run because
+	// Tarjan's SCC ordering processes each function's callees first
+	// within a simple cycle.
 	if len(component) > 1 {
 		for _, key := range sortedForDefs {
 			for _, decl := range depGraph.GetDecls(key) {
@@ -1268,7 +1273,10 @@ func (c *Checker) InferComponent(
 				if !ok || ft == nil {
 					continue
 				}
-				c.InferLifetimes(fd.FuncSig.Params, fd.Body, ft)
+				if len(fd.FuncSig.LifetimeParams) > 0 {
+					continue
+				}
+				c.ReinferLifetimes(fd.FuncSig.Params, fd.Body, ft)
 			}
 		}
 	}

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1244,6 +1244,35 @@ func (c *Checker) InferComponent(
 		}
 	}
 
+	// Phase 8.7 (best-effort): for SCCs of size > 1 (mutually recursive
+	// function groups), do a single re-run pass over the component's
+	// FuncDecls. The re-run picks up lifetimes for any function that
+	// didn't infer them on its first pass — its peers may now have
+	// lifetime info via determineCheckerAliasSource that wasn't
+	// available the first time. Functions that DID infer lifetimes on
+	// the first pass are skipped by InferLifetimes' early-return guard.
+	//
+	// This is a one-pass re-run, not a true fixed-point — chains
+	// requiring 3+ iterations still won't converge fully. In practice
+	// most mutual-recursion cases need at most one re-run because at
+	// least one function in the cycle has a base case that determines
+	// its lifetime independent of the recursive calls.
+	if len(component) > 1 {
+		for _, key := range sortedForDefs {
+			for _, decl := range depGraph.GetDecls(key) {
+				fd, ok := decl.(*ast.FuncDecl)
+				if !ok || fd.Body == nil {
+					continue
+				}
+				ft, ok := funcTypeForDecl[fd]
+				if !ok || ft == nil {
+					continue
+				}
+				c.InferLifetimes(fd.FuncSig.Params, fd.Body, ft)
+			}
+		}
+	}
+
 	// Resolve any type references that were deferred during type annotation inference
 	// to allow for recursive definitions between type and variable declarations.
 	for _, refs := range typeRefsToUpdate {

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -53,20 +53,18 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, param
 
 	// Initialize alias tracker and seed parameters so that aliases from
 	// parameters are tracked and mutability transitions are detected.
+	//
+	// Walk every parameter pattern recursively so destructured leaves
+	// (e.g. `head` in `{head, tail}: ...` or `tail` in `[head, ...tail]`)
+	// each get their own alias set. Seeding only top-level IdentPats
+	// would leave destructured leaves untracked, and AddAlias against
+	// an unseeded VarID is a silent no-op — masking transition errors
+	// against the leaves. Read VarIDs directly from the AST nodes
+	// (the rename pass above wrote them there) and look up the leaf's
+	// type by name in paramBindings, which inferPattern populated with
+	// one entry per leaf.
 	aliases := liveness.NewAliasTracker()
-	for _, param := range astParams {
-		if identPat, ok := param.Pattern.(*ast.IdentPat); ok && identPat.VarID > 0 {
-			varID := liveness.VarID(identPat.VarID)
-			// Determine mutability from the parameter's type binding in scope.
-			mut := liveness.AliasImmutable
-			if binding := ctx.Scope.Namespace.Values[identPat.Name]; binding != nil {
-				if isMutableType(binding.Type) {
-					mut = liveness.AliasMutable
-				}
-			}
-			aliases.NewValue(varID, mut)
-		}
-	}
+	seedParamLeafAliases(astParams, paramBindings, aliases)
 	// Seed extra params (e.g. 'self') into the alias tracker.
 	for name, varID := range renameResult.ExtraParamVarIDs {
 		mut := liveness.AliasImmutable
@@ -83,6 +81,56 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, param
 	ctx.Aliases = aliases
 	ctx.StmtToRef = stmtToRef
 	ctx.VarIDNames = renameResult.VarIDNames
+}
+
+// seedParamLeafAliases walks each parameter pattern recursively and seeds
+// the alias tracker with one alias set per leaf binding. The mutability of
+// each leaf is read from its corresponding paramBindings entry so that
+// transitions involving the leaf are checked correctly.
+func seedParamLeafAliases(
+	astParams []*ast.Param,
+	paramBindings map[string]*type_system.Binding,
+	aliases *liveness.AliasTracker,
+) {
+	var walk func(pat ast.Pat)
+	seed := func(name string, varID int) {
+		if varID <= 0 {
+			return
+		}
+		mut := liveness.AliasImmutable
+		if binding := paramBindings[name]; binding != nil && isMutableType(binding.Type) {
+			mut = liveness.AliasMutable
+		}
+		aliases.NewValue(liveness.VarID(varID), mut)
+	}
+	walk = func(pat ast.Pat) {
+		switch p := pat.(type) {
+		case *ast.IdentPat:
+			seed(p.Name, p.VarID)
+		case *ast.TuplePat:
+			for _, elem := range p.Elems {
+				walk(elem)
+			}
+		case *ast.ObjectPat:
+			for _, elem := range p.Elems {
+				switch e := elem.(type) {
+				case *ast.ObjKeyValuePat:
+					walk(e.Value)
+				case *ast.ObjShorthandPat:
+					if e.Key != nil {
+						seed(e.Key.Name, e.VarID)
+					}
+				case *ast.ObjRestPat:
+					walk(e.Pattern)
+				}
+			}
+		case *ast.RestPat:
+			walk(p.Pattern)
+		}
+	}
+	for _, param := range astParams {
+		walk(param.Pattern)
+	}
 }
 
 // collectOuterBindings walks the scope chain and collects all value binding

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -24,11 +24,15 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, param
 	// Compute extra param names: bindings in paramBindings that are not in
 	// astParams (e.g. implicit 'self' in methods). These need positive VarIDs
 	// so their uses in the body are tracked as local variables.
+	//
+	// Walk destructuring patterns recursively so that every leaf name bound
+	// by an explicit pattern is recognized — otherwise the rename pass would
+	// also re-define those names from paramBindings, leaving the
+	// pattern-leaf's IdentPat.VarID stale relative to what the body's
+	// IdentExpr.VarID resolves to.
 	astParamNames := set.NewSet[string]()
 	for _, p := range astParams {
-		if identPat, ok := p.Pattern.(*ast.IdentPat); ok {
-			astParamNames.Add(identPat.Name)
-		}
+		collectPatternBindingNames(p.Pattern, astParamNames)
 	}
 	var extraParamNames []string
 	for name := range paramBindings {

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -92,44 +92,17 @@ func seedParamLeafAliases(
 	paramBindings map[string]*type_system.Binding,
 	aliases *liveness.AliasTracker,
 ) {
-	var walk func(pat ast.Pat)
-	seed := func(name string, varID int) {
-		if varID <= 0 {
-			return
-		}
-		mut := liveness.AliasImmutable
-		if binding := paramBindings[name]; binding != nil && isMutableType(binding.Type) {
-			mut = liveness.AliasMutable
-		}
-		aliases.NewValue(liveness.VarID(varID), mut)
-	}
-	walk = func(pat ast.Pat) {
-		switch p := pat.(type) {
-		case *ast.IdentPat:
-			seed(p.Name, p.VarID)
-		case *ast.TuplePat:
-			for _, elem := range p.Elems {
-				walk(elem)
-			}
-		case *ast.ObjectPat:
-			for _, elem := range p.Elems {
-				switch e := elem.(type) {
-				case *ast.ObjKeyValuePat:
-					walk(e.Value)
-				case *ast.ObjShorthandPat:
-					if e.Key != nil {
-						seed(e.Key.Name, e.VarID)
-					}
-				case *ast.ObjRestPat:
-					walk(e.Pattern)
-				}
-			}
-		case *ast.RestPat:
-			walk(p.Pattern)
-		}
-	}
 	for _, param := range astParams {
-		walk(param.Pattern)
+		forEachLeafBinding(param.Pattern, func(name string, varID int) {
+			if varID <= 0 {
+				return
+			}
+			mut := liveness.AliasImmutable
+			if binding := paramBindings[name]; binding != nil && isMutableType(binding.Type) {
+				mut = liveness.AliasMutable
+			}
+			aliases.NewValue(liveness.VarID(varID), mut)
+		})
 	}
 }
 

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -195,6 +195,27 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"pickHead": "fn <'a>({head: mut 'a {x: number}, tail: mut {x: number}}) -> mut 'a {x: number}",
 			},
 		},
+		"ObjectDestructuredParamWithRest": {
+			// Regression test for the forEachLeafBinding refactor:
+			// object-destructured params using ObjRestPat
+			// (`{x, ...rest}`) must seed an alias entry for `rest` and
+			// a unique VarID via the rename pass, even though
+			// walkPatternForLeaves itself skips ObjRestPat for lifetime
+			// attachment (a freshly-assembled rest object has no
+			// caller-provided lifetime). Returning `x` still yields a
+			// lifetime; the rest binding is type-inferred but doesn't
+			// contribute one.
+			input: `
+				fn pickX(
+					{x, ...rest}: {x: mut {a: number}, y: mut {a: number}},
+				) -> mut {a: number} {
+					return x
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pickX": "fn <'a>({x: mut 'a {a: number}, ...rest}) -> mut 'a {a: number}",
+			},
+		},
 		"ObjectDestructuredParamConditional": {
 			// Phase 8.6: conditional return from an object-destructured
 			// param produces a LifetimeUnion combining both leaves —

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -66,6 +66,51 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"pick": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}, cond: boolean) -> mut ('a | 'b) {x: number}",
 			},
 		},
+		"EscapingRefIntoModuleLevelVar": {
+			// Phase 8.4: storing a parameter into a module-level mutable
+			// variable forces the parameter to outlive the program — its
+			// lifetime is 'static. The return is a primitive so no return
+			// lifetime is involved.
+			input: `
+				var cache: mut {x: number} = {x: 0}
+				fn cacheItem(item: mut {x: number}) -> number {
+					cache = item
+					return item.x
+				}
+			`,
+			expectedTypes: map[string]string{
+				"cacheItem": "fn (item: mut 'static {x: number}) -> number",
+			},
+		},
+		"EscapingRefViaPropertyAssignment": {
+			// Phase 8.4: assigning into a property of a module-level
+			// object also escapes — the root of the lvalue chain is a
+			// non-local binding.
+			input: `
+				var cache: mut {item: mut {x: number}} = {item: {x: 0}}
+				fn cacheItem(item: mut {x: number}) -> number {
+					cache.item = item
+					return item.x
+				}
+			`,
+			expectedTypes: map[string]string{
+				"cacheItem": "fn (item: mut 'static {x: number}) -> number",
+			},
+		},
+		"NoEscapeWhenAssigningToLocal": {
+			// Sanity check: assigning a param into a local variable does
+			// NOT trigger 'static. The return is a primitive, so no
+			// lifetime is inferred at all.
+			input: `
+				fn copyItem(item: mut {x: number}) -> number {
+					var local: mut {x: number} = item
+					return local.x
+				}
+			`,
+			expectedTypes: map[string]string{
+				"copyItem": "fn (item: mut {x: number}) -> number",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -126,6 +126,43 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"pickFirst": "fn <'a>([a: mut 'a {x: number}, b: mut {x: number}]) -> mut 'a {x: number}",
 			},
 		},
+		"MutuallyRecursiveBaseAndRecursive": {
+			// Phase 8.7 (best-effort fixed-point): two mutually-recursive
+			// functions where one has a base-case `return p` and the
+			// other only forwards via the recursive call. After the
+			// re-run pass, the forwarding function picks up the lifetime
+			// from its peer.
+			//
+			// (The processing order within an SCC is not guaranteed, so
+			// this test is robust against either order.)
+			input: `
+				fn even(p: mut {x: number}, n: number) -> mut {x: number} {
+					if n == 0 { return p }
+					return odd(p, n - 1)
+				}
+				fn odd(p: mut {x: number}, n: number) -> mut {x: number} {
+					return even(p, n)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"even": "fn <'a>(p: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
+				"odd":  "fn <'a>(p: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
+			},
+		},
+		"GeneratorYieldsAliasParam": {
+			// Phase 8.3: a generator that yields a parameter should
+			// propagate the parameter's lifetime to the yield type T
+			// inside Generator<T, _, _> (rather than to the Generator
+			// container itself). Each yielded value carries the lifetime.
+			input: `
+				fn iter(p: mut {x: number}) -> Generator<mut {x: number}, void, never> {
+					yield p
+				}
+			`,
+			expectedTypes: map[string]string{
+				"iter": "fn <'a>(p: mut 'a {x: number}) -> Generator<mut 'a {x: number}, void, never>",
+			},
+		},
 		"RestParamReturnsElement": {
 			// Phase 8.3: rest param `...args: Array<T>` — the lifetime-
 			// bearing position is the *element* type T, not the array
@@ -288,6 +325,30 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCallSiteAliasFromLifetimeUnion exercises the LifetimeUnion call-site
+// path: a function whose return aliases either of two parameters
+// (`('a | 'b)`) is called, the result variable joins the alias sets of
+// BOTH arguments, and a later immutable read of either arg while the
+// mutable result is live produces a transition error.
+func TestCallSiteAliasFromLifetimeUnion(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		fn pick(a: mut {x: number}, b: mut {x: number}, cond: boolean) -> mut {x: number} {
+			if cond { return a } else { return b }
+		}
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			val q: mut {x: number} = {x: 1}
+			val r: mut {x: number} = pick(p, q, true)
+			val frozenP: {x: number} = p
+			r.x = 5
+			frozenP
+		}
+	`)
+	require.Len(t, mutErrors, 1)
+	assert.Contains(t, mutErrors[0], "cannot assign 'p' to immutable 'frozenP'")
 }
 
 // TestCallSiteAliasFromInferredLifetime exercises the end-to-end path:

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -155,7 +155,7 @@ func TestInferLifetimeTypes(t *testing.T) {
 			// inside Generator<T, _, _> (rather than to the Generator
 			// container itself). Each yielded value carries the lifetime.
 			input: `
-				fn iter(p: mut {x: number}) -> Generator<mut {x: number}, void, never> {
+				fn iter(p: mut {x: number}) {
 					yield p
 				}
 			`,
@@ -352,8 +352,10 @@ func TestInferLifetimeTypes(t *testing.T) {
 // reference fields.
 func TestInferConstructorLifetimeTypes(t *testing.T) {
 	tests := map[string]struct {
-		input         string
-		expectedTypes map[string]string
+		input                     string
+		expectedTypes             map[string]string
+		expectedInstanceType      map[string]string
+		expectedInstanceLifetimes map[string]int
 	}{
 		"ContainerStoresMutRef": {
 			input: `
@@ -437,6 +439,17 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			expectedTypes: map[string]string{
 				"C": "{new fn (p: mut {x: number}) -> mut? C}",
 			},
+			expectedInstanceType: map[string]string{
+				// `foo`'s own `p` parameter independently gets a
+				// fresh 'a (the method threads its arg to its
+				// return). The class type alias itself has zero
+				// lifetime params, confirming no capture from the
+				// constructor.
+				"C": "{foo<'a>(self, p: mut 'a {x: number}) -> mut 'a {x: number}}",
+			},
+			expectedInstanceLifetimes: map[string]int{
+				"C": 0,
+			},
 		},
 		"GetterCapturesConstructorParam": {
 			// Bug B5: getters and setters were not scanned for
@@ -451,6 +464,12 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"C": "{new fn <'a>(p: mut 'a {x: number}) -> mut? C<'a>}",
+			},
+			expectedInstanceType: map[string]string{
+				"C": "{get q(self) -> mut {x: number}}",
+			},
+			expectedInstanceLifetimes: map[string]int{
+				"C": 1,
 			},
 		},
 		"SetterCapturesConstructorParam": {
@@ -489,6 +508,19 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				require.Truef(t, ok, "binding %q not found", varName)
 				assert.Equalf(t, want, got,
 					"unexpected type for %q", varName)
+			}
+			for typeName, want := range test.expectedInstanceType {
+				alias, ok := ns.Types[typeName]
+				require.Truef(t, ok, "type alias %q not found", typeName)
+				assert.Equalf(t, want, alias.Type.String(),
+					"unexpected instance type for %q", typeName)
+			}
+			for typeName, want := range test.expectedInstanceLifetimes {
+				alias, ok := ns.Types[typeName]
+				require.Truef(t, ok, "type alias %q not found", typeName)
+				assert.Lenf(t, alias.LifetimeParams, want,
+					"unexpected lifetime-param count on type alias %q",
+					typeName)
 			}
 		})
 	}

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -224,6 +224,63 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"pickEither": "fn <'a, 'b>([a: mut 'a {x: number}, b: mut 'b {x: number}], cond: boolean) -> mut ('a | 'b) {x: number}",
 			},
 		},
+		"EscapingRefViaCallResult": {
+			// Bug B3: when a parameter flows through a function call into
+			// module-level state (`cache = wrap(p)`), the escape-detection
+			// pass must use the checker-aware alias source so the call's
+			// return-aliases-its-arg lifetime info propagates. Without
+			// this, `p` would not be marked as escaping and would not get
+			// 'static, leaving the program unsound.
+			input: `
+				fn wrap(q: mut {x: number}) -> mut {x: number} { return q }
+				var cache: mut {x: number} = {x: 0}
+				fn store(p: mut {x: number}) -> number {
+					cache = wrap(p)
+					return p.x
+				}
+			`,
+			expectedTypes: map[string]string{
+				"store": "fn (p: mut 'static {x: number}) -> number",
+			},
+		},
+		"AsyncReturnsParam": {
+			// Design D6: by analogy with Generator handling, an async
+			// function whose return aliases a parameter should attach
+			// the lifetime to the inner T (the resolved value type)
+			// rather than to the Promise container, which is freshly
+			// allocated per call. The Promise container itself has no
+			// caller-provided lifetime.
+			input: `
+				async fn passthrough(p: mut {x: number}) -> mut {x: number} { return p }
+			`,
+			expectedTypes: map[string]string{
+				"passthrough": "fn <'a>(p: mut 'a {x: number}) -> Promise<mut 'a {x: number}, never>",
+			},
+		},
+		"MutuallyRecursivePartialFirstPass": {
+			// Bug B4: in a true mutual-recursion cycle, the function with
+			// the base case (`even` here, via `return p`) infers a non-
+			// empty LifetimeParams on its first pass — but only for the
+			// directly-returned param. The forwarding return path
+			// (`return odd(q, n - 1)`) cannot detect that `q` is also
+			// aliased through the call until `odd`'s signature has a
+			// lifetime, which only happens AFTER even is first processed.
+			// The re-run must re-examine `even` and add `q`'s lifetime;
+			// the existing early-return guard incorrectly skips it.
+			input: `
+				fn even(p: mut {x: number}, q: mut {x: number}, n: number) -> mut {x: number} {
+					if n == 0 { return p }
+					return odd(q, n - 1)
+				}
+				fn odd(q: mut {x: number}, n: number) -> mut {x: number} {
+					return even(q, q, n - 1)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"even": "fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}, n: number) -> mut ('a | 'b) {x: number}",
+				"odd":  "fn <'a>(q: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -330,6 +387,32 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"C": "{new fn (p: mut {x: number}) -> mut? C}",
+			},
+		},
+		"GetterCapturesConstructorParam": {
+			// Bug B5: getters and setters were not scanned for
+			// constructor-param captures (only FieldElem / MethodElem
+			// were). A getter whose body references a constructor
+			// param by name should force a lifetime onto the
+			// constructor param, just like a method body.
+			input: `
+				class C(p: mut {x: number}) {
+					get q -> mut {x: number} { return p }
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn <'a>(p: mut 'a {x: number}) -> mut? C<'a>}",
+			},
+		},
+		"SetterCapturesConstructorParam": {
+			// Bug B5: same as the getter case but for setters.
+			input: `
+				class C(p: mut {x: number}) {
+					set q(mut self, v: number) { p.x = v }
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn <'a>(p: mut 'a {x: number}) -> mut? C<'a>}",
 			},
 		},
 		"StaticMethodDoesNotCapture": {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -257,6 +257,55 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"passthrough": "fn <'a>(p: mut 'a {x: number}) -> Promise<mut 'a {x: number}, never>",
 			},
 		},
+		"NonAsyncReturnsParamPromise": {
+			// A non-async function whose parameter and return type are
+			// both Promise<T> — the function passes the param through
+			// without unwrapping. The Promise container itself IS the
+			// parameter (not freshly assembled), so the lifetime should
+			// attach to the Promise<T> reference at both the param and
+			// return positions, NOT to the inner T (which would be the
+			// case for an async function whose Promise is built from
+			// the resolved T).
+			input: `
+				fn forward(p: Promise<mut {x: number}, never>) -> Promise<mut {x: number}, never> {
+					return p
+				}
+			`,
+			expectedTypes: map[string]string{
+				"forward": "fn <'a>(p: 'a Promise<mut {x: number}, never>) -> 'a Promise<mut {x: number}, never>",
+			},
+		},
+		"NonGeneratorReturnsParamGenerator": {
+			// A plain function (no `yield`) whose parameter and return
+			// type are both Generator<T,_,_> — the param is forwarded
+			// directly. The Generator container IS the parameter, not
+			// freshly assembled, so the lifetime should attach to the
+			// Generator<T,_,_> reference at both positions, NOT to the
+			// inner yield type T.
+			input: `
+				fn forwardIter(g: Generator<mut {x: number}, void, never>) -> Generator<mut {x: number}, void, never> {
+					return g
+				}
+			`,
+			expectedTypes: map[string]string{
+				"forwardIter": "fn <'a>(g: 'a Generator<mut {x: number}, void, never>) -> 'a Generator<mut {x: number}, void, never>",
+			},
+		},
+		"TupleRestParamReturnsRestElement": {
+			// Tuple-destructured rest pattern: `[head, ...tail]` paired
+			// with a tuple type that has a rest spread `[T, ...Array<T>]`.
+			// Returning `tail[0]` must give the rest binding `tail` a
+			// lifetime — the destructured tuple-rest's element is a
+			// caller-provided position, not freshly assembled.
+			input: `
+				fn pickRest([head, ...tail]: [mut {x: number}, ...Array<mut {x: number}>]) -> mut {x: number} {
+					return tail[0]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pickRest": "fn <'a>([head: mut {x: number}, ...tail: Array<mut 'a {x: number}>]) -> mut 'a {x: number}",
+			},
+		},
 		"MutuallyRecursivePartialFirstPass": {
 			// Bug B4: in a true mutual-recursion cycle, the function with
 			// the base case (`even` here, via `return p`) infers a non-
@@ -488,6 +537,30 @@ func TestCallSiteAliasFromInferredLifetime(t *testing.T) {
 	`)
 	require.Len(t, mutErrors, 1)
 	assert.Contains(t, mutErrors[0], "cannot assign 'p' to immutable 'q'")
+}
+
+// TestDestructuredParamLeafSeededInAliasTracker verifies that when a
+// function parameter is a destructured pattern (object or tuple), each
+// leaf binding is seeded into the alias tracker so that subsequent
+// aliases of the leaf participate in mutability transition checks.
+//
+// Previously the prepass only seeded top-level IdentPat params, leaving
+// destructured leaves (e.g. `head` in `{head, tail}: ...`) without an
+// alias set. AddAlias against a leaf without a set is a silent no-op, so
+// transitions involving the leaf were not detected.
+func TestDestructuredParamLeafSeededInAliasTracker(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		fn identity(p: mut {x: number}) -> mut {x: number} { return p }
+		fn test({head, tail}: {head: mut {x: number}, tail: mut {x: number}}) {
+			val r: mut {x: number} = identity(head)
+			val q: {x: number} = head
+			r.x = 5
+			q
+		}
+	`)
+	require.Len(t, mutErrors, 1)
+	assert.Contains(t, mutErrors[0], "cannot assign 'head' to immutable 'q'")
 }
 
 // TestCallSiteNoAliasForFreshReturn verifies that a function returning a

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -504,6 +504,26 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"C": "{new fn <'a>(p: mut 'a {x: number}) -> mut? C<'a>}",
 			},
 		},
+		"NestedFuncParamDefaultCapturesConstructorParam": {
+			// A nested function's parameter default expression evaluates
+			// in its enclosing scope (here, the setter body, where the
+			// constructor's `p` is visible). The capture visitor must
+			// visit nested-function param defaults BEFORE pushing the
+			// nested-function's own scope, otherwise the reference is
+			// silently dropped and the constructor fails to receive a
+			// lifetime. The setter body itself does not directly mention
+			// `p` — only the nested function's param default does.
+			input: `
+				class C(p: mut {x: number}) {
+					set q(mut self, v: number) {
+						val nested = fn(w = p) -> number { return 0 }
+					}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn <'a>(p: mut 'a {x: number}) -> mut? C<'a>}",
+			},
+		},
 		"StaticMethodDoesNotCapture": {
 			// Phase 8.6 (#4): static methods can't access instance state,
 			// so they should never trigger constructor-param capture even

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -111,6 +111,47 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"copyItem": "fn (item: mut {x: number}) -> number",
 			},
 		},
+		"TupleDestructuredParamFirstReturned": {
+			// Phase 8.3: tuple-destructured param. Only the leaf actually
+			// returned (`a`) gets a lifetime; `b` is unconstrained, just
+			// like a non-destructured param that isn't returned. The
+			// printer renders the leaf's lifetime inline at the
+			// destructured position.
+			input: `
+				fn pickFirst([a, b]: [mut {x: number}, mut {x: number}]) -> mut {x: number} {
+					return a
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pickFirst": "fn <'a>([a: mut 'a {x: number}, b: mut {x: number}]) -> mut 'a {x: number}",
+			},
+		},
+		"RestParamReturnsElement": {
+			// Phase 8.3: rest param `...args: Array<T>` — the lifetime-
+			// bearing position is the *element* type T, not the array
+			// container (the container is freshly assembled per call).
+			// Returning args[0] must inherit that element-level lifetime.
+			input: `
+				fn first(...args: Array<mut {x: number}>) -> mut {x: number} {
+					return args[0]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"first": "fn <'a>(...args: Array<mut 'a {x: number}>) -> mut 'a {x: number}",
+			},
+		},
+		"TupleDestructuredParamConditional": {
+			// Phase 8.3: conditional return from a tuple-destructured
+			// param produces a LifetimeUnion combining both leaves.
+			input: `
+				fn pickEither([a, b]: [mut {x: number}, mut {x: number}], cond: boolean) -> mut {x: number} {
+					if cond { return a } else { return b }
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pickEither": "fn <'a, 'b>([a: mut 'a {x: number}, b: mut 'b {x: number}], cond: boolean) -> mut ('a | 'b) {x: number}",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -644,4 +644,3 @@ func collectBindingTypes(ns *type_system.Namespace) map[string]string {
 	}
 	return out
 }
-

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -177,6 +177,41 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"first": "fn <'a>(...args: Array<mut 'a {x: number}>) -> mut 'a {x: number}",
 			},
 		},
+		"ObjectDestructuredParamFirstReturned": {
+			// Phase 8.6: object-destructured param using shorthand
+			// patterns. Each leaf's lifetime is resolved against the
+			// corresponding property's type position; only the leaf
+			// actually returned (`head`) gets a lifetime. Destructured
+			// shorthand prints as `{key: <type>}` rather than carrying
+			// the binding name through.
+			input: `
+				fn pickHead(
+					{head, tail}: {head: mut {x: number}, tail: mut {x: number}},
+				) -> mut {x: number} {
+					return head
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pickHead": "fn <'a>({head: mut 'a {x: number}, tail: mut {x: number}}) -> mut 'a {x: number}",
+			},
+		},
+		"ObjectDestructuredParamConditional": {
+			// Phase 8.6: conditional return from an object-destructured
+			// param produces a LifetimeUnion combining both leaves —
+			// matching the per-position lifetime story of `Pair<'a, 'b>`
+			// from Phase 8.6 but expressed through destructuring.
+			input: `
+				fn pickEither(
+					{head, tail}: {head: mut {x: number}, tail: mut {x: number}},
+					cond: boolean,
+				) -> mut {x: number} {
+					if cond { return head } else { return tail }
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pickEither": "fn <'a, 'b>({head: mut 'a {x: number}, tail: mut 'b {x: number}}, cond: boolean) -> mut ('a | 'b) {x: number}",
+			},
+		},
 		"TupleDestructuredParamConditional": {
 			// Phase 8.3: conditional return from a tuple-destructured
 			// param produces a LifetimeUnion combining both leaves.

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -127,6 +127,66 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"Container": "{new fn <'a>(item: mut 'a {x: number}) -> mut? Container<'a>}",
 			},
 		},
+		"FieldWithMemberAccessOfParam": {
+			// Phase 8.6 (#6): non-identity initializer that reaches into a
+			// param via a property access still captures the param.
+			input: `
+				class Wrap(p: mut {x: {y: number}}) {
+					inner: p.x,
+				}
+			`,
+			expectedTypes: map[string]string{
+				"Wrap": "{new fn <'a>(p: mut 'a {x: {y: number}}) -> mut? Wrap<'a>}",
+			},
+		},
+		"FieldWithObjectLiteralCapturingParam": {
+			// Phase 8.6 (#5): nested object literal in a field initializer.
+			input: `
+				class Wrap(p: mut {x: number}) {
+					inner: {nested: p},
+				}
+			`,
+			expectedTypes: map[string]string{
+				"Wrap": "{new fn <'a>(p: mut 'a {x: number}) -> mut? Wrap<'a>}",
+			},
+		},
+		"FieldWithTupleLiteralCapturingParam": {
+			// Phase 8.6 (#5): tuple/array literal in a field initializer.
+			input: `
+				class Wrap(p: mut {x: number}, q: mut {x: number}) {
+					pair: [p, q],
+				}
+			`,
+			expectedTypes: map[string]string{
+				"Wrap": "{new fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut? Wrap<'a, 'b>}",
+			},
+		},
+		"MethodBodyShadowedParamNotCaptured": {
+			// Phase 8.6 (#4): a method with its own param named `p` must
+			// not be treated as capturing the constructor's `p` — the
+			// inner param shadows the outer name within the method body.
+			input: `
+				class C(p: mut {x: number}) {
+					foo(self, p: mut {x: number}) -> mut {x: number} { return p }
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn (p: mut {x: number}) -> mut? C}",
+			},
+		},
+		"StaticMethodDoesNotCapture": {
+			// Phase 8.6 (#4): static methods can't access instance state,
+			// so they should never trigger constructor-param capture even
+			// if their bodies happen to mention the param name.
+			input: `
+				class C(p: mut {x: number}) {
+					static make() -> number { return 0 }
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn (p: mut {x: number}) -> mut? C, make() -> number}",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -445,12 +445,21 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 				result += "new " + printFuncType(elem.Fn, pt)
 			case *MethodElem:
 				result += elem.Name.String()
-				if len(elem.Fn.TypeParams) > 0 {
+				if len(elem.Fn.LifetimeParams) > 0 || len(elem.Fn.TypeParams) > 0 {
 					result += "<"
-					for i, param := range elem.Fn.TypeParams {
-						if i > 0 {
+					first := true
+					for _, lp := range elem.Fn.LifetimeParams {
+						if !first {
 							result += ", "
 						}
+						first = false
+						result += "'" + lp.Name
+					}
+					for _, param := range elem.Fn.TypeParams {
+						if !first {
+							result += ", "
+						}
+						first = false
 						result += param.Name
 						if param.Constraint != nil {
 							result += ": " + pt(param.Constraint)
@@ -489,9 +498,9 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 					result += " throws " + pt(elem.Fn.Throws)
 				}
 			case *SetterElem:
-				result += "set " + elem.Name.String() + "(mut self, "
+				result += "set " + elem.Name.String() + "(mut self"
 				if len(elem.Fn.Params) > 0 {
-					result += printFuncParam(elem.Fn.Params[0], pt)
+					result += ", " + printFuncParam(elem.Fn.Params[0], pt)
 				}
 				result += ") -> undefined"
 				if !IsNeverType(elem.Fn.Throws) {

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1423,59 +1423,43 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
   `'static` lifetime assignment for parameters stored into module-level state
   are not yet implemented.
 - **8.6 implicit captures from method bodies.** `InferConstructorLifetimes`
-  detects "param is stored on the instance" purely from `*ast.FieldElem`
-  syntax in the class body — shorthand fields (`{ p, }`) and explicit
-  identifier-valued fields (`{ p: p, }`). `*ast.MethodElem` nodes are
-  skipped entirely (see the `if !ok { continue }` at
-  [infer_lifetime.go:256-259](../../internal/checker/infer_lifetime.go#L256-L259)).
-  But Escalier lets a method body reference constructor parameters by
-  name without going through `self`, so:
+  now walks instance method bodies looking for `IdentExpr` references
+  whose name matches a constructor parameter, and adds matching indices
+  to `storedParams` so the constructor gets a lifetime on those params.
+  The walk respects shadowing introduced by inner function params and
+  by `let`/`var` declarations within the method body, and skips static
+  methods, nested classes, and nested function declarations. The
+  matching is by name (not VarID) because `InferConstructorLifetimes`
+  runs during the namespace placeholder phase, before the rename pass
+  populates VarIDs on identifiers in method bodies.
 
-  ```esc
-  class C(p: mut Point) { foo(self) { return p } }
-  ```
+  **Status note:** the analysis is in place but currently dormant
+  end-to-end, because Escalier's method-body scope does not (yet) bring
+  constructor parameters into scope by name — `class C(p) { foo(self) { return p } }`
+  produces an "Unknown identifier: p" type error today. Once the
+  language wires constructor params into method-body scope, the
+  capture detection will activate without further changes.
 
-  is operationally equivalent to:
-
-  ```esc
-  class C(p: mut Point) { p, foo(self) { return self.p } }
-  ```
-
-  yet only the second form gets a lifetime parameter today. The first
-  form silently falls out of the analysis: `storedParams` is empty, no
-  `<'a>` is inferred, and the borrow checker cannot enforce that
-  `C` instances must outlive their captured `p`. This is a **soundness
-  gap** — a caller who constructs `C` from a short-lived borrow can
-  call `c.foo()` after that borrow is gone with no diagnostic.
-
-  Treatment: extend the body walk in `InferConstructorLifetimes` to
-  inspect `*ast.MethodElem` nodes. For each method, walk the method
-  body and collect `IdentExpr` references whose VarID resolves to a
-  constructor parameter; treat any such reference as an implicit
-  capture and add the param's index to `storedParams`. The same VarID
-  set should also feed `InferLifetimes` when it analyzes the method
-  body, so that method return types correctly inherit the captured
-  param's lifetime (e.g. `foo<'a>('a self) -> mut 'a Point` for the
-  example above).
-
-  Static methods (if/when added) should be exempt from capture
-  detection since they don't have access to instance state.
-
+  Still deferred: feeding the captured-param VarID set into
+  `InferLifetimes` so that the *method's* return type inherits the
+  captured param's lifetime (e.g. `foo<'a>('a self) -> mut 'a Point`).
+  The constructor-side lifetime — which is the soundness-critical part
+  — is now handled.
 - **8.6 storage through nested expressions and literals.** Field-init
-  expressions whose value is anything other than a bare identifier are
-  not analyzed today. Concretely, `class C(p: mut P) { x: f(p) }`,
-  `class C(p: mut P) { x: {inner: p} }`, and similar shapes leave the
-  param unstored from the analysis's perspective. Treatment: walk the
-  initializer expression looking for any path that retains a borrow of
-  the parameter — same kind of structural traversal the body-side
-  alias analysis already does for property/element projections.
-- **8.6 non-identity field-initializer expressions.** Even when an
-  expression *does* reference a constructor parameter, the current
-  analysis only treats `field: param` (an exact identity initializer)
-  as a store. `field: param.x`, `field: borrow(param)`, and
-  intermediate-let binding (`let q = p; field: q`) are all skipped.
-  Treatment overlaps with the previous bullet: use the existing alias
-  machinery to resolve the initializer's actual borrow source.
+  expressions are now walked structurally by `findCapturedParamsInExpr`,
+  which descends into object literals (including shorthand props),
+  tuple literals, member/index access, type casts, await, and
+  conditional branches. Function-call initializers (`x: f(p)`) are
+  still not analyzed — calls are treated as fresh; tightening this
+  would require lifetime info from callees that may not yet be
+  resolved at the point where `InferConstructorLifetimes` runs.
+- **8.6 non-identity field-initializer expressions.** `field: p.x`,
+  `field: {inner: p}`, `field: [p, q]`, and analogous projection /
+  composite expressions are now recognized via the
+  `findCapturedParamsInExpr` walker described above.
+  Intermediate-let bindings inside a class-body initializer are still
+  not tracked (none of the field initializers in scope today are
+  multi-statement blocks).
 - **8.7 mutually recursive fixed-point iteration.** Lifetime inference runs
   once per function during the existing dep-graph traversal. Self-recursive
   functions work as long as their lifetime is determined by a non-recursive

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1396,8 +1396,19 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
     lifetime annotations. Closing this requires extending
     `DetermineAliasSource` with an "element-of" variant and annotating
     the prelude.
-- **8.3 generator yield lifetimes.** `yield` is treated as a fresh value;
-  `Generator<'a T, _, _>` propagation from yields is not yet implemented.
+- **8.3 generator yield lifetimes.** `InferLifetimes` now collects every
+  non-delegate `yield expr` value alongside `return` expressions. When
+  the function's return type is `Generator<T, TReturn, TNext>` (or
+  `AsyncGenerator<...>`), the lifetime is attached to T (the yield
+  type) rather than to the Generator container itself, so each yielded
+  value carries the lifetime. Concretely,
+  `fn iter(p: mut Point) -> Generator<mut Point, void, never> { yield p }`
+  infers `<'a>(p: mut 'a Point) -> Generator<mut 'a Point, void, never>`.
+  `inferFuncBodyWithFuncSigType` was extended to call `InferLifetimes`
+  in the generator branch (which previously short-circuited).
+  Still deferred: `yield from` (delegate yield) propagation from the
+  inner iterator's element type, and lifetime inference for the
+  generator's `TReturn` slot from explicit `return value` paths.
 - **8.4 escaping reference detection.** `DetectEscapingRefs` walks a
   function body for assignment expressions whose lvalue root is a
   non-local identifier (VarID ≤ 0, set by the rename pass for
@@ -1450,15 +1461,35 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
   Intermediate-let bindings inside a class-body initializer are still
   not tracked (none of the field initializers in scope today are
   multi-statement blocks).
-- **8.7 mutually recursive fixed-point iteration.** Lifetime inference runs
-  once per function during the existing dep-graph traversal. Self-recursive
-  functions work as long as their lifetime is determined by a non-recursive
-  return; mutual recursion that requires fixed-point iteration is deferred.
-- **`LifetimeUnion` inference at call sites.** The `LifetimeUnion` type
-  exists and parses, and `InferLifetimes` records multi-source returns, but
-  the call-site path that adds the result to *all* corresponding arguments'
-  alias sets is best-effort — it works for the simple two-branch case and
-  may be tightened later.
+- **8.7 mutually recursive fixed-point iteration.** `InferComponent` now
+  does a single re-run pass over the FuncDecls in any SCC of size > 1
+  after their initial inference. The re-run picks up lifetimes for any
+  function that didn't infer them on its first pass — its peers may now
+  have lifetime info that wasn't available the first time. Functions
+  that DID infer lifetimes on the first pass are skipped by
+  `InferLifetimes`' early-return guard.
+  This required two supporting fixes: (1) `InferLifetimes` now uses
+  `determineCheckerAliasSource` (the call-aware variant) when collecting
+  return-source aliases, so peer-function lifetimes propagate through
+  call expressions; (2) `determineCheckerAliasSource` no longer gates
+  on `fnType.LifetimeParams` being non-empty — by the time a call is
+  type-checked, callee-side instantiation may have cleared
+  `LifetimeParams` while leaving the lifetime vars themselves attached
+  to the param/return types. Presence of a lifetime on the return type
+  is now the authoritative signal.
+  Still deferred: a true fixed-point loop that iterates until no
+  changes (the current implementation does exactly one re-run, which
+  is enough for most 2-cycle mutual recursion cases but not for chains
+  requiring 3+ iterations).
+- **`LifetimeUnion` inference at call sites.** Verified end-to-end via
+  `TestCallSiteAliasFromLifetimeUnion`: when a function returning
+  `('a | 'b) Point` is called, the result variable joins the alias
+  sets of *both* arguments via `lifetimeVarIDs` walking the union
+  members and matching against each parameter's lifetime. The behavior
+  was already correct for two-branch unions; the `determineCheckerAliasSource`
+  change for Phase 8.7 (no longer gating on `LifetimeParams`) made this
+  work robustly even after callee instantiation clears the
+  `LifetimeParams` list.
 
 The deferred items do not block the rest of Phase 8 from being usable: callers
 of annotated or inferred functions get correct alias-set updates for

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1359,64 +1359,43 @@ function bodies.
 The initial Phase 8 PR delivers a foundational subset; the following items are
 **deferred to a follow-up PR** so they can be reviewed and tested in isolation:
 
-- **8.3 element-level vs. container-level lifetimes.** Inference produces
-  container-level lifetimes (`'a Array<T>`) for any return that aliases a
-  parameter. Element-level inference (`Array<'a T>` for fresh-container,
-  aliased-elements returns from `.filter`/`.slice`/array-literal-of-aliases)
-  is not yet implemented.
-  - **Rest parameters (`...args: T[]`).** `InferLifetimes` skips rest
-    params entirely (see explicit `case *ast.RestPat` in
-    [infer_lifetime.go:65-79](../../internal/checker/infer_lifetime.go#L65-L79)).
-    A function like `fn first(...args: mut {x: number}[]) -> mut {x: number}`
-    that returns `args[0]` should infer `<'a>` on the element type and
-    on the return; today it produces no lifetime, the same wrong shape
-    as for a non-rest array param. Treatment falls out of element-level
-    lifetimes: descend into the rest pattern, attach the lifetime to the
-    *element* type (not the container, which is freshly assembled per
-    call), and unify against caller-arg lifetimes at call sites (each
-    caller arg must outlive the element lifetime). Aliasing analysis on
-    the body side will also need to recognize that `args[i]` is an
-    element-of source, not a container source — the existing
-    `DetermineAliasSource` will need an "element-of" alias variant for
-    this to work cleanly.
-  - **Destructured parameters (`fn f([a, b]: [mut P, mut P])`,
-    `fn g({x, y}: mut P)`).** `InferLifetimes` skips any param whose
-    pattern is not a bare `IdentPat`, including all tuple/object
-    destructuring patterns (see the `switch` in
-    [infer_lifetime.go:65-79](../../internal/checker/infer_lifetime.go#L65-L79)
-    and the comment on [line 64](../../internal/checker/infer_lifetime.go#L64)).
-    Body-side liveness/alias analysis already tracks the leaf bindings
-    correctly via Phase 7's destructuring-alias work; the gap is on the
-    *param-side wiring*. The current `VarID → param index` map assumes
-    one VarID per parameter, but a destructured param produces N leaf
-    VarIDs and no top-level "whole-param" VarID. Two reasonable
-    implementation shapes:
-    - *Synthesize a top-level param VarID* and treat each leaf binding
-      as if it were `let a = paramSlot.x` introduced at body entry.
-      The existing property/element-projection alias machinery (Phase 7)
-      takes over from there, and `InferLifetimes` just maps the
-      synthetic VarID to its param index. Most uniform with Phase 7;
-      requires a small AST/IR addition for the synthetic slot.
-    - *Track projection paths per leaf VarID* by extending `paramIndex`
-      to `VarID → (paramIndex, projection path)` and generalizing
-      `setLifetimeOnType` to attach a lifetime at a sub-position rather
-      than only at the top. No AST changes; more bookkeeping in this
-      file. Recommended starting shape — keeps the change localized.
+- **8.3 element-level vs. container-level lifetimes.** `InferLifetimes`
+  now walks each parameter's pattern in lockstep with the parameter's
+  inferred type via `collectParamLeaves`, producing a list of
+  `(VarID, leafType)` pairs for every leaf binding. Lifetime allocation
+  and attachment use these leaves rather than the top-level param,
+  which generalizes the analysis to:
+  - **Tuple-destructured parameters** (`fn f([a, b]: [mut P, mut P])`):
+    each leaf gets its own lifetime when aliased by a return; only
+    leaves actually returned receive a lifetime, matching the behavior
+    of non-destructured params. The leaf's lifetime is attached to the
+    corresponding sub-position of the param's tuple type and shows up
+    inline in the printed destructured form.
+  - **Rest parameters** (`...args: Array<T>`): the leaf's `leafType`
+    points at the array's *element* type `T` rather than the container,
+    since the array is freshly assembled per call. Returns of `args[i]`
+    inherit the element-level lifetime, producing
+    `<'a>(...args: Array<mut 'a T>) -> mut 'a T`.
+  - As part of this change, `runLivenessPrePass` was fixed to walk
+    destructuring-pattern leaves when computing `astParamNames`,
+    preventing the rename pass from double-defining destructured leaf
+    bindings (once via `renamePat` walking the pattern, once via the
+    `extraParamNames` path). Without that fix the leaf's `IdentPat.VarID`
+    was stale relative to the body's `IdentExpr.VarID`.
 
-    Either way, the inferred signature should be able to express
-    per-field lifetimes for destructured composite params, e.g.:
-
-    ```esc
-    fn pickFirst<'a, 'b>(
-        {head, tail}: {head: mut 'a Point, tail: mut 'b Point}
-    ) -> mut 'a Point { return head }
-    ```
-
-    This is the same per-position lifetime story as `Pair<'a, 'b>` from
-    Phase 8.6, just expressed through destructuring rather than class
-    fields. The semantics piggyback on Phase 7's existing
-    destructuring-alias work; this deferral is purely about the
-    param-side bookkeeping in `InferLifetimes`.
+  Still deferred:
+  - **Object-destructured parameters** (`fn g({x, y}: mut P)`) — the
+    walker currently descends into `*ast.TuplePat` and `*ast.RestPat`
+    only; `*ast.ObjectPat` would need `key → ObjectType.Elems` lookup
+    to find the matching property's type position. Same approach as
+    tuple, but with key-based traversal rather than positional.
+  - **Element-level lifetimes from fresh-container returns**
+    (`return [a, b]` producing `Array<'a T>`, `.filter()` /
+    `.slice()` propagation): the alias-source machinery still treats
+    array literals as fresh and built-in array methods don't carry
+    lifetime annotations. Closing this requires extending
+    `DetermineAliasSource` with an "element-of" variant and annotating
+    the prelude.
 - **8.3 generator yield lifetimes.** `yield` is treated as a fresh value;
   `Generator<'a T, _, _>` propagation from yields is not yet implemented.
 - **8.4 escaping reference detection.** `DetectEscapingRefs` walks a

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1419,9 +1419,20 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
     param-side bookkeeping in `InferLifetimes`.
 - **8.3 generator yield lifetimes.** `yield` is treated as a fresh value;
   `Generator<'a T, _, _>` propagation from yields is not yet implemented.
-- **8.4 escaping reference detection.** `DetectEscapingRefs` and the
-  `'static` lifetime assignment for parameters stored into module-level state
-  are not yet implemented.
+- **8.4 escaping reference detection.** `DetectEscapingRefs` walks a
+  function body for assignment expressions whose lvalue root is a
+  non-local identifier (VarID ≤ 0, set by the rename pass for
+  outer-scope references) and whose RHS aliases one of the function's
+  parameters. Such parameters are assigned `'static` directly via a
+  `LifetimeValue{IsStatic: true}` on their type, bypassing the regular
+  fresh-`'a` allocation path. When the function also returns an
+  escaping param, the return type inherits `'static` (combined with any
+  non-escaping return-aliased lifetimes via `LifetimeUnion`).
+  Limitations: closures over a *nested* function's local will still
+  mark a param as `'static` (over-conservative but sound — the
+  borrow-checker accepts a stricter signature); stores via property
+  assignment whose root is a local but is itself stored elsewhere are
+  not chained-tracked.
 - **8.6 implicit captures from method bodies.** `InferConstructorLifetimes`
   now walks instance method bodies looking for `IdentExpr` references
   whose name matches a constructor parameter, and adds matching indices

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1415,6 +1415,19 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
   Still deferred: `yield from` (delegate yield) propagation from the
   inner iterator's element type, and lifetime inference for the
   generator's `TReturn` slot from explicit `return value` paths.
+- **8.3 async generators.** `inferLifetimesCore` branches on
+  `isGenerator` (yields → yield type) vs. `isAsync` (returns →
+  Promise value type), but the combined async-generator case isn't
+  exercised end-to-end. Although `generatorYieldType` already
+  recognizes `AsyncGenerator<T, TReturn, TNext>` so yields *should*
+  flow to T, there are no tests covering `async fn*` with
+  parameter-aliasing yields, and the `return value` → TReturn slot
+  inherits the same TReturn deferral as regular generators (returns
+  in an async generator do not wrap into Promise). Closing this
+  requires test coverage for parameter-aliasing yields in async
+  generators and, alongside the regular-generator TReturn work,
+  inferring the lifetime on TReturn from explicit `return value`
+  paths.
 - **8.4 escaping reference detection.** `DetectEscapingRefs` walks a
   function body for assignment expressions whose lvalue root is a
   non-local identifier (VarID ≤ 0, set by the rename pass for

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1383,12 +1383,18 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
     `extraParamNames` path). Without that fix the leaf's `IdentPat.VarID`
     was stale relative to the body's `IdentExpr.VarID`.
 
+  - **Object-destructured parameters** (`fn g({head, tail}: {head: mut P, tail: mut P})`):
+    the walker now handles `*ast.ObjectPat` by building a key→Type
+    lookup against the corresponding ObjectType's PropertyElems and
+    descending per leaf. Both shorthand (`{ head, tail }`) and
+    key-value (`{ head: first, tail: second }`) patterns are
+    supported. ObjRestPat (`{ ...rest }`) is intentionally skipped —
+    like a function rest param's container, the rest object is
+    freshly assembled per call, and per-property element lifetimes
+    for it are deferred (would require synthesizing a per-call
+    object type).
+
   Still deferred:
-  - **Object-destructured parameters** (`fn g({x, y}: mut P)`) — the
-    walker currently descends into `*ast.TuplePat` and `*ast.RestPat`
-    only; `*ast.ObjectPat` would need `key → ObjectType.Elems` lookup
-    to find the matching property's type position. Same approach as
-    tuple, but with key-based traversal rather than positional.
   - **Element-level lifetimes from fresh-container returns**
     (`return [a, b]` producing `Array<'a T>`, `.filter()` /
     `.slice()` propagation): the alias-source machinery still treats

--- a/planning/lifetimes/requirements.md
+++ b/planning/lifetimes/requirements.md
@@ -2062,6 +2062,23 @@ because `shared` is permanently live and mutable.
   analogous to Rust's MIR "place" system. The workaround for the
   variable-level model is to extract properties into separate variables
   before freezing, which gives each its own alias set.
+- **Projection-level lifetime attachment for constructor capture:** When
+  a class field initializer captures a constructor parameter through a
+  projection (e.g. `class Wrap(p: mut {x: {y: number}}) { inner: p.x }`),
+  the inferred fresh `'a` is attached to the entire param's type
+  (`mut 'a {x: {y: number}}`) rather than to the captured sub-position
+  (`mut {x: mut 'a {y: number}}`). The capture detector in
+  `findCapturedParamsInExpr` currently records only *which* param was
+  captured, not the projection path within it; reaching projection-level
+  precision would require tracking `(paramIdx, path)` pairs and walking
+  the param's type to set the lifetime on the matching sub-position.
+  Related to "Property-level alias sets" above — both are forms of
+  path-aware precision deferred from the variable-level baseline and
+  could share a common path-representation infrastructure, though they
+  sit in different parts of the system (constructor lifetime inference
+  vs. borrow-checker alias tracking). The current attachment is sound
+  but over-conservative: the whole param is treated as bounded by
+  `'a` even when only a sub-position needed to be.
 
 ## Error Messages
 


### PR DESCRIPTION
## Summary

Phase 8.2 of the lifetime inference work, plus soundness fixes from code review:

- **Per-leaf lifetimes for destructured params** — tuple, rest, and object patterns each get a lifetime per leaf binding, resolved against the corresponding sub-position of the param's inferred type.
- **`'static` for params escaping into module-level state** — assignments whose lvalue root is a non-local identifier mark the RHS-aliased param as `'static`. Now also detects escapes through call results (`cache = wrap(p)`) via the checker-aware alias source.
- **Generator yield lifetimes** — `yield expr` propagates the param's lifetime to `T` inside `Generator<T, _, _>` rather than to the container.
- **Async return-type unwrap** — by analogy with Generator, `Promise<T, E>` returns attach the lifetime to inner `T`, not the freshly-allocated container.
- **Mutual-recursion convergence** — SCC re-run uses an idempotent `ReinferLifetimes` entry point that appends new lifetime params for leaves revealed by newly-resolved peer signatures. Replaces the previous early-return that prematurely skipped functions whose first pass found only some aliased params.
- **Constructor lifetime inference** for composite field inits, member/index projections of params, and method-body / getter / setter captures.
- **Visitor scoping correctness** — `methodCaptureVisitor` now visits VarDecl initializers before adding the binding to the shadow set, and tracks block-scope shadowing with proper push/pop. (Dormant end-to-end pending the language change that brings constructor params into method scope.)

## Test plan

- [x] All existing checker tests still pass (`go test ./internal/checker/...`)
- [x] Full repo test suite passes (`go test ./...`)
- [x] New tests added for each fixed bug (each was failing before its fix):
  - `EscapingRefViaCallResult` — escape detection through a call result
  - `MutuallyRecursivePartialFirstPass` — true 2-cycle where one function has both a base case and a peer-call return path
  - `AsyncReturnsParam` — Promise inner-T unwrap
  - `GetterCapturesConstructorParam` / `SetterCapturesConstructorParam` — getter/setter constructor-param capture
- [x] New tests for the per-leaf and call-site features:
  - `TupleDestructuredParamFirstReturned` / `TupleDestructuredParamConditional`
  - `ObjectDestructuredParamFirstReturned` / `ObjectDestructuredParamConditional`
  - `RestParamReturnsElement`
  - `EscapingRefIntoModuleLevelVar` / `EscapingRefViaPropertyAssignment` / `NoEscapeWhenAssigningToLocal`
  - `GeneratorYieldsAliasParam`
  - `MutuallyRecursiveBaseAndRecursive`
  - `TestCallSiteAliasFromLifetimeUnion` / `TestCallSiteAliasFromInferredLifetime` / `TestCallSiteNoAliasForFreshReturn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifetime inference: async/generator-aware analysis, leaf-level handling for destructured parameters, better escape detection assigning 'static where appropriate, constructor-capture detection refined, and a mutual-recursion re-run to discover additional lifetimes. Also fixed type-print formatting for element signatures.
* **Tests**
  * Expanded lifetime tests for destructuring, generators/async, constructor captures, escapes, reinference, and mutability transitions.
* **Documentation**
  * Updated lifetime implementation plan and requirements notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->