### PR TITLE
Class Constructor 5: Optional fields

### DIFF
--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -67,6 +67,7 @@ type FieldElem struct {
 	Static   bool // true if this is a static field
 	Private  bool // true if this field is private
 	Readonly bool // true if this field is readonly
+	Optional bool // true if this field is declared `name?: T`
 	Span_    Span
 }
 

--- a/internal/checker/infer_class_ctor.go
+++ b/internal/checker/infer_class_ctor.go
@@ -202,6 +202,13 @@ func (c *Checker) synthesizeConstructorElem(decl *ast.ClassDecl) (*ast.Construct
 		if field.Static {
 			continue
 		}
+		// Optional fields (`x?: T`) are not synthesized as constructor
+		// parameters — they default to `undefined` and may be assigned
+		// later. Including them would force callers to pass arguments
+		// for every optional field.
+		if field.Optional {
+			continue
+		}
 
 		fieldSpan := field.Span()
 

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -504,7 +504,11 @@ func (c *Checker) InferComponent(
 						}
 
 						if elem.Static {
-							// Static fields go to the class object type
+							// Static fields go to the class object type.
+							// Optional is intentionally not propagated here:
+							// the parser rejects `static x?: T`, so a static
+							// field with Optional=true only reaches this
+							// point in error-recovery paths.
 							tvar := c.FreshVar(nil)
 							tvar.FromBinding = true
 							propElem := type_system.NewPropertyElem(*key, tvar)
@@ -519,6 +523,7 @@ func (c *Checker) InferComponent(
 							tvar.FromBinding = true
 							propElem := type_system.NewPropertyElem(*key, tvar)
 							propElem.Readonly = elem.Readonly
+							propElem.Optional = elem.Optional
 							objTypeElems = append(
 								objTypeElems,
 								propElem,

--- a/internal/checker/init_check.go
+++ b/internal/checker/init_check.go
@@ -496,12 +496,8 @@ func (ic *initChecker) checkExitMissing(span ast.Span, st initState) {
 
 // requiredFieldNames returns the names of instance fields that must be
 // definitely-assigned by every reachable exit of a constructor body.
-// Static fields, fields with default initializers (`= expr` or the legacy
-// `x: expr` shorthand), and fields with computed keys are excluded.
-//
-// Optional fields (`x?: T`) are not yet plumbed through the AST
-// (see the §2.4 note in `tests/constructor_test.go`); when they are,
-// they should be excluded here too.
+// Static fields, optional fields (`x?: T`), fields with default
+// initializers (`= expr`), and fields with computed keys are excluded.
 func requiredFieldNames(decl *ast.ClassDecl) []string {
 	out := []string{}
 	for _, elem := range decl.Body {
@@ -510,6 +506,9 @@ func requiredFieldNames(decl *ast.ClassDecl) []string {
 			continue
 		}
 		if field.Static {
+			continue
+		}
+		if field.Optional {
 			continue
 		}
 		switch k := field.Name.(type) {

--- a/internal/checker/tests/constructor_test.go
+++ b/internal/checker/tests/constructor_test.go
@@ -394,10 +394,9 @@ func TestOptionalFields(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		input           string
-		expectedTypes   map[string]string   // binding name -> type string
-		typeContains    map[string][]string // type alias name -> substrings that must appear
-		typeNotContains map[string][]string // type alias name -> substrings that must not appear
+		input             string
+		expectedTypes     map[string]string // binding name -> type string
+		expectedAliasType map[string]string // type alias name -> full type string
 	}
 
 	cases := map[string]testCase{
@@ -418,8 +417,9 @@ func TestOptionalFields(t *testing.T) {
 					y?: string,
 				}
 			`,
-			typeContains:    map[string][]string{"Foo": {"y?:"}},
-			typeNotContains: map[string][]string{"Foo": {"x?:"}},
+			expectedAliasType: map[string]string{
+				"Foo": "{x: number, y?: string}",
+			},
 		},
 		"MixedRequiredAndOptionalDropsOptionalFromParams": {
 			input: `
@@ -474,23 +474,11 @@ func TestOptionalFields(t *testing.T) {
 						"unexpected type for binding %q", binding)
 				}
 			}
-			for typeName, subs := range tc.typeContains {
+			for typeName, want := range tc.expectedAliasType {
 				alias, ok := ns.Types[typeName]
 				require.Truef(t, ok, "type alias %q not found", typeName)
-				got := alias.Type.String()
-				for _, sub := range subs {
-					assert.Containsf(t, got, sub,
-						"expected type %q to contain %q; got %q", typeName, sub, got)
-				}
-			}
-			for typeName, subs := range tc.typeNotContains {
-				alias, ok := ns.Types[typeName]
-				require.Truef(t, ok, "type alias %q not found", typeName)
-				got := alias.Type.String()
-				for _, sub := range subs {
-					assert.NotContainsf(t, got, sub,
-						"expected type %q not to contain %q; got %q", typeName, sub, got)
-				}
+				assert.Equalf(t, want, alias.Type.String(),
+					"unexpected type for alias %q", typeName)
 			}
 		})
 	}

--- a/internal/checker/tests/constructor_test.go
+++ b/internal/checker/tests/constructor_test.go
@@ -409,6 +409,9 @@ func TestOptionalFields(t *testing.T) {
 				val f = Foo()
 			`,
 			expectedTypes: map[string]string{"f": "Foo"},
+			expectedAliasType: map[string]string{
+				"Foo": "{x?: number, y?: string}",
+			},
 		},
 		"OptionalBitPropagatedToInstanceType": {
 			input: `
@@ -442,6 +445,9 @@ func TestOptionalFields(t *testing.T) {
 				}
 				val b = Box(1)
 			`,
+			expectedAliasType: map[string]string{
+				"Box": "{x: number, note?: string}",
+			},
 		},
 		"OptionalAssignedInSomeBranchesIsOk": {
 			input: `
@@ -457,6 +463,9 @@ func TestOptionalFields(t *testing.T) {
 				}
 				val b = Box(1, true)
 			`,
+			expectedAliasType: map[string]string{
+				"Box": "{x: number, note?: string}",
+			},
 		},
 	}
 
@@ -538,7 +547,6 @@ func TestSubclassSynthesisIsNotAllowed(t *testing.T) {
 	require.NotEmpty(t, errs,
 		"expected a diagnostic for subclass without an explicit constructor; got none")
 }
-
 
 func formatErrs(errs []Error) []string {
 	out := make([]string, len(errs))

--- a/internal/checker/tests/constructor_test.go
+++ b/internal/checker/tests/constructor_test.go
@@ -496,6 +496,19 @@ func TestOptionalFields(t *testing.T) {
 		_, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
 		require.NotEmpty(t, parseErrors,
 			"expected a parse error for `static x?: number = 0`")
+		var sawStaticOptional, sawDefault bool
+		for _, e := range parseErrors {
+			if strings.Contains(e.Message, "Static fields cannot be optional") {
+				sawStaticOptional = true
+			}
+			if strings.Contains(e.Message, "Optional fields cannot have a default initializer") {
+				sawDefault = true
+			}
+		}
+		assert.True(t, sawStaticOptional,
+			"expected `Static fields cannot be optional` diagnostic; got: %v", parseErrors)
+		assert.True(t, sawDefault,
+			"expected `Optional fields cannot have a default initializer` diagnostic; got: %v", parseErrors)
 	})
 }
 

--- a/internal/checker/tests/constructor_test.go
+++ b/internal/checker/tests/constructor_test.go
@@ -387,11 +387,117 @@ func TestConstructorInferredTypes(t *testing.T) {
 	}
 }
 
-// Note: optional-field syntax (`x?: T`) is in the §2.4 plan but isn't
-// yet plumbed through the AST, so the "only optional fields → Foo()"
-// case described in the plan can't be exercised at the source level
-// today. The closest current shape — an empty class — is already
-// covered by `TestSynthesizedConstructor/NoFields`.
+// TestOptionalFields covers Phase 5: optional field declarations
+// (`x?: T`) are excluded from the definite-assignment requirement and
+// from synthesized-constructor parameter lists.
+func TestOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AllOptionalSynthesizesZeroArgCtor", func(t *testing.T) {
+		t.Parallel()
+		input := `
+			class Foo {
+				x?: number,
+				y?: string,
+			}
+			val f = Foo()
+		`
+		errs := inferModuleErrors(t, input)
+		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
+		ns := mustInferAsModule(t, input)
+		actual := collectBindingTypes(ns)
+		assert.Equal(t, "Foo", actual["f"])
+	})
+
+	t.Run("OptionalBitPropagatedToInstanceType", func(t *testing.T) {
+		t.Parallel()
+		input := `
+			class Foo {
+				x: number,
+				y?: string,
+			}
+		`
+		errs := inferModuleErrors(t, input)
+		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
+		ns := mustInferAsModule(t, input)
+		alias, ok := ns.Types["Foo"]
+		require.True(t, ok, "type alias Foo not found")
+		got := alias.Type.String()
+		assert.Contains(t, got, "y?:",
+			"expected instance type to render `y?:` (Optional propagated); got %q", got)
+		assert.NotContains(t, got, "x?:",
+			"required field x must not render as optional; got %q", got)
+	})
+
+	t.Run("MixedRequiredAndOptionalDropsOptionalFromParams", func(t *testing.T) {
+		t.Parallel()
+		input := `
+			class Mixed {
+				x: number,
+				y?: number,
+			}
+			val m = Mixed(1)
+		`
+		errs := inferModuleErrors(t, input)
+		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
+		ns := mustInferAsModule(t, input)
+		actual := collectBindingTypes(ns)
+		assert.Equal(t, "Mixed", actual["m"])
+	})
+
+	t.Run("ExplicitCtorMayLeaveOptionalUnassigned", func(t *testing.T) {
+		t.Parallel()
+		input := `
+			class Box {
+				x: number,
+				note?: string,
+				constructor(mut self, x: number) {
+					self.x = x
+				}
+			}
+			val b = Box(1)
+		`
+		errs := inferModuleErrors(t, input)
+		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
+	})
+
+	t.Run("OptionalAssignedInSomeBranchesIsOk", func(t *testing.T) {
+		t.Parallel()
+		input := `
+			class Box {
+				x: number,
+				note?: string,
+				constructor(mut self, x: number, tag: boolean) {
+					self.x = x
+					if tag {
+						self.note = "tagged"
+					}
+				}
+			}
+			val b = Box(1, true)
+		`
+		errs := inferModuleErrors(t, input)
+		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
+	})
+
+	t.Run("StaticOptionalWithDefaultIsParseError", func(t *testing.T) {
+		t.Parallel()
+		input := `
+			class Foo {
+				static x?: number = 0,
+			}
+		`
+		// Triggers both the static+optional and optional+default
+		// diagnostics; the dedicated single-error cases live in
+		// internal/parser/stmt_test.go.
+		source := &ast.Source{ID: 0, Path: "input.esc", Contents: input}
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+		require.NotEmpty(t, parseErrors,
+			"expected a parse error for `static x?: number = 0`")
+	})
+}
 
 // Note on `mut self` / explicit-return-type validation: the surface
 // parser already rejects `constructor(self, ...)` /

--- a/internal/checker/tests/constructor_test.go
+++ b/internal/checker/tests/constructor_test.go
@@ -393,122 +393,131 @@ func TestConstructorInferredTypes(t *testing.T) {
 func TestOptionalFields(t *testing.T) {
 	t.Parallel()
 
-	t.Run("AllOptionalSynthesizesZeroArgCtor", func(t *testing.T) {
-		t.Parallel()
-		input := `
-			class Foo {
-				x?: number,
-				y?: string,
-			}
-			val f = Foo()
-		`
-		errs := inferModuleErrors(t, input)
-		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
-		ns := mustInferAsModule(t, input)
-		actual := collectBindingTypes(ns)
-		assert.Equal(t, "Foo", actual["f"])
-	})
+	type testCase struct {
+		input           string
+		expectedTypes   map[string]string   // binding name -> type string
+		typeContains    map[string][]string // type alias name -> substrings that must appear
+		typeNotContains map[string][]string // type alias name -> substrings that must not appear
+	}
 
-	t.Run("OptionalBitPropagatedToInstanceType", func(t *testing.T) {
-		t.Parallel()
-		input := `
-			class Foo {
-				x: number,
-				y?: string,
-			}
-		`
-		errs := inferModuleErrors(t, input)
-		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
-		ns := mustInferAsModule(t, input)
-		alias, ok := ns.Types["Foo"]
-		require.True(t, ok, "type alias Foo not found")
-		got := alias.Type.String()
-		assert.Contains(t, got, "y?:",
-			"expected instance type to render `y?:` (Optional propagated); got %q", got)
-		assert.NotContains(t, got, "x?:",
-			"required field x must not render as optional; got %q", got)
-	})
-
-	t.Run("MixedRequiredAndOptionalDropsOptionalFromParams", func(t *testing.T) {
-		t.Parallel()
-		input := `
-			class Mixed {
-				x: number,
-				y?: number,
-			}
-			val m = Mixed(1)
-		`
-		errs := inferModuleErrors(t, input)
-		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
-		ns := mustInferAsModule(t, input)
-		actual := collectBindingTypes(ns)
-		assert.Equal(t, "Mixed", actual["m"])
-	})
-
-	t.Run("ExplicitCtorMayLeaveOptionalUnassigned", func(t *testing.T) {
-		t.Parallel()
-		input := `
-			class Box {
-				x: number,
-				note?: string,
-				constructor(mut self, x: number) {
-					self.x = x
+	cases := map[string]testCase{
+		"AllOptionalSynthesizesZeroArgCtor": {
+			input: `
+				class Foo {
+					x?: number,
+					y?: string,
 				}
-			}
-			val b = Box(1)
-		`
-		errs := inferModuleErrors(t, input)
-		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
-	})
-
-	t.Run("OptionalAssignedInSomeBranchesIsOk", func(t *testing.T) {
-		t.Parallel()
-		input := `
-			class Box {
-				x: number,
-				note?: string,
-				constructor(mut self, x: number, tag: boolean) {
-					self.x = x
-					if tag {
-						self.note = "tagged"
+				val f = Foo()
+			`,
+			expectedTypes: map[string]string{"f": "Foo"},
+		},
+		"OptionalBitPropagatedToInstanceType": {
+			input: `
+				class Foo {
+					x: number,
+					y?: string,
+				}
+			`,
+			typeContains:    map[string][]string{"Foo": {"y?:"}},
+			typeNotContains: map[string][]string{"Foo": {"x?:"}},
+		},
+		"MixedRequiredAndOptionalDropsOptionalFromParams": {
+			input: `
+				class Mixed {
+					x: number,
+					y?: number,
+				}
+				val m = Mixed(1)
+			`,
+			expectedTypes: map[string]string{"m": "Mixed"},
+		},
+		"ExplicitCtorMayLeaveOptionalUnassigned": {
+			input: `
+				class Box {
+					x: number,
+					note?: string,
+					constructor(mut self, x: number) {
+						self.x = x
 					}
 				}
-			}
-			val b = Box(1, true)
-		`
-		errs := inferModuleErrors(t, input)
-		require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
-	})
+				val b = Box(1)
+			`,
+		},
+		"OptionalAssignedInSomeBranchesIsOk": {
+			input: `
+				class Box {
+					x: number,
+					note?: string,
+					constructor(mut self, x: number, tag: boolean) {
+						self.x = x
+						if tag {
+							self.note = "tagged"
+						}
+					}
+				}
+				val b = Box(1, true)
+			`,
+		},
+	}
 
-	t.Run("StaticOptionalWithDefaultIsParseError", func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			errs := inferModuleErrors(t, tc.input)
+			require.Empty(t, errs, "expected no errors; got: %v", formatErrs(errs))
+			ns := mustInferAsModule(t, tc.input)
+
+			if len(tc.expectedTypes) > 0 {
+				actual := collectBindingTypes(ns)
+				for binding, want := range tc.expectedTypes {
+					assert.Equal(t, want, actual[binding],
+						"unexpected type for binding %q", binding)
+				}
+			}
+			for typeName, subs := range tc.typeContains {
+				alias, ok := ns.Types[typeName]
+				require.Truef(t, ok, "type alias %q not found", typeName)
+				got := alias.Type.String()
+				for _, sub := range subs {
+					assert.Containsf(t, got, sub,
+						"expected type %q to contain %q; got %q", typeName, sub, got)
+				}
+			}
+			for typeName, subs := range tc.typeNotContains {
+				alias, ok := ns.Types[typeName]
+				require.Truef(t, ok, "type alias %q not found", typeName)
+				got := alias.Type.String()
+				for _, sub := range subs {
+					assert.NotContainsf(t, got, sub,
+						"expected type %q not to contain %q; got %q", typeName, sub, got)
+				}
+			}
+		})
+	}
+
+	// StaticOptionalIsParseError is kept separate: it exercises the
+	// parser-error path rather than the inference pipeline.
+	t.Run("StaticOptionalIsParseError", func(t *testing.T) {
 		t.Parallel()
 		input := `
 			class Foo {
-				static x?: number = 0,
+				static x?: number,
 			}
 		`
-		// Triggers both the static+optional and optional+default
-		// diagnostics; the dedicated single-error cases live in
-		// internal/parser/stmt_test.go.
 		source := &ast.Source{ID: 0, Path: "input.esc", Contents: input}
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 		_, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
 		require.NotEmpty(t, parseErrors,
-			"expected a parse error for `static x?: number = 0`")
-		var sawStaticOptional, sawDefault bool
+			"expected a parse error for `static x?: number`")
+		var sawStaticOptional bool
 		for _, e := range parseErrors {
 			if strings.Contains(e.Message, "Static fields cannot be optional") {
 				sawStaticOptional = true
 			}
-			if strings.Contains(e.Message, "Optional fields cannot have a default initializer") {
-				sawDefault = true
-			}
 		}
 		assert.True(t, sawStaticOptional,
 			"expected `Static fields cannot be optional` diagnostic; got: %v", parseErrors)
-		assert.True(t, sawDefault,
-			"expected `Optional fields cannot have a default initializer` diagnostic; got: %v", parseErrors)
 	})
 }
 

--- a/internal/interop/__snapshots__/helper_test.snap
+++ b/internal/interop/__snapshots__/helper_test.snap
@@ -4457,6 +4457,7 @@
     Static:   false,
     Private:  false,
     Readonly: false,
+    Optional: false,
     Span_:    ast.Span{
         Start:    ast.Location{Line:1, Column:22},
         End:      ast.Location{Line:1, Column:35},
@@ -4491,6 +4492,7 @@
     Static:   false,
     Private:  false,
     Readonly: true,
+    Optional: false,
     Span_:    ast.Span{
         Start:    ast.Location{Line:1, Column:31},
         End:      ast.Location{Line:1, Column:41},
@@ -4525,6 +4527,7 @@
     Static:   true,
     Private:  false,
     Readonly: false,
+    Optional: false,
     Span_:    ast.Span{
         Start:    ast.Location{Line:1, Column:29},
         End:      ast.Location{Line:1, Column:44},
@@ -4559,6 +4562,7 @@
     Static:   false,
     Private:  true,
     Readonly: false,
+    Optional: false,
     Span_:    ast.Span{
         Start:    ast.Location{Line:1, Column:30},
         End:      ast.Location{Line:1, Column:44},
@@ -4593,6 +4597,7 @@
     Static:   false,
     Private:  false,
     Readonly: false,
+    Optional: false,
     Span_:    ast.Span{
         Start:    ast.Location{Line:1, Column:22},
         End:      ast.Location{Line:1, Column:42},
@@ -4627,6 +4632,7 @@
     Static:   true,
     Private:  false,
     Readonly: true,
+    Optional: false,
     Span_:    ast.Span{
         Start:    ast.Location{Line:1, Column:38},
         End:      ast.Location{Line:1, Column:54},

--- a/internal/interop/__snapshots__/helper_test.snap
+++ b/internal/interop/__snapshots__/helper_test.snap
@@ -4597,7 +4597,7 @@
     Static:   false,
     Private:  false,
     Readonly: false,
-    Optional: false,
+    Optional: true,
     Span_:    ast.Span{
         Start:    ast.Location{Line:1, Column:22},
         End:      ast.Location{Line:1, Column:42},

--- a/internal/interop/decl_test.go
+++ b/internal/interop/decl_test.go
@@ -472,6 +472,23 @@ func TestConvertClassDecl(t *testing.T) {
 			},
 		},
 		{
+			name:      "class with optional property",
+			input:     "declare class Box { note?: string }",
+			wantError: false,
+			checkFunc: func(t *testing.T, decl *ast.ClassDecl) {
+				if len(decl.Body) != 1 {
+					t.Fatalf("expected 1 body element, got %d", len(decl.Body))
+				}
+				field, ok := decl.Body[0].(*ast.FieldElem)
+				if !ok {
+					t.Fatalf("expected FieldElem, got %T", decl.Body[0])
+				}
+				if !field.Optional {
+					t.Errorf("expected Optional=true on field converted from `note?: string`")
+				}
+			},
+		},
+		{
 			name:      "class with method",
 			input:     "declare class Calculator { add(a: number): number }",
 			wantError: false,

--- a/internal/interop/helper.go
+++ b/internal/interop/helper.go
@@ -683,6 +683,7 @@ func convertPropertyDecl(pd *dts_parser.PropertyDecl) (*ast.FieldElem, error) {
 		Static:   pd.Modifiers.Static,
 		Private:  pd.Modifiers.Private,
 		Readonly: pd.Modifiers.Readonly,
+		Optional: pd.Optional,
 		Span_:    pd.Span(),
 	}, nil
 }

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -6850,6 +6850,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:15},
@@ -6881,6 +6882,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:4, Column:6},
                     End:      ast.Location{Line:4, Column:15},
@@ -9042,6 +9044,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:18},
@@ -9385,6 +9388,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:15},
@@ -9580,6 +9584,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:14},
@@ -9775,6 +9780,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:15},
@@ -11144,6 +11150,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:14},
@@ -11351,6 +11358,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:18},

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -2565,6 +2565,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:14},
@@ -2596,6 +2597,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:5},
                     End:      ast.Location{Line:3, Column:14},
@@ -3177,6 +3179,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:13},
@@ -3479,6 +3482,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:13},
@@ -3779,6 +3783,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:1, Column:35},
                     End:      ast.Location{Line:1, Column:42},
@@ -3878,6 +3883,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:13},
@@ -3920,6 +3926,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:5},
                     End:      ast.Location{Line:3, Column:14},
@@ -5285,6 +5292,7 @@
                 Static:   false,
                 Private:  true,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:24},
@@ -5316,6 +5324,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:5},
                     End:      ast.Location{Line:3, Column:16},
@@ -5755,6 +5764,7 @@
                 Static:   false,
                 Private:  true,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:27},
@@ -6032,6 +6042,7 @@
                 Static:   false,
                 Private:  true,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:27},
@@ -6605,6 +6616,7 @@
                 Static:   false,
                 Private:  true,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:8},
                     End:      ast.Location{Line:2, Column:30},
@@ -6778,6 +6790,7 @@
                 Static:   false,
                 Private:  true,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:8},
                     End:      ast.Location{Line:2, Column:30},
@@ -7041,6 +7054,7 @@
                 Static:   false,
                 Private:  true,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:8},
                     End:      ast.Location{Line:2, Column:31},
@@ -7291,6 +7305,7 @@
                 Static:   false,
                 Private:  true,
                 Readonly: true,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:2, Column:8},
                     End:      ast.Location{Line:2, Column:35},
@@ -7322,6 +7337,7 @@
                 Static:   false,
                 Private:  false,
                 Readonly: true,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:3, Column:5},
                     End:      ast.Location{Line:3, Column:29},
@@ -9119,6 +9135,7 @@ nil
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:1, Column:13},
                     End:      ast.Location{Line:1, Column:22},
@@ -9150,6 +9167,7 @@ nil
                 Static:   false,
                 Private:  false,
                 Readonly: false,
+                Optional: false,
                 Span_:    ast.Span{
                     Start:    ast.Location{Line:1, Column:24},
                     End:      ast.Location{Line:1, Column:33},

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -591,15 +591,8 @@ modifiers_done:
 		// the grammar permissive lets the parser recover after an
 		// erroneous instance-field initializer.
 		if p.lexer.peek().Type == Equal {
-			eqSpan := p.lexer.peek().Span
 			p.lexer.consume()
 			value = p.expr()
-			if isOptional {
-				// `x?: T = expr` is rejected: an optional field with a
-				// default initializer is contradictory — the default
-				// would always apply, leaving nothing optional about it.
-				p.reportError(eqSpan, "Optional fields cannot have a default initializer")
-			}
 		}
 
 		// TODO: report an error if `isAsync` is true

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -556,8 +556,25 @@ modifiers_done:
 		//                            initialized in the constructor body.
 		var typeAnn ast.TypeAnn
 		var value ast.Expr
+		isOptional := false
 
 		next = p.lexer.peek()
+
+		// `name?: T` declares an optional field. The `?` binds to the
+		// name and must precede the type annotation.
+		if next.Type == Question {
+			p.lexer.consume()
+			// We still set isOptional even when isStatic — downstream
+			// consumers (requiredFieldNames, synthesizeConstructorElem)
+			// short-circuit on Static first, so leaving the bit set keeps
+			// error recovery consistent rather than depending on the
+			// order of these guards.
+			isOptional = true
+			if isStatic {
+				p.reportError(next.Span, "Static fields cannot be optional")
+			}
+			next = p.lexer.peek()
+		}
 
 		if next.Type == Colon {
 			p.lexer.consume()
@@ -574,8 +591,15 @@ modifiers_done:
 		// the grammar permissive lets the parser recover after an
 		// erroneous instance-field initializer.
 		if p.lexer.peek().Type == Equal {
+			eqSpan := p.lexer.peek().Span
 			p.lexer.consume()
 			value = p.expr()
+			if isOptional {
+				// `x?: T = expr` is rejected: an optional field with a
+				// default initializer is contradictory — the default
+				// would always apply, leaving nothing optional about it.
+				p.reportError(eqSpan, "Optional fields cannot have a default initializer")
+			}
 		}
 
 		// TODO: report an error if `isAsync` is true
@@ -587,6 +611,7 @@ modifiers_done:
 			Static:   isStatic,
 			Private:  isPrivate,
 			Readonly: isReadonly,
+			Optional: isOptional,
 			Span_:    span,
 		}
 	}

--- a/internal/parser/stmt_test.go
+++ b/internal/parser/stmt_test.go
@@ -400,10 +400,6 @@ func TestRetiredClassSyntax(t *testing.T) {
 			input:         `class Foo { x, }`,
 			wantSubstring: "Class fields require a type annotation",
 		},
-		"OptionalFieldWithDefault": {
-			input:         `class Foo { x?: number = 0, }`,
-			wantSubstring: "Optional fields cannot have a default initializer",
-		},
 		"StaticOptionalField": {
 			input:         `class Foo { static x?: number, }`,
 			wantSubstring: "Static fields cannot be optional",

--- a/internal/parser/stmt_test.go
+++ b/internal/parser/stmt_test.go
@@ -400,6 +400,14 @@ func TestRetiredClassSyntax(t *testing.T) {
 			input:         `class Foo { x, }`,
 			wantSubstring: "Class fields require a type annotation",
 		},
+		"OptionalFieldWithDefault": {
+			input:         `class Foo { x?: number = 0, }`,
+			wantSubstring: "Optional fields cannot have a default initializer",
+		},
+		"StaticOptionalField": {
+			input:         `class Foo { static x?: number, }`,
+			wantSubstring: "Static fields cannot be optional",
+		},
 	}
 
 	for name, test := range tests {

--- a/planning/class_constructor/implementation_plan.md
+++ b/planning/class_constructor/implementation_plan.md
@@ -22,7 +22,7 @@ cut-over, on top of the new single-constructor codepath.
 |     3 | Definite-assignment analysis on constructor bodies                                         | 2          | Done   |
 |     4 | Combined cut-over: single-ctor codegen, fixture migration, removal of primary ctor + `data` | 3          | Done (PR [#520](https://github.com/escalier-lang/escalier/pull/520)) |
 |   4.9 | Post-cut-over cleanups (parser tightening, follow-up issues filed)                         | 4          | Done   |
-|     5 | Optional fields (`x?: T`): parser/AST plumbing, exclude from definite-assignment, enable all-optional synthesized ctor | 4          |        |
+|     5 | Optional fields (`x?: T`): parser/AST plumbing, exclude from definite-assignment, enable all-optional synthesized ctor | 4          | Done   |
 |     6 | Multiple constructors: overload resolution, runtime discriminator analysis, merged codegen | 5          |        |
 |     7 | Polish: error messages, diagnostics, documentation                                         | 6          |        |
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional class field declarations using `?` syntax (e.g., `fieldName?: Type`)
  * Optional fields are automatically excluded from synthesized constructor parameters and default to `undefined`
  * Optional fields don't require assignment in all code paths within constructors
  * Static fields and optional fields with default initializers are not supported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->