### PR TITLE
Finish 8.6, 8.7, 8.8 - Lifetimes

### DIFF
--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1087,8 +1088,20 @@ func (c *Checker) InferComponent(
 						if methodType != nil {
 							paramBindings := make(map[string]*type_system.Binding)
 
-							// For instance methods, add 'self' parameter
+							// For instance methods, add 'self' parameter and the
+							// enclosing class's constructor params. Escalier
+							// allows method bodies to reference constructor
+							// parameters by name (the analysis in
+							// InferConstructorLifetimes already relies on this);
+							// these copies make the names resolvable during type
+							// checking and the rename/liveness pre-pass. Method
+							// params declared with the same name are added below
+							// and overwrite the constructor binding, preserving
+							// the shadowing semantics covered by
+							// MethodBodyShadowedParamNotCaptured.
 							if !isStatic {
+								maps.Copy(paramBindings, paramBindingsForDecl[decl])
+
 								// We use the name of the class as the type here to avoid
 								// a RecursiveUnificationError.
 								// TODO: handle generic classes
@@ -1166,8 +1179,12 @@ func (c *Checker) InferComponent(
 						if getterType != nil {
 							paramBindings := make(map[string]*type_system.Binding)
 
-							// For instance getters, add 'self' parameter
+							// For instance getters, add 'self' and the enclosing
+							// class's constructor params (see the matching note
+							// in the MethodElem case above for rationale).
 							if !isStatic {
+								maps.Copy(paramBindings, paramBindingsForDecl[decl])
+
 								// We use the name of the class as the type here to avoid
 								// a RecursiveUnificationError.
 								// TODO: handle generic classes
@@ -1234,8 +1251,14 @@ func (c *Checker) InferComponent(
 						if setterType != nil {
 							paramBindings := make(map[string]*type_system.Binding)
 
-							// For instance setters, add 'self' parameter
+							// For instance setters, add 'self' and the enclosing
+							// class's constructor params (see the matching note
+							// in the MethodElem case above for rationale). The
+							// setter's own value param is added below and
+							// shadows any constructor binding sharing its name.
 							if !isStatic {
+								maps.Copy(paramBindings, paramBindingsForDecl[decl])
+
 								// We use the name of the class as the type here to avoid
 								// a RecursiveUnificationError.
 								// TODO: handle generic classes
@@ -1283,39 +1306,50 @@ func (c *Checker) InferComponent(
 		}
 	}
 
-	// Phase 8.7 (best-effort): for SCCs of size > 1 (mutually recursive
-	// function groups), do a single re-run pass over the component's
-	// FuncDecls. The re-run picks up lifetimes for any function that
-	// didn't infer them on its first pass — its peers may now have
-	// lifetime info via determineCheckerAliasSource that wasn't
-	// available the first time. The re-run uses ReinferLifetimes
-	// (instead of InferLifetimes) so that functions whose first pass
-	// already inferred SOME lifetimes can still pick up additional ones
-	// via newly-resolved peer signatures (e.g. a return path through a
-	// peer call whose lifetime wasn't yet known on the first pass).
+	// Phase 8.7: for SCCs of size > 1 (mutually recursive function
+	// groups), iterate lifetime inference to a fixed point. Each pass
+	// can pick up additional lifetimes for functions whose peers gained
+	// lifetime info on the previous pass (visible through
+	// determineCheckerAliasSource). The loop terminates when a full
+	// pass over the component grows no function's LifetimeParams. The
+	// re-run uses ReinferLifetimes (instead of InferLifetimes) so that
+	// functions whose earlier pass already inferred SOME lifetimes can
+	// still acquire additional ones via newly-resolved peer signatures.
 	// User-explicit lifetimes (declared in the AST) are preserved by
 	// skipping the reinfer entry point for those decls.
 	//
-	// This is a one-pass re-run, not a true fixed-point — chains
-	// requiring 3+ iterations still won't converge fully. In practice
-	// most mutual-recursion cases need at most one re-run because
-	// Tarjan's SCC ordering processes each function's callees first
-	// within a simple cycle.
+	// `maxIterations` guards against pathological non-convergence. The
+	// loop is monotonic (each pass can only *add* LifetimeParams, never
+	// remove them) and the worst-case chain length within an SCC is
+	// `len(component) - 1` forwarding hops, so that bound is sufficient
+	// to reach a fixed point. If type-checking is ever flagged as slow
+	// on large SCCs, profile before tightening this.
 	if len(component) > 1 {
-		for _, key := range sortedForDefs {
-			for _, decl := range depGraph.GetDecls(key) {
-				fd, ok := decl.(*ast.FuncDecl)
-				if !ok || fd.Body == nil {
-					continue
+		maxIterations := len(component) - 1
+		for range maxIterations {
+			grew := false
+			for _, key := range sortedForDefs {
+				for _, decl := range depGraph.GetDecls(key) {
+					fd, ok := decl.(*ast.FuncDecl)
+					if !ok || fd.Body == nil {
+						continue
+					}
+					ft, ok := funcTypeForDecl[fd]
+					if !ok || ft == nil {
+						continue
+					}
+					if len(fd.FuncSig.LifetimeParams) > 0 {
+						continue
+					}
+					before := len(ft.LifetimeParams)
+					c.ReinferLifetimes(fd.FuncSig.Params, fd.Body, ft, fd.FuncSig.Async)
+					if len(ft.LifetimeParams) > before {
+						grew = true
+					}
 				}
-				ft, ok := funcTypeForDecl[fd]
-				if !ok || ft == nil {
-					continue
-				}
-				if len(fd.FuncSig.LifetimeParams) > 0 {
-					continue
-				}
-				c.ReinferLifetimes(fd.FuncSig.Params, fd.Body, ft, fd.FuncSig.Async)
+			}
+			if !grew {
+				break
 			}
 		}
 	}

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -2268,7 +2268,7 @@ func TestCheckModuleTypeAliases(t *testing.T) {
 				type ContainerOfContainers = Container<NumberContainer>
 			`,
 			expectedTypes: map[string]string{
-				"NumberContainer":      "{items: number}",
+				"NumberContainer":       "{items: number}",
 				"ContainerOfContainers": "{items: NumberContainer}",
 			},
 		},

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -149,6 +149,30 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"odd":  "fn <'a>(p: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
 			},
 		},
+		"MutuallyRecursiveThreeCycle": {
+			// Phase 8.7 (fixed-point): three mutually-recursive functions
+			// where only one has a base-case `return p`. The two
+			// forwarding functions can only acquire the lifetime once
+			// their peer has it, so worst-case ordering needs more than
+			// one re-run pass — exercising the fixed-point loop.
+			input: `
+				fn a(p: mut {x: number}, n: number) -> mut {x: number} {
+					if n == 0 { return p }
+					return b(p, n - 1)
+				}
+				fn b(p: mut {x: number}, n: number) -> mut {x: number} {
+					return c(p, n)
+				}
+				fn c(p: mut {x: number}, n: number) -> mut {x: number} {
+					return a(p, n)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"a": "fn <'a>(p: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
+				"b": "fn <'a>(p: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
+				"c": "fn <'a>(p: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
+			},
+		},
 		"GeneratorYieldsAliasParam": {
 			// Phase 8.3: a generator that yields a parameter should
 			// propagate the parameter's lifetime to the yield type T
@@ -634,6 +658,28 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"C": "{new fn (p: mut {x: number}) -> C, make() -> number}",
+			},
+		},
+		"MethodBodyResolvesConstructorParam": {
+			// Phase 8.6: with constructor params now wired into instance
+			// method scope, a method body that references a constructor
+			// param by name type-checks (previously this failed with
+			// "Unknown identifier: p"). The constructor still acquires
+			// the lifetime from the capture; threading it onto the
+			// method's own return type (so `foo` would print as
+			// `foo(self) -> mut 'a {x: number}`) is deferred to Phase 9
+			// lifetime unification, which is why `foo`'s expected
+			// signature here has no `'a`.
+			input: `
+				class C(p: mut {x: number}) {
+					foo(self) -> mut {x: number} { return p }
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn <'a>(p: mut 'a {x: number}) -> C<'a>}",
+			},
+			expectedInstanceType: map[string]string{
+				"C": "{foo(self) -> mut {x: number}}",
 			},
 		},
 	}

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1937,7 +1937,7 @@ constructors always have bodies).
   `IdentExpr` references whose name matches a constructor parameter,
   and adds matching indices to `storedParams` so the constructor gets a
   lifetime on those params. The walk respects shadowing introduced by
-  inner function params and by `let`/`var` declarations within the
+  inner function params and by `val`/`var` declarations within the
   method body, and skips static methods, nested classes, and nested
   function declarations. The matching is by name (not VarID) because
   `InferConstructorLifetimes` runs during the namespace placeholder
@@ -2012,6 +2012,13 @@ within each group.
   set), and skips any decl whose `FuncSig.LifetimeParams` is non-empty
   to preserve user-declared annotations. 3-cycle convergence is
   covered by `TestInferLifetimeTypes/MutuallyRecursiveThreeCycle`.
+  The cap is sufficient because lifetime info propagates at least one
+  hop along an unresolved forwarding chain per pass, and the longest
+  simple chain within an SCC is `len(component) - 1`; if the cap is
+  reached without convergence, the loop simply exits — there is no
+  failure or overflow signal, so any not-yet-acquired lifetimes would
+  silently be missing from the affected signatures. Profile and revisit
+  the bound if this ever surfaces in practice.
 
   This required two supporting fixes: (1) `InferLifetimes` uses
   `determineCheckerAliasSource` (the call-aware variant) when collecting

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -1932,30 +1932,39 @@ constructors always have bodies).
 
 #### Status
 
-- **Implicit captures from method bodies.** `InferConstructorLifetimes`
-  walks instance method bodies looking for `IdentExpr` references whose
-  name matches a constructor parameter, and adds matching indices to
-  `storedParams` so the constructor gets a lifetime on those params.
-  The walk respects shadowing introduced by inner function params and
-  by `let`/`var` declarations within the method body, and skips static
-  methods, nested classes, and nested function declarations. The
-  matching is by name (not VarID) because `InferConstructorLifetimes`
-  runs during the namespace placeholder phase, before the rename pass
-  populates VarIDs on identifiers in method bodies.
+- **Implicit captures from method bodies (Done).**
+  `InferConstructorLifetimes` walks instance method bodies looking for
+  `IdentExpr` references whose name matches a constructor parameter,
+  and adds matching indices to `storedParams` so the constructor gets a
+  lifetime on those params. The walk respects shadowing introduced by
+  inner function params and by `let`/`var` declarations within the
+  method body, and skips static methods, nested classes, and nested
+  function declarations. The matching is by name (not VarID) because
+  `InferConstructorLifetimes` runs during the namespace placeholder
+  phase, before the rename pass populates VarIDs on identifiers in
+  method bodies.
 
-  **Status note:** the analysis is in place but currently dormant
-  end-to-end, because Escalier's method-body scope does not (yet) bring
-  constructor parameters into scope by name —
-  `class C(p) { foo(self) { return p } }` produces an
-  "Unknown identifier: p" type error today. Once the language wires
-  constructor params into method-body scope, the capture detection will
-  activate without further changes.
+  Method, getter, and setter bodies now also bring the enclosing
+  class's constructor params into scope as bindings (alongside `self`
+  and the function's own params), so
+  `class C(p) { foo(self) { return p } }` type-checks. The wiring is
+  in `infer_module.go` — each non-static `MethodElem`/`GetterElem`/
+  `SetterElem` `maps.Copy`s `paramBindingsForDecl[decl]` into its
+  `paramBindings` map before adding `self` and method params; method
+  params declared with the same name as a constructor param overwrite
+  and shadow the constructor binding (covered by
+  `MethodBodyShadowedParamNotCaptured`). The capture-detection logic
+  in `InferConstructorLifetimes` was already correct; this change just
+  removes the "dormant end-to-end" caveat.
 
   **Still deferred:** feeding the captured-param VarID set into
   `InferLifetimes` so that the *method's* return type inherits the
   captured param's lifetime (e.g.
   `foo<'a>('a self) -> mut 'a Point`). The constructor-side lifetime —
-  which is the soundness-critical part — is now handled.
+  which is the soundness-critical part — is handled. Implementing this
+  cleanly likely wants Phase 9 lifetime unification (so the method can
+  reference the class's `'a` rather than allocating a fresh one), so
+  it is deliberately left for that phase.
 
 - **Storage through nested expressions and literals (Done).** Field-init
   expressions are walked structurally by `findCapturedParamsInExpr`,
@@ -1991,13 +2000,18 @@ within each group.
 
 #### Status
 
-- **Mutually recursive single-pass re-run (Done).** `InferComponent`
-  does a single re-run pass over the FuncDecls in any SCC of size > 1
-  after their initial inference. The re-run picks up lifetimes for any
-  function that didn't infer them on its first pass — its peers may now
-  have lifetime info that wasn't available the first time. Functions
-  that DID infer lifetimes on the first pass are skipped by
-  `InferLifetimes`' early-return guard.
+- **Mutually recursive fixed-point iteration (Done).** `InferComponent`
+  iterates lifetime inference over the FuncDecls in any SCC of size > 1
+  until a full pass over the component grows no function's
+  `LifetimeParams`, capped at `len(component) - 1` iterations (the
+  worst-case forwarding-chain length within an SCC). Each pass picks up lifetimes for any function
+  that didn't infer them on a previous pass — peers may now have
+  lifetime info visible via `determineCheckerAliasSource`. The loop
+  uses `ReinferLifetimes` (the variant that bypasses the
+  user-explicit-lifetime guard so it can extend an already-inferred
+  set), and skips any decl whose `FuncSig.LifetimeParams` is non-empty
+  to preserve user-declared annotations. 3-cycle convergence is
+  covered by `TestInferLifetimeTypes/MutuallyRecursiveThreeCycle`.
 
   This required two supporting fixes: (1) `InferLifetimes` uses
   `determineCheckerAliasSource` (the call-aware variant) when collecting
@@ -2008,11 +2022,6 @@ within each group.
   `LifetimeParams` while leaving the lifetime vars themselves attached
   to the param/return types. Presence of a lifetime on the return type
   is now the authoritative signal.
-
-- **Still deferred:** a true fixed-point loop that iterates until no
-  changes (the current implementation does exactly one re-run, which is
-  enough for most 2-cycle mutual recursion cases but not for chains
-  requiring 3+ iterations).
 
 ### 8.8 Tests
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Constructor parameter names are now properly resolvable within instance method, getter, and setter bodies, improving type checking accuracy.
  * Lifetime inference for mutually recursive function groups now uses iterative fixed-point computation instead of single-pass analysis, ensuring convergence for complex circular dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->