### PR TITLE
Fix #531

### DIFF
--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -935,6 +935,9 @@ func (c *Checker) InferConstructorLifetimes(
 			break
 		}
 	}
+	// User-written ctors always parse with a body, and no synthesizer
+	// produces a body-less ConstructorElem; the Body == nil guard is
+	// defensive only.
 	if ctorElem == nil || ctorElem.Fn == nil || ctorElem.Fn.Body == nil {
 		return
 	}
@@ -955,6 +958,13 @@ func (c *Checker) InferConstructorLifetimes(
 	// name (mirroring how methods see their implicit receiver in
 	// `runLivenessPrePass`). Rename errors are ignored: any unresolved
 	// references will be re-reported by the body phase's rename pass.
+	//
+	// VarIDs written here are safely overwritten when the body phase later
+	// runs `runLivenessPrePass` on the same ctor body: `liveness.Rename`
+	// does not recurse into nested FuncExpr/FuncDecl bodies (those get
+	// their own pass), so the only nodes touched here are the outer ctor
+	// body's IdentExprs/IdentPats — exactly the nodes the body phase
+	// overwrites. Inner functions are unaffected by this pass.
 	outerBindings := collectOuterBindings(ctx.Scope)
 	renameResult := liveness.Rename(callableParams, *ctorElem.Fn.Body, outerBindings, "self")
 	selfVarID, ok := renameResult.ExtraParamVarIDs["self"]
@@ -989,42 +999,22 @@ func (c *Checker) InferConstructorLifetimes(
 		return
 	}
 
-	// Map escaped leaf indices back to top-level callable-param indices,
-	// preserving param order for determinism.
-	storedParams := set.NewSet[int]()
-	for i, p := range callableParams {
-		identPat, ok := p.Pattern.(*ast.IdentPat)
-		if !ok {
-			continue
-		}
-		leafIdx, found := leafIndex[liveness.VarID(identPat.VarID)]
-		if !found {
-			continue
-		}
-		if escapingLeaves.Contains(leafIdx) {
-			storedParams.Add(i)
-		}
-	}
-	if storedParams.Len() == 0 {
-		return
-	}
-
-	// Allocate lifetimes in parameter order for determinism.
+	// Allocate one lifetime per escaping leaf (in declaration order for
+	// determinism). For an IdentPat top-level param the leaf type IS the
+	// whole param type; for destructured patterns the leaf type is the
+	// sub-position the rename pass bound (e.g. the tuple element type for
+	// `[a, b]: [mut T, mut U]`).
 	var lifetimeParams []*type_system.LifetimeVar
-	for i := range callableParams {
-		if !storedParams.Contains(i) {
+	for leafIdx, leaf := range leaves {
+		if !escapingLeaves.Contains(leafIdx) {
 			continue
 		}
-		if i >= len(ctorFn.Params) {
-			continue
-		}
-		paramType := ctorFn.Params[i].Type
-		if !typeCarriesLifetime(paramType) {
+		if !typeCarriesLifetime(leaf.leafType) {
 			continue
 		}
 		lv := c.FreshLifetimeVar(lifetimeParamName(len(lifetimeParams)))
 		lifetimeParams = append(lifetimeParams, lv)
-		setLifetimeOnType(paramType, lv)
+		setLifetimeOnType(leaf.leafType, lv)
 	}
 
 	if len(lifetimeParams) == 0 {

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -159,7 +159,7 @@ func (c *Checker) inferLifetimesCore(
 	// pass so that an escaping param gets 'static rather than a fresh 'a
 	// even when it is also returned by some path. Already-set 'static
 	// (from a prior pass) is a no-op.
-	escapingLeaves := detectEscapingLeafIndices(body, leafIndex)
+	escapingLeaves := detectEscapingLeafIndices(body, leafIndex, nil)
 	for idx := range escapingLeaves {
 		leaf := leaves[idx]
 		if !typeCarriesLifetime(leaf.leafType) {
@@ -544,6 +544,12 @@ func arrayElemType(t type_system.Type) type_system.Type {
 // frame. Stores into locals don't escape because the local's lifetime
 // is bounded by the function body.
 //
+// extraEscapeRoots, if non-nil, names additional positive-VarID roots
+// whose lvalue assignments should ALSO be treated as escaping. Used for
+// constructor bodies, where `self` is a local parameter (positive VarID)
+// but `self.<field> = expr` should escape because the receiver outlives
+// the constructor's stack frame. Pass nil for ordinary function bodies.
+//
 // Limitations:
 //   - Closures over a *nested* function's local: inner functions whose
 //     body assigns to an outer function's local will mark that param as
@@ -552,20 +558,6 @@ func arrayElemType(t type_system.Type) type_system.Type {
 //   - Stores via property assignment whose root is a local but is
 //     itself stored elsewhere: not tracked here.
 func detectEscapingLeafIndices(
-	body *ast.Block,
-	leafIndex map[liveness.VarID]int,
-) set.Set[int] {
-	return detectEscapingLeafIndicesWithRoots(body, leafIndex, nil)
-}
-
-// detectEscapingLeafIndicesWithRoots is the constructor-aware variant of
-// detectEscapingLeafIndices: in addition to assignments whose lvalue root
-// is non-local (VarID <= 0), it also flags assignments whose lvalue root
-// VarID is in extraEscapeRoots. Used for constructor bodies, where `self`
-// is a local parameter (positive VarID) but `self.<field> = expr` should
-// be treated as escaping because the receiver outlives the constructor's
-// stack frame.
-func detectEscapingLeafIndicesWithRoots(
 	body *ast.Block,
 	leafIndex map[liveness.VarID]int,
 	extraEscapeRoots set.Set[liveness.VarID],
@@ -882,12 +874,11 @@ func lifetimeContainsStatic(lt type_system.Lifetime) bool {
 // drop-in fit, even after sharing the escape-detection primitives:
 //
 //  1. Escape root differs. `inferLifetimesCore` calls
-//     `detectEscapingLeafIndices`, which only flags lvalues whose root
-//     has `VarID <= 0` (non-local). In a constructor, `self` is a
-//     local positive-VarID parameter, so `self.x = p` wouldn't be
-//     detected. The constructor path uses
-//     `detectEscapingLeafIndicesWithRoots` with `self`'s VarID added
-//     as an extra escape root.
+//     `detectEscapingLeafIndices` with a nil extra-roots set, which
+//     only flags lvalues whose root has `VarID <= 0` (non-local). In a
+//     constructor, `self` is a local positive-VarID parameter, so
+//     `self.x = p` wouldn't be detected. The constructor path passes
+//     `self`'s VarID as an extra escape root to the same function.
 //
 //  2. No return-alias pass needed. `inferLifetimesCore` does most of
 //     its work in `attachLifetimeToResult` — collecting return/yield
@@ -1002,12 +993,11 @@ func (c *Checker) InferConstructorLifetimes(
 
 	// Detect escapes: assignments `self.<…> = expr` where the RHS aliases
 	// one of the callable params. `self`'s VarID is added as an extra
-	// escape root because it is itself a positive-VarID parameter (so
-	// `isNonLocalLValue` alone wouldn't recognize `self.x = p` as
-	// escaping).
+	// escape root because it is itself a positive-VarID parameter — the
+	// non-local-only check would not recognize `self.x = p` as escaping.
 	escapeRoots := set.NewSet[liveness.VarID]()
 	escapeRoots.Add(selfVarID)
-	escapingLeaves := detectEscapingLeafIndicesWithRoots(ctorElem.Fn.Body, leafIndex, escapeRoots)
+	escapingLeaves := detectEscapingLeafIndices(ctorElem.Fn.Body, leafIndex, escapeRoots)
 	if escapingLeaves.Len() == 0 {
 		return
 	}

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -907,6 +907,19 @@ func lifetimeContainsStatic(lt type_system.Lifetime) bool {
 //   - Inference of method-side return-type lifetimes when a method
 //     captures a constructor param (the constructor gets the lifetime,
 //     but the method's return type does not yet inherit it).
+//   - Capture through call results: `self.f = wrap(p)` where `wrap`'s
+//     return aliases its argument is currently NOT detected. This pass
+//     runs in the placeholder phase, before any callee body has been
+//     inferred, so `determineCheckerAliasSource` sees no lifetime info on
+//     the callee's return type and falls back to treating the call as
+//     opaque. The non-ctor path solves the analogous problem via the
+//     post-body fixed-point reinference loop (`ReinferLifetimes` in
+//     `InferComponent`); extending that loop to constructors requires
+//     making `setLifetimeOnType` / `setLifetimeArgsOnType` /
+//     `typeAlias.LifetimeParams` updates idempotent and reconciling them
+//     with class consumers that may have already resolved the class
+//     during the body phase. Tracked by `TestCtorCapturesViaWrappingCall`
+//     (currently t.Skip).
 func (c *Checker) InferConstructorLifetimes(
 	ctx Context,
 	classDecl *ast.ClassDecl,

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -847,28 +847,52 @@ func lifetimeContainsStatic(lt type_system.Lifetime) bool {
 	return false
 }
 
+// findSelfVarID returns the VarID of the first `self` IdentExpr it
+// finds in the given body. All references to `self` within a single
+// ctor body share the same VarID (assigned as an extra param by
+// `runLivenessPrePass`), so the first match is sufficient. Returns 0
+// when the body has no `self` reference.
+func findSelfVarID(body *ast.Block) liveness.VarID {
+	if body == nil {
+		return 0
+	}
+	v := &selfVarIDVisitor{}
+	body.Accept(v)
+	return v.found
+}
+
+type selfVarIDVisitor struct {
+	ast.DefaultVisitor
+	found liveness.VarID
+}
+
+func (v *selfVarIDVisitor) EnterExpr(e ast.Expr) bool {
+	if v.found != 0 {
+		return false
+	}
+	if ident, ok := e.(*ast.IdentExpr); ok && ident.Name == "self" && ident.VarID > 0 {
+		v.found = liveness.VarID(ident.VarID)
+		return false
+	}
+	return true
+}
+
 // InferConstructorLifetimes analyzes a class declaration to determine
 // which constructor parameters are stored into `self` (as fields or
 // through transitive aliases), attaches a fresh LifetimeVar to each such
 // parameter and to the constructor's return type, and records the
 // lifetime parameters on the class TypeAlias.
 //
-// Capture detection reuses the *escape-detection* primitives from
-// `inferLifetimesCore` — `escapingRefsVisitor`,
-// `determineCheckerAliasSource`, `collectParamLeaves` — to walk the
-// constructor body for assignments whose lvalue root is `self` (e.g.
-// `self.x = p`, `self.list[0] = p`) and trace the RHS back to the
-// underlying parameter VarID(s). This is precise: guards like
-// `if x < 0 { throw … }`, side-effect calls like `validate(x)`, and
-// transient computation like `var tmp = x * 2` are correctly identified
-// as NOT capturing `x`.
-//
-// To produce VarIDs in the body and on parameter pattern leaves, this
-// function runs its own `liveness.Rename` pass on the constructor body.
-// VarIDs written here will be overwritten by the body phase's
-// `runLivenessPrePass` when the constructor body is later type-checked,
-// which is fine — we only need a consistent VarID space for the
-// duration of this call.
+// Runs in the body phase, after `inferFuncBodyWithFuncSigType` has
+// type-checked the constructor body. By that point the body phase's
+// `runLivenessPrePass` has already populated VarIDs on the callable
+// param patterns and every IdentExpr in the body, and callee signatures
+// from peers in the same SCC are resolved — so
+// `determineCheckerAliasSource` can see lifetime info on call returns
+// and trace escapes like `self.f = wrap(p)`. The only piece the body
+// phase doesn't write is `self`'s IdentPat VarID (it's an extra param,
+// not in the rename's astParams), which `findSelfVarID` recovers by
+// looking at any `self` IdentExpr in the body.
 //
 // Why not call `inferLifetimesCore` directly? Three reasons it isn't a
 // drop-in fit, even after sharing the escape-detection primitives:
@@ -899,7 +923,6 @@ func lifetimeContainsStatic(lt type_system.Lifetime) bool {
 //     captures a constructor param (the constructor gets the lifetime,
 //     but the method's return type does not yet inherit it).
 func (c *Checker) InferConstructorLifetimes(
-	ctx Context,
 	classDecl *ast.ClassDecl,
 	typeAlias *type_system.TypeAlias,
 	ctorFn *type_system.FuncType,
@@ -944,22 +967,16 @@ func (c *Checker) InferConstructorLifetimes(
 		return
 	}
 
-	// Run a mini rename pass so we have VarIDs on the callable params and
-	// on every IdentExpr in the body. `self` is treated as an extra param
-	// name (mirroring how methods see their implicit receiver in
-	// `runLivenessPrePass`). Rename errors are ignored: any unresolved
-	// references will be re-reported by the body phase's rename pass.
-	//
-	// VarIDs written here are safely overwritten when the body phase later
-	// runs `runLivenessPrePass` on the same ctor body: `liveness.Rename`
-	// does not recurse into nested FuncExpr/FuncDecl bodies (those get
-	// their own pass), so the only nodes touched here are the outer ctor
-	// body's IdentExprs/IdentPats — exactly the nodes the body phase
-	// overwrites. Inner functions are unaffected by this pass.
-	outerBindings := collectOuterBindings(ctx.Scope)
-	renameResult := liveness.Rename(callableParams, *ctorElem.Fn.Body, outerBindings, "self")
-	selfVarID, ok := renameResult.ExtraParamVarIDs["self"]
-	if !ok {
+	// VarIDs on the callable params and on every IdentExpr in the body
+	// were already populated by the body phase's `runLivenessPrePass`
+	// before this function was called; we just reuse them. To find
+	// `self`'s VarID we walk the body for any `self` IdentExpr — the
+	// extra-param treatment in `runLivenessPrePass` ensures every `self`
+	// reference resolves to the same positive VarID. If the body never
+	// references `self`, no `self.x = ...` assignment exists, so there
+	// is nothing to capture.
+	selfVarID := findSelfVarID(ctorElem.Fn.Body)
+	if selfVarID == 0 {
 		return
 	}
 

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -898,19 +898,6 @@ func lifetimeContainsStatic(lt type_system.Lifetime) bool {
 //   - Inference of method-side return-type lifetimes when a method
 //     captures a constructor param (the constructor gets the lifetime,
 //     but the method's return type does not yet inherit it).
-//   - Capture through call results: `self.f = wrap(p)` where `wrap`'s
-//     return aliases its argument is currently NOT detected. This pass
-//     runs in the placeholder phase, before any callee body has been
-//     inferred, so `determineCheckerAliasSource` sees no lifetime info on
-//     the callee's return type and falls back to treating the call as
-//     opaque. The non-ctor path solves the analogous problem via the
-//     post-body fixed-point reinference loop (`ReinferLifetimes` in
-//     `InferComponent`); extending that loop to constructors requires
-//     making `setLifetimeOnType` / `setLifetimeArgsOnType` /
-//     `typeAlias.LifetimeParams` updates idempotent and reconciling them
-//     with class consumers that may have already resolved the class
-//     during the body phase. Tracked by `TestCtorCapturesViaWrappingCall`
-//     (currently t.Skip).
 func (c *Checker) InferConstructorLifetimes(
 	ctx Context,
 	classDecl *ast.ClassDecl,

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -555,13 +555,29 @@ func detectEscapingLeafIndices(
 	body *ast.Block,
 	leafIndex map[liveness.VarID]int,
 ) set.Set[int] {
+	return detectEscapingLeafIndicesWithRoots(body, leafIndex, nil)
+}
+
+// detectEscapingLeafIndicesWithRoots is the constructor-aware variant of
+// detectEscapingLeafIndices: in addition to assignments whose lvalue root
+// is non-local (VarID <= 0), it also flags assignments whose lvalue root
+// VarID is in extraEscapeRoots. Used for constructor bodies, where `self`
+// is a local parameter (positive VarID) but `self.<field> = expr` should
+// be treated as escaping because the receiver outlives the constructor's
+// stack frame.
+func detectEscapingLeafIndicesWithRoots(
+	body *ast.Block,
+	leafIndex map[liveness.VarID]int,
+	extraEscapeRoots set.Set[liveness.VarID],
+) set.Set[int] {
 	escaped := set.NewSet[int]()
 	if body == nil || len(leafIndex) == 0 {
 		return escaped
 	}
 	v := &escapingRefsVisitor{
-		leafIndex: leafIndex,
-		escaped:   escaped,
+		leafIndex:        leafIndex,
+		extraEscapeRoots: extraEscapeRoots,
+		escaped:          escaped,
 	}
 	body.Accept(v)
 	return escaped
@@ -569,13 +585,14 @@ func detectEscapingLeafIndices(
 
 type escapingRefsVisitor struct {
 	ast.DefaultVisitor
-	leafIndex map[liveness.VarID]int
-	escaped   set.Set[int]
+	leafIndex        map[liveness.VarID]int
+	extraEscapeRoots set.Set[liveness.VarID] // may be nil
+	escaped          set.Set[int]
 }
 
 func (v *escapingRefsVisitor) EnterExpr(e ast.Expr) bool {
 	if be, ok := e.(*ast.BinaryExpr); ok && be.Op == ast.Assign {
-		if isNonLocalLValue(be.Left) {
+		if v.isEscapingLValue(be.Left) {
 			// Use the checker-aware variant so a parameter that flows
 			// through a call whose callee returns its argument
 			// (`cache = wrap(p)`) is still detected as escaping.
@@ -606,13 +623,22 @@ func (v *escapingRefsVisitor) EnterDecl(d ast.Decl) bool {
 	return true
 }
 
-// isNonLocalLValue returns true if the given assignment-target expression's
-// root identifier resolves to a non-local binding (VarID <= 0). Walks
-// through MemberExpr/IndexExpr chains to find the root identifier.
-// rootObjectVarID returns 0 when the root is non-local (or not a simple
-// ident chain), which matches what we want to flag as escaping.
-func isNonLocalLValue(expr ast.Expr) bool {
-	return rootObjectVarID(expr) == 0
+// isEscapingLValue returns true if the given assignment-target expression's
+// root identifier (walking through MemberExpr/IndexExpr chains) is an
+// escape root: either a non-local binding (rootObjectVarID returns 0,
+// meaning module-level / prelude / outer-scope) or a positive VarID that
+// the caller declared as a forced escape root (e.g. `self` in a
+// constructor body, where `self.<field> = expr` outlives the local frame
+// even though `self` itself is a local parameter).
+func (v *escapingRefsVisitor) isEscapingLValue(expr ast.Expr) bool {
+	root := rootObjectVarID(expr)
+	if root == 0 {
+		return true
+	}
+	if v.extraEscapeRoots != nil && v.extraEscapeRoots.Contains(root) {
+		return true
+	}
+	return false
 }
 
 // setLifetimeOnType attaches a lifetime to a type's Lifetime field, walking
@@ -830,34 +856,59 @@ func lifetimeContainsStatic(lt type_system.Lifetime) bool {
 }
 
 // InferConstructorLifetimes analyzes a class declaration to determine
-// which constructor parameters are stored as fields (or implicitly
-// captured by method bodies), attaches a fresh LifetimeVar to each such
+// which constructor parameters are stored into `self` (as fields or
+// through transitive aliases), attaches a fresh LifetimeVar to each such
 // parameter and to the constructor's return type, and records the
-// lifetime parameters and default mutability on the class TypeAlias.
+// lifetime parameters on the class TypeAlias.
 //
-// Detected storage / capture patterns (Phase 8.6):
-//   - Shorthand field referring to a constructor parameter by name,
-//     with or without a default:
-//     `class C(p: mut Point) { p, }`
-//     `class C(p: mut Point) { p = fallback, }`
-//   - Explicit field whose value references a constructor parameter,
-//     directly or through composite/projection expressions:
-//     `class C(p: mut Point) { x: p, }`
-//     `class C(p: mut Point) { x: p.inner, }`
-//     `class C(p: mut Point) { x: {inner: p}, }`
-//     `class C(p: mut Point) { x: [p, p], }`
-//   - Implicit capture: a method body references a constructor parameter
-//     by name (Escalier allows methods to see constructor params without
-//     going through `self`):
-//     `class C(p: mut Point) { foo(self) { return p } }`
+// Capture detection reuses the *escape-detection* primitives from
+// `inferLifetimesCore` — `escapingRefsVisitor`,
+// `determineCheckerAliasSource`, `collectParamLeaves` — to walk the
+// constructor body for assignments whose lvalue root is `self` (e.g.
+// `self.x = p`, `self.list[0] = p`) and trace the RHS back to the
+// underlying parameter VarID(s). This is precise: guards like
+// `if x < 0 { throw … }`, side-effect calls like `validate(x)`, and
+// transient computation like `var tmp = x * 2` are correctly identified
+// as NOT capturing `x`.
+//
+// To produce VarIDs in the body and on parameter pattern leaves, this
+// function runs its own `liveness.Rename` pass on the constructor body.
+// VarIDs written here will be overwritten by the body phase's
+// `runLivenessPrePass` when the constructor body is later type-checked,
+// which is fine — we only need a consistent VarID space for the
+// duration of this call.
+//
+// Why not call `inferLifetimesCore` directly? Three reasons it isn't a
+// drop-in fit, even after sharing the escape-detection primitives:
+//
+//  1. Escape root differs. `inferLifetimesCore` calls
+//     `detectEscapingLeafIndices`, which only flags lvalues whose root
+//     has `VarID <= 0` (non-local). In a constructor, `self` is a
+//     local positive-VarID parameter, so `self.x = p` wouldn't be
+//     detected. The constructor path uses
+//     `detectEscapingLeafIndicesWithRoots` with `self`'s VarID added
+//     as an extra escape root.
+//
+//  2. No return-alias pass needed. `inferLifetimesCore` does most of
+//     its work in `attachLifetimeToResult` — collecting return/yield
+//     exprs and unioning lifetimes onto the result type. Constructor
+//     bodies have no `return expr` (the return is the implicit
+//     `self`), and the return type already gets `LifetimeArgs`
+//     attached separately below. Running the result-side machinery
+//     would be a no-op at best.
+//
+//  3. Output shape differs. `inferLifetimesCore` writes lifetimes
+//     onto `funcType.LifetimeParams` only. Constructors also write
+//     to `typeAlias.LifetimeParams` and call `setLifetimeArgsOnType`
+//     on the return so callers see `C<'a>`. That's class-specific
+//     bookkeeping `inferLifetimesCore` doesn't do.
 //
 // Deferred (see implementation_plan.md Phase 8 status):
 //   - Inference of method-side return-type lifetimes when a method
 //     captures a constructor param (the constructor gets the lifetime,
 //     but the method's return type does not yet inherit it).
-//   - Storage through function-call results (`x: f(p)`) — calls are
-//     conservatively treated as fresh by the field walker.
 func (c *Checker) InferConstructorLifetimes(
+	ctx Context,
 	classDecl *ast.ClassDecl,
 	typeAlias *type_system.TypeAlias,
 	ctorFn *type_system.FuncType,
@@ -874,16 +925,6 @@ func (c *Checker) InferConstructorLifetimes(
 		return
 	}
 
-	// For each constructor param that is a reference type AND is stored
-	// as a field (or captured by a method), allocate a fresh LifetimeVar.
-	//
-	// Note: matching is by *name* rather than VarID because
-	// InferConstructorLifetimes runs during the namespace placeholder phase,
-	// before the rename pass has populated VarIDs on identifiers in field
-	// initializers or method bodies. We must run this early so the class's
-	// TypeAlias advertises its LifetimeParams before any consumer — function
-	// param annotations, var decls, constructor call sites — resolves the
-	// class by name during the body phase.
 	// Locate the (single) in-body `ConstructorElem`. After Phase 4 there is
 	// no other source of constructor params on a class. If synthesis or
 	// parsing left no constructor in place, there's nothing to do.
@@ -894,77 +935,86 @@ func (c *Checker) InferConstructorLifetimes(
 			break
 		}
 	}
-	if ctorElem == nil || ctorElem.Fn == nil {
+	if ctorElem == nil || ctorElem.Fn == nil || ctorElem.Fn.Body == nil {
 		return
 	}
-	// Skip the leading `mut self` — it is not a callable parameter and
-	// the corresponding `ctorFn.Params` slice already excludes it.
-	ctorParams := ctorElem.Fn.Params
-	if len(ctorParams) > 0 {
-		ctorParams = ctorParams[1:]
+	// The first AST param is `mut self`. The remaining params are the
+	// callable params and line up with `ctorFn.Params` (which
+	// `inferConstructorSig` populates by dropping `self`).
+	allCtorParams := ctorElem.Fn.Params
+	if len(allCtorParams) == 0 {
+		return
+	}
+	callableParams := allCtorParams[1:]
+	if len(callableParams) == 0 {
+		return
 	}
 
-	paramNameToIndex := make(map[string]int)
-	for i, p := range ctorParams {
-		if identPat, ok := p.Pattern.(*ast.IdentPat); ok {
-			paramNameToIndex[identPat.Name] = i
-		}
+	// Run a mini rename pass so we have VarIDs on the callable params and
+	// on every IdentExpr in the body. `self` is treated as an extra param
+	// name (mirroring how methods see their implicit receiver in
+	// `runLivenessPrePass`). Rename errors are ignored: any unresolved
+	// references will be re-reported by the body phase's rename pass.
+	outerBindings := collectOuterBindings(ctx.Scope)
+	renameResult := liveness.Rename(callableParams, *ctorElem.Fn.Body, outerBindings, "self")
+	selfVarID, ok := renameResult.ExtraParamVarIDs["self"]
+	if !ok {
+		return
 	}
 
+	// Build the per-leaf index from callable-param patterns × types so
+	// that destructured leaves are tracked individually (e.g. for
+	// `constructor(self, [a, b]: [...])` each of `a`, `b` gets its own
+	// leaf). Lifetime allocation below still happens at the top-level
+	// param granularity, but per-leaf escape tracking lets the RHS
+	// alias-source tracing find the right binding.
+	leaves := collectParamLeaves(callableParams, ctorFn.Params)
+	if len(leaves) == 0 {
+		return
+	}
+	leafIndex := make(map[liveness.VarID]int)
+	for i, l := range leaves {
+		leafIndex[l.varID] = i
+	}
+
+	// Detect escapes: assignments `self.<…> = expr` where the RHS aliases
+	// one of the callable params. `self`'s VarID is added as an extra
+	// escape root because it is itself a positive-VarID parameter (so
+	// `isNonLocalLValue` alone wouldn't recognize `self.x = p` as
+	// escaping).
+	escapeRoots := set.NewSet[liveness.VarID]()
+	escapeRoots.Add(selfVarID)
+	escapingLeaves := detectEscapingLeafIndicesWithRoots(ctorElem.Fn.Body, leafIndex, escapeRoots)
+	if escapingLeaves.Len() == 0 {
+		return
+	}
+
+	// Map escaped leaf indices back to top-level callable-param indices,
+	// preserving param order for determinism.
 	storedParams := set.NewSet[int]()
-
-	// Walk the constructor body itself: any unshadowed reference to a
-	// callable param is currently treated as a capture. This is a
-	// conservative approximation — a param can appear in a body without
-	// being stored into `self` (e.g. as a guard `if x < 0 { throw … }`,
-	// passed to a function for its side effects, used to derive a fresh
-	// value, etc.). The empty scope below is intentional: the ctor's own
-	// params ARE the names we want to detect references to and must not
-	// appear shadowed.
-	//
-	// TODO(#531): drop this name-match walk and run the same machinery
-	// `inferLifetimesCore` already uses for methods, setters, and regular
-	// functions. That path detects escapes via `escapingRefsVisitor` —
-	// `self.x = p` is a non-local-lvalue assignment with `self` as the
-	// root, and `determineCheckerAliasSource` traces the RHS back to the
-	// captured params. Reusing it would (a) make constructor capture
-	// detection precise instead of conservative, (b) align the
-	// constructor with how every other body is analyzed, and (c) delete
-	// `ctorBodyCaptureVisitor` and the empty-scope hack here.
-	if ctorElem.Fn.Body != nil {
-		v := &ctorBodyCaptureVisitor{
-			paramNameToIndex: paramNameToIndex,
-			storedParams:     storedParams,
+	for i, p := range callableParams {
+		identPat, ok := p.Pattern.(*ast.IdentPat)
+		if !ok {
+			continue
 		}
-		v.pushScope()
-		ctorElem.Fn.Body.Accept(v)
-		v.popScope()
+		leafIdx, found := leafIndex[liveness.VarID(identPat.VarID)]
+		if !found {
+			continue
+		}
+		if escapingLeaves.Contains(leafIdx) {
+			storedParams.Add(i)
+		}
 	}
-
-	// The constructor body walk above is the single source of truth for
-	// captures: every assignment of a ctor param into `self` (whether by
-	// the synthesizer or a user-written `self.x = x` style body) flows
-	// through that walk. Methods/getters/setters cannot reference ctor
-	// params by name (the type checker rejects such references as unknown
-	// identifiers — see `TestConstructorParamsDoNotLeakIntoMethods`), and
-	// instance fields no longer carry initializers, so there is nothing
-	// further to inspect on the class body itself.
-
 	if storedParams.Len() == 0 {
 		return
 	}
 
-	// Allocate lifetimes in parameter order for determinism. `ctorParams`
-	// already excludes the leading `mut self`, so the indices line up with
-	// `ctorFn.Params` (which `inferConstructorSig` also populates from the
-	// callable params, dropping `self`).
+	// Allocate lifetimes in parameter order for determinism.
 	var lifetimeParams []*type_system.LifetimeVar
-	for i, p := range ctorParams {
+	for i := range callableParams {
 		if !storedParams.Contains(i) {
 			continue
 		}
-		// Skip params whose declared type is not a reference type — the
-		// lifetime would have nowhere to attach.
 		if i >= len(ctorFn.Params) {
 			continue
 		}
@@ -972,11 +1022,6 @@ func (c *Checker) InferConstructorLifetimes(
 		if !typeCarriesLifetime(paramType) {
 			continue
 		}
-
-		// storedParams (above) was populated only from params whose name
-		// is in paramNameToIndex, which only contains IdentPat params, so
-		// p.Pattern is guaranteed to be *ast.IdentPat.
-		_ = p.Pattern.(*ast.IdentPat)
 		lv := c.FreshLifetimeVar(lifetimeParamName(len(lifetimeParams)))
 		lifetimeParams = append(lifetimeParams, lv)
 		setLifetimeOnType(paramType, lv)
@@ -996,174 +1041,6 @@ func (c *Checker) InferConstructorLifetimes(
 		lifetimeArgs[i] = lv
 	}
 	setLifetimeArgsOnType(ctorFn.Return, lifetimeArgs)
-}
-
-// ctorBodyCaptureVisitor walks a constructor body looking for identifier
-// references whose name matches a constructor parameter, while tracking
-// the lexical scopes that shadow such names. Used by
-// `InferConstructorLifetimes` only — every other function body
-// (methods, setters, getters, regular functions) goes through
-// `inferLifetimesCore`, which performs precise data-flow analysis via
-// `escapingRefsVisitor` instead of name-matching. See the TODO(#531) at
-// the call site for the plan to retire this visitor.
-//
-// It implements ast.Visitor directly: EnterBlock/ExitBlock maintain the
-// shadow stack for ordinary blocks; EnterExpr/EnterDecl handle the cases
-// that need bespoke ordering (FuncExpr/FuncDecl push their own scope
-// around the body; VarDecl visits its initializer BEFORE adding the new
-// binding so that `var p = p` resolves the RHS against the outer scope).
-type ctorBodyCaptureVisitor struct {
-	ast.DefaultVisitor
-	paramNameToIndex map[string]int
-	storedParams     set.Set[int]
-	// shadowed is a stack of block/function scopes. Each entry is the set
-	// of names bound in that scope. A name is considered shadowed if it
-	// appears in any active scope.
-	shadowed []set.Set[string]
-}
-
-func (v *ctorBodyCaptureVisitor) pushScope() {
-	v.shadowed = append(v.shadowed, set.NewSet[string]())
-}
-
-func (v *ctorBodyCaptureVisitor) popScope() {
-	v.shadowed = v.shadowed[:len(v.shadowed)-1]
-}
-
-func (v *ctorBodyCaptureVisitor) addBindings(pat ast.Pat) {
-	if len(v.shadowed) == 0 {
-		return
-	}
-	collectPatternBindingNames(pat, v.shadowed[len(v.shadowed)-1])
-}
-
-// visitParamDefaults visits the default expression of every leaf in a
-// parameter pattern (IdentPat.Default, ObjShorthandPat.Default), recursing
-// through container patterns. Defaults evaluate in the *enclosing* scope
-// at call time, so this must be called BEFORE the param's own bindings
-// are added to the shadow stack — otherwise a default like `q = p` would
-// incorrectly resolve `p` against the freshly-shadowed inner binding
-// instead of the outer scope.
-func (v *ctorBodyCaptureVisitor) visitParamDefaults(pat ast.Pat) {
-	if pat == nil {
-		return
-	}
-	switch p := pat.(type) {
-	case *ast.IdentPat:
-		if p.Default != nil {
-			p.Default.Accept(v)
-		}
-	case *ast.TuplePat:
-		for _, elem := range p.Elems {
-			v.visitParamDefaults(elem)
-		}
-	case *ast.ObjectPat:
-		for _, elem := range p.Elems {
-			switch e := elem.(type) {
-			case *ast.ObjKeyValuePat:
-				v.visitParamDefaults(e.Value)
-			case *ast.ObjShorthandPat:
-				if e.Default != nil {
-					e.Default.Accept(v)
-				}
-			case *ast.ObjRestPat:
-				v.visitParamDefaults(e.Pattern)
-			}
-		}
-	case *ast.RestPat:
-		v.visitParamDefaults(p.Pattern)
-	}
-}
-
-func (v *ctorBodyCaptureVisitor) isShadowed(name string) bool {
-	for _, s := range v.shadowed {
-		if s.Contains(name) {
-			return true
-		}
-	}
-	return false
-}
-
-func (v *ctorBodyCaptureVisitor) EnterBlock(b ast.Block) bool {
-	v.pushScope()
-	return true
-}
-
-func (v *ctorBodyCaptureVisitor) ExitBlock(b ast.Block) {
-	v.popScope()
-}
-
-func (v *ctorBodyCaptureVisitor) EnterExpr(e ast.Expr) bool {
-	switch ex := e.(type) {
-	case *ast.IdentExpr:
-		if !v.isShadowed(ex.Name) {
-			if idx, ok := v.paramNameToIndex[ex.Name]; ok {
-				v.storedParams.Add(idx)
-			}
-		}
-		return false
-	case *ast.FuncExpr:
-		// Nested function: its params introduce new shadows for the
-		// duration of its body. Drive the body traversal manually so
-		// the param-scope wraps the body's own block scope; return
-		// false to suppress the framework's default child recursion.
-		// Param defaults must be visited BEFORE pushing the new scope —
-		// they resolve against the enclosing scope, not the
-		// freshly-shadowed inner one.
-		for _, p := range ex.Params {
-			v.visitParamDefaults(p.Pattern)
-		}
-		v.pushScope()
-		for _, p := range ex.Params {
-			v.addBindings(p.Pattern)
-		}
-		if ex.Body != nil {
-			ex.Body.Accept(v)
-		}
-		v.popScope()
-		return false
-	}
-	return true
-}
-
-func (v *ctorBodyCaptureVisitor) EnterDecl(d ast.Decl) bool {
-	switch dd := d.(type) {
-	case *ast.VarDecl:
-		// Visit the initializer BEFORE adding the new binding to the
-		// current scope. This prevents `var p = p` from incorrectly
-		// treating the RHS `p` as the freshly-shadowed inner binding —
-		// it should resolve against the enclosing scope (potentially
-		// the constructor's param).
-		if dd.Init != nil {
-			dd.Init.Accept(v)
-		}
-		v.addBindings(dd.Pattern)
-		return false
-	case *ast.FuncDecl:
-		// Nested function declaration: similar to FuncExpr, its params
-		// shadow outer names within its body. Param defaults resolve
-		// against the enclosing scope and must be visited BEFORE the
-		// new param scope is pushed.
-		if dd.Body == nil {
-			return false
-		}
-		for _, p := range dd.Params {
-			v.visitParamDefaults(p.Pattern)
-		}
-		v.pushScope()
-		for _, p := range dd.Params {
-			v.addBindings(p.Pattern)
-		}
-		dd.Body.Accept(v)
-		v.popScope()
-		return false
-	case *ast.ClassDecl:
-		// Skip nested classes — their constructor param names introduce
-		// a fresh shadow scope that's outside the analysis we care about.
-		_ = dd
-		return false
-	}
-	return true
 }
 
 // forEachLeafBinding invokes fn for every identifier-binding leaf

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1545,7 +1545,7 @@ func (c *Checker) InferComponent(
 						// in the same SCC are visible to
 						// `determineCheckerAliasSource`, so escapes through call
 						// expressions like `self.f = wrap(p)` are detected.
-						c.InferConstructorLifetimes(ctorBodyCtx, decl, typeAlias, ctorFuncType)
+						c.InferConstructorLifetimes(decl, typeAlias, ctorFuncType)
 
 						// Phase 3: definite-assignment analysis. Subclasses
 						// (`extends`) are deferred — `super(...)` semantics

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -733,10 +733,10 @@ func (c *Checker) InferComponent(
 				}
 				nsCtx.Scope.setValue(decl.Name.Name, ctor)
 
-				// Infer lifetime parameters and default mutability for the
-				// class. Runs once during the placeholder phase since the class
-				// body's stored-field structure is purely syntactic.
-				c.InferConstructorLifetimes(declCtx, decl, typeAlias, funcType)
+				// Lifetime inference for the constructor runs in the body
+				// phase (mirroring methods/funcs), after the ctor body has
+				// been type-checked and callee signatures in the same SCC
+				// have been resolved.
 			case *ast.EnumDecl:
 				// Check if we've already processed this enum from another binding key
 				// (enums have both type and value keys that may be in different components)
@@ -1538,6 +1538,14 @@ func (c *Checker) InferComponent(
 						)
 						errors = slices.Concat(errors, bodyErrors)
 						ctorFuncType.Throws = bodyFuncType.Throws
+
+						// Infer lifetime parameters for the ctor now that its
+						// body is fully type-checked. Running here (vs. in the
+						// placeholder phase) means callee signatures from peers
+						// in the same SCC are visible to
+						// `determineCheckerAliasSource`, so escapes through call
+						// expressions like `self.f = wrap(p)` are detected.
+						c.InferConstructorLifetimes(ctorBodyCtx, decl, typeAlias, ctorFuncType)
 
 						// Phase 3: definite-assignment analysis. Subclasses
 						// (`extends`) are deferred — `super(...)` semantics

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -736,7 +736,7 @@ func (c *Checker) InferComponent(
 				// Infer lifetime parameters and default mutability for the
 				// class. Runs once during the placeholder phase since the class
 				// body's stored-field structure is purely syntactic.
-				c.InferConstructorLifetimes(decl, typeAlias, funcType)
+				c.InferConstructorLifetimes(declCtx, decl, typeAlias, funcType)
 			case *ast.EnumDecl:
 				// Check if we've already processed this enum from another binding key
 				// (enums have both type and value keys that may be in different components)

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -525,6 +525,48 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"Pair": "{new fn <'a, 'b>(first: mut 'a {x: number}, second: mut 'b {x: number}) -> Pair<'a, 'b>}",
 			},
 		},
+		"GuardOnlyParamNotCaptured": {
+			// A param read by a guard but never stored into self should
+			// NOT pin a lifetime onto the constructor — there's no
+			// reachable state that aliases it after the constructor
+			// returns. (#531)
+			input: `
+				class C {
+					n: number,
+					constructor(mut self, p: mut {x: number}) {
+						self.n = 0
+						if p.x < 0 {
+							self.n = 1
+						}
+					}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn (p: mut {x: number}) -> C}",
+			},
+			expectedInstanceLifetimes: map[string]int{
+				"C": 0,
+			},
+		},
+		"DerivedValueParamNotCaptured": {
+			// A param used purely to derive a fresh value and store
+			// THAT fresh value should not pin a lifetime onto the param
+			// itself. (#531)
+			input: `
+				class C {
+					n: number,
+					constructor(mut self, p: {x: number}) {
+						self.n = p.x + 1
+					}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn (p: {x: number}) -> C}",
+			},
+			expectedInstanceLifetimes: map[string]int{
+				"C": 0,
+			},
+		},
 		"GetterCapturesConstructorParam": {
 			// A getter whose body references a constructor param by name
 			// (made visible via the synthesized `self.p = p` body) forces

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -632,6 +632,36 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 	}
 }
 
+// TestCtorCapturesViaWrappingCall is a known-failing case for #531:
+// `self.f = wrap(p)` should pin p's lifetime onto the ctor because wrap's
+// return aliases its argument. The detection works for non-ctor functions
+// (see the SCC reinfer loop in InferComponent) but not for constructors,
+// because InferConstructorLifetimes runs once during the placeholder
+// phase — before any callee body has been inferred — so
+// determineCheckerAliasSource sees no lifetime info on `wrap`'s return
+// and treats the call as opaque. The fix needs the constructor path to
+// participate in the post-body fixed-point reinference loop, which
+// requires making setLifetimeOnType / setLifetimeArgsOnType /
+// typeAlias.LifetimeParams updates idempotent and reconciling them with
+// any class consumers that already resolved C during the body phase.
+func TestCtorCapturesViaWrappingCall(t *testing.T) {
+	t.Skip("known limitation: ctor-call escapes need post-body reinference (#531)")
+	t.Parallel()
+	ns := mustInferAsModule(t, `
+		fn wrap(x: mut {y: number}) -> mut {y: number} { return x }
+		class C {
+			f: mut {y: number},
+			constructor(mut self, p: mut {y: number}) {
+				self.f = wrap(p)
+			}
+		}
+	`)
+	actual := collectBindingTypes(ns)
+	got, ok := actual["C"]
+	require.True(t, ok, "binding C not found")
+	assert.Equal(t, "{new fn <'a>(p: mut 'a {y: number}) -> C<'a>}", got)
+}
+
 // TestCallSiteAliasFromLifetimeUnion exercises the LifetimeUnion call-site
 // path: a function whose return aliases either of two parameters
 // (`('a | 'b)`) is called, the result variable joins the alias sets of

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -632,20 +632,12 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 	}
 }
 
-// TestCtorCapturesViaWrappingCall is a known-failing case for #531:
-// `self.f = wrap(p)` should pin p's lifetime onto the ctor because wrap's
-// return aliases its argument. The detection works for non-ctor functions
-// (see the SCC reinfer loop in InferComponent) but not for constructors,
-// because InferConstructorLifetimes runs once during the placeholder
-// phase — before any callee body has been inferred — so
-// determineCheckerAliasSource sees no lifetime info on `wrap`'s return
-// and treats the call as opaque. The fix needs the constructor path to
-// participate in the post-body fixed-point reinference loop, which
-// requires making setLifetimeOnType / setLifetimeArgsOnType /
-// typeAlias.LifetimeParams updates idempotent and reconciling them with
-// any class consumers that already resolved C during the body phase.
+// TestCtorCapturesViaWrappingCall: `self.f = wrap(p)` pins p's lifetime
+// onto the ctor because wrap's return aliases its argument. Works because
+// InferConstructorLifetimes runs in the body phase (after wrap's signature
+// has been resolved), letting determineCheckerAliasSource trace through
+// the call. (#531)
 func TestCtorCapturesViaWrappingCall(t *testing.T) {
-	t.Skip("known limitation: ctor-call escapes need post-body reinference (#531)")
 	t.Parallel()
 	ns := mustInferAsModule(t, `
 		fn wrap(x: mut {y: number}) -> mut {y: number} { return x }

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -567,6 +567,24 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"C": 0,
 			},
 		},
+		"DestructuredTupleCtorParamCapture": {
+			// A destructured tuple ctor param whose leaves are stored
+			// into self should still pin lifetimes onto the param. (#531)
+			input: `
+				class C {
+					a: mut {x: number},
+					constructor(mut self, [a, b]: [mut {x: number}, mut {x: number}]) {
+						self.a = a
+					}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"C": "{new fn <'a>([a: mut 'a {x: number}, b: mut {x: number}]) -> C<'a>}",
+			},
+			expectedInstanceLifetimes: map[string]int{
+				"C": 1,
+			},
+		},
 		"GetterCapturesConstructorParam": {
 			// A getter whose body references a constructor param by name
 			// (made visible via the synthesized `self.p = p` body) forces


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved constructor lifetime inference to more accurately detect which parameters require lifetime annotations, reducing unnecessary lifetime constraints in constructors.

* **Tests**
  * Expanded constructor lifetime inference test coverage with additional test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->