### PR TITLE
Phase 8.3: element-level vs. container-level lifetimes

### DIFF
--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -39,10 +39,13 @@ func lifetimeParamName(i int) string {
 //     LifetimeUnion on the return type.
 //   - Parameters stored into module-level (non-local) state: assigned
 //     'static directly. See detectEscapingLeafIndices.
-//   - Yields aliasing parameters (generators): the lifetime is attached
-//     to the yield type T inside Generator<T, TReturn, TNext> rather than
-//     to the Generator container itself, so each yielded value carries
-//     the lifetime.
+//   - Yields and returns aliasing parameters (generators): yields drive
+//     the yield T slot inside Generator<T, TReturn, TNext>; explicit
+//     `return expr` paths drive the TReturn slot. Each is inferred
+//     independently, so a generator may carry distinct lifetimes on
+//     T and TReturn. Lifetimes attach to the inner slots rather than
+//     the Generator container, since the container is freshly assembled
+//     per call. See "Generator-specific behavior" below.
 //   - Per-leaf lifetimes for tuple-, object-, and rest-destructured
 //     parameters: walkPatternForLeaves walks each parameter's pattern in
 //     lockstep with its inferred type, producing one (VarID, leafType)
@@ -54,12 +57,24 @@ func lifetimeParamName(i int) string {
 // previously-inferred LifetimeParams can be extended once peers' signatures
 // become resolvable on the second pass.
 //
+// Generator-specific behavior (Phase 8.3):
+//   - Yields (regular and delegate) drive the yield T position;
+//     `return expr` paths drive the TReturn position; the two are
+//     inferred independently via `attachLifetimeToResult`.
+//   - For `yield from iter`, the iterator expression is the alias
+//     source — each yielded element borrows from iter, so iter's
+//     lifetime propagates to the relay generator's yield T.
+//
 // Deferred (see implementation_plan.md Phase 8 status):
 //   - Element-level lifetimes (Array<'a T>) for fresh containers whose
 //     elements alias a parameter.
-//   - `yield from` (delegate yield) propagation from the inner iterator's
-//     element type.
 //   - Propagating lifetimes through nested calls into other functions.
+//   - TODO(#507): Shared-instance overspecification for unioned yield
+//     types and `yield from`: when the result position shares its
+//     underlying Type instance with a parameter, attaching a lifetime
+//     to the result also writes through to the parameter, producing
+//     tighter output than necessary. Fix would require shallow-cloning
+//     the yield T / TReturn before lifetime attachment.
 //
 // astParams is the list of parameter ASTs (used to map their VarIDs to
 // parameter indices). funcType is mutated in place. isAsync reports
@@ -179,48 +194,71 @@ func (c *Checker) inferLifetimesCore(
 	// lifetime as a whole, not just its inner yield T.
 	isGenerator := len(yields) > 0
 
-	// Determine the *result type* — the position to which the
-	// per-source lifetime is attached. For generators, the result is
-	// the yield type T inside Generator<T, TReturn, TNext>; for async
-	// functions, the result is the resolved type T inside
-	// Promise<T, E>; for plain functions, it's the return type itself.
-	// In the generator/async cases the container is freshly assembled
-	// per call and has no caller-provided lifetime — only its inner T
-	// does. When the function is neither (so the Promise<T>/Generator<T>
-	// in its signature is the user's actual result, not a wrapper the
-	// compiler synthesized), the lifetime must attach to that container.
-	resultType := funcType.Return
+	// Generators have two lifetime-bearing result positions: the yield
+	// type T (driven by `yield expr` paths) and TReturn (driven by
+	// `return expr` paths). They are inferred independently — a generator
+	// might yield from one parameter and return another, in which case
+	// each receives its own lifetime variable. For non-generators there
+	// is a single result position: the return type for plain functions,
+	// or the inner T inside Promise<T, E> for async functions (the
+	// Promise container itself is freshly assembled per call, with no
+	// caller-provided lifetime).
 	if isGenerator {
-		if t := generatorYieldType(funcType.Return); t != nil {
-			resultType = t
-		}
-	} else if isAsync {
+		c.attachLifetimeToResult(funcType, leaves, leafIndex, escapingLeaves, yields, generatorYieldType(funcType.Return))
+		c.attachLifetimeToResult(funcType, leaves, leafIndex, escapingLeaves, v.exprs, generatorReturnType(funcType.Return))
+		return
+	}
+	resultType := funcType.Return
+	if isAsync {
 		if t := promiseValueType(funcType.Return); t != nil {
 			resultType = t
 		}
 	}
+	c.attachLifetimeToResult(funcType, leaves, leafIndex, escapingLeaves, v.exprs, resultType)
+}
 
-	// Skip the alias-source walk entirely when the result type cannot
-	// carry a lifetime (e.g. it's a TypeVar, primitive, or
-	// union/intersection without a common lifetime-bearing structure).
-	// Without a place to attach the lifetime on the result side, the
-	// lifetime parameter would be unused noise in the signature.
-	if !typeCarriesLifetime(resultType) {
+// attachLifetimeToResult is the per-result-position core of lifetime
+// inference: given a list of alias-source expressions (e.g. `return e`
+// or `yield e`) and a single result-type position, walk the expressions
+// to collect aliased leaves, allocate / reuse a LifetimeVar per leaf,
+// attach those lifetimes to the leaves AND to the result, and append
+// any fresh LifetimeVars to funcType.LifetimeParams.
+//
+// resultType may be nil (e.g. a Generator<_, void, _>'s TReturn slot is
+// `void` and carries no lifetime); in that case the function bails
+// without allocating any lifetime params even if returns happen to
+// alias parameters, since there is no result-side position to attach.
+//
+// This is invoked once per result position. Generators call it twice
+// (yields → yield T, returns → TReturn); plain and async functions
+// call it once. When called twice, fresh LifetimeVars allocated by the
+// first call are appended to funcType.LifetimeParams before the second
+// call begins, so the second call's `nameIdx` (which reads
+// len(funcType.LifetimeParams)) correctly continues the 'a, 'b, ...
+// sequence.
+//
+// escapingLeaves names leaves whose lifetime was already overwritten to
+// 'static by inferLifetimesCore prior to this call. Reading those leaves
+// here is read-only — the helper records returnHasStatic but does not
+// re-mutate the leaf's lifetime — so it is safe to invoke twice.
+func (c *Checker) attachLifetimeToResult(
+	funcType *type_system.FuncType,
+	leaves []paramLeaf,
+	leafIndex map[liveness.VarID]int,
+	escapingLeaves set.Set[int],
+	sourceExprs []ast.Expr,
+	resultType type_system.Type,
+) {
+	if resultType == nil || !typeCarriesLifetime(resultType) {
+		return
+	}
+	if len(sourceExprs) == 0 {
 		return
 	}
 
 	// Determine which leaves are aliased across all alias-source
 	// expressions. Use insertion order so the resulting LifetimeParams
 	// list is deterministic.
-	sourceExprs := make([]ast.Expr, 0, len(v.exprs)+len(yields))
-	if isGenerator {
-		// Generator: yields are the lifetime-bearing source.
-		// The function's `return` (if any) sets TReturn — that lifetime
-		// position is not yet inferred (deferred).
-		sourceExprs = append(sourceExprs, yields...)
-	} else {
-		sourceExprs = append(sourceExprs, v.exprs...)
-	}
 	seen := set.NewSet[int]()
 	var orderedLeaves []int
 	for _, re := range sourceExprs {
@@ -277,7 +315,10 @@ func (c *Checker) inferLifetimesCore(
 		}
 		// Reuse an already-inferred LifetimeVar on the leaf so the
 		// signature stays stable across re-runs and pointer identity
-		// is preserved with anything that already references it.
+		// is preserved with anything that already references it. This
+		// also lets the second call (e.g. for generator TReturn) reuse
+		// a lifetime allocated by the first (yield T) call when the
+		// same parameter is aliased on both sides.
 		if existingLV, ok := type_system.PruneLifetime(type_system.GetLifetime(leaf.leafType)).(*type_system.LifetimeVar); ok && existingLV != nil {
 			returnLifetimeMembers = append(returnLifetimeMembers, existingLV)
 			continue
@@ -313,6 +354,10 @@ func (c *Checker) inferLifetimesCore(
 	} else {
 		returnLifetime = &type_system.LifetimeUnion{Lifetimes: returnLifetimeMembers}
 	}
+	// TODO(#507): if resultType is pointer-shared with a param leaf
+	// (which happens for unioned yield types and for `yield from`),
+	// this write bleeds through to the param. Shallow-clone resultType
+	// here and substitute the clone back into funcType.Return.TypeArgs.
 	setLifetimeOnType(resultType, returnLifetime)
 
 	if len(newLifetimeParams) > 0 {
@@ -1337,6 +1382,26 @@ func generatorYieldType(t type_system.Type) type_system.Type {
 	return tref.TypeArgs[0]
 }
 
+// generatorReturnType returns the TReturn slot of a
+// Generator<T, TReturn, TNext> or AsyncGenerator<T, TReturn, TNext>
+// reference, walking past mutability wrappers. Returns nil if t is not
+// a generator reference or doesn't have a second type arg.
+func generatorReturnType(t type_system.Type) type_system.Type {
+	pt := stripMutabilityWrapper(type_system.Prune(t))
+	tref, ok := pt.(*type_system.TypeRefType)
+	if !ok {
+		return nil
+	}
+	name := type_system.QualIdentToString(tref.Name)
+	if name != "Generator" && name != "AsyncGenerator" {
+		return nil
+	}
+	if len(tref.TypeArgs) < 2 {
+		return nil
+	}
+	return tref.TypeArgs[1]
+}
+
 // promiseValueType returns the resolved value type T of a
 // Promise<T, E> reference, walking past mutability wrappers. Returns
 // nil if t is not a Promise reference or has no type args.
@@ -1356,10 +1421,12 @@ func promiseValueType(t type_system.Type) type_system.Type {
 }
 
 // collectYieldExprs walks a function body collecting the value
-// expressions of every (non-delegate) yield expression. Delegate yields
-// (`yield from iter`) are skipped — propagating lifetimes from the
-// inner iterator's element type is deferred. Bare `yield` (with no
-// value) is also skipped because there is no value to alias.
+// expressions of every yield expression — both regular (`yield e`) and
+// delegate (`yield from iter`). For a delegate yield, the iterator
+// expression itself is the alias source: each yielded value is an
+// element of the iterator and so borrows from it, meaning the relay
+// generator's yield T inherits the iterator's lifetime. Bare `yield`
+// (with no value) is skipped because there is no value to alias.
 func collectYieldExprs(body *ast.Block) []ast.Expr {
 	v := &yieldExprVisitor{}
 	for _, stmt := range body.Stmts {
@@ -1376,7 +1443,12 @@ type yieldExprVisitor struct {
 func (v *yieldExprVisitor) EnterExpr(expr ast.Expr) bool {
 	switch e := expr.(type) {
 	case *ast.YieldExpr:
-		if e.Value != nil && !e.IsDelegate {
+		// Both regular and delegate yields contribute alias-source
+		// information. For `yield expr`, expr is the yielded value;
+		// for `yield from iter`, iter is the source whose elements
+		// are yielded one by one — propagating iter's lifetime to
+		// each yielded element.
+		if e.Value != nil {
 			v.exprs = append(v.exprs, e.Value)
 		}
 		return true

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -163,6 +163,105 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"iter": "fn <'a>(p: mut 'a {x: number}) -> Generator<mut 'a {x: number}, void, never>",
 			},
 		},
+		"GeneratorReturnAliasParam": {
+			// Phase 8.3: a generator's TReturn slot inherits the lifetime
+			// of any parameter aliased by an explicit `return value`
+			// path. The yield type T is unconstrained when no yields
+			// alias parameters; the lifetime attaches only to TReturn.
+			input: `
+				fn iter(p: mut {x: number}) -> Generator<number, mut {x: number}, never> {
+					yield 1
+					return p
+				}
+			`,
+			expectedTypes: map[string]string{
+				"iter": "fn <'a>(p: mut 'a {x: number}) -> Generator<number, mut 'a {x: number}, never>",
+			},
+		},
+		"GeneratorYieldAndReturnAliasDistinctParams": {
+			// Phase 8.3: yield T and TReturn are inferred independently.
+			// A generator that yields one parameter and returns another
+			// gets distinct lifetime variables on the two result
+			// positions, each propagated to its own param.
+			input: `
+				fn iter(p: mut {x: number}, q: mut {x: number}) -> Generator<mut {x: number}, mut {x: number}, never> {
+					yield p
+					return q
+				}
+			`,
+			expectedTypes: map[string]string{
+				"iter": "fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> Generator<mut 'a {x: number}, mut 'b {x: number}, never>",
+			},
+		},
+		"GeneratorYieldAndReturnAliasSameParam": {
+			// Phase 8.3: when yield T and TReturn alias the SAME
+			// parameter, the lifetime is allocated once and reused on
+			// both result positions — `existingLV` reuse in
+			// attachLifetimeToResult preserves pointer identity so the
+			// signature shows a single 'a flowing to all three positions.
+			input: `
+				fn iter(p: mut {x: number}) -> Generator<mut {x: number}, mut {x: number}, never> {
+					yield p
+					return p
+				}
+			`,
+			expectedTypes: map[string]string{
+				"iter": "fn <'a>(p: mut 'a {x: number}) -> Generator<mut 'a {x: number}, mut 'a {x: number}, never>",
+			},
+		},
+		"GeneratorYieldFromAliasParam": {
+			// Phase 8.3: `yield from iter` propagates the iterator's
+			// lifetime to each delegated yield. When iter is a
+			// parameter, the relay generator's yield T inherits the
+			// parameter's lifetime — every value yielded through the
+			// delegate borrows from iter, so its lifetime is bounded
+			// by iter's.
+			input: `
+				fn relay(g: Generator<mut {x: number}, void, never>) {
+					yield from g
+				}
+			`,
+			expectedTypes: map[string]string{
+				"relay": "fn <'a>(g: 'a Generator<mut 'a {x: number}, void, never>) -> Generator<mut 'a {x: number}, void, never>",
+			},
+		},
+		"AsyncGeneratorYieldsAliasParam": {
+			// Phase 8.3: an async generator (async fn containing yield)
+			// should propagate the parameter's lifetime to the yield
+			// type T inside AsyncGenerator<T, _, _>. The AsyncGenerator
+			// container is freshly assembled per call so it has no
+			// caller-provided lifetime — only its inner T does.
+			input: `
+				async fn iter(p: mut {x: number}) {
+					yield p
+				}
+			`,
+			expectedTypes: map[string]string{
+				"iter": "fn <'a>(p: mut 'a {x: number}) -> AsyncGenerator<mut 'a {x: number}, void, never>",
+			},
+		},
+		"GeneratorYieldEscapingReturnAliasing": {
+			// Phase 8.3 + 8.4 cross-cutting: a generator where one param
+			// escapes into module-level state (forcing 'static) AND
+			// another param is aliased on the TReturn path. The escape
+			// detection runs once before either attachLifetimeToResult
+			// call, so 'static is set on `p` up front; the yields call
+			// then sees `returnHasStatic` and writes 'static onto yield T,
+			// while the returns call independently allocates 'a for `q`
+			// and writes it onto TReturn. Confirms the helper is safe to
+			// invoke twice when one of the two paths escapes.
+			input: `
+				var cache: mut {x: number} = {x: 0}
+				fn iter(p: mut {x: number}, q: mut {x: number}) -> Generator<mut {x: number}, mut {x: number}, never> {
+					cache = p
+					yield p
+					return q
+				}
+			`,
+			expectedTypes: map[string]string{
+				"iter": "fn <'a>(p: mut 'static {x: number}, q: mut 'a {x: number}) -> Generator<mut 'static {x: number}, mut 'a {x: number}, never>",
+			},
+		},
 		"RestParamReturnsElement": {
 			// Phase 8.3: rest param `...args: Array<T>` — the lifetime-
 			// bearing position is the *element* type T, not the array

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1398,7 +1398,6 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
     bindings (once via `renamePat` walking the pattern, once via the
     `extraParamNames` path). Without that fix the leaf's `IdentPat.VarID`
     was stale relative to the body's `IdentExpr.VarID`.
-
   - **Object-destructured parameters** (`fn g({head, tail}: {head: mut P, tail: mut P})`):
     the walker now handles `*ast.ObjectPat` by building a key→Type
     lookup against the corresponding ObjectType's PropertyElems and
@@ -1409,41 +1408,68 @@ The initial Phase 8 PR delivers a foundational subset; the following items are
     freshly assembled per call, and per-property element lifetimes
     for it are deferred (would require synthesizing a per-call
     object type).
-
-  Still deferred:
-  - **Element-level lifetimes from fresh-container returns**
-    (`return [a, b]` producing `Array<'a T>`, `.filter()` /
-    `.slice()` propagation): the alias-source machinery still treats
-    array literals as fresh and built-in array methods don't carry
-    lifetime annotations. Closing this requires extending
-    `DetermineAliasSource` with an "element-of" variant and annotating
-    the prelude.
-- **8.3 generator yield lifetimes.** `InferLifetimes` now collects every
-  non-delegate `yield expr` value alongside `return` expressions. When
-  the function's return type is `Generator<T, TReturn, TNext>` (or
-  `AsyncGenerator<...>`), the lifetime is attached to T (the yield
-  type) rather than to the Generator container itself, so each yielded
-  value carries the lifetime. Concretely,
+- **8.3 generator yield lifetimes.** `InferLifetimes` collects every
+  yield expression (regular AND delegate) alongside `return`
+  expressions. When the function's return type is
+  `Generator<T, TReturn, TNext>` (or `AsyncGenerator<...>`), the
+  yield-side lifetime is attached to T rather than to the Generator
+  container itself, so each yielded value carries the lifetime.
+  Concretely,
   `fn iter(p: mut Point) -> Generator<mut Point, void, never> { yield p }`
   infers `<'a>(p: mut 'a Point) -> Generator<mut 'a Point, void, never>`.
+  For `yield from iter`, the iterator expression itself is the alias
+  source — each yielded element borrows from `iter`, so the relay
+  generator's yield T inherits `iter`'s lifetime. Concretely,
+  `fn relay(g: Generator<mut Point, void, never>) { yield from g }`
+  infers `<'a>(g: 'a Generator<mut 'a Point, void, never>) -> Generator<mut 'a Point, void, never>`
+  (g's container picks up the alias-source 'a directly; the inner T
+  ends up with 'a too because the underlying type instance is shared
+  with the relay's yield T — see "shared-instance overspecification"
+  below).
+- **8.3 generator `TReturn` lifetimes.** `inferLifetimesCore` was
+  refactored to call a per-result-position helper
+  (`attachLifetimeToResult`) twice for generators: once for yields →
+  yield T, once for `return expr` paths → TReturn. Each result
+  position is inferred independently, so a generator that yields one
+  parameter and returns another gets distinct lifetime variables on
+  the two slots; when both alias the *same* parameter, the
+  pre-existing-LifetimeVar reuse path keeps a single 'a flowing to
+  both positions. Concretely,
+  `fn iter(p: mut Point, q: mut Point) -> Generator<mut Point, mut Point, never> { yield p; return q }`
+  infers `<'a, 'b>(p: mut 'a Point, q: mut 'b Point) -> Generator<mut 'a Point, mut 'b Point, never>`.
   `inferFuncBodyWithFuncSigType` was extended to call `InferLifetimes`
   in the generator branch (which previously short-circuited).
-  Still deferred: `yield from` (delegate yield) propagation from the
-  inner iterator's element type, and lifetime inference for the
-  generator's `TReturn` slot from explicit `return value` paths.
-- **8.3 async generators.** `inferLifetimesCore` branches on
-  `isGenerator` (yields → yield type) vs. `isAsync` (returns →
-  Promise value type), but the combined async-generator case isn't
-  exercised end-to-end. Although `generatorYieldType` already
-  recognizes `AsyncGenerator<T, TReturn, TNext>` so yields *should*
-  flow to T, there are no tests covering `async fn*` with
-  parameter-aliasing yields, and the `return value` → TReturn slot
-  inherits the same TReturn deferral as regular generators (returns
-  in an async generator do not wrap into Promise). Closing this
-  requires test coverage for parameter-aliasing yields in async
-  generators and, alongside the regular-generator TReturn work,
-  inferring the lifetime on TReturn from explicit `return value`
-  paths.
+- **8.3 async generators.** `inferLifetimesCore` is now exercised
+  end-to-end for async generators (`async fn` containing `yield`):
+  `generatorYieldType` already recognized
+  `AsyncGenerator<T, TReturn, TNext>` so yields flow to T. A simple
+  test (`AsyncGeneratorYieldsAliasParam`) confirms parameter-aliasing
+  yields produce
+  `<'a>(p: mut 'a Point) -> AsyncGenerator<mut 'a Point, void, never>`.
+  The TReturn refactor above also runs for async generators, since
+  the per-result-position helper is invoked uniformly for both
+  Generator and AsyncGenerator. Returns in an async generator
+  populate TReturn directly (they do not wrap into Promise — the
+  AsyncGenerator wrapper is the only synthesis the compiler does).
+
+  Still deferred — **shared-instance overspecification (#507).** When a
+  generator's body has multiple `yield` paths whose value types are
+  structurally identical (e.g.
+  `if cond { yield a } else { yield b }` with both params
+  `mut {x: number}`), `NewUnionType` collapses the
+  yielded-types list to a single instance — which is one of the
+  parameter types. The result-side `setLifetimeOnType` then
+  overwrites that param's individual lifetime with the union, leaking
+  `('a | 'b)` onto the param's annotation instead of just 'a. The
+  same pointer-sharing also produces overspecified output for
+  `yield from g`: g's inner T ends up with 'a too, even though only
+  g's container needs it. Both cases are sound (the compiler is
+  *over*-constraining) but visually misleading. Fixing properly
+  requires shallow-cloning the yield T / TReturn type before
+  attaching a result-side lifetime, so the result position can carry
+  a different lifetime than any param it shares structure with.
+  Tracked in
+  [#507](https://github.com/escalier-lang/escalier/issues/507).
 - **8.4 escaping reference detection.** `DetectEscapingRefs` walks a
   function body for assignment expressions whose lvalue root is a
   non-local identifier (VarID ≤ 0, set by the rename pass for
@@ -2061,6 +2087,216 @@ data class Config(host: string) {
 }
 val cfg = Config("localhost")    // type: Config (immutable despite setHost)
 ```
+
+### 8.9 Element-Level and Property-Level Lifetimes
+
+**Goal:** Extend `DetermineAliasSource` so that fresh containers (array
+literals, object literals, tuple literals, calls to builtins like
+`.filter()` / `.slice()` / `.map()`) propagate lifetimes from their
+constituents to the matching slot of the result type — covering both
+the element-of-array case and the property-of-object case under a
+single, path-based abstraction.
+
+This is split out from Phase 8.3 into its own child phase because it
+touches the core alias-source machinery, the prelude annotations, and
+the lifetime-attachment logic — and the two shapes (element-of and
+property-of) want a unified design rather than two parallel ad-hoc
+walkers.
+
+#### Motivation
+
+Today, `DetermineAliasSource` returns a single `VarID` (or "fresh") for
+an expression. Phase 8.3's lifetime attachment works at the
+**top-level** of the return type only:
+
+- `return p` → return type gets `'a` at the top: `mut 'a Point`
+- `return [a, b]` → "fresh", no lifetime attached, even though each
+  element aliases a parameter
+- `return { head: a }` → "fresh", same problem
+
+For element-level (`Array<'a T>`) and property-level (`{ head: 'a P }`)
+lifetimes, the alias source is no longer a single root — it's a *path*
+into a freshly constructed container, where each leaf of the path
+carries its own root and its own lifetime obligation.
+
+A separate ad-hoc walker (`findCapturedParamsInExpr` in
+`InferConstructorLifetimes`, Phase 8.6) already implements a
+specialized version of this for class-body field initializers. This
+phase folds that walker into the general machinery so there is one
+implementation, not two.
+
+#### Design — Projection-Path Alias Source
+
+Replace the flat `AliasSource` with a path-based variant:
+
+```go
+// ProjectionStep names one step from a root variable to a leaf slot
+// inside a freshly-constructed composite value.
+type ProjectionStep interface{ projectionStep() }
+
+type ElementOf  struct{}                  // [a, b]    — array element
+type PropertyOf struct{ Key string }      // {k: a}    — object property
+type IndexOf    struct{ Index int }       // tuple [a, b] at fixed index
+type AwaitOf    struct{}                  // await p   — Promise<T> → T
+type CastOf     struct{ Target Type }     // (p as T)  — pass-through
+
+func (ElementOf)  projectionStep() {}
+func (PropertyOf) projectionStep() {}
+func (IndexOf)    projectionStep() {}
+func (AwaitOf)    projectionStep() {}
+func (CastOf)     projectionStep() {}
+
+// AliasLeaf is one (root, path) pair contributing a lifetime to a
+// specific slot of the surrounding fresh container.
+type AliasLeaf struct {
+    RootVarID VarID
+    Path      []ProjectionStep   // empty path = root itself (legacy case)
+}
+
+// AliasSource is now a *set* of leaves. A direct return of a
+// parameter is a single leaf with empty path; a return of
+// [a, {head: b}] is two leaves: (a, [ElementOf]) and
+// (b, [ElementOf, PropertyOf("head")]).
+type AliasSource struct {
+    Leaves []AliasLeaf
+    Fresh  bool   // true iff Leaves is empty AND nothing aliases out
+}
+```
+
+The empty-path case preserves all existing behavior: a single leaf with
+`Path == nil` is exactly today's "this expression aliases VarID X".
+
+#### Extending `DetermineAliasSource`
+
+For each composite expression form, push the appropriate step before
+recursing:
+
+| Expression                  | Behavior                                           |
+| --------------------------- | -------------------------------------------------- |
+| `[a, b, ...]`               | union of children with `ElementOf` prepended       |
+| `{k1: e1, k2: e2}`          | union of children with `PropertyOf(ki)` prepended  |
+| `{k}` (shorthand)           | same as `{k: k}` — `PropertyOf("k")` + lookup of `k` |
+| `[e1, e2]` (tuple)          | children with `IndexOf(i)` prepended               |
+| `await e`                   | child with `AwaitOf` prepended                     |
+| `e as T`                    | child unchanged (cast is pass-through)             |
+| `f(args)`                   | look up callee's `LifetimeParams`; for each lifetime on the return type, find which arg(s) bind it and emit a leaf for each, using the **return-type path** of that lifetime (see "Prelude annotations" below) |
+| `e.k` (member)              | if `e` is a leaf with path `P`, result is `(root, P ++ [PropertyOf(k)])`; this lets us *un-project* through aliased structs |
+| `e[i]` (index, const i)     | analogous: `P ++ [IndexOf(i)]` for tuples          |
+| identifier / parameter ref  | single leaf, empty path (today's behavior)         |
+
+#### Lifetime Attachment Along a Path
+
+Today, lifetime allocation walks param leaves and attaches a fresh
+`'a` at the top of the return type. With path-based leaves, the
+attachment walks **into** the return type along each path:
+
+```
+Path                                     Attaches 'a at
+[]                                       top of return type
+[ElementOf]                              return type's element type T (Array<T>)
+[PropertyOf("head")]                     return type's "head" property type
+[ElementOf, PropertyOf("head")]          element-of-array's "head" property
+[AwaitOf]                                inside Promise<T>'s T
+```
+
+This requires a small helper that, given a return type and a
+projection path, descends to the correct slot and replaces (or
+unions-in) a lifetime there. The descent fails gracefully (no
+attachment) if the return type's shape doesn't match the path — e.g.
+the body returns a literal but the declared return type is a primitive.
+
+#### Prelude Annotations for Built-in Methods
+
+Built-in collection methods need lifetime signatures so that calls
+through them propagate element-level lifetimes:
+
+```esc
+// Container-level passthrough — return aliases self
+fn (mut self) sort() -> mut Array<T>           // no element-level lifetime needed
+fn (mut self) reverse() -> mut Array<T>
+
+// Fresh container, elements alias self's elements
+fn (self) filter<'a>(self: 'a Array<T>, f: fn(T) -> boolean) -> Array<'a T>
+fn (self) slice<'a>(self: 'a Array<T>, start: number, end: number) -> Array<'a T>
+fn (self) concat<'a, 'b>(self: 'a Array<T>, other: 'b Array<T>) -> Array<('a | 'b) T>
+
+// Map/flatMap — fresh elements (callback constructs them)
+fn (self) map<U>(self: Array<T>, f: fn(T) -> U) -> Array<U>          // no propagation
+// (unless the callback's return type carries a lifetime tied to T —
+// elision rule extension, deferred)
+```
+
+These annotations live in `internal/prelude/` (or wherever the array
+intrinsics are defined today) and are picked up by the call-site
+handling in `DetermineAliasSource`.
+
+#### Unifying with `findCapturedParamsInExpr`
+
+`InferConstructorLifetimes` (Phase 8.6) already walks object literals,
+tuple literals, and member access ad-hoc to discover which constructor
+params a field stores. Once the projection-path alias source exists,
+that walker collapses into:
+
+```go
+src := DetermineAliasSource(fieldInitExpr)
+for _, leaf := range src.Leaves {
+    if leaf.RootVarID matches a constructor param {
+        record (paramIndex, leaf.Path) → field
+    }
+}
+```
+
+The recorded path then drives where on the *class type* the lifetime is
+attached — top-level for `field: p` (today's behavior), element-level
+for `field: [p]`, property-level for `field: { inner: p }`, etc.
+
+#### Tests
+
+```esc
+// Array literal — element-level lifetime on a fresh container
+fn pair(a: mut Point, b: mut Point) -> mut Array<mut Point> {
+    return [a, b]
+}
+// Inferred: fn pair<'a, 'b>(a: mut 'a Point, b: mut 'b Point)
+//             -> mut Array<mut ('a | 'b) Point>
+
+// Object literal — property-level lifetimes on distinct keys
+fn wrap(a: mut Point, b: mut Point) -> { head: mut Point, tail: mut Point } {
+    return { head: a, tail: b }
+}
+// Inferred: fn wrap<'a, 'b>(a: mut 'a Point, b: mut 'b Point)
+//             -> { head: mut 'a Point, tail: mut 'b Point }
+
+// Nested — element of array, property of object inside it
+fn box(p: mut Point) -> Array<{ inner: mut Point }> {
+    return [{ inner: p }]
+}
+// Inferred: fn box<'a>(p: mut 'a Point) -> Array<{ inner: mut 'a Point }>
+
+// Built-in propagation through .filter()
+fn keepBig(items: Array<mut Point>) -> Array<mut Point> {
+    return items.filter(fn (p) { p.x > 0 })
+}
+// Inferred: fn keepBig<'a>(items: 'a Array<mut Point>)
+//             -> Array<mut 'a Point>
+// (filter's signature carries 'a from self to result element type)
+
+// Constructor field with composite initializer
+class Pair(a: mut Point, b: mut Point) {
+    items: [a, b]      // tuple field
+}
+// Inferred: Pair<'a, 'b>(a: mut 'a Point, b: mut 'b Point)
+//   with Pair's `items` field typed as [mut 'a Point, mut 'b Point]
+```
+
+#### Out of scope for 8.9
+
+- Lifetimes flowing through user-defined `.map()` callbacks (requires
+  a notion of "lifetime polymorphism over callback return types").
+  Left for a follow-up.
+- `ObjRestPat` (`{ ...rest }`) per-property lifetimes on rest objects —
+  still requires synthesizing a per-call object type, which is
+  orthogonal to projection paths.
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced lifetime type inference for generators and async generators with improved tracking of yield and return value types
  * Better handling of delegated yield expressions in generators

* **Tests**
  * Added comprehensive test coverage for generator lifetime inference scenarios, including yield paths, return paths, and parameter aliasing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->