### PR TITLE
Finish 8.4 and 8.5 of lifetimes

### DIFF
--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -14,7 +14,8 @@ import (
 // MutabilityTransitionError.ConflictingVars to represent a permanent
 // alias from a `'static` escape (e.g. an argument passed to a callee
 // whose parameter has a `'static` lifetime, meaning the value was
-// stored into outer-lived state). The error message renders this
+// stored into storage whose lifetime outlives the callee's stack
+// frame). The error message renders this
 // specially rather than printing the literal sentinel.
 const staticConflictName = "<static escape>"
 

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -10,6 +10,14 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
+// staticConflictName is a sentinel placeholder used in
+// MutabilityTransitionError.ConflictingVars to represent a permanent
+// alias from a `'static` escape (e.g. an argument passed to a callee
+// whose parameter has a `'static` lifetime, meaning the value was
+// stored into outer-lived state). The error message renders this
+// specially rather than printing the literal sentinel.
+const staticConflictName = "<static escape>"
+
 // MutabilityTransitionError is reported when a mutability transition
 // (mut→immutable or immutable→mut) is attempted while conflicting live
 // aliases exist.
@@ -33,7 +41,18 @@ func (e MutabilityTransitionError) IsWarning() bool {
 	return false
 }
 func (e MutabilityTransitionError) Message() string {
-	vars := "'" + strings.Join(e.ConflictingVars, "', '") + "'"
+	// Render conflicts. The staticConflictName sentinel is rendered
+	// without quotes so the message reads naturally; everything else is
+	// a real identifier that gets single-quoted.
+	parts := make([]string, len(e.ConflictingVars))
+	for i, name := range e.ConflictingVars {
+		if name == staticConflictName {
+			parts[i] = "a `'static` escape"
+		} else {
+			parts[i] = "'" + name + "'"
+		}
+	}
+	vars := strings.Join(parts, ", ")
 	// When the conflicting variable is the source itself, the message is
 	// straightforward. When it's a different variable (an alias), we
 	// clarify the relationship so the user understands the connection.
@@ -115,6 +134,20 @@ func (c *Checker) checkMutabilityTransition(
 	conflictingSet := make(map[string]struct{})
 	aliasSets := ctx.Aliases.GetAliasSets(sourceVarID)
 	for _, aliasSet := range aliasSets {
+		// A `'static` escape on the alias set represents a permanent
+		// outside reference — no liveness check is meaningful, so it
+		// always counts as a live alias of its escaped mutability.
+		// Phase 8.5: callees with `'static` parameters mark the
+		// argument's alias sets via AliasTracker.MarkStatic.
+		if sourceMut && !targetMut {
+			if aliasSet.HasStaticMutAlias {
+				conflictingSet[staticConflictName] = struct{}{}
+			}
+		} else {
+			if aliasSet.HasStaticImmAlias {
+				conflictingSet[staticConflictName] = struct{}{}
+			}
+		}
 		for varID, aliasMut := range aliasSet.Members {
 			if !ctx.Liveness.IsLiveAfter(assignRef, varID) {
 				continue

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -140,14 +140,14 @@ func (c *Checker) checkMutabilityTransition(
 		// always counts as a live alias of its escaped mutability.
 		// Phase 8.5: callees with `'static` parameters mark the
 		// argument's alias sets via AliasTracker.MarkStatic.
-		if sourceMut && !targetMut {
-			if aliasSet.HasStaticMutAlias {
-				conflictingSet[staticConflictName] = struct{}{}
-			}
-		} else {
-			if aliasSet.HasStaticImmAlias {
-				conflictingSet[staticConflictName] = struct{}{}
-			}
+		//
+		// Rule 1 (mut → immutable): a permanent mutable escape conflicts.
+		if sourceMut && !targetMut && aliasSet.HasStaticMutAlias {
+			conflictingSet[staticConflictName] = struct{}{}
+		}
+		// Rule 2 (immutable → mut): a permanent immutable escape conflicts.
+		if !sourceMut && targetMut && aliasSet.HasStaticImmAlias {
+			conflictingSet[staticConflictName] = struct{}{}
 		}
 		for varID, aliasMut := range aliasSet.Members {
 			if !ctx.Liveness.IsLiveAfter(assignRef, varID) {

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1251,9 +1251,10 @@ func (c *Checker) handleFuncCall(
 			returnType.SetProvenance(provneance)
 		}
 		// Phase 8.5: if the callee marks any parameter `'static` (i.e. the
-		// value escapes into outer-lived state inside the callee), record
-		// the escape on the corresponding argument's alias sets so the
-		// transition checker can reject later mut↔immut transitions.
+		// value escapes into storage whose lifetime outlives the callee's
+		// stack frame), record the escape on the corresponding argument's
+		// alias sets so the transition checker can reject later mut↔immut
+		// transitions.
 		//
 		// Run this even when `errors` is non-empty: the static-lifetime
 		// annotation is a property of the callee's signature, the
@@ -1301,9 +1302,10 @@ func (c *Checker) handleFuncCall(
 			returnType.SetProvenance(provneance)
 		}
 		// Phase 8.5: if the callee marks any parameter `'static` (i.e. the
-		// value escapes into outer-lived state inside the callee), record
-		// the escape on the corresponding argument's alias sets so the
-		// transition checker can reject later mut↔immut transitions.
+		// value escapes into storage whose lifetime outlives the callee's
+		// stack frame), record the escape on the corresponding argument's
+		// alias sets so the transition checker can reject later mut↔immut
+		// transitions.
 		//
 		// Run this even when `errors` is non-empty: the static-lifetime
 		// annotation is a property of the callee's signature, the

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1254,6 +1254,14 @@ func (c *Checker) handleFuncCall(
 		// value escapes into outer-lived state inside the callee), record
 		// the escape on the corresponding argument's alias sets so the
 		// transition checker can reject later mut↔immut transitions.
+		//
+		// Run this even when `errors` is non-empty: the static-lifetime
+		// annotation is a property of the callee's signature, the
+		// arg→param mapping is positional, and MarkStatic only sets
+		// flags that make transitions *stricter* — it can never cause
+		// unsound acceptance. Gating on `len(errors) == 0` would only
+		// suppress cascading mut-transition errors on already-invalid
+		// code, which is not worth the extra branch.
 		c.propagateCalleeStaticLifetimes(ctx, fnType, expr.Args)
 		return returnType, errors
 	} else {
@@ -1296,6 +1304,14 @@ func (c *Checker) handleFuncCall(
 		// value escapes into outer-lived state inside the callee), record
 		// the escape on the corresponding argument's alias sets so the
 		// transition checker can reject later mut↔immut transitions.
+		//
+		// Run this even when `errors` is non-empty: the static-lifetime
+		// annotation is a property of the callee's signature, the
+		// arg→param mapping is positional, and MarkStatic only sets
+		// flags that make transitions *stricter* — it can never cause
+		// unsound acceptance. Gating on `len(errors) == 0` would only
+		// suppress cascading mut-transition errors on already-invalid
+		// code, which is not worth the extra branch.
 		c.propagateCalleeStaticLifetimes(ctx, fnType, expr.Args)
 		return returnType, errors
 	}

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1250,6 +1250,11 @@ func (c *Checker) handleFuncCall(
 			returnType = returnType.Copy()
 			returnType.SetProvenance(provneance)
 		}
+		// Phase 8.5: if the callee marks any parameter `'static` (i.e. the
+		// value escapes into outer-lived state inside the callee), record
+		// the escape on the corresponding argument's alias sets so the
+		// transition checker can reject later mut↔immut transitions.
+		c.propagateCalleeStaticLifetimes(ctx, fnType, expr.Args)
 		return returnType, errors
 	} else {
 		// No rest parameters
@@ -1287,6 +1292,11 @@ func (c *Checker) handleFuncCall(
 			returnType = returnType.Copy()
 			returnType.SetProvenance(provneance)
 		}
+		// Phase 8.5: if the callee marks any parameter `'static` (i.e. the
+		// value escapes into outer-lived state inside the callee), record
+		// the escape on the corresponding argument's alias sets so the
+		// transition checker can reject later mut↔immut transitions.
+		c.propagateCalleeStaticLifetimes(ctx, fnType, expr.Args)
 		return returnType, errors
 	}
 }

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -671,7 +671,7 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 				mut = liveness.AliasMutable
 			}
 			for j := i; j < len(args); j++ {
-				src := liveness.DetermineAliasSource(args[j])
+				src := determineCheckerAliasSource(args[j])
 				switch src.Kind {
 				case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 					for _, vid := range src.VarIDs {
@@ -696,12 +696,12 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 		if isMutableType(p.Type) {
 			mut = liveness.AliasMutable
 		}
-		// Use the liveness alias-source helper (not the checker-aware
-		// variant) because we want the argument's underlying source —
-		// not whatever the call's *return* would alias. Marking each
-		// referenced VarID's alias sets propagates the escape to all
-		// existing aliases of the argument.
-		src := liveness.DetermineAliasSource(args[i])
+		// Use the checker-aware alias-source helper so a nested call whose
+		// return aliases its argument (e.g. an identity-like wrapper)
+		// propagates the escape to the underlying variable. The plain
+		// liveness helper treats every CallExpr as fresh, hiding such
+		// transitive aliases from the static-escape check.
+		src := determineCheckerAliasSource(args[i])
 		switch src.Kind {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 			for _, vid := range src.VarIDs {

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -540,8 +540,9 @@ func arrayElemType(t type_system.Type) type_system.Type {
 // Detection is by VarID: the rename pass assigns positive VarIDs to
 // locals and negative VarIDs to outer-scope references. An assignment
 // whose lvalue root is a non-local identifier (VarID <= 0) is treated
-// as a store into outer-lived state. Stores into locals don't escape
-// because the local's lifetime is bounded by the function body.
+// as a store into storage whose lifetime outlives the callee's stack
+// frame. Stores into locals don't escape because the local's lifetime
+// is bounded by the function body.
 //
 // Limitations:
 //   - Closures over a *nested* function's local: inner functions whose
@@ -634,12 +635,12 @@ func setLifetimeOnType(t type_system.Type, lt type_system.Lifetime) {
 // propagateCalleeStaticLifetimes is the caller-side counterpart of Phase
 // 8.4's escape detection. After a call is type-checked, walk the
 // callee's parameters: any param whose lifetime resolves to `'static`
-// represents a value that the callee stored into outer-lived state.
-// For each such param, mark the corresponding argument variable's alias
-// sets via AliasTracker.MarkStatic with the param's mutability — this
-// records that a permanent reference to the argument has escaped, so
-// the transition checker can flag later mut↔immut transitions on the
-// argument as unsafe.
+// represents a value that the callee stored into storage whose lifetime
+// outlives the callee's stack frame. For each such param, mark the
+// corresponding argument variable's alias sets via AliasTracker.MarkStatic
+// with the param's mutability — this records that a permanent reference
+// to the argument has escaped, so the transition checker can flag later
+// mut↔immut transitions on the argument as unsafe.
 //
 // Has no effect when the call's argument is not a simple identifier
 // (e.g. `f(p.x)` would need projection-path tracking, deferred to a
@@ -657,25 +658,28 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 		// bearing position is the *element* type T, not the Array
 		// container. Every variadic argument from this index onward is
 		// passed as an element, so we mark each one — not just args[i].
-		if _, isRest := p.Pattern.(*type_system.RestPat); isRest {
+		if rp, isRest := p.Pattern.(*type_system.RestPat); isRest {
 			elem := arrayElemType(p.Type)
 			if elem == nil {
 				continue
 			}
-			elemLifetime := type_system.PruneLifetime(type_system.GetLifetime(elem))
-			if !lifetimeContainsStatic(elemLifetime) {
+			// Walk the rest's inner pattern × element type to collect
+			// every leaf-position mutability whose lifetime resolved to
+			// `'static`. This catches both `...args: T[]` (a single
+			// IdentPat leaf) and the destructured form `...[a, b]: ...[]`
+			// where individual elements may escape independently.
+			muts := collectStaticEscapeMutabilities(rp.Pattern, elem)
+			if len(muts) == 0 {
 				continue
-			}
-			mut := liveness.AliasImmutable
-			if isMutableType(elem) {
-				mut = liveness.AliasMutable
 			}
 			for j := i; j < len(args); j++ {
 				src := determineCheckerAliasSource(args[j])
 				switch src.Kind {
 				case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-					for _, vid := range src.VarIDs {
-						ctx.Aliases.MarkStatic(vid, mut)
+					for _, mut := range muts {
+						for _, vid := range src.VarIDs {
+							ctx.Aliases.MarkStatic(vid, mut)
+						}
 					}
 				}
 			}
@@ -685,16 +689,17 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 		if i >= len(args) {
 			break
 		}
-		paramLifetime := type_system.PruneLifetime(type_system.GetLifetime(p.Type))
-		if !lifetimeContainsStatic(paramLifetime) {
+		// Walk the param's pattern × type in lockstep (same shape as
+		// collectParamLeaves) so that destructured leaves carrying
+		// `'static` are detected even when the *outer* param type has no
+		// `'static` annotation. Phase 8.4's setLifetimeOnType attaches
+		// `'static` at the leaf type position only — a tuple- or object-
+		// destructured param with one escaping leaf has no top-level
+		// static lifetime, so a single `GetLifetime(p.Type)` check would
+		// silently miss it.
+		muts := collectStaticEscapeMutabilities(p.Pattern, p.Type)
+		if len(muts) == 0 {
 			continue
-		}
-		// Determine the alias mutability the callee saw — a `mut 'static`
-		// param means a permanent mutable reference escaped, an immutable
-		// `'static` param means a permanent immutable reference escaped.
-		mut := liveness.AliasImmutable
-		if isMutableType(p.Type) {
-			mut = liveness.AliasMutable
 		}
 		// Use the checker-aware alias-source helper so a nested call whose
 		// return aliases its argument (e.g. an identity-like wrapper)
@@ -704,10 +709,102 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 		src := determineCheckerAliasSource(args[i])
 		switch src.Kind {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-			for _, vid := range src.VarIDs {
-				ctx.Aliases.MarkStatic(vid, mut)
+			for _, mut := range muts {
+				for _, vid := range src.VarIDs {
+					ctx.Aliases.MarkStatic(vid, mut)
+				}
 			}
 		}
+	}
+}
+
+// collectStaticEscapeMutabilities walks a callee's parameter pattern in
+// lockstep with its inferred type and returns the alias mutability of
+// every leaf whose pruned lifetime contains `'static`. Pattern shapes
+// match collectParamLeaves / walkPatternForLeaves: IdentPat is a leaf
+// at the param's full type, TuplePat / ObjectPat / RestPat descend into
+// the matching sub-type, ObjShorthandPat is a leaf at the property
+// type, and ObjRestPat is skipped (its container is freshly assembled
+// per call and can't carry a caller-provided lifetime). The mutability
+// is determined per-leaf via isMutableType so a destructured param can
+// emit a mix of mut/immut escapes.
+func collectStaticEscapeMutabilities(pat type_system.Pat, t type_system.Type) []liveness.AliasMutability {
+	var out []liveness.AliasMutability
+	walkPatternForStaticLeaves(pat, t, &out)
+	return out
+}
+
+func walkPatternForStaticLeaves(pat type_system.Pat, t type_system.Type, into *[]liveness.AliasMutability) {
+	if pat == nil || t == nil {
+		return
+	}
+	pt := stripMutabilityWrapper(type_system.Prune(t))
+	switch p := pat.(type) {
+	case *type_system.IdentPat:
+		lt := type_system.PruneLifetime(type_system.GetLifetime(t))
+		if !lifetimeContainsStatic(lt) {
+			return
+		}
+		mut := liveness.AliasImmutable
+		if isMutableType(t) {
+			mut = liveness.AliasMutable
+		}
+		*into = append(*into, mut)
+	case *type_system.TuplePat:
+		tt, ok := pt.(*type_system.TupleType)
+		if !ok {
+			return
+		}
+		for i, elem := range p.Elems {
+			if i >= len(tt.Elems) {
+				break
+			}
+			elemType := tt.Elems[i]
+			if rest, ok := elemType.(*type_system.RestSpreadType); ok {
+				elemType = rest.Type
+			}
+			walkPatternForStaticLeaves(elem, elemType, into)
+		}
+	case *type_system.ObjectPat:
+		ot, ok := pt.(*type_system.ObjectType)
+		if !ok {
+			return
+		}
+		propTypes := make(map[string]type_system.Type)
+		for _, elem := range ot.Elems {
+			if prop, ok := elem.(*type_system.PropertyElem); ok &&
+				prop.Name.Kind == type_system.StrObjTypeKeyKind {
+				propTypes[prop.Name.Str] = prop.Value
+			}
+		}
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *type_system.ObjKeyValuePat:
+				if propType, exists := propTypes[e.Key]; exists {
+					walkPatternForStaticLeaves(e.Value, propType, into)
+				}
+			case *type_system.ObjShorthandPat:
+				propType, exists := propTypes[e.Key]
+				if !exists {
+					continue
+				}
+				lt := type_system.PruneLifetime(type_system.GetLifetime(propType))
+				if !lifetimeContainsStatic(lt) {
+					continue
+				}
+				mut := liveness.AliasImmutable
+				if isMutableType(propType) {
+					mut = liveness.AliasMutable
+				}
+				*into = append(*into, mut)
+			}
+		}
+	case *type_system.RestPat:
+		elem := arrayElemType(t)
+		if elem == nil {
+			return
+		}
+		walkPatternForStaticLeaves(p.Pattern, elem, into)
 	}
 }
 

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -642,9 +642,12 @@ func setLifetimeOnType(t type_system.Type, lt type_system.Lifetime) {
 // to the argument has escaped, so the transition checker can flag later
 // mut↔immut transitions on the argument as unsafe.
 //
-// Has no effect when the call's argument is not a simple identifier
-// (e.g. `f(p.x)` would need projection-path tracking, deferred to a
-// later phase) or when the corresponding leaf has no positive VarID.
+// Argument resolution goes through determineCheckerAliasSource, so the
+// escape propagates through identity-like nested calls whose return
+// type aliases an argument (e.g. `cacheItem(id(p))` marks `p`). Has no
+// effect when no underlying VarID can be resolved — e.g. property
+// projections like `f(p.x)`, which would need projection-path tracking,
+// deferred to a later phase.
 func (c *Checker) propagateCalleeStaticLifetimes(
 	ctx Context,
 	fnType *type_system.FuncType,

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -631,6 +631,104 @@ func setLifetimeOnType(t type_system.Type, lt type_system.Lifetime) {
 	}
 }
 
+// propagateCalleeStaticLifetimes is the caller-side counterpart of Phase
+// 8.4's escape detection. After a call is type-checked, walk the
+// callee's parameters: any param whose lifetime resolves to `'static`
+// represents a value that the callee stored into outer-lived state.
+// For each such param, mark the corresponding argument variable's alias
+// sets via AliasTracker.MarkStatic with the param's mutability — this
+// records that a permanent reference to the argument has escaped, so
+// the transition checker can flag later mut↔immut transitions on the
+// argument as unsafe.
+//
+// Has no effect when the call's argument is not a simple identifier
+// (e.g. `f(p.x)` would need projection-path tracking, deferred to a
+// later phase) or when the corresponding leaf has no positive VarID.
+func (c *Checker) propagateCalleeStaticLifetimes(
+	ctx Context,
+	fnType *type_system.FuncType,
+	args []ast.Expr,
+) {
+	if ctx.Aliases == nil || fnType == nil {
+		return
+	}
+	for i, p := range fnType.Params {
+		// For a rest parameter (`...items: Array<T>`), the lifetime-
+		// bearing position is the *element* type T, not the Array
+		// container. Every variadic argument from this index onward is
+		// passed as an element, so we mark each one — not just args[i].
+		if _, isRest := p.Pattern.(*type_system.RestPat); isRest {
+			elem := arrayElemType(p.Type)
+			if elem == nil {
+				continue
+			}
+			elemLifetime := type_system.PruneLifetime(type_system.GetLifetime(elem))
+			if !lifetimeContainsStatic(elemLifetime) {
+				continue
+			}
+			mut := liveness.AliasImmutable
+			if isMutableType(elem) {
+				mut = liveness.AliasMutable
+			}
+			for j := i; j < len(args); j++ {
+				src := liveness.DetermineAliasSource(args[j])
+				switch src.Kind {
+				case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
+					for _, vid := range src.VarIDs {
+						ctx.Aliases.MarkStatic(vid, mut)
+					}
+				}
+			}
+			return
+		}
+
+		if i >= len(args) {
+			break
+		}
+		paramLifetime := type_system.PruneLifetime(type_system.GetLifetime(p.Type))
+		if !lifetimeContainsStatic(paramLifetime) {
+			continue
+		}
+		// Determine the alias mutability the callee saw — a `mut 'static`
+		// param means a permanent mutable reference escaped, an immutable
+		// `'static` param means a permanent immutable reference escaped.
+		mut := liveness.AliasImmutable
+		if isMutableType(p.Type) {
+			mut = liveness.AliasMutable
+		}
+		// Use the liveness alias-source helper (not the checker-aware
+		// variant) because we want the argument's underlying source —
+		// not whatever the call's *return* would alias. Marking each
+		// referenced VarID's alias sets propagates the escape to all
+		// existing aliases of the argument.
+		src := liveness.DetermineAliasSource(args[i])
+		switch src.Kind {
+		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
+			for _, vid := range src.VarIDs {
+				ctx.Aliases.MarkStatic(vid, mut)
+			}
+		}
+	}
+}
+
+// lifetimeContainsStatic reports whether the given (already pruned)
+// lifetime is `'static` or a LifetimeUnion that contains `'static`. A
+// LifetimeUnion containing `'static` means at least one branch escaped,
+// which is enough to treat the argument as permanently aliased.
+func lifetimeContainsStatic(lt type_system.Lifetime) bool {
+	switch v := lt.(type) {
+	case *type_system.LifetimeValue:
+		return v != nil && v.IsStatic
+	case *type_system.LifetimeUnion:
+		for _, m := range v.Lifetimes {
+			if lifetimeContainsStatic(type_system.PruneLifetime(m)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // InferConstructorLifetimes analyzes a class declaration to determine
 // which constructor parameters are stored as fields (or implicitly
 // captured by method bodies), attaches a fresh LifetimeVar to each such

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -735,131 +735,156 @@ func TestDestructuredParamLeafSeededInAliasTracker(t *testing.T) {
 	assert.Contains(t, mutErrors[0], "cannot assign 'head' to immutable 'q'")
 }
 
-// TestCallSiteStaticEscapeBlocksImmutableAlias exercises Phase 8.5 step 4:
-// when a callee has a `mut 'static` parameter, calling it with a local
-// argument records a permanent mutable escape on the argument's alias
-// sets. A later attempt to freeze the argument as immutable must fail
-// because the permanent external mutable reference could mutate the
-// value while the immutable view assumes it is unchanged.
-func TestCallSiteStaticEscapeBlocksImmutableAlias(t *testing.T) {
-	t.Parallel()
-	mutErrors := mustInferScriptMutErrors(t, `
-		var cache: mut {x: number} = {x: 0}
-		fn cacheItem(item: mut {x: number}) -> number {
-			cache = item
-			return item.x
-		}
-		fn test() {
-			val p: mut {x: number} = {x: 0}
-			cacheItem(p)
-			val frozen: {x: number} = p
-			frozen
-		}
-	`)
-	require.Len(t, mutErrors, 1)
-	assert.Contains(t, mutErrors[0], "cannot assign 'p' to immutable 'frozen'")
-	assert.Contains(t, mutErrors[0], "'static")
-}
+// TestCallSiteStaticEscapePropagation exercises Phase 8.5 step 4: when a
+// callee has a `'static` parameter, the call records a permanent escape
+// on the corresponding argument's alias sets. Subsequent mut↔immut
+// transitions on the argument must observe the escape as an always-live
+// alias of the escaped mutability.
+func TestCallSiteStaticEscapePropagation(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		expectedErrors []string
+	}{
+		// A `mut 'static` escape on the argument blocks a later attempt
+		// to freeze it as immutable: the permanent external mutable
+		// reference could mutate the value while the immutable view
+		// assumes it is unchanged.
+		"MutStaticBlocksImmutableAlias": {
+			input: `
+				var cache: mut {x: number} = {x: 0}
+				fn cacheItem(item: mut {x: number}) -> number {
+					cache = item
+					return item.x
+				}
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					cacheItem(p)
+					val frozen: {x: number} = p
+					frozen
+				}
+			`,
+			expectedErrors: []string{
+				"cannot assign 'p' to immutable 'frozen': a `'static` escape still has mutable access to 'p' after this point",
+			},
+		},
+		// Symmetric immutable case: an immutable `'static` escape on the
+		// argument blocks a later attempt to upgrade it to a mutable
+		// view. Closes the symmetric gap to MutStaticBlocksImmutableAlias.
+		"ImmStaticBlocksMutableAlias": {
+			input: `
+				var cache: {x: number} = {x: 0}
+				fn cacheItem(item: {x: number}) -> number {
+					cache = item
+					return item.x
+				}
+				fn test() {
+					val p: {x: number} = {x: 0}
+					cacheItem(p)
+					val mutp: mut {x: number} = p
+					mutp.x = 5
+					mutp
+				}
+			`,
+			expectedErrors: []string{
+				"cannot assign 'p' to mutable 'mutp': a `'static` escape still has immutable access to 'p' after this point",
+			},
+		},
+		// The caller-side escape marking does NOT block legitimate
+		// mutable use of the argument after the call — the value is
+		// still mutable for the caller, just permanently aliased.
+		"AllowsMutableUseAfterCall": {
+			input: `
+				var cache: mut {x: number} = {x: 0}
+				fn cacheItem(item: mut {x: number}) -> number {
+					cache = item
+					return item.x
+				}
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					cacheItem(p)
+					p.x = 5
+					p
+				}
+			`,
+		},
+		// When a callee has a rest parameter whose elements escape to
+		// `'static`, *every* variadic argument (not just the first)
+		// must be marked. Otherwise later args silently violate the
+		// mut→immut transition rule.
+		"RestParamMarksAllArgs": {
+			input: `
+				var cache: mut Array<mut {x: number}> = []
+				fn cacheAll(...items: Array<mut {x: number}>) -> number {
+					cache = items
+					return 0
+				}
+				fn test() {
+					val a: mut {x: number} = {x: 0}
+					val b: mut {x: number} = {x: 1}
+					cacheAll(a, b)
+					val frozenB: {x: number} = b
+					frozenB
+				}
+			`,
+			expectedErrors: []string{
+				"cannot assign 'b' to immutable 'frozenB': a `'static` escape still has mutable access to 'b' after this point",
+			},
+		},
+		// Caller-side propagation considers per-leaf `'static` lifetimes
+		// on a tuple-destructured parameter, not just the top-level
+		// tuple lifetime. Without leaf-level walking, a callee that
+		// escapes a single tuple element silently drops the marking.
+		"TupleDestructuredLeafEscape": {
+			input: `
+				var cache: mut {x: number} = {x: 0}
+				fn cacheFirst([a, b]: [mut {x: number}, mut {x: number}]) -> number {
+					cache = a
+					return 0
+				}
+				fn test() {
+					val pair: mut [mut {x: number}, mut {x: number}] = [{x: 0}, {x: 1}]
+					cacheFirst(pair)
+					val frozen: [{x: number}, {x: number}] = pair
+					frozen
+				}
+			`,
+			expectedErrors: []string{
+				"cannot assign 'pair' to immutable 'frozen': a `'static` escape still has mutable access to 'pair' after this point",
+			},
+		},
+		// When a static-escape parameter is filled by a nested call
+		// whose return aliases the inner argument, propagation still
+		// records the escape on that underlying argument. Without
+		// checker-aware alias-source resolution, the inner call's
+		// return looks "fresh" and the escape silently disappears.
+		"PropagatesThroughIdentityCall": {
+			input: `
+				var cache: mut {x: number} = {x: 0}
+				fn cacheItem(item: mut {x: number}) -> number {
+					cache = item
+					return item.x
+				}
+				fn id(p: mut {x: number}) -> mut {x: number} { return p }
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					cacheItem(id(p))
+					val frozen: {x: number} = p
+					frozen
+				}
+			`,
+			expectedErrors: []string{
+				"cannot assign 'p' to immutable 'frozen': a `'static` escape still has mutable access to 'p' after this point",
+			},
+		},
+	}
 
-// TestCallSiteStaticEscapeAllowsMutableUse verifies that the caller-side
-// escape marking does NOT block legitimate mutable use of the argument
-// after the call — the value is still mutable for the caller, just
-// permanently aliased.
-func TestCallSiteStaticEscapeAllowsMutableUse(t *testing.T) {
-	t.Parallel()
-	mutErrors := mustInferScriptMutErrors(t, `
-		var cache: mut {x: number} = {x: 0}
-		fn cacheItem(item: mut {x: number}) -> number {
-			cache = item
-			return item.x
-		}
-		fn test() {
-			val p: mut {x: number} = {x: 0}
-			cacheItem(p)
-			p.x = 5
-			p
-		}
-	`)
-	assert.Empty(t, mutErrors,
-		"mutating the argument after a 'static escape is allowed; only mut→immut transitions are blocked")
-}
-
-// TestCallSiteStaticEscapeAllRestArgs verifies that when a callee has a
-// rest parameter whose elements escape to `'static`, *every* variadic
-// argument (not just the first) gets its alias sets marked. Without
-// this, only the first rest arg would be flagged, letting later args
-// silently violate mut→immut transitions.
-func TestCallSiteStaticEscapeAllRestArgs(t *testing.T) {
-	t.Parallel()
-	mutErrors := mustInferScriptMutErrors(t, `
-		var cache: mut Array<mut {x: number}> = []
-		fn cacheAll(...items: Array<mut {x: number}>) -> number {
-			cache = items
-			return 0
-		}
-		fn test() {
-			val a: mut {x: number} = {x: 0}
-			val b: mut {x: number} = {x: 1}
-			cacheAll(a, b)
-			val frozenB: {x: number} = b
-			frozenB
-		}
-	`)
-	require.NotEmpty(t, mutErrors,
-		"freezing 'b' after it escaped via a 'static rest param should be rejected")
-	assert.Contains(t, mutErrors[0], "cannot assign 'b' to immutable 'frozenB'")
-}
-
-// TestCallSiteStaticEscapeOnTupleDestructuredLeaf verifies that
-// caller-side propagation considers per-leaf `'static` lifetimes on a
-// tuple-destructured parameter, not just the top-level tuple lifetime.
-// Without leaf-level walking, a callee that escapes a single tuple
-// element silently drops the caller-side alias-set marking.
-func TestCallSiteStaticEscapeOnTupleDestructuredLeaf(t *testing.T) {
-	t.Parallel()
-	mutErrors := mustInferScriptMutErrors(t, `
-		var cache: mut {x: number} = {x: 0}
-		fn cacheFirst([a, b]: [mut {x: number}, mut {x: number}]) -> number {
-			cache = a
-			return 0
-		}
-		fn test() {
-			val pair: mut [mut {x: number}, mut {x: number}] = [{x: 0}, {x: 1}]
-			cacheFirst(pair)
-			val frozen: [{x: number}, {x: number}] = pair
-			frozen
-		}
-	`)
-	require.Len(t, mutErrors, 1)
-	assert.Contains(t, mutErrors[0], "cannot assign 'pair' to immutable 'frozen'")
-	assert.Contains(t, mutErrors[0], "'static")
-}
-
-// TestCallSiteStaticEscapeThroughIdentityCall verifies that when a
-// static-escape parameter is filled by a *nested* call whose return
-// value aliases the inner argument, the caller-side propagation still
-// records the escape on that underlying argument. Without checker-aware
-// alias-source resolution, the inner call's return looks "fresh" and
-// the escape silently disappears.
-func TestCallSiteStaticEscapeThroughIdentityCall(t *testing.T) {
-	t.Parallel()
-	mutErrors := mustInferScriptMutErrors(t, `
-		var cache: mut {x: number} = {x: 0}
-		fn cacheItem(item: mut {x: number}) -> number {
-			cache = item
-			return item.x
-		}
-		fn id(p: mut {x: number}) -> mut {x: number} { return p }
-		fn test() {
-			val p: mut {x: number} = {x: 0}
-			cacheItem(id(p))
-			val frozen: {x: number} = p
-			frozen
-		}
-	`)
-	require.Len(t, mutErrors, 1)
-	assert.Contains(t, mutErrors[0], "cannot assign 'p' to immutable 'frozen'")
-	assert.Contains(t, mutErrors[0], "'static")
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			mutErrors := mustInferScriptMutErrors(t, tc.input)
+			assert.Equal(t, tc.expectedErrors, mutErrors)
+		})
+	}
 }
 
 // TestCallSiteNoAliasForFreshReturn verifies that a function returning a

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -735,6 +735,81 @@ func TestDestructuredParamLeafSeededInAliasTracker(t *testing.T) {
 	assert.Contains(t, mutErrors[0], "cannot assign 'head' to immutable 'q'")
 }
 
+// TestCallSiteStaticEscapeBlocksImmutableAlias exercises Phase 8.5 step 4:
+// when a callee has a `mut 'static` parameter, calling it with a local
+// argument records a permanent mutable escape on the argument's alias
+// sets. A later attempt to freeze the argument as immutable must fail
+// because the permanent external mutable reference could mutate the
+// value while the immutable view assumes it is unchanged.
+func TestCallSiteStaticEscapeBlocksImmutableAlias(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		var cache: mut {x: number} = {x: 0}
+		fn cacheItem(item: mut {x: number}) -> number {
+			cache = item
+			return item.x
+		}
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			cacheItem(p)
+			val frozen: {x: number} = p
+			frozen
+		}
+	`)
+	require.Len(t, mutErrors, 1)
+	assert.Contains(t, mutErrors[0], "cannot assign 'p' to immutable 'frozen'")
+	assert.Contains(t, mutErrors[0], "'static")
+}
+
+// TestCallSiteStaticEscapeAllowsMutableUse verifies that the caller-side
+// escape marking does NOT block legitimate mutable use of the argument
+// after the call — the value is still mutable for the caller, just
+// permanently aliased.
+func TestCallSiteStaticEscapeAllowsMutableUse(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		var cache: mut {x: number} = {x: 0}
+		fn cacheItem(item: mut {x: number}) -> number {
+			cache = item
+			return item.x
+		}
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			cacheItem(p)
+			p.x = 5
+			p
+		}
+	`)
+	assert.Empty(t, mutErrors,
+		"mutating the argument after a 'static escape is allowed; only mut→immut transitions are blocked")
+}
+
+// TestCallSiteStaticEscapeAllRestArgs verifies that when a callee has a
+// rest parameter whose elements escape to `'static`, *every* variadic
+// argument (not just the first) gets its alias sets marked. Without
+// this, only the first rest arg would be flagged, letting later args
+// silently violate mut→immut transitions.
+func TestCallSiteStaticEscapeAllRestArgs(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		var cache: mut Array<mut {x: number}> = []
+		fn cacheAll(...items: Array<mut {x: number}>) -> number {
+			cache = items
+			return 0
+		}
+		fn test() {
+			val a: mut {x: number} = {x: 0}
+			val b: mut {x: number} = {x: 1}
+			cacheAll(a, b)
+			val frozenB: {x: number} = b
+			frozenB
+		}
+	`)
+	require.NotEmpty(t, mutErrors,
+		"freezing 'b' after it escaped via a 'static rest param should be rejected")
+	assert.Contains(t, mutErrors[0], "cannot assign 'b' to immutable 'frozenB'")
+}
+
 // TestCallSiteNoAliasForFreshReturn verifies that a function returning a
 // fresh value does NOT cause its argument and the result to share an
 // alias set.

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -810,6 +810,31 @@ func TestCallSiteStaticEscapeAllRestArgs(t *testing.T) {
 	assert.Contains(t, mutErrors[0], "cannot assign 'b' to immutable 'frozenB'")
 }
 
+// TestCallSiteStaticEscapeOnTupleDestructuredLeaf verifies that
+// caller-side propagation considers per-leaf `'static` lifetimes on a
+// tuple-destructured parameter, not just the top-level tuple lifetime.
+// Without leaf-level walking, a callee that escapes a single tuple
+// element silently drops the caller-side alias-set marking.
+func TestCallSiteStaticEscapeOnTupleDestructuredLeaf(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		var cache: mut {x: number} = {x: 0}
+		fn cacheFirst([a, b]: [mut {x: number}, mut {x: number}]) -> number {
+			cache = a
+			return 0
+		}
+		fn test() {
+			val pair: mut [mut {x: number}, mut {x: number}] = [{x: 0}, {x: 1}]
+			cacheFirst(pair)
+			val frozen: [{x: number}, {x: number}] = pair
+			frozen
+		}
+	`)
+	require.Len(t, mutErrors, 1)
+	assert.Contains(t, mutErrors[0], "cannot assign 'pair' to immutable 'frozen'")
+	assert.Contains(t, mutErrors[0], "'static")
+}
+
 // TestCallSiteStaticEscapeThroughIdentityCall verifies that when a
 // static-escape parameter is filled by a *nested* call whose return
 // value aliases the inner argument, the caller-side propagation still

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -810,6 +810,33 @@ func TestCallSiteStaticEscapeAllRestArgs(t *testing.T) {
 	assert.Contains(t, mutErrors[0], "cannot assign 'b' to immutable 'frozenB'")
 }
 
+// TestCallSiteStaticEscapeThroughIdentityCall verifies that when a
+// static-escape parameter is filled by a *nested* call whose return
+// value aliases the inner argument, the caller-side propagation still
+// records the escape on that underlying argument. Without checker-aware
+// alias-source resolution, the inner call's return looks "fresh" and
+// the escape silently disappears.
+func TestCallSiteStaticEscapeThroughIdentityCall(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		var cache: mut {x: number} = {x: 0}
+		fn cacheItem(item: mut {x: number}) -> number {
+			cache = item
+			return item.x
+		}
+		fn id(p: mut {x: number}) -> mut {x: number} { return p }
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			cacheItem(id(p))
+			val frozen: {x: number} = p
+			frozen
+		}
+	`)
+	require.Len(t, mutErrors, 1)
+	assert.Contains(t, mutErrors[0], "cannot assign 'p' to immutable 'frozen'")
+	assert.Contains(t, mutErrors[0], "'static")
+}
+
 // TestCallSiteNoAliasForFreshReturn verifies that a function returning a
 // fresh value does NOT cause its argument and the result to share an
 // alias set.

--- a/internal/liveness/alias.go
+++ b/internal/liveness/alias.go
@@ -17,11 +17,20 @@ type SetID int
 // AliasSet tracks a group of variables that reference the same underlying
 // value. Each value created at runtime gets its own AliasSet. Variables
 // join an alias set when assigned from another variable in the set.
+//
+// A value may also have escaped to a location that outlives the function
+// (e.g. stored into a module-level variable via a `'static` parameter at
+// a call site). The HasStaticMutAlias / HasStaticImmAlias flags record
+// whether such an escape happened, and at what mutability — these are
+// independent because the same value can escape twice via different
+// callees, once mutably and once immutably. Transition checking treats
+// these as permanent (always-live) aliases.
 type AliasSet struct {
-	ID       SetID
-	Members  map[VarID]AliasMutability // variable → whether it holds a mut ref
-	Origin   VarID                     // the variable that created the value
-	IsStatic bool                      // true if this value has 'static lifetime
+	ID                SetID
+	Members           map[VarID]AliasMutability // variable → whether it holds a mut ref
+	Origin            VarID                     // the variable that created the value
+	HasStaticMutAlias bool                      // a `mut 'static` reference escaped
+	HasStaticImmAlias bool                      // an immutable `'static` reference escaped
 }
 
 // AliasTracker manages alias sets for a function body.
@@ -186,6 +195,12 @@ func (a *AliasTracker) MergeAliasSets(v1 VarID, v2 VarID) {
 		if source == nil {
 			continue
 		}
+		// Static-escape flags are properties of the underlying value, not
+		// of any individual member. Merging two sets means the values are
+		// being treated as the same value, so any escape on either side
+		// must apply to the merged set.
+		target.HasStaticMutAlias = target.HasStaticMutAlias || source.HasStaticMutAlias
+		target.HasStaticImmAlias = target.HasStaticImmAlias || source.HasStaticImmAlias
 		for member, mut := range source.Members {
 			target.Members[member] = mut
 			// Update VarToSets: replace setID with targetID, deduplicating
@@ -206,6 +221,33 @@ func (a *AliasTracker) MergeAliasSets(v1 VarID, v2 VarID) {
 			a.VarToSets[member] = newSets
 		}
 		delete(a.Sets, setID)
+	}
+}
+
+// MarkStatic records that a `'static` reference to the value(s) v
+// participates in has escaped to a location that outlives the function
+// (e.g. via a callee whose parameter has a `'static` lifetime). All
+// alias sets v belongs to are marked, since they all share the value
+// that escaped.
+//
+// The mutability records the escape's reference mutability, not v's:
+// a `mut 'static` parameter creates a permanent mutable alias somewhere
+// outside, an immutable `'static` parameter creates a permanent
+// immutable alias. The two flags are independent — the same value may
+// escape twice through different callees.
+//
+// Marking is idempotent: re-marking with the same mutability is a no-op.
+func (a *AliasTracker) MarkStatic(v VarID, mut AliasMutability) {
+	for _, setID := range a.VarToSets[v] {
+		set := a.Sets[setID]
+		if set == nil {
+			continue
+		}
+		if mut == AliasMutable {
+			set.HasStaticMutAlias = true
+		} else {
+			set.HasStaticImmAlias = true
+		}
 	}
 }
 

--- a/internal/liveness/alias_test.go
+++ b/internal/liveness/alias_test.go
@@ -162,6 +162,45 @@ func TestMergeAliasSetsNoDuplicateSetIDs(t *testing.T) {
 	}
 }
 
+func TestMergeAliasSetsPropagatesStaticFlags(t *testing.T) {
+	tracker := NewAliasTracker()
+	var x VarID = 1
+	var y VarID = 2
+
+	// y's set has a `mut 'static` escape; x's set has none.
+	tracker.NewValue(x, AliasMutable)
+	tracker.NewValue(y, AliasMutable)
+	tracker.MarkStatic(y, AliasMutable)
+
+	require.True(t, tracker.GetAliasSets(y)[0].HasStaticMutAlias)
+
+	// Merging y into x — x is the target. The static flag from y's set
+	// must be preserved on the merged target.
+	tracker.MergeAliasSets(x, y)
+
+	sets := tracker.GetAliasSets(x)
+	require.Len(t, sets, 1)
+	require.True(t, sets[0].HasStaticMutAlias,
+		"merged set should inherit HasStaticMutAlias from the source set")
+}
+
+func TestMergeAliasSetsPropagatesStaticImmFlag(t *testing.T) {
+	tracker := NewAliasTracker()
+	var x VarID = 1
+	var y VarID = 2
+
+	tracker.NewValue(x, AliasImmutable)
+	tracker.NewValue(y, AliasImmutable)
+	tracker.MarkStatic(y, AliasImmutable)
+
+	tracker.MergeAliasSets(x, y)
+
+	sets := tracker.GetAliasSets(x)
+	require.Len(t, sets, 1)
+	require.True(t, sets[0].HasStaticImmAlias,
+		"merged set should inherit HasStaticImmAlias from the source set")
+}
+
 func TestReassignMulti(t *testing.T) {
 	tracker := NewAliasTracker()
 	var a VarID = 1

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1370,193 +1370,6 @@ Additional tests beyond the original plan:
 **Goal:** Add lifetime annotations to function signatures and infer them from
 function bodies.
 
-### Phase 8 implementation status
-
-The initial Phase 8 PR delivers a foundational subset; the following items are
-**deferred to a follow-up PR** so they can be reviewed and tested in isolation:
-
-- **8.3 element-level vs. container-level lifetimes.** `InferLifetimes`
-  now walks each parameter's pattern in lockstep with the parameter's
-  inferred type via `collectParamLeaves`, producing a list of
-  `(VarID, leafType)` pairs for every leaf binding. Lifetime allocation
-  and attachment use these leaves rather than the top-level param,
-  which generalizes the analysis to:
-  - **Tuple-destructured parameters** (`fn f([a, b]: [mut P, mut P])`):
-    each leaf gets its own lifetime when aliased by a return; only
-    leaves actually returned receive a lifetime, matching the behavior
-    of non-destructured params. The leaf's lifetime is attached to the
-    corresponding sub-position of the param's tuple type and shows up
-    inline in the printed destructured form.
-  - **Rest parameters** (`...args: Array<T>`): the leaf's `leafType`
-    points at the array's *element* type `T` rather than the container,
-    since the array is freshly assembled per call. Returns of `args[i]`
-    inherit the element-level lifetime, producing
-    `<'a>(...args: Array<mut 'a T>) -> mut 'a T`.
-  - As part of this change, `runLivenessPrePass` was fixed to walk
-    destructuring-pattern leaves when computing `astParamNames`,
-    preventing the rename pass from double-defining destructured leaf
-    bindings (once via `renamePat` walking the pattern, once via the
-    `extraParamNames` path). Without that fix the leaf's `IdentPat.VarID`
-    was stale relative to the body's `IdentExpr.VarID`.
-  - **Object-destructured parameters** (`fn g({head, tail}: {head: mut P, tail: mut P})`):
-    the walker now handles `*ast.ObjectPat` by building a key→Type
-    lookup against the corresponding ObjectType's PropertyElems and
-    descending per leaf. Both shorthand (`{ head, tail }`) and
-    key-value (`{ head: first, tail: second }`) patterns are
-    supported. ObjRestPat (`{ ...rest }`) is intentionally skipped —
-    like a function rest param's container, the rest object is
-    freshly assembled per call, and per-property element lifetimes
-    for it are deferred (would require synthesizing a per-call
-    object type).
-- **8.3 generator yield lifetimes.** `InferLifetimes` collects every
-  yield expression (regular AND delegate) alongside `return`
-  expressions. When the function's return type is
-  `Generator<T, TReturn, TNext>` (or `AsyncGenerator<...>`), the
-  yield-side lifetime is attached to T rather than to the Generator
-  container itself, so each yielded value carries the lifetime.
-  Concretely,
-  `fn iter(p: mut Point) -> Generator<mut Point, void, never> { yield p }`
-  infers `<'a>(p: mut 'a Point) -> Generator<mut 'a Point, void, never>`.
-  For `yield from iter`, the iterator expression itself is the alias
-  source — each yielded element borrows from `iter`, so the relay
-  generator's yield T inherits `iter`'s lifetime. Concretely,
-  `fn relay(g: Generator<mut Point, void, never>) { yield from g }`
-  infers `<'a>(g: 'a Generator<mut 'a Point, void, never>) -> Generator<mut 'a Point, void, never>`
-  (g's container picks up the alias-source 'a directly; the inner T
-  ends up with 'a too because the underlying type instance is shared
-  with the relay's yield T — see "shared-instance overspecification"
-  below).
-- **8.3 generator `TReturn` lifetimes.** `inferLifetimesCore` was
-  refactored to call a per-result-position helper
-  (`attachLifetimeToResult`) twice for generators: once for yields →
-  yield T, once for `return expr` paths → TReturn. Each result
-  position is inferred independently, so a generator that yields one
-  parameter and returns another gets distinct lifetime variables on
-  the two slots; when both alias the *same* parameter, the
-  pre-existing-LifetimeVar reuse path keeps a single 'a flowing to
-  both positions. Concretely,
-  `fn iter(p: mut Point, q: mut Point) -> Generator<mut Point, mut Point, never> { yield p; return q }`
-  infers `<'a, 'b>(p: mut 'a Point, q: mut 'b Point) -> Generator<mut 'a Point, mut 'b Point, never>`.
-  `inferFuncBodyWithFuncSigType` was extended to call `InferLifetimes`
-  in the generator branch (which previously short-circuited).
-- **8.3 async generators.** `inferLifetimesCore` is now exercised
-  end-to-end for async generators (`async fn` containing `yield`):
-  `generatorYieldType` already recognized
-  `AsyncGenerator<T, TReturn, TNext>` so yields flow to T. A simple
-  test (`AsyncGeneratorYieldsAliasParam`) confirms parameter-aliasing
-  yields produce
-  `<'a>(p: mut 'a Point) -> AsyncGenerator<mut 'a Point, void, never>`.
-  The TReturn refactor above also runs for async generators, since
-  the per-result-position helper is invoked uniformly for both
-  Generator and AsyncGenerator. Returns in an async generator
-  populate TReturn directly (they do not wrap into Promise — the
-  AsyncGenerator wrapper is the only synthesis the compiler does).
-
-  Still deferred — **shared-instance overspecification (#507).** When a
-  generator's body has multiple `yield` paths whose value types are
-  structurally identical (e.g.
-  `if cond { yield a } else { yield b }` with both params
-  `mut {x: number}`), `NewUnionType` collapses the
-  yielded-types list to a single instance — which is one of the
-  parameter types. The result-side `setLifetimeOnType` then
-  overwrites that param's individual lifetime with the union, leaking
-  `('a | 'b)` onto the param's annotation instead of just 'a. The
-  same pointer-sharing also produces overspecified output for
-  `yield from g`: g's inner T ends up with 'a too, even though only
-  g's container needs it. Both cases are sound (the compiler is
-  *over*-constraining) but visually misleading. Fixing properly
-  requires shallow-cloning the yield T / TReturn type before
-  attaching a result-side lifetime, so the result position can carry
-  a different lifetime than any param it shares structure with.
-  Tracked in
-  [#507](https://github.com/escalier-lang/escalier/issues/507).
-- **8.4 escaping reference detection.** `DetectEscapingRefs` walks a
-  function body for assignment expressions whose lvalue root is a
-  non-local identifier (VarID ≤ 0, set by the rename pass for
-  outer-scope references) and whose RHS aliases one of the function's
-  parameters. Such parameters are assigned `'static` directly via a
-  `LifetimeValue{IsStatic: true}` on their type, bypassing the regular
-  fresh-`'a` allocation path. When the function also returns an
-  escaping param, the return type inherits `'static` (combined with any
-  non-escaping return-aliased lifetimes via `LifetimeUnion`).
-  Limitations: closures over a *nested* function's local will still
-  mark a param as `'static` (over-conservative but sound — the
-  borrow-checker accepts a stricter signature); stores via property
-  assignment whose root is a local but is itself stored elsewhere are
-  not chained-tracked.
-- **8.6 implicit captures from method bodies.** `InferConstructorLifetimes`
-  now walks instance method bodies looking for `IdentExpr` references
-  whose name matches a constructor parameter, and adds matching indices
-  to `storedParams` so the constructor gets a lifetime on those params.
-  The walk respects shadowing introduced by inner function params and
-  by `let`/`var` declarations within the method body, and skips static
-  methods, nested classes, and nested function declarations. The
-  matching is by name (not VarID) because `InferConstructorLifetimes`
-  runs during the namespace placeholder phase, before the rename pass
-  populates VarIDs on identifiers in method bodies.
-
-  **Status note:** the analysis is in place but currently dormant
-  end-to-end, because Escalier's method-body scope does not (yet) bring
-  constructor parameters into scope by name — `class C(p) { foo(self) { return p } }`
-  produces an "Unknown identifier: p" type error today. Once the
-  language wires constructor params into method-body scope, the
-  capture detection will activate without further changes.
-
-  Still deferred: feeding the captured-param VarID set into
-  `InferLifetimes` so that the *method's* return type inherits the
-  captured param's lifetime (e.g. `foo<'a>('a self) -> mut 'a Point`).
-  The constructor-side lifetime — which is the soundness-critical part
-  — is now handled.
-- **8.6 storage through nested expressions and literals.** Field-init
-  expressions are now walked structurally by `findCapturedParamsInExpr`,
-  which descends into object literals (including shorthand props),
-  tuple literals, member/index access, type casts, await, and
-  conditional branches. Function-call initializers (`x: f(p)`) are
-  still not analyzed — calls are treated as fresh; tightening this
-  would require lifetime info from callees that may not yet be
-  resolved at the point where `InferConstructorLifetimes` runs.
-- **8.6 non-identity field-initializer expressions.** `field: p.x`,
-  `field: {inner: p}`, `field: [p, q]`, and analogous projection /
-  composite expressions are now recognized via the
-  `findCapturedParamsInExpr` walker described above.
-  Intermediate-let bindings inside a class-body initializer are still
-  not tracked (none of the field initializers in scope today are
-  multi-statement blocks).
-- **8.7 mutually recursive fixed-point iteration.** `InferComponent` now
-  does a single re-run pass over the FuncDecls in any SCC of size > 1
-  after their initial inference. The re-run picks up lifetimes for any
-  function that didn't infer them on its first pass — its peers may now
-  have lifetime info that wasn't available the first time. Functions
-  that DID infer lifetimes on the first pass are skipped by
-  `InferLifetimes`' early-return guard.
-  This required two supporting fixes: (1) `InferLifetimes` now uses
-  `determineCheckerAliasSource` (the call-aware variant) when collecting
-  return-source aliases, so peer-function lifetimes propagate through
-  call expressions; (2) `determineCheckerAliasSource` no longer gates
-  on `fnType.LifetimeParams` being non-empty — by the time a call is
-  type-checked, callee-side instantiation may have cleared
-  `LifetimeParams` while leaving the lifetime vars themselves attached
-  to the param/return types. Presence of a lifetime on the return type
-  is now the authoritative signal.
-  Still deferred: a true fixed-point loop that iterates until no
-  changes (the current implementation does exactly one re-run, which
-  is enough for most 2-cycle mutual recursion cases but not for chains
-  requiring 3+ iterations).
-- **`LifetimeUnion` inference at call sites.** Verified end-to-end via
-  `TestCallSiteAliasFromLifetimeUnion`: when a function returning
-  `('a | 'b) Point` is called, the result variable joins the alias
-  sets of *both* arguments via `lifetimeVarIDs` walking the union
-  members and matching against each parameter's lifetime. The behavior
-  was already correct for two-branch unions; the `determineCheckerAliasSource`
-  change for Phase 8.7 (no longer gating on `LifetimeParams`) made this
-  work robustly even after callee instantiation clears the
-  `LifetimeParams` list.
-
-The deferred items do not block the rest of Phase 8 from being usable: callers
-of annotated or inferred functions get correct alias-set updates for
-single-source returns and constructor parameters, which is the most common
-case.
-
 ### 8.1 Parser Changes — Lifetime Syntax
 
 Extend the parser to recognize lifetime parameters in function declarations
@@ -1803,7 +1616,110 @@ In practice, the inference examines the return expression's structure:
 after the body has been type-checked. Attach the inferred lifetimes to the
 `FuncType`.
 
-### 8.4 Escaping Reference Detection
+#### Status
+
+- **Per-leaf lifetimes from destructured parameters (Done).**
+  `InferLifetimes` walks each parameter's pattern in lockstep with the
+  parameter's inferred type via `collectParamLeaves`, producing a list of
+  `(VarID, leafType)` pairs for every leaf binding. Lifetime allocation
+  and attachment use these leaves rather than the top-level param,
+  generalizing the analysis to:
+  - **Tuple-destructured parameters** (`fn f([a, b]: [mut P, mut P])`):
+    each leaf gets its own lifetime when aliased by a return; only
+    leaves actually returned receive a lifetime, matching the behavior
+    of non-destructured params. The leaf's lifetime is attached to the
+    corresponding sub-position of the param's tuple type and shows up
+    inline in the printed destructured form.
+  - **Object-destructured parameters**
+    (`fn g({head, tail}: {head: mut P, tail: mut P})`): the walker
+    handles `*ast.ObjectPat` by building a key→Type lookup against the
+    corresponding ObjectType's PropertyElems and descending per leaf.
+    Both shorthand (`{ head, tail }`) and key-value
+    (`{ head: first, tail: second }`) patterns are supported. ObjRestPat
+    (`{ ...rest }`) is intentionally skipped — like a function rest
+    param's container, the rest object is freshly assembled per call,
+    and per-property element lifetimes for it are deferred (would
+    require synthesizing a per-call object type).
+  - **Rest parameters** (`...args: Array<T>`): the leaf's `leafType`
+    points at the array's *element* type `T` rather than the container,
+    since the array is freshly assembled per call. Returns of `args[i]`
+    inherit the element-level lifetime, producing
+    `<'a>(...args: Array<mut 'a T>) -> mut 'a T`.
+  - As part of this change, `runLivenessPrePass` was fixed to walk
+    destructuring-pattern leaves when computing `astParamNames`,
+    preventing the rename pass from double-defining destructured leaf
+    bindings (once via `renamePat` walking the pattern, once via the
+    `extraParamNames` path). Without that fix the leaf's `IdentPat.VarID`
+    was stale relative to the body's `IdentExpr.VarID`.
+
+- **Generator yield lifetimes (Done).** `InferLifetimes` collects every
+  yield expression (regular AND delegate) alongside `return`
+  expressions. When the function's return type is
+  `Generator<T, TReturn, TNext>` (or `AsyncGenerator<...>`), the
+  yield-side lifetime is attached to T rather than to the Generator
+  container itself, so each yielded value carries the lifetime.
+  Concretely,
+  `fn iter(p: mut Point) -> Generator<mut Point, void, never> { yield p }`
+  infers `<'a>(p: mut 'a Point) -> Generator<mut 'a Point, void, never>`.
+  For `yield from iter`, the iterator expression itself is the alias
+  source — each yielded element borrows from `iter`, so the relay
+  generator's yield T inherits `iter`'s lifetime. Concretely,
+  `fn relay(g: Generator<mut Point, void, never>) { yield from g }`
+  infers `<'a>(g: 'a Generator<mut 'a Point, void, never>) -> Generator<mut 'a Point, void, never>`
+  (g's container picks up the alias-source 'a directly; the inner T
+  ends up with 'a too because the underlying type instance is shared
+  with the relay's yield T — see "shared-instance overspecification"
+  below).
+
+- **Generator `TReturn` lifetimes (Done).** `inferLifetimesCore` calls a
+  per-result-position helper (`attachLifetimeToResult`) twice for
+  generators: once for yields → yield T, once for `return expr` paths →
+  TReturn. Each result position is inferred independently, so a
+  generator that yields one parameter and returns another gets distinct
+  lifetime variables on the two slots; when both alias the *same*
+  parameter, the pre-existing-LifetimeVar reuse path keeps a single 'a
+  flowing to both positions. Concretely,
+  `fn iter(p: mut Point, q: mut Point) -> Generator<mut Point, mut Point, never> { yield p; return q }`
+  infers `<'a, 'b>(p: mut 'a Point, q: mut 'b Point) -> Generator<mut 'a Point, mut 'b Point, never>`.
+  `inferFuncBodyWithFuncSigType` was extended to call `InferLifetimes`
+  in the generator branch (which previously short-circuited).
+
+- **Async generators (Done).** `inferLifetimesCore` is exercised
+  end-to-end for async generators (`async fn` containing `yield`):
+  `generatorYieldType` already recognized
+  `AsyncGenerator<T, TReturn, TNext>` so yields flow to T. A simple
+  test (`AsyncGeneratorYieldsAliasParam`) confirms parameter-aliasing
+  yields produce
+  `<'a>(p: mut 'a Point) -> AsyncGenerator<mut 'a Point, void, never>`.
+  The TReturn refactor above also runs for async generators, since the
+  per-result-position helper is invoked uniformly for both Generator
+  and AsyncGenerator. Returns in an async generator populate TReturn
+  directly (they do not wrap into Promise — the AsyncGenerator wrapper
+  is the only synthesis the compiler does).
+
+- **Deferred — shared-instance overspecification (#507).** When a
+  generator's body has multiple `yield` paths whose value types are
+  structurally identical (e.g. `if cond { yield a } else { yield b }`
+  with both params `mut {x: number}`), `NewUnionType` collapses the
+  yielded-types list to a single instance — which is one of the
+  parameter types. The result-side `setLifetimeOnType` then overwrites
+  that param's individual lifetime with the union, leaking
+  `('a | 'b)` onto the param's annotation instead of just 'a. The same
+  pointer-sharing also produces overspecified output for
+  `yield from g`: g's inner T ends up with 'a too, even though only g's
+  container needs it. Both cases are sound (the compiler is
+  *over*-constraining) but visually misleading. Fixing properly
+  requires shallow-cloning the yield T / TReturn type before attaching
+  a result-side lifetime, so the result position can carry a different
+  lifetime than any param it shares structure with. Tracked in
+  [#507](https://github.com/escalier-lang/escalier/issues/507).
+
+- **Deferred — propagating lifetimes through nested calls into other
+  functions (Phase 8.9 territory).** Element-level lifetimes
+  (`Array<'a T>`) for fresh containers whose elements alias a parameter
+  are covered by Phase 8.9 (projection-path alias source).
+
+### 8.4 Escaping Reference Detection (Done)
 
 When a function stores a parameter into a location that outlives the function
 (e.g. a module-level variable, an object property that escapes), the parameter
@@ -1826,7 +1742,27 @@ Escaping locations include:
 - Properties of objects that are themselves module-level
 - Return values (handled by lifetime inference, not escaping detection)
 
-### 8.5 Effect on Callers — Alias Set Updates
+#### Status
+
+Implemented as `detectEscapingLeafIndices` in
+`internal/checker/infer_lifetime.go`. It walks a function body for
+assignment expressions whose lvalue root is a non-local identifier
+(VarID ≤ 0, set by the rename pass for outer-scope references) and
+whose RHS aliases one of the function's parameters. Such parameters are
+assigned `'static` directly via a `LifetimeValue{IsStatic: true}` on
+their type, bypassing the regular fresh-`'a` allocation path. When the
+function also returns an escaping param, the return type inherits
+`'static` (combined with any non-escaping return-aliased lifetimes via
+`LifetimeUnion`).
+
+**Limitations:**
+- Closures over a *nested* function's local will still mark a param as
+  `'static` (over-conservative but sound — the borrow-checker accepts a
+  stricter signature).
+- Stores via property assignment whose root is a local but is itself
+  stored elsewhere are not chained-tracked.
+
+### 8.5 Effect on Callers — Alias Set Updates (Done)
 
 When a function with lifetime annotations is called, the caller's alias
 tracker must be updated:
@@ -1853,6 +1789,44 @@ func (c *Checker) updateAliasesFromCall(
     resultVarID VarID,
 ) { ... }
 ```
+
+#### Status
+
+- **Return-side aliasing (Done).** Handled by
+  `determineCheckerAliasSource` (the call-aware variant of
+  `liveness.DetermineAliasSource`): when the callee's return type
+  carries a `LifetimeVar` shared with one or more parameter types, the
+  call expression's alias source forwards the matching argument's
+  underlying VarIDs. This is wired into `trackAliasesForVarDecl`,
+  `trackAliasesForAssignment`, and `trackAliasesForPropAssignment`, so
+  `let r = f(p)` (and assignment / property-store equivalents) joins
+  `r` to `p`'s alias set.
+
+- **`LifetimeUnion` inference at call sites (Done).** Verified
+  end-to-end via `TestCallSiteAliasFromLifetimeUnion`: when a function
+  returning `('a | 'b) Point` is called, the result variable joins the
+  alias sets of *both* arguments via `lifetimeVarIDs` walking the union
+  members and matching against each parameter's lifetime. The behavior
+  was already correct for two-branch unions; the
+  `determineCheckerAliasSource` change for Phase 8.7 (no longer gating
+  on `LifetimeParams`) made this work robustly even after callee
+  instantiation clears the `LifetimeParams` list.
+
+- **`'static` argument propagation (Done).**
+  `propagateCalleeStaticLifetimes` runs at the end of `handleFuncCall`:
+  for each callee parameter whose (pruned) lifetime is `'static` (or a
+  `LifetimeUnion` containing `'static`), the helper marks the
+  argument's underlying alias sets via `AliasTracker.MarkStatic`,
+  recording a permanent mutable or immutable external alias depending
+  on the parameter's mutability. `checkMutabilityTransition` then
+  treats those static flags as always-live conflicts — a
+  `mut → immutable` transition on a value with `HasStaticMutAlias` is
+  rejected, and an `immutable → mut` transition on a value with
+  `HasStaticImmAlias` is rejected. The error is rendered as a
+  `<static escape>` conflict in the existing
+  `MutabilityTransitionError`. Covered by
+  `TestCallSiteStaticEscapeBlocksImmutableAlias` and
+  `TestCallSiteStaticEscapeAllowsMutableUse`.
 
 ### 8.6 Constructor Lifetime Inference
 
@@ -1956,6 +1930,49 @@ parameters, explicit annotation is required (or inference determines the
 lifetimes from the class definition, which is the common case since
 constructors always have bodies).
 
+#### Status
+
+- **Implicit captures from method bodies.** `InferConstructorLifetimes`
+  walks instance method bodies looking for `IdentExpr` references whose
+  name matches a constructor parameter, and adds matching indices to
+  `storedParams` so the constructor gets a lifetime on those params.
+  The walk respects shadowing introduced by inner function params and
+  by `let`/`var` declarations within the method body, and skips static
+  methods, nested classes, and nested function declarations. The
+  matching is by name (not VarID) because `InferConstructorLifetimes`
+  runs during the namespace placeholder phase, before the rename pass
+  populates VarIDs on identifiers in method bodies.
+
+  **Status note:** the analysis is in place but currently dormant
+  end-to-end, because Escalier's method-body scope does not (yet) bring
+  constructor parameters into scope by name —
+  `class C(p) { foo(self) { return p } }` produces an
+  "Unknown identifier: p" type error today. Once the language wires
+  constructor params into method-body scope, the capture detection will
+  activate without further changes.
+
+  **Still deferred:** feeding the captured-param VarID set into
+  `InferLifetimes` so that the *method's* return type inherits the
+  captured param's lifetime (e.g.
+  `foo<'a>('a self) -> mut 'a Point`). The constructor-side lifetime —
+  which is the soundness-critical part — is now handled.
+
+- **Storage through nested expressions and literals (Done).** Field-init
+  expressions are walked structurally by `findCapturedParamsInExpr`,
+  which descends into object literals (including shorthand props),
+  tuple literals, member/index access, type casts, await, and
+  conditional branches. Function-call initializers (`x: f(p)`) are
+  still not analyzed — calls are treated as fresh; tightening this
+  would require lifetime info from callees that may not yet be
+  resolved at the point where `InferConstructorLifetimes` runs.
+
+- **Non-identity field-initializer expressions (Done).** `field: p.x`,
+  `field: {inner: p}`, `field: [p, q]`, and analogous projection /
+  composite expressions are recognized via the
+  `findCapturedParamsInExpr` walker described above. Intermediate-let
+  bindings inside a class-body initializer are still not tracked (none
+  of the field initializers in scope today are multi-statement blocks).
+
 ### 8.7 Recursive and Mutually Recursive Functions
 
 For recursive functions, lifetime inference works the same as for non-recursive
@@ -1971,6 +1988,31 @@ For mutually recursive functions, use fixed-point iteration:
 **Integration:** The existing dependency graph (`internal/dep_graph/`) already
 identifies mutual recursion groups. Extend it to iterate lifetime inference
 within each group.
+
+#### Status
+
+- **Mutually recursive single-pass re-run (Done).** `InferComponent`
+  does a single re-run pass over the FuncDecls in any SCC of size > 1
+  after their initial inference. The re-run picks up lifetimes for any
+  function that didn't infer them on its first pass — its peers may now
+  have lifetime info that wasn't available the first time. Functions
+  that DID infer lifetimes on the first pass are skipped by
+  `InferLifetimes`' early-return guard.
+
+  This required two supporting fixes: (1) `InferLifetimes` uses
+  `determineCheckerAliasSource` (the call-aware variant) when collecting
+  return-source aliases, so peer-function lifetimes propagate through
+  call expressions; (2) `determineCheckerAliasSource` no longer gates
+  on `fnType.LifetimeParams` being non-empty — by the time a call is
+  type-checked, callee-side instantiation may have cleared
+  `LifetimeParams` while leaving the lifetime vars themselves attached
+  to the param/return types. Presence of a lifetime on the return type
+  is now the authoritative signal.
+
+- **Still deferred:** a true fixed-point loop that iterates until no
+  changes (the current implementation does exactly one re-run, which is
+  enough for most 2-cycle mutual recursion cases but not for chains
+  requiring 3+ iterations).
 
 ### 8.8 Tests
 
@@ -2304,6 +2346,33 @@ class Pair(a: mut Point, b: mut Point) {
 
 **Goal:** Integrate lifetime variables into the type unification engine so
 that lifetimes are propagated through type inference.
+
+**Follow-ups after Phase 9 completes:** Phase 9 makes inferred lifetimes
+user-visible in signatures, which raises the cost of Phase 8.4's
+remaining false-positive / false-negative cases. Two limitations are
+worth revisiting together at that point — they touch the same file and
+similar visitor patterns, so bundling them is cheaper than two passes:
+
+1. **Closures over a *nested* function's local.** Generalize
+   `detectEscapingLeafIndices` to walk into nested function bodies
+   while maintaining a scope-frontier of "locals belonging to *our*
+   function," using the `methodCaptureVisitor` (8.6) as a template.
+   See §8.4's limitations note for the analysis sketch.
+
+2. **Chained property-stores through a local intermediary.** Today the
+   detector looks only at the *syntactic root* of an assignment's
+   lvalue: `globalCache = p` is flagged, but
+   `val local = globalCache; local.wrap = p` is not, because
+   `local`'s VarID is positive. Fixing this requires consulting the
+   alias tracker at each store site (`is the lvalue root in an alias
+   set that contains a non-local binding?`) and treating prior
+   `nonLocal.field = local` stores as marking `local`'s alias set
+   already-escaped, so subsequent stores through `local` count too.
+   Concretely this requires running escape detection *after* alias
+   tracking (or interleaving them) rather than as a pre-pass, since
+   the necessary alias-set info isn't built yet at the current call
+   point. See §8.4's limitations note for the shapes that fall
+   through the gap today.
 
 ### 9.1 Lifetime Variable Binding
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for `'static` escape conflicts with clearer mutability-specific formatting.
  * Mutability-transition checks now treat `'static`-escaped aliases as permanent conflicts, preventing invalid mut↔immut conversions.
  * `'static` escape propagation now applies through function calls, including variadic/rest arguments.

* **Tests**
  * Added tests covering call-site static-escape behavior and mutability transition outcomes.

* **Documentation**
  * Updated lifetime implementation plan/status to reflect completed work and remaining follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->