### PR TITLE
Fix #516

### DIFF
--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -380,16 +380,29 @@ func (e *FuncExpr) Accept(v Visitor) {
 }
 
 type CallExpr struct {
-	Callee       Expr
-	Args         []Expr
-	OptChain     bool
-	span         Span
-	inferredType Type
+	Callee         Expr
+	Args           []Expr
+	OptChain       bool
+	span           Span
+	inferredType   Type
+	resolvedThrows Type
 }
 
 func NewCall(callee Expr, args []Expr, optChain bool, span Span) *CallExpr {
 	return &CallExpr{Callee: callee, Args: args, OptChain: optChain, span: span, inferredType: nil}
 }
+
+// ResolvedThrows returns the post-instantiation `Throws` type of the
+// function actually dispatched to at this call site — i.e. the picked
+// overload arm and/or the generic substitution. Returns nil when no
+// dispatch was resolved (error paths).
+func (e *CallExpr) ResolvedThrows() Type { return e.resolvedThrows }
+
+// SetResolvedThrows records the throws type from the function signature
+// that was selected and instantiated for this call. Should be set by
+// inferCallExpr at every successful dispatch site.
+func (e *CallExpr) SetResolvedThrows(t Type) { e.resolvedThrows = t }
+
 func (e *CallExpr) Accept(v Visitor) {
 	if v.EnterExpr(e) {
 		e.Callee.Accept(v)

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -394,13 +394,23 @@ func NewCall(callee Expr, args []Expr, optChain bool, span Span) *CallExpr {
 
 // ResolvedThrows returns the post-instantiation `Throws` type of the
 // function actually dispatched to at this call site — i.e. the picked
-// overload arm and/or the generic substitution. Returns nil when no
-// dispatch was resolved (error paths).
+// overload arm and/or the generic substitution.
+//
+//   - nil           → no dispatch was resolved (error paths)
+//   - NeverType     → resolved to a non-throwing arm (sentinel: the
+//                     callee declared no throws clause)
+//   - any other Type → the resolved throws type
+//
+// Callers that just want "what does this call throw" should treat
+// NeverType the same as nil; the distinction only matters for deciding
+// whether to fall back to walking the declaration-time callee type.
 func (e *CallExpr) ResolvedThrows() Type { return e.resolvedThrows }
 
 // SetResolvedThrows records the throws type from the function signature
 // that was selected and instantiated for this call. Should be set by
-// inferCallExpr at every successful dispatch site.
+// inferCallExpr at every successful dispatch site. Pass a NeverType
+// sentinel (not nil) to mark "resolved but non-throwing" so that
+// readers can distinguish that case from "unresolved".
 func (e *CallExpr) SetResolvedThrows(t Type) { e.resolvedThrows = t }
 
 func (e *CallExpr) Accept(v Visitor) {

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1195,8 +1195,14 @@ func (c *Checker) handleFuncCall(
 	// Record the post-instantiation throws type on the CallExpr so that
 	// later passes (e.g. throws inference) can read the substituted
 	// Throws type rather than re-deriving it from the declaration-time
-	// callee type.
-	expr.SetResolvedThrows(fnType.Throws)
+	// callee type. We substitute a NeverType sentinel when the callee
+	// has no throws clause so that ResolvedThrows() can distinguish
+	// "resolved to a non-throwing arm" from "unresolved" (nil).
+	resolvedThrows := fnType.Throws
+	if resolvedThrows == nil {
+		resolvedThrows = type_system.NewNeverType(nil)
+	}
+	expr.SetResolvedThrows(resolvedThrows)
 
 	// Find if the function has a rest parameter
 	var restIndex = -1

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1098,7 +1098,11 @@ func (c *Checker) inferCallExpr(
 			}
 		}
 
-		// No overload matched - create a comprehensive error
+		// No overload matched - create a comprehensive error.
+		// Clear ResolvedThrows since handleFuncCall set it on the last
+		// attempted (failing) arm; downstream code should treat this
+		// call as having no resolved signature.
+		expr.SetResolvedThrows(nil)
 		overloadErr := &NoMatchingOverloadError{
 			CallExpr:         expr,
 			IntersectionType: t,
@@ -1187,6 +1191,12 @@ func (c *Checker) handleFuncCall(
 	if len(fnType.TypeParams) > 0 {
 		fnType = c.instantiateGenericFunc(fnType)
 	}
+
+	// Record the post-instantiation throws type on the CallExpr so that
+	// later passes (e.g. throws inference) can read the substituted
+	// Throws type rather than re-deriving it from the declaration-time
+	// callee type.
+	expr.SetResolvedThrows(fnType.Throws)
 
 	// Find if the function has a rest parameter
 	var restIndex = -1

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -645,12 +645,15 @@ func (c *Checker) findThrowTypes(ctx Context, block *ast.Block) ([]type_system.T
 // Preferred path: read `ResolvedThrows`, which inferCallExpr records
 // after picking an overload arm and instantiating any generics. This
 // gives precise throws for both generic substitutions (T → "boom")
-// and overload resolution (only the matched arm's throws).
+// and overload resolution (only the matched arm's throws). A NeverType
+// here is a sentinel meaning "resolved to a non-throwing arm" — we
+// must NOT fall back to the declaration-time walk in that case, or
+// we'd re-introduce the overload-union bug for non-throwing arms.
 //
-// Fallback path: when no resolved signature is recorded (error paths,
-// or callee shapes inferCallExpr doesn't dispatch through), walk the
-// declaration-time callee type as a sound upper bound — for an
-// intersection that's the union of every arm's throws.
+// Fallback path: only when no dispatch was resolved (nil — error
+// paths, or callee shapes inferCallExpr doesn't dispatch through),
+// walk the declaration-time callee type as a sound upper bound — for
+// an intersection that's the union of every arm's throws.
 //
 // Returns nil when no throws can be attributed (callee has no throws
 // clause, or its throws type is `never`).

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -639,29 +639,28 @@ func (c *Checker) findThrowTypes(ctx Context, block *ast.Block) ([]type_system.T
 	return throwTypes, errors
 }
 
-// TODO(#516): this reads the callee's declaration-time type, so it
-// loses generic substitutions and unions all overload arms instead of
-// using the one `inferCallExpr` actually picked. Fix by recording the
-// instantiated/resolved signature on `CallExpr` during inference and
-// reading it back here.
+// calleeThrowsType returns the `Throws` type of the function actually
+// dispatched to at this call site.
 //
-// calleeThrowsType returns the `Throws` type declared on the callee of
-// `callExpr`, walking through the type-system shapes a callee can take:
+// Preferred path: read `ResolvedThrows`, which inferCallExpr records
+// after picking an overload arm and instantiating any generics. This
+// gives precise throws for both generic substitutions (T → "boom")
+// and overload resolution (only the matched arm's throws).
 //
-//   - FuncType: the throws clause is right there.
-//   - ObjectType: a class instance / constructor object — the throws
-//     lives on the embedded ConstructorElem or CallableElem.
-//   - TypeRefType: alias to one of the above; resolve via the
-//     attached `TypeAlias`.
-//   - IntersectionType (overload set): we can't pick a specific
-//     overload here without re-running resolution, so we return the
-//     union of every arm's throws as a sound upper bound. A caller
-//     might dispatch to any arm, so callers must be prepared to handle
-//     any arm's throws.
+// Fallback path: when no resolved signature is recorded (error paths,
+// or callee shapes inferCallExpr doesn't dispatch through), walk the
+// declaration-time callee type as a sound upper bound — for an
+// intersection that's the union of every arm's throws.
 //
-// Returns nil when no throws can be attributed (callee has no
-// throws clause, or its throws type is `never`).
+// Returns nil when no throws can be attributed (callee has no throws
+// clause, or its throws type is `never`).
 func calleeThrowsType(callExpr *ast.CallExpr) type_system.Type {
+	if rt := callExpr.ResolvedThrows(); rt != nil {
+		if _, isNever := type_system.Prune(rt).(*type_system.NeverType); isNever {
+			return nil
+		}
+		return rt
+	}
 	if callExpr.Callee == nil {
 		return nil
 	}

--- a/internal/checker/tests/throw_inference_test.go
+++ b/internal/checker/tests/throw_inference_test.go
@@ -366,6 +366,16 @@ func TestCallSiteThrowsInference(t *testing.T) {
 			`,
 			expectedTestFunc: `fn (x: string) -> number throws "bad-string"`,
 		},
+		"OverloadResolutionPicksNonThrowingArm": {
+			input: `
+				declare fn parse(s: string) -> number throws "bad-string"
+				declare fn parse(n: number) -> number
+				val testFunc = fn (x: number) -> number throws _ {
+					return parse(x)
+				}
+			`,
+			expectedTestFunc: `fn (x: number) -> number`,
+		},
 		"GenericCallSubstitutesThrowsType": {
 			input: `
 				val raise = fn <T>(x: T) -> never throws T {

--- a/internal/checker/tests/throw_inference_test.go
+++ b/internal/checker/tests/throw_inference_test.go
@@ -343,44 +343,66 @@ func TestDivergingBodyRejectsNonNeverReturn(t *testing.T) {
 	}
 }
 
-// TestOverloadSetUnionsThrowsAcrossArms verifies that when a callee
-// resolves to an intersection of overload signatures, the caller's
-// inferred `throws _` is the union of throws across every arm. This is
-// a sound upper bound — at the call site we don't know which arm will
-// dispatch, so the caller must be prepared to handle any.
-func TestOverloadSetUnionsThrowsAcrossArms(t *testing.T) {
-	t.Parallel()
-	source := &ast.Source{
-		ID:   0,
-		Path: "input.esc",
-		Contents: `
-			declare fn parse(s: string) -> number throws "bad-string"
-			declare fn parse(n: number) -> number throws "bad-number"
-			val testFunc = fn (x: string) -> number throws _ {
-				return parse(x)
-			}
-		`,
+// TestCallSiteThrowsInference covers how `throws _` on a caller is
+// resolved against different kinds of callees:
+//   - OverloadResolutionPicksMatchingArm: when a callee resolves to an
+//     intersection of overload signatures, the inferred throws reflects
+//     only the matched arm (not a union of all arms).
+//   - GenericCallSubstitutesThrowsType: when a generic callee declares
+//     `throws T`, the inferred throws reflects the instantiated type
+//     parameter, not the schema's T.
+func TestCallSiteThrowsInference(t *testing.T) {
+	tests := map[string]struct {
+		input            string
+		expectedTestFunc string
+	}{
+		"OverloadResolutionPicksMatchingArm": {
+			input: `
+				declare fn parse(s: string) -> number throws "bad-string"
+				declare fn parse(n: number) -> number throws "bad-number"
+				val testFunc = fn (x: string) -> number throws _ {
+					return parse(x)
+				}
+			`,
+			expectedTestFunc: `fn (x: string) -> number throws "bad-string"`,
+		},
+		"GenericCallSubstitutesThrowsType": {
+			input: `
+				val raise = fn <T>(x: T) -> never throws T {
+					throw x
+				}
+				val testFunc = fn () -> never throws _ {
+					raise("boom")
+				}
+			`,
+			expectedTestFunc: `fn () -> never throws "boom"`,
+		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
-	assert.Empty(t, parseErrors, "Expected no parse errors")
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := &ast.Source{ID: 0, Path: "input.esc", Contents: test.input}
 
-	c := NewChecker(ctx)
-	inferCtx := Context{Scope: Prelude(c)}
-	errors := c.InferModule(inferCtx, module)
-	assert.Empty(t, errors, "Expected no type errors, got: %v", errors)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+			assert.Empty(t, parseErrors, "Expected no parse errors")
 
-	binding, ok := inferCtx.Scope.Namespace.Values["testFunc"]
-	assert.Truef(t, ok, "Expected testFunc to be defined")
+			c := NewChecker(ctx)
+			inferCtx := Context{Scope: Prelude(c)}
+			errors := c.InferModule(inferCtx, module)
+			assert.Empty(t, errors, "Expected no type errors, got: %v", errors)
 
-	funcType, ok := type_system.Prune(binding.Type).(*type_system.FuncType)
-	assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type))
+			binding, ok := inferCtx.Scope.Namespace.Values["testFunc"]
+			assert.Truef(t, ok, "Expected testFunc to be defined")
 
-	throwsStr := type_system.Prune(funcType.Throws).String()
-	assert.Equal(t, "\"bad-string\" | \"bad-number\"", throwsStr,
-		"Expected throws type to union across overload arms")
+			funcType, ok := type_system.Prune(binding.Type).(*type_system.FuncType)
+			assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type))
+
+			assert.Equal(t, test.expectedTestFunc, funcType.String())
+		})
+	}
 }
 
 func TestThrowExpressionUnification(t *testing.T) {

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -158,7 +158,8 @@
         End:      ast.Location{Line:1, Column:7},
         SourceID: 0,
     },
-    inferredType: nil,
+    inferredType:   nil,
+    resolvedThrows: nil,
 }
 ---
 
@@ -1365,7 +1366,8 @@
         End:      ast.Location{Line:1, Column:13},
         SourceID: 0,
     },
-    inferredType: nil,
+    inferredType:   nil,
+    resolvedThrows: nil,
 }
 ---
 
@@ -2258,7 +2260,8 @@
                 End:      ast.Location{Line:1, Column:7},
                 SourceID: 0,
             },
-            inferredType: nil,
+            inferredType:   nil,
+            resolvedThrows: nil,
         },
         Args: {
             &ast.IdentExpr{
@@ -2280,7 +2283,8 @@
             End:      ast.Location{Line:1, Column:10},
             SourceID: 0,
         },
-        inferredType: nil,
+        inferredType:   nil,
+        resolvedThrows: nil,
     },
     Args: {
         &ast.IdentExpr{
@@ -2302,7 +2306,8 @@
         End:      ast.Location{Line:1, Column:13},
         SourceID: 0,
     },
-    inferredType: nil,
+    inferredType:   nil,
+    resolvedThrows: nil,
 }
 ---
 
@@ -2642,7 +2647,8 @@
             End:      ast.Location{Line:1, Column:11},
             SourceID: 0,
         },
-        inferredType: nil,
+        inferredType:   nil,
+        resolvedThrows: nil,
     },
     span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
@@ -2786,7 +2792,8 @@
         End:      ast.Location{Line:1, Column:10},
         SourceID: 0,
     },
-    inferredType: nil,
+    inferredType:   nil,
+    resolvedThrows: nil,
 }
 ---
 
@@ -3571,7 +3578,8 @@
         End:      ast.Location{Line:1, Column:6},
         SourceID: 0,
     },
-    inferredType: nil,
+    inferredType:   nil,
+    resolvedThrows: nil,
 }
 ---
 
@@ -3732,7 +3740,8 @@
             End:      ast.Location{Line:1, Column:10},
             SourceID: 0,
         },
-        inferredType: nil,
+        inferredType:   nil,
+        resolvedThrows: nil,
     },
     Op:    "/",
     Right: &ast.IdentExpr{
@@ -4508,7 +4517,8 @@
                                     End:      ast.Location{Line:2, Column:17},
                                     SourceID: 0,
                                 },
-                                inferredType: nil,
+                                inferredType:   nil,
+                                resolvedThrows: nil,
                             },
                             span: ast.Span{
                                 Start:    ast.Location{Line:2, Column:3},
@@ -5089,7 +5099,8 @@
                         End:      ast.Location{Line:1, Column:23},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -5174,7 +5185,8 @@
                                     End:      ast.Location{Line:1, Column:63},
                                     SourceID: 0,
                                 },
-                                inferredType: nil,
+                                inferredType:   nil,
+                                resolvedThrows: nil,
                             },
                             span: ast.Span{
                                 Start:    ast.Location{Line:1, Column:45},
@@ -5237,7 +5249,8 @@
                                         End:      ast.Location{Line:1, Column:29},
                                         SourceID: 0,
                                     },
-                                    inferredType: nil,
+                                    inferredType:   nil,
+                                    resolvedThrows: nil,
                                 },
                                 span: ast.Span{
                                     Start:    ast.Location{Line:1, Column:13},
@@ -5381,7 +5394,8 @@
                         End:      ast.Location{Line:1, Column:23},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -5432,7 +5446,8 @@
                         End:      ast.Location{Line:1, Column:17},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -5630,7 +5645,8 @@
                         End:      ast.Location{Line:1, Column:18},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -5836,7 +5852,8 @@
                         End:      ast.Location{Line:1, Column:25},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -5904,7 +5921,8 @@
                                     End:      ast.Location{Line:2, Column:18},
                                     SourceID: 0,
                                 },
-                                inferredType: nil,
+                                inferredType:   nil,
+                                resolvedThrows: nil,
                             },
                             span: ast.Span{
                                 Start:    ast.Location{Line:2, Column:3},
@@ -6007,7 +6025,8 @@
                         End:      ast.Location{Line:1, Column:18},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -6092,7 +6111,8 @@
                         End:      ast.Location{Line:1, Column:18},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -6213,7 +6233,8 @@
                         End:      ast.Location{Line:1, Column:18},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -6443,7 +6464,8 @@
                         End:      ast.Location{Line:1, Column:18},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -6507,7 +6529,8 @@
                         End:      ast.Location{Line:1, Column:18},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -6687,7 +6710,8 @@
                         End:      ast.Location{Line:1, Column:18},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:7},
@@ -7068,7 +7092,8 @@
             End:      ast.Location{Line:1, Column:21},
             SourceID: 0,
         },
-        inferredType: nil,
+        inferredType:   nil,
+        resolvedThrows: nil,
     },
     span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
@@ -8928,7 +8953,8 @@
         End:      ast.Location{Line:1, Column:9},
         SourceID: 0,
     },
-    inferredType: nil,
+    inferredType:   nil,
+    resolvedThrows: nil,
 }
 ---
 

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -22,7 +22,8 @@
             End:      ast.Location{Line:2, Column:10},
             SourceID: 0,
         },
-        inferredType: nil,
+        inferredType:   nil,
+        resolvedThrows: nil,
     },
     span: ast.Span{
         Start:    ast.Location{Line:2, Column:5},
@@ -554,7 +555,8 @@
             End:      ast.Location{Line:3, Column:10},
             SourceID: 0,
         },
-        inferredType: nil,
+        inferredType:   nil,
+        resolvedThrows: nil,
     },
     span: ast.Span{
         Start:    ast.Location{Line:3, Column:5},
@@ -1585,7 +1587,8 @@
                                     End:      ast.Location{Line:3, Column:37},
                                     SourceID: 0,
                                 },
-                                inferredType: nil,
+                                inferredType:   nil,
+                                resolvedThrows: nil,
                             },
                             span: ast.Span{
                                 Start:    ast.Location{Line:3, Column:21},
@@ -1650,7 +1653,8 @@
                                 End:      ast.Location{Line:4, Column:34},
                                 SourceID: 0,
                             },
-                            inferredType: nil,
+                            inferredType:   nil,
+                            resolvedThrows: nil,
                         },
                         span: ast.Span{
                             Start:    ast.Location{Line:4, Column:13},
@@ -2095,7 +2099,8 @@
                                 End:      ast.Location{Line:3, Column:34},
                                 SourceID: 0,
                             },
-                            inferredType: nil,
+                            inferredType:   nil,
+                            resolvedThrows: nil,
                         },
                         span: ast.Span{
                             Start:    ast.Location{Line:3, Column:13},
@@ -2216,7 +2221,8 @@
                                     End:      ast.Location{Line:3, Column:38},
                                     SourceID: 0,
                                 },
-                                inferredType: nil,
+                                inferredType:   nil,
+                                resolvedThrows: nil,
                             },
                             span: ast.Span{
                                 Start:    ast.Location{Line:3, Column:13},
@@ -2334,7 +2340,8 @@
                                 End:      ast.Location{Line:5, Column:41},
                                 SourceID: 0,
                             },
-                            inferredType: nil,
+                            inferredType:   nil,
+                            resolvedThrows: nil,
                         },
                         span: ast.Span{
                             Start:    ast.Location{Line:5, Column:28},
@@ -2350,7 +2357,8 @@
                     End:      ast.Location{Line:5, Column:42},
                     SourceID: 0,
                 },
-                inferredType: nil,
+                inferredType:   nil,
+                resolvedThrows: nil,
             },
             span: ast.Span{
                 Start:    ast.Location{Line:5, Column:18},
@@ -2469,7 +2477,8 @@
                                 End:      ast.Location{Line:1, Column:52},
                                 SourceID: 0,
                             },
-                            inferredType: nil,
+                            inferredType:   nil,
+                            resolvedThrows: nil,
                         },
                         span: ast.Span{
                             Start:    ast.Location{Line:1, Column:31},

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -3587,7 +3587,8 @@
                                         End:      ast.Location{Line:3, Column:41},
                                         SourceID: 0,
                                     },
-                                    inferredType: nil,
+                                    inferredType:   nil,
+                                    resolvedThrows: nil,
                                 },
                                 span: ast.Span{
                                     Start:    ast.Location{Line:3, Column:6},
@@ -4191,7 +4192,8 @@
                                         End:      ast.Location{Line:1, Column:56},
                                         SourceID: 0,
                                     },
-                                    inferredType: nil,
+                                    inferredType:   nil,
+                                    resolvedThrows: nil,
                                 },
                                 span: ast.Span{
                                     Start:    ast.Location{Line:1, Column:40},
@@ -5214,7 +5216,8 @@
                                         End:      ast.Location{Line:3, Column:38},
                                         SourceID: 0,
                                     },
-                                    inferredType: nil,
+                                    inferredType:   nil,
+                                    resolvedThrows: nil,
                                 },
                                 span: ast.Span{
                                     Start:    ast.Location{Line:3, Column:18},
@@ -5956,7 +5959,8 @@
                                         End:      ast.Location{Line:4, Column:38},
                                         SourceID: 0,
                                     },
-                                    inferredType: nil,
+                                    inferredType:   nil,
+                                    resolvedThrows: nil,
                                 },
                                 span: ast.Span{
                                     Start:    ast.Location{Line:4, Column:18},
@@ -7987,7 +7991,8 @@ nil
                         End:      ast.Location{Line:1, Column:38},
                         SourceID: 0,
                     },
-                    inferredType: nil,
+                    inferredType:   nil,
+                    resolvedThrows: nil,
                 },
                 span: ast.Span{
                     Start:    ast.Location{Line:1, Column:21},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved exception type inference for function calls to accurately track exceptions thrown at specific call sites, particularly for overloaded and generic functions. Exception types are now properly resolved during dispatch rather than incorrectly union'd across multiple overload candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->