### PR TITLE
Lifetimes 8.9: Element-Level and Property-Level Lifetimes

### DIFF
--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -283,7 +283,7 @@ func (c *Checker) trackAliasesForIdentPat(
 		aliasMut = liveness.AliasImmutable
 	}
 
-	switch source.Kind() {
+	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
 		sourceVarID := source.VarIDs()[0]
 		ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
@@ -339,7 +339,7 @@ func (c *Checker) trackAliasesForIdentPat(
 		// Unknown — create a fresh value conservatively
 		ctx.Aliases.NewValue(targetVarID, aliasMut)
 	default:
-		panic(fmt.Sprintf("trackAliasesForIdentPat: unhandled alias source kind %d", source.Kind()))
+		panic(fmt.Sprintf("trackAliasesForIdentPat: unhandled alias source kind %d", source.RootKind()))
 	}
 
 	return nil
@@ -428,7 +428,7 @@ func (c *Checker) trackAliasesForDestructuringPat(
 		return nil
 	}
 
-	switch source.Kind() {
+	switch source.RootKind() {
 	case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 		// Each destructured binding aliases the source(s).
 		var allErrors []Error
@@ -483,7 +483,7 @@ func (c *Checker) trackAliasesForDestructuringPat(
 			ctx.Aliases.NewValue(targetVarID, aliasMut)
 		}
 	default:
-		panic(fmt.Sprintf("trackAliasesForDestructuringPat: unhandled alias source kind %d", source.Kind()))
+		panic(fmt.Sprintf("trackAliasesForDestructuringPat: unhandled alias source kind %d", source.RootKind()))
 	}
 
 	return nil
@@ -547,7 +547,7 @@ func (c *Checker) trackAliasesForAssignment(
 
 	source := determineCheckerAliasSource(rhs)
 
-	switch source.Kind() {
+	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
 		sourceVarID := source.VarIDs()[0]
 
@@ -610,7 +610,7 @@ func (c *Checker) trackAliasesForAssignment(
 	case liveness.AliasSourceUnknown:
 		ctx.Aliases.Reassign(targetVarID, nil, aliasMut)
 	default:
-		panic(fmt.Sprintf("trackAliasesForAssignment: unhandled alias source kind %d", source.Kind()))
+		panic(fmt.Sprintf("trackAliasesForAssignment: unhandled alias source kind %d", source.RootKind()))
 	}
 
 	return nil
@@ -642,7 +642,7 @@ func (c *Checker) trackAliasesForPropAssignment(
 	}
 
 	source := determineCheckerAliasSource(rhs)
-	switch source.Kind() {
+	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
 		ctx.Aliases.MergeAliasSets(objVarID, source.VarIDs()[0])
 	case liveness.AliasSourceMultiple:
@@ -652,7 +652,7 @@ func (c *Checker) trackAliasesForPropAssignment(
 	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
 		// No alias relationship to track.
 	default:
-		panic(fmt.Sprintf("trackAliasesForPropAssignment: unhandled alias source kind %d", source.Kind()))
+		panic(fmt.Sprintf("trackAliasesForPropAssignment: unhandled alias source kind %d", source.RootKind()))
 	}
 }
 

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -285,7 +285,7 @@ func (c *Checker) trackAliasesForIdentPat(
 
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
-		sourceVarID := source.VarIDs()[0]
+		sourceVarID := source.UniqueVarIDs()[0]
 		ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 
 		// Check mutability transition
@@ -308,7 +308,7 @@ func (c *Checker) trackAliasesForIdentPat(
 	case liveness.AliasSourceMultiple:
 		// Conditional aliasing: the target aliases all possible
 		// source variables. Add it to each source's alias sets.
-		for _, sourceVarID := range source.VarIDs() {
+		for _, sourceVarID := range source.UniqueVarIDs() {
 			ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 		}
 
@@ -316,7 +316,7 @@ func (c *Checker) trackAliasesForIdentPat(
 		var allErrors []Error
 		stmtRef, hasRef := ctx.StmtToRef[enclosingStmt]
 		if hasRef {
-			for _, sourceVarID := range source.VarIDs() {
+			for _, sourceVarID := range source.UniqueVarIDs() {
 				sourceMut := isSourceMutable(ctx, sourceVarID)
 				transErrors := c.checkMutabilityTransition(
 					ctx,
@@ -443,14 +443,14 @@ func (c *Checker) trackAliasesForDestructuringPat(
 				aliasMut = liveness.AliasImmutable
 			}
 
-			for _, sourceVarID := range source.VarIDs() {
+			for _, sourceVarID := range source.UniqueVarIDs() {
 				ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 			}
 
 			// Check mutability transition
 			stmtRef, hasRef := ctx.StmtToRef[enclosingStmt]
 			if hasRef {
-				for _, sourceVarID := range source.VarIDs() {
+				for _, sourceVarID := range source.UniqueVarIDs() {
 					sourceMut := isSourceMutable(ctx, sourceVarID)
 					transErrors := c.checkMutabilityTransition(
 						ctx,
@@ -549,7 +549,7 @@ func (c *Checker) trackAliasesForAssignment(
 
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
-		sourceVarID := source.VarIDs()[0]
+		sourceVarID := source.UniqueVarIDs()[0]
 
 		// Check mutability transition before reassigning
 		stmtRef, hasRef := ctx.StmtToRef[ctx.CurrentStmt]
@@ -580,13 +580,13 @@ func (c *Checker) trackAliasesForAssignment(
 		// ReassignMulti is called before checking transitions (unlike the
 		// single-source case) because we want alias state to be consistent
 		// regardless of whether errors are reported.
-		ctx.Aliases.ReassignMulti(targetVarID, source.VarIDs(), aliasMut)
+		ctx.Aliases.ReassignMulti(targetVarID, source.UniqueVarIDs(), aliasMut)
 
 		// Check mutability transition against each source
 		var allErrors []Error
 		stmtRef, hasRef := ctx.StmtToRef[ctx.CurrentStmt]
 		if hasRef {
-			for _, sourceVarID := range source.VarIDs() {
+			for _, sourceVarID := range source.UniqueVarIDs() {
 				sourceMut := isSourceMutable(ctx, sourceVarID)
 				transErrors := c.checkMutabilityTransition(
 					ctx,
@@ -644,9 +644,9 @@ func (c *Checker) trackAliasesForPropAssignment(
 	source := determineCheckerAliasSource(rhs)
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
-		ctx.Aliases.MergeAliasSets(objVarID, source.VarIDs()[0])
+		ctx.Aliases.MergeAliasSets(objVarID, source.UniqueVarIDs()[0])
 	case liveness.AliasSourceMultiple:
-		for _, srcID := range source.VarIDs() {
+		for _, srcID := range source.UniqueVarIDs() {
 			ctx.Aliases.MergeAliasSets(objVarID, srcID)
 		}
 	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -283,9 +283,9 @@ func (c *Checker) trackAliasesForIdentPat(
 		aliasMut = liveness.AliasImmutable
 	}
 
-	switch source.Kind {
+	switch source.Kind() {
 	case liveness.AliasSourceVariable:
-		sourceVarID := source.VarIDs[0]
+		sourceVarID := source.VarIDs()[0]
 		ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 
 		// Check mutability transition
@@ -308,7 +308,7 @@ func (c *Checker) trackAliasesForIdentPat(
 	case liveness.AliasSourceMultiple:
 		// Conditional aliasing: the target aliases all possible
 		// source variables. Add it to each source's alias sets.
-		for _, sourceVarID := range source.VarIDs {
+		for _, sourceVarID := range source.VarIDs() {
 			ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 		}
 
@@ -316,7 +316,7 @@ func (c *Checker) trackAliasesForIdentPat(
 		var allErrors []Error
 		stmtRef, hasRef := ctx.StmtToRef[enclosingStmt]
 		if hasRef {
-			for _, sourceVarID := range source.VarIDs {
+			for _, sourceVarID := range source.VarIDs() {
 				sourceMut := isSourceMutable(ctx, sourceVarID)
 				transErrors := c.checkMutabilityTransition(
 					ctx,
@@ -339,7 +339,7 @@ func (c *Checker) trackAliasesForIdentPat(
 		// Unknown — create a fresh value conservatively
 		ctx.Aliases.NewValue(targetVarID, aliasMut)
 	default:
-		panic(fmt.Sprintf("trackAliasesForIdentPat: unhandled alias source kind %d", source.Kind))
+		panic(fmt.Sprintf("trackAliasesForIdentPat: unhandled alias source kind %d", source.Kind()))
 	}
 
 	return nil
@@ -428,7 +428,7 @@ func (c *Checker) trackAliasesForDestructuringPat(
 		return nil
 	}
 
-	switch source.Kind {
+	switch source.Kind() {
 	case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 		// Each destructured binding aliases the source(s).
 		var allErrors []Error
@@ -443,14 +443,14 @@ func (c *Checker) trackAliasesForDestructuringPat(
 				aliasMut = liveness.AliasImmutable
 			}
 
-			for _, sourceVarID := range source.VarIDs {
+			for _, sourceVarID := range source.VarIDs() {
 				ctx.Aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 			}
 
 			// Check mutability transition
 			stmtRef, hasRef := ctx.StmtToRef[enclosingStmt]
 			if hasRef {
-				for _, sourceVarID := range source.VarIDs {
+				for _, sourceVarID := range source.VarIDs() {
 					sourceMut := isSourceMutable(ctx, sourceVarID)
 					transErrors := c.checkMutabilityTransition(
 						ctx,
@@ -483,7 +483,7 @@ func (c *Checker) trackAliasesForDestructuringPat(
 			ctx.Aliases.NewValue(targetVarID, aliasMut)
 		}
 	default:
-		panic(fmt.Sprintf("trackAliasesForDestructuringPat: unhandled alias source kind %d", source.Kind))
+		panic(fmt.Sprintf("trackAliasesForDestructuringPat: unhandled alias source kind %d", source.Kind()))
 	}
 
 	return nil
@@ -547,9 +547,9 @@ func (c *Checker) trackAliasesForAssignment(
 
 	source := determineCheckerAliasSource(rhs)
 
-	switch source.Kind {
+	switch source.Kind() {
 	case liveness.AliasSourceVariable:
-		sourceVarID := source.VarIDs[0]
+		sourceVarID := source.VarIDs()[0]
 
 		// Check mutability transition before reassigning
 		stmtRef, hasRef := ctx.StmtToRef[ctx.CurrentStmt]
@@ -580,13 +580,13 @@ func (c *Checker) trackAliasesForAssignment(
 		// ReassignMulti is called before checking transitions (unlike the
 		// single-source case) because we want alias state to be consistent
 		// regardless of whether errors are reported.
-		ctx.Aliases.ReassignMulti(targetVarID, source.VarIDs, aliasMut)
+		ctx.Aliases.ReassignMulti(targetVarID, source.VarIDs(), aliasMut)
 
 		// Check mutability transition against each source
 		var allErrors []Error
 		stmtRef, hasRef := ctx.StmtToRef[ctx.CurrentStmt]
 		if hasRef {
-			for _, sourceVarID := range source.VarIDs {
+			for _, sourceVarID := range source.VarIDs() {
 				sourceMut := isSourceMutable(ctx, sourceVarID)
 				transErrors := c.checkMutabilityTransition(
 					ctx,
@@ -610,7 +610,7 @@ func (c *Checker) trackAliasesForAssignment(
 	case liveness.AliasSourceUnknown:
 		ctx.Aliases.Reassign(targetVarID, nil, aliasMut)
 	default:
-		panic(fmt.Sprintf("trackAliasesForAssignment: unhandled alias source kind %d", source.Kind))
+		panic(fmt.Sprintf("trackAliasesForAssignment: unhandled alias source kind %d", source.Kind()))
 	}
 
 	return nil
@@ -642,17 +642,17 @@ func (c *Checker) trackAliasesForPropAssignment(
 	}
 
 	source := determineCheckerAliasSource(rhs)
-	switch source.Kind {
+	switch source.Kind() {
 	case liveness.AliasSourceVariable:
-		ctx.Aliases.MergeAliasSets(objVarID, source.VarIDs[0])
+		ctx.Aliases.MergeAliasSets(objVarID, source.VarIDs()[0])
 	case liveness.AliasSourceMultiple:
-		for _, srcID := range source.VarIDs {
+		for _, srcID := range source.VarIDs() {
 			ctx.Aliases.MergeAliasSets(objVarID, srcID)
 		}
 	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
 		// No alias relationship to track.
 	default:
-		panic(fmt.Sprintf("trackAliasesForPropAssignment: unhandled alias source kind %d", source.Kind))
+		panic(fmt.Sprintf("trackAliasesForPropAssignment: unhandled alias source kind %d", source.Kind()))
 	}
 }
 

--- a/internal/checker/generalize_test.go
+++ b/internal/checker/generalize_test.go
@@ -183,11 +183,11 @@ func TestDetermineCheckerAliasSource_UnionLifetimeParam(t *testing.T) {
 	src := determineCheckerAliasSource(call)
 
 	// Expect aliasing of args 1 and 2 (overlap on 'a), but not arg 3 ('b only).
-	assert.Equal(t, liveness.AliasSourceMultiple, src.Kind,
+	assert.Equal(t, liveness.AliasSourceMultiple, src.Kind(),
 		"two distinct sources should produce AliasSourceMultiple")
 	assert.ElementsMatch(t,
 		[]liveness.VarID{liveness.VarID(101), liveness.VarID(102)},
-		src.VarIDs,
+		src.VarIDs(),
 		"unioned arg (overlap on 'a) and returned arg (exact 'a) should propagate; other arg ('b only) should not")
 }
 

--- a/internal/checker/generalize_test.go
+++ b/internal/checker/generalize_test.go
@@ -183,7 +183,7 @@ func TestDetermineCheckerAliasSource_UnionLifetimeParam(t *testing.T) {
 	src := determineCheckerAliasSource(call)
 
 	// Expect aliasing of args 1 and 2 (overlap on 'a), but not arg 3 ('b only).
-	assert.Equal(t, liveness.AliasSourceMultiple, src.Kind(),
+	assert.Equal(t, liveness.AliasSourceMultiple, src.RootKind(),
 		"two distinct sources should produce AliasSourceMultiple")
 	assert.ElementsMatch(t,
 		[]liveness.VarID{liveness.VarID(101), liveness.VarID(102)},

--- a/internal/checker/generalize_test.go
+++ b/internal/checker/generalize_test.go
@@ -187,7 +187,7 @@ func TestDetermineCheckerAliasSource_UnionLifetimeParam(t *testing.T) {
 		"two distinct sources should produce AliasSourceMultiple")
 	assert.ElementsMatch(t,
 		[]liveness.VarID{liveness.VarID(101), liveness.VarID(102)},
-		src.VarIDs(),
+		src.UniqueVarIDs(),
 		"unioned arg (overlap on 'a) and returned arg (exact 'a) should propagate; other arg ('b only) should not")
 }
 

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -377,9 +377,21 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					}))
 				}
 			} else {
+				// Use a per-slot fresh var as the literal's slot type
+				// and unify the element's value into it. This mirrors
+				// how object literals handle property values: when the
+				// surrounding context later unifies the tuple type
+				// against `[mut T, mut T]`, each slot var binds to the
+				// MutType-wrapped target, and the element's actual var
+				// (e.g. an unannotated param) inherits the wrapper via
+				// its link to the slot var. Inferring elements directly
+				// would expose the unannotated-param var to the
+				// `_, MutType` unwrap rule and silently strip `mut`.
+				slotVar := c.FreshVar(&ast.NodeProvenance{Node: elem})
 				elemType, elemErrors := c.inferExpr(ctx, elem)
-				elemTypes = append(elemTypes, elemType)
-				errors = slices.Concat(errors, elemErrors)
+				unifyErrors := c.Unify(ctx, elemType, slotVar)
+				elemTypes = append(elemTypes, slotVar)
+				errors = slices.Concat(errors, elemErrors, unifyErrors)
 			}
 		}
 

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1,6 +1,9 @@
 package checker
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/set"
@@ -1310,7 +1313,14 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 
 	retLifetime := type_system.PruneLifetime(type_system.GetLifetime(fnType.Return))
 	if retLifetime == nil {
-		return liveness.DetermineAliasSource(expr)
+		// Top-level lifetime is missing, but the return type may still
+		// embed lifetimes inside its slots (e.g. wrap returns
+		// `{head: 'a Point, tail: 'b Point}` with no top-level
+		// Lifetime). Walk the return type to surface those embedded
+		// slots as fresh-rooted leaves with per-slot paths so callers
+		// like `return wrap(a, b)` can drive per-slot lifetime
+		// attachment in their own signatures.
+		return embeddedLifetimeAliasSource(fnType, callExpr)
 	}
 
 	// Build the set of LifetimeVar IDs that the return type carries.
@@ -1383,6 +1393,163 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 		// the historical Variable/Multiple kind.
 		return liveness.AliasSource{Origin: liveness.AliasOriginAlias, Leaves: leaves}
 	}
+}
+
+// embeddedLifetimeAliasSource handles the case where a callee's return
+// type carries no top-level Lifetime but has lifetimes embedded in its
+// slots — e.g. `wrap` returns `{head: 'a Point, tail: 'b Point}` with
+// no Lifetime on the ObjectType itself. Walks the return type to
+// collect (path, lifetimeVar) entries; for each entry, finds the
+// param whose lifetime matches and folds the corresponding arg's
+// alias source into the result with the slot's path prepended.
+//
+// Returns a fresh-rooted source — `wrap(a, b)` has a freshly
+// constructed root whose nested slots alias args. If no embedded
+// slots match any param, falls back to the plain liveness handling
+// (which classifies the call as fresh with no leaves).
+//
+// TODO(#541): downstream MemberExpr/IndexExpr projection through this
+// source's leaves still uses append-only path semantics, so
+// `wrap(a, b).head` does not yet narrow to `'a`-only. Bidirectional
+// path semantics for the fresh-rooted case are tracked separately.
+func embeddedLifetimeAliasSource(fnType *type_system.FuncType, callExpr *ast.CallExpr) liveness.AliasSource {
+	slots := collectReturnLifetimeSlots(fnType.Return)
+	if len(slots) == 0 {
+		return liveness.DetermineAliasSource(callExpr)
+	}
+
+	// Per-(arg-leaf-root, slot-path) leaves. Dedupe by (RootVarID,
+	// canonical path) so two slots that bind the same lifetime to the
+	// same arg don't produce duplicate leaves.
+	type leafKey struct {
+		rootVarID liveness.VarID
+		pathKey   string
+	}
+	seen := map[leafKey]bool{}
+	var leaves []liveness.AliasLeaf
+	for _, slot := range slots {
+		for i, p := range fnType.Params {
+			if i >= len(callExpr.Args) {
+				break
+			}
+			paramVarIDs := lifetimeVarIDs(type_system.PruneLifetime(type_system.GetLifetime(p.Type)))
+			if !paramVarIDs.Contains(slot.lifetimeVarID) {
+				continue
+			}
+			argSource := determineCheckerAliasSource(callExpr.Args[i])
+			for _, argLeaf := range argSource.Leaves {
+				combined := make([]liveness.ProjectionStep, 0, len(slot.path)+len(argLeaf.Path))
+				combined = append(combined, slot.path...)
+				combined = append(combined, argLeaf.Path...)
+				key := leafKey{rootVarID: argLeaf.RootVarID, pathKey: pathKey(combined)}
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				leaves = append(leaves, liveness.AliasLeaf{
+					RootVarID: argLeaf.RootVarID,
+					Path:      combined,
+				})
+			}
+		}
+	}
+
+	if len(leaves) == 0 {
+		return liveness.DetermineAliasSource(callExpr)
+	}
+	return liveness.AliasSource{Origin: liveness.AliasOriginFresh, Leaves: leaves}
+}
+
+// returnLifetimeSlot records one (path, lifetimeVarID) pair for a
+// lifetime-bearing slot inside a return type. A slot whose lifetime is
+// a LifetimeUnion produces multiple entries (one per LifetimeVar
+// member) so that each var can be matched independently against
+// param lifetimes.
+type returnLifetimeSlot struct {
+	path          []liveness.ProjectionStep
+	lifetimeVarID int
+}
+
+// collectReturnLifetimeSlots walks a return type and returns one entry
+// per (slot, LifetimeVar) — including the top-level slot when the type
+// carries a Lifetime. Recurses into ObjectType properties and TupleType
+// elements; container TypeRefTypes (Array<T>, Promise<T>) are not
+// descended into here because their TypeArg slots aren't reachable via
+// the projection-step vocabulary that downstream attachment uses
+// (Array<T> would need ElementOf, but TupleType.IndexOf already covers
+// the common literal-as-tuple case). Extending to ElementOf / AwaitOf
+// is straightforward when needed.
+func collectReturnLifetimeSlots(t type_system.Type) []returnLifetimeSlot {
+	var out []returnLifetimeSlot
+	walkReturnLifetimeSlots(t, nil, &out)
+	return out
+}
+
+func walkReturnLifetimeSlots(t type_system.Type, path []liveness.ProjectionStep, into *[]returnLifetimeSlot) {
+	pruned := type_system.Prune(t)
+	if mut, ok := pruned.(*type_system.MutType); ok {
+		pruned = type_system.Prune(mut.Type)
+	}
+	var lifetime type_system.Lifetime
+	switch ty := pruned.(type) {
+	case *type_system.TypeRefType:
+		lifetime = ty.Lifetime
+	case *type_system.ObjectType:
+		lifetime = ty.Lifetime
+	case *type_system.TupleType:
+		lifetime = ty.Lifetime
+	}
+	if lifetime != nil {
+		for id := range lifetimeVarIDs(type_system.PruneLifetime(lifetime)) {
+			pathCopy := make([]liveness.ProjectionStep, len(path))
+			copy(pathCopy, path)
+			*into = append(*into, returnLifetimeSlot{path: pathCopy, lifetimeVarID: id})
+		}
+	}
+	switch ty := pruned.(type) {
+	case *type_system.ObjectType:
+		for _, elem := range ty.Elems {
+			prop, ok := elem.(*type_system.PropertyElem)
+			if !ok {
+				continue
+			}
+			if prop.Name.Kind != type_system.StrObjTypeKeyKind {
+				continue
+			}
+			childPath := append(path, liveness.PropertyOf{Key: prop.Name.Str})
+			walkReturnLifetimeSlots(prop.Value, childPath, into)
+		}
+	case *type_system.TupleType:
+		for i, elem := range ty.Elems {
+			childPath := append(path, liveness.IndexOf{Index: i})
+			walkReturnLifetimeSlots(elem, childPath, into)
+		}
+	}
+}
+
+// pathKey builds a deterministic string key from a projection path so
+// (RootVarID, path) tuples can be deduped via a map.
+func pathKey(path []liveness.ProjectionStep) string {
+	if len(path) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, step := range path {
+		switch s := step.(type) {
+		case liveness.PropertyOf:
+			b.WriteString(".")
+			b.WriteString(s.Key)
+		case liveness.IndexOf:
+			fmt.Fprintf(&b, "[%d]", s.Index)
+		case liveness.ElementOf:
+			b.WriteString(".[]")
+		case liveness.AwaitOf:
+			b.WriteString(".await")
+		case liveness.CastOf:
+			b.WriteString(".cast")
+		}
+	}
+	return b.String()
 }
 
 // extractFuncType reaches into the (possibly wrapped) callee type to find

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -271,11 +271,44 @@ func (c *Checker) attachLifetimeToResult(
 		return
 	}
 
-	// Determine which leaves are aliased across all alias-source
-	// expressions. Use insertion order so the resulting LifetimeParams
-	// list is deterministic.
-	seen := set.NewSet[int]()
-	var orderedLeaves []int
+	// Per-paramLeaf lifetime allocation: each aliased leaf gets at most
+	// one fresh LifetimeVar across all sources. Reused if the leaf
+	// already carries one from an earlier pass / the first generator
+	// call.
+	leafLV := map[int]*type_system.LifetimeVar{}
+	var newLifetimeParams []*type_system.LifetimeVar
+
+	// Per-slot accumulation in the result type. Each (Path-driven)
+	// destination slot collects the lifetimes contributed to it across
+	// all sourceExprs. Slot identity is the post-Prune Type pointer
+	// returned by descendIntoSlot, so two paths landing on the same
+	// element type of an Array<T> dedupe naturally.
+	type slotEntry struct {
+		members  []type_system.Lifetime
+		hasStatic bool
+	}
+	slotByPtr := map[type_system.Type]*slotEntry{}
+	var slotOrder []type_system.Type
+
+	addToSlot := func(slot type_system.Type, lt type_system.Lifetime) {
+		entry, exists := slotByPtr[slot]
+		if !exists {
+			entry = &slotEntry{}
+			slotByPtr[slot] = entry
+			slotOrder = append(slotOrder, slot)
+		}
+		entry.members = append(entry.members, lt)
+	}
+	markSlotStatic := func(slot type_system.Type) {
+		entry, exists := slotByPtr[slot]
+		if !exists {
+			entry = &slotEntry{}
+			slotByPtr[slot] = entry
+			slotOrder = append(slotOrder, slot)
+		}
+		entry.hasStatic = true
+	}
+
 	for _, re := range sourceExprs {
 		// Use the checker-aware variant so call expressions whose callee
 		// has inferred lifetime parameters propagate the relevant
@@ -284,100 +317,209 @@ func (c *Checker) attachLifetimeToResult(
 		// converge: on the second pass, peers' lifetimes are visible
 		// here.
 		src := determineCheckerAliasSource(re)
-		switch src.Kind() {
-		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-			for _, vid := range src.VarIDs() {
-				idx, ok := leafIndex[vid]
-				if !ok {
-					continue
-				}
-				if !seen.Contains(idx) {
-					seen.Add(idx)
-					orderedLeaves = append(orderedLeaves, idx)
-				}
+		if len(src.Leaves) == 0 {
+			continue
+		}
+		for _, leaf := range src.Leaves {
+			idx, ok := leafIndex[leaf.RootVarID]
+			if !ok {
+				continue
 			}
+			paramLeafEntry := leaves[idx]
+			if !typeCarriesLifetime(paramLeafEntry.leafType) {
+				continue
+			}
+
+			// Pick the destination slot in the return type. For
+			// fresh-rooted sources (`[a, b]`, `{k: a}`) the leaf path
+			// describes a descent INTO the new container — walk the
+			// return type along it. For alias-rooted sources (`obj`,
+			// `obj.field`) the path describes a projection into the
+			// source root, not a return-side slot — attach at the top.
+			var slot type_system.Type
+			switch src.Origin {
+			case liveness.AliasOriginFresh:
+				slot = descendIntoSlot(resultType, leaf.Path)
+			default:
+				slot = resultType
+			}
+			// If the destination slot can't carry a lifetime (e.g. the
+			// path landed on a type parameter, void, or a primitive),
+			// skip the leaf entirely. Allocating a fresh LifetimeVar
+			// for the param without anywhere to attach it on the
+			// result side would surface as a phantom 'a in the
+			// signature with no observable effect.
+			if !typeCarriesLifetime(slot) {
+				continue
+			}
+
+			if escapingLeaves.Contains(idx) {
+				markSlotStatic(slot)
+				continue
+			}
+
+			lv, allocated := leafLV[idx]
+			if !allocated {
+				// Reuse any LifetimeVar already on the leaf so the
+				// signature stays stable across re-runs / generator
+				// TReturn reuse from a prior yield call.
+				if existing, ok := type_system.PruneLifetime(type_system.GetLifetime(paramLeafEntry.leafType)).(*type_system.LifetimeVar); ok && existing != nil {
+					lv = existing
+				} else {
+					nameIdx := len(funcType.LifetimeParams) + len(newLifetimeParams)
+					lv = c.FreshLifetimeVar(lifetimeParamName(nameIdx))
+					newLifetimeParams = append(newLifetimeParams, lv)
+					setLifetimeOnType(paramLeafEntry.leafType, lv)
+				}
+				leafLV[idx] = lv
+			}
+			addToSlot(slot, lv)
 		}
 	}
 
-	if len(orderedLeaves) == 0 {
+	if len(slotOrder) == 0 {
 		return
 	}
 
-	// Walk the aliased leaves. For each, either:
-	//   (a) Reuse the leaf's existing lifetime (set by a prior pass —
-	//       the LifetimeVar is pointer-shared, already in
-	//       funcType.LifetimeParams).
-	//   (b) Treat as escaping — contribute 'static to the return.
-	//   (c) Allocate a fresh LifetimeVar — append it to LifetimeParams.
-	// returnLifetimeMembers accumulates ALL lifetimes contributed to
-	// the return, so that on a re-run we can rebuild the union over
-	// both pre-existing and newly-discovered leaves.
-	var newLifetimeParams []*type_system.LifetimeVar
-	returnHasStatic := false
-	var returnLifetimeMembers []type_system.Lifetime
-	for _, idx := range orderedLeaves {
-		leaf := leaves[idx]
-		if !typeCarriesLifetime(leaf.leafType) {
-			continue
+	// Attach a (possibly-unioned) lifetime to each destination slot.
+	// Members within a slot are deduped by pointer identity — repeating
+	// the same LifetimeVar across multiple sourceExprs is common (e.g.
+	// `return p` in two branches both contribute leaf p).
+	for _, slot := range slotOrder {
+		entry := slotByPtr[slot]
+		members := dedupeLifetimes(entry.members)
+		if entry.hasStatic {
+			members = append(members, &type_system.LifetimeValue{
+				Name:     "static",
+				IsStatic: true,
+			})
 		}
-		if escapingLeaves.Contains(idx) {
-			// Leaf already carries 'static. Record that the return
-			// shares this 'static lifetime, but don't allocate a 'a for
-			// it (since the leaf's lifetime is a concrete value, not a
-			// variable).
-			returnHasStatic = true
+		var lt type_system.Lifetime
+		switch len(members) {
+		case 0:
 			continue
+		case 1:
+			lt = members[0]
+		default:
+			lt = &type_system.LifetimeUnion{Lifetimes: members}
 		}
-		// Reuse an already-inferred LifetimeVar on the leaf so the
-		// signature stays stable across re-runs and pointer identity
-		// is preserved with anything that already references it. This
-		// also lets the second call (e.g. for generator TReturn) reuse
-		// a lifetime allocated by the first (yield T) call when the
-		// same parameter is aliased on both sides.
-		if existingLV, ok := type_system.PruneLifetime(type_system.GetLifetime(leaf.leafType)).(*type_system.LifetimeVar); ok && existingLV != nil {
-			returnLifetimeMembers = append(returnLifetimeMembers, existingLV)
-			continue
-		}
-		nameIdx := len(funcType.LifetimeParams) + len(newLifetimeParams)
-		newLV := c.FreshLifetimeVar(lifetimeParamName(nameIdx))
-		newLifetimeParams = append(newLifetimeParams, newLV)
-		returnLifetimeMembers = append(returnLifetimeMembers, newLV)
-
-		// Attach the lifetime to the leaf's type position.
-		setLifetimeOnType(leaf.leafType, newLV)
+		// TODO(#507): if slot is pointer-shared with a param leaf
+		// (which happens for unioned yield types and for `yield from`),
+		// this write bleeds through to the param. Shallow-clone the
+		// shared type here and substitute the clone back.
+		setLifetimeOnType(slot, lt)
 	}
-
-	if len(returnLifetimeMembers) == 0 && !returnHasStatic {
-		return
-	}
-
-	// Construct the lifetime to attach to the return type. The members
-	// include any fresh LifetimeVars allocated above plus a 'static value
-	// when the return aliases an escaping param. The union expresses
-	// "the result could have come from any of these sources, depending on
-	// which branch ran"; the caller treats the result as bounded by the
-	// shortest of the listed lifetimes (and 'static is unbounded).
-	if returnHasStatic {
-		returnLifetimeMembers = append(returnLifetimeMembers, &type_system.LifetimeValue{
-			Name:     "static",
-			IsStatic: true,
-		})
-	}
-	var returnLifetime type_system.Lifetime
-	if len(returnLifetimeMembers) == 1 {
-		returnLifetime = returnLifetimeMembers[0]
-	} else {
-		returnLifetime = &type_system.LifetimeUnion{Lifetimes: returnLifetimeMembers}
-	}
-	// TODO(#507): if resultType is pointer-shared with a param leaf
-	// (which happens for unioned yield types and for `yield from`),
-	// this write bleeds through to the param. Shallow-clone resultType
-	// here and substitute the clone back into funcType.Return.TypeArgs.
-	setLifetimeOnType(resultType, returnLifetime)
 
 	if len(newLifetimeParams) > 0 {
 		funcType.LifetimeParams = append(funcType.LifetimeParams, newLifetimeParams...)
 	}
+}
+
+// dedupeLifetimes returns a copy of members with duplicates (by pointer
+// identity) removed, preserving order of first occurrence. Used to
+// avoid emitting `('a | 'a)` when the same param leaf is aliased by
+// multiple branches of the same source position.
+func dedupeLifetimes(members []type_system.Lifetime) []type_system.Lifetime {
+	if len(members) <= 1 {
+		return members
+	}
+	seen := map[type_system.Lifetime]bool{}
+	out := make([]type_system.Lifetime, 0, len(members))
+	for _, m := range members {
+		if seen[m] {
+			continue
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	return out
+}
+
+// descendIntoSlot walks a return type along a projection path and
+// returns the slot type to attach a lifetime to. When a step cannot be
+// applied to the current type's shape (e.g. a PropertyOf step on an
+// Array<T>), descent stops gracefully and the deepest type reached so
+// far is returned. This realizes the spec's "the descent fails
+// gracefully (no attachment) if the return type's shape doesn't match
+// the path" clause: a partial descent still yields the best slot we
+// could find for a lifetime.
+func descendIntoSlot(t type_system.Type, path []liveness.ProjectionStep) type_system.Type {
+	current := t
+	for _, step := range path {
+		next := stepIntoSlot(current, step)
+		if next == nil {
+			return current
+		}
+		current = next
+	}
+	return current
+}
+
+// stepIntoSlot applies a single projection step to a type, returning
+// the inner slot type or nil if the step doesn't fit the type's shape.
+// The caller is responsible for unwrapping MutType — we Prune and peel
+// here so we can match against TupleType / ObjectType / Array<T> /
+// Promise<T> regardless of mutability wrappers.
+func stepIntoSlot(t type_system.Type, step liveness.ProjectionStep) type_system.Type {
+	pruned := type_system.Prune(t)
+	if mut, ok := pruned.(*type_system.MutType); ok {
+		pruned = type_system.Prune(mut.Type)
+	}
+	switch s := step.(type) {
+	case liveness.IndexOf:
+		if tup, ok := pruned.(*type_system.TupleType); ok {
+			if s.Index >= 0 && s.Index < len(tup.Elems) {
+				return tup.Elems[s.Index]
+			}
+			return nil
+		}
+		// IndexOf on Array<T>: collapse to ElementOf — the source
+		// expression was a tuple-like literal `[a, b]` whose container
+		// type happens to be Array<T> (all elements share T).
+		if elem := arrayElement(pruned); elem != nil {
+			return elem
+		}
+	case liveness.ElementOf:
+		if elem := arrayElement(pruned); elem != nil {
+			return elem
+		}
+	case liveness.PropertyOf:
+		if obj, ok := pruned.(*type_system.ObjectType); ok {
+			for _, elem := range obj.Elems {
+				prop, ok := elem.(*type_system.PropertyElem)
+				if !ok {
+					continue
+				}
+				if prop.Name.Kind == type_system.StrObjTypeKeyKind && prop.Name.Str == s.Key {
+					return prop.Value
+				}
+			}
+		}
+	case liveness.AwaitOf:
+		if ref, ok := pruned.(*type_system.TypeRefType); ok && type_system.QualIdentToString(ref.Name) == "Promise" && len(ref.TypeArgs) >= 1 {
+			return ref.TypeArgs[0]
+		}
+	case liveness.CastOf:
+		return pruned
+	}
+	return nil
+}
+
+// arrayElement returns the element type of an Array<T> reference, or
+// nil if the type isn't an Array<T>. Centralized so future container
+// recognizers (ReadonlyArray<T>, etc.) have one place to extend.
+func arrayElement(t type_system.Type) type_system.Type {
+	ref, ok := t.(*type_system.TypeRefType)
+	if !ok {
+		return nil
+	}
+	if type_system.QualIdentToString(ref.Name) != "Array" {
+		return nil
+	}
+	if len(ref.TypeArgs) != 1 {
+		return nil
+	}
+	return ref.TypeArgs[0]
 }
 
 // paramLeaf represents a leaf binding within a function-parameter pattern,

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1,6 +1,9 @@
 package checker
 
 import (
+	"slices"
+	"strconv"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/set"
@@ -284,7 +287,7 @@ func (c *Checker) attachLifetimeToResult(
 	// returned by descendIntoSlot, so two paths landing on the same
 	// element type of an Array<T> dedupe naturally.
 	type slotEntry struct {
-		members  []type_system.Lifetime
+		members   []type_system.Lifetime
 		hasStatic bool
 	}
 	slotByPtr := map[type_system.Type]*slotEntry{}
@@ -343,6 +346,7 @@ func (c *Checker) attachLifetimeToResult(
 			default:
 				slot = resultType
 			}
+
 			// If the destination slot can't carry a lifetime (e.g. the
 			// path landed on a type parameter, void, or a primitive),
 			// skip the leaf entirely. Allocating a fresh LifetimeVar
@@ -363,7 +367,8 @@ func (c *Checker) attachLifetimeToResult(
 				// Reuse any LifetimeVar already on the leaf so the
 				// signature stays stable across re-runs / generator
 				// TReturn reuse from a prior yield call.
-				if existing, ok := type_system.PruneLifetime(type_system.GetLifetime(paramLeafEntry.leafType)).(*type_system.LifetimeVar); ok && existing != nil {
+				prunedLT := type_system.PruneLifetime(type_system.GetLifetime(paramLeafEntry.leafType))
+				if existing, ok := prunedLT.(*type_system.LifetimeVar); ok && existing != nil {
 					lv = existing
 				} else {
 					nameIdx := len(funcType.LifetimeParams) + len(newLifetimeParams)
@@ -485,13 +490,34 @@ func stepIntoSlot(t type_system.Type, step liveness.ProjectionStep) type_system.
 		}
 	case liveness.PropertyOf:
 		if obj, ok := pruned.(*type_system.ObjectType); ok {
+			// Numeric keys: the producer (propertyKeyToString) stringifies
+			// NumLit indexes via strconv.FormatFloat, so to compare against
+			// a NumObjTypeKeyKind property we parse s.Key back to float64.
+			// Going through float comparison (rather than string round-trip)
+			// avoids coupling to the producer's exact format choice.
+			var keyAsFloat float64
+			var keyIsNumeric bool
+			if f, err := strconv.ParseFloat(s.Key, 64); err == nil {
+				keyAsFloat = f
+				keyIsNumeric = true
+			}
+			// TODO(#543): SymObjTypeKeyKind properties are not handled —
+			// the producer side can't emit symbol-keyed PropertyOf steps
+			// today, so this is currently unreachable.
 			for _, elem := range obj.Elems {
 				prop, ok := elem.(*type_system.PropertyElem)
 				if !ok {
 					continue
 				}
-				if prop.Name.Kind == type_system.StrObjTypeKeyKind && prop.Name.Str == s.Key {
-					return prop.Value
+				switch prop.Name.Kind {
+				case type_system.StrObjTypeKeyKind:
+					if prop.Name.Str == s.Key {
+						return prop.Value
+					}
+				case type_system.NumObjTypeKeyKind:
+					if keyIsNumeric && prop.Name.Num == keyAsFloat {
+						return prop.Value
+					}
 				}
 			}
 		}
@@ -1385,30 +1411,38 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 		for i, id := range aggregated {
 			leaves[i] = liveness.AliasLeaf{RootVarID: id}
 		}
-		// Aggregated leaves come from arg variable references whose
-		// roots the call result aliases — Alias-origin so callers see
-		// the historical Variable/Multiple kind.
+		// The callee returns one of its parameters at the top level, so
+		// the call result aliases the corresponding argument root(s) — use
+		// Alias origin (not Fresh) so RootKind() reports Variable for one
+		// aggregated leaf and Multiple for several. That matches what the
+		// alias tracker and transition checker expect for "this expression
+		// directly aliases these variables."
 		return liveness.AliasSource{Origin: liveness.AliasOriginAlias, Leaves: leaves}
 	}
 }
 
-// embeddedLifetimeAliasSource handles the case where a callee's return
-// type carries no top-level Lifetime but has lifetimes embedded in its
-// slots — e.g. `wrap` returns `{head: 'a Point, tail: 'b Point}` with
-// no Lifetime on the ObjectType itself. Walks the return type to
-// collect (path, lifetimeVar) entries; for each entry, finds the
-// param whose lifetime matches and folds the corresponding arg's
-// alias source into the result with the slot's path prepended.
+// embeddedLifetimeAliasSource handles calls whose return type carries
+// no top-level Lifetime but has lifetimes embedded in its inner slots.
+// For example, `wrap` returns `{head: 'a Point, tail: 'b Point}`: the
+// outer ObjectType has no Lifetime, but the `head` and `tail` slots do.
 //
-// Returns a fresh-rooted source — `wrap(a, b)` has a freshly
-// constructed root whose nested slots alias args. If no embedded
-// slots match any param, falls back to the plain liveness handling
-// (which classifies the call as fresh with no leaves).
+// The function walks the return type to collect each (path, lifetimeVar)
+// pair, then for every pair it finds the parameter whose lifetime
+// matches and pulls in the corresponding argument's alias source,
+// prepending the slot's path to each leaf. The result is a fresh-rooted
+// source — calling `wrap(a, b)` constructs a new container whose root
+// aliases nothing, but whose nested slots alias the arguments at the
+// matching paths.
 //
-// TODO(#541): downstream MemberExpr/IndexExpr projection through this
-// source's leaves still uses append-only path semantics, so
-// `wrap(a, b).head` does not yet narrow to `'a`-only. Bidirectional
-// path semantics for the fresh-rooted case are tracked separately.
+// If no embedded slot matches any parameter, the function falls back to
+// the plain liveness handling, which classifies the call as fresh with
+// no leaves.
+//
+// TODO(#541): downstream `MemberExpr` / `IndexExpr` projection through
+// the leaves of this source only ever appends to the leaf paths, so
+// `wrap(a, b).head` doesn't yet narrow to the `'a`-only leaf. Adding
+// bidirectional path semantics for fresh-rooted sources is tracked
+// separately.
 func embeddedLifetimeAliasSource(fnType *type_system.FuncType, callExpr *ast.CallExpr) liveness.AliasSource {
 	slots := collectReturnLifetimeSlots(fnType.Return)
 	if len(slots) == 0 {
@@ -1435,9 +1469,7 @@ func embeddedLifetimeAliasSource(fnType *type_system.FuncType, callExpr *ast.Cal
 			}
 			argSource := determineCheckerAliasSource(callExpr.Args[i])
 			for _, argLeaf := range argSource.Leaves {
-				combined := make([]liveness.ProjectionStep, 0, len(slot.path)+len(argLeaf.Path))
-				combined = append(combined, slot.path...)
-				combined = append(combined, argLeaf.Path...)
+				combined := slices.Concat(slot.path, argLeaf.Path)
 				key := leafKey{rootVarID: argLeaf.RootVarID, pathKey: liveness.PathKey(combined)}
 				if seen[key] {
 					continue
@@ -1470,12 +1502,16 @@ type returnLifetimeSlot struct {
 // collectReturnLifetimeSlots walks a return type and returns one entry
 // per (slot, LifetimeVar) — including the top-level slot when the type
 // carries a Lifetime. Recurses into ObjectType properties and TupleType
-// elements; container TypeRefTypes (Array<T>, Promise<T>) are not
-// descended into here because their TypeArg slots aren't reachable via
-// the projection-step vocabulary that downstream attachment uses
-// (Array<T> would need ElementOf, but TupleType.IndexOf already covers
-// the common literal-as-tuple case). Extending to ElementOf / AwaitOf
-// is straightforward when needed.
+// elements.
+//
+// TODO(#544): container TypeRefTypes (Array<T>, Promise<T>, etc.) are
+// not descended into here, so call sites of explicitly-typed
+// generic-returning functions like `fn wrap<'a>(p: 'a P) -> Array<'a P>`
+// don't pick up the embedded lifetime. The downstream attachment
+// vocabulary already supports ElementOf and AwaitOf (stepIntoSlot
+// handles them); extending this walker to emit them is the missing
+// piece. The literal-as-tuple case is unaffected because TupleType
+// recursion + IndexOf already covers it.
 func collectReturnLifetimeSlots(t type_system.Type) []returnLifetimeSlot {
 	var out []returnLifetimeSlot
 	walkReturnLifetimeSlots(t, nil, &out)
@@ -1510,10 +1546,19 @@ func walkReturnLifetimeSlots(t type_system.Type, path []liveness.ProjectionStep,
 			if !ok {
 				continue
 			}
-			if prop.Name.Kind != type_system.StrObjTypeKeyKind {
+			var key string
+			switch prop.Name.Kind {
+			case type_system.StrObjTypeKeyKind:
+				key = prop.Name.Str
+			case type_system.NumObjTypeKeyKind:
+				key = liveness.FormatNumKey(prop.Name.Num)
+			// TODO(#543): SymObjTypeKeyKind not handled — symbol-keyed
+			// properties need a representation in PropertyOf (or a new
+			// step kind) before they can be walked here.
+			default:
 				continue
 			}
-			childPath := append(path, liveness.PropertyOf{Key: prop.Name.Str})
+			childPath := append(path, liveness.PropertyOf{Key: key})
 			walkReturnLifetimeSlots(prop.Value, childPath, into)
 		}
 	case *type_system.TupleType:

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -855,7 +855,7 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 			}
 			for j := i; j < len(args); j++ {
 				src := determineCheckerAliasSource(args[j])
-				switch src.Kind() {
+				switch src.RootKind() {
 				case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 					for _, mut := range muts {
 						for _, vid := range src.VarIDs() {
@@ -888,7 +888,7 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 		// liveness helper treats every CallExpr as fresh, hiding such
 		// transitive aliases from the static-escape check.
 		src := determineCheckerAliasSource(args[i])
-		switch src.Kind() {
+		switch src.RootKind() {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 			for _, mut := range muts {
 				for _, vid := range src.VarIDs() {
@@ -1364,7 +1364,7 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 			continue
 		}
 		argSource := determineCheckerAliasSource(callExpr.Args[i])
-		switch argSource.Kind() {
+		switch argSource.RootKind() {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 			for _, id := range argSource.VarIDs() {
 				if !seen.Contains(id) {

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -745,13 +745,16 @@ func (v *escapingRefsVisitor) EnterExpr(e ast.Expr) bool {
 			// Use the checker-aware variant so a parameter that flows
 			// through a call whose callee returns its argument
 			// (`cache = wrap(p)`) is still detected as escaping.
+			//
+			// Iterate Leaves directly (rather than via Kind/VarIDs) so
+			// fresh-rooted sources like `self.items = [a, b]` are
+			// recognized: each leaf names a param that escapes via the
+			// new container's slot, regardless of whether the root of
+			// the RHS is alias-of-existing or freshly-constructed.
 			src := determineCheckerAliasSource(be.Right)
-			switch src.Kind() {
-			case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-				for _, vid := range src.VarIDs() {
-					if idx, ok := v.leafIndex[vid]; ok {
-						v.escaped.Add(idx)
-					}
+			for _, leaf := range src.Leaves {
+				if idx, ok := v.leafIndex[leaf.RootVarID]; ok {
+					v.escaped.Add(idx)
 				}
 			}
 		}

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1233,7 +1233,10 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 		for i, id := range aggregated {
 			leaves[i] = liveness.AliasLeaf{RootVarID: id}
 		}
-		return liveness.AliasSource{Leaves: leaves}
+		// Aggregated leaves come from arg variable references whose
+		// roots the call result aliases — Alias-origin so callers see
+		// the historical Variable/Multiple kind.
+		return liveness.AliasSource{Origin: liveness.AliasOriginAlias, Leaves: leaves}
 	}
 }
 

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1,9 +1,6 @@
 package checker
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/set"
@@ -1441,7 +1438,7 @@ func embeddedLifetimeAliasSource(fnType *type_system.FuncType, callExpr *ast.Cal
 				combined := make([]liveness.ProjectionStep, 0, len(slot.path)+len(argLeaf.Path))
 				combined = append(combined, slot.path...)
 				combined = append(combined, argLeaf.Path...)
-				key := leafKey{rootVarID: argLeaf.RootVarID, pathKey: pathKey(combined)}
+				key := leafKey{rootVarID: argLeaf.RootVarID, pathKey: liveness.PathKey(combined)}
 				if seen[key] {
 					continue
 				}
@@ -1525,31 +1522,6 @@ func walkReturnLifetimeSlots(t type_system.Type, path []liveness.ProjectionStep,
 			walkReturnLifetimeSlots(elem, childPath, into)
 		}
 	}
-}
-
-// pathKey builds a deterministic string key from a projection path so
-// (RootVarID, path) tuples can be deduped via a map.
-func pathKey(path []liveness.ProjectionStep) string {
-	if len(path) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for _, step := range path {
-		switch s := step.(type) {
-		case liveness.PropertyOf:
-			b.WriteString(".")
-			b.WriteString(s.Key)
-		case liveness.IndexOf:
-			fmt.Fprintf(&b, "[%d]", s.Index)
-		case liveness.ElementOf:
-			b.WriteString(".[]")
-		case liveness.AwaitOf:
-			b.WriteString(".await")
-		case liveness.CastOf:
-			b.WriteString(".cast")
-		}
-	}
-	return b.String()
 }
 
 // extractFuncType reaches into the (possibly wrapped) callee type to find

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -858,7 +858,7 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 				switch src.RootKind() {
 				case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 					for _, mut := range muts {
-						for _, vid := range src.VarIDs() {
+						for _, vid := range src.UniqueVarIDs() {
 							ctx.Aliases.MarkStatic(vid, mut)
 						}
 					}
@@ -891,7 +891,7 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 		switch src.RootKind() {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 			for _, mut := range muts {
-				for _, vid := range src.VarIDs() {
+				for _, vid := range src.UniqueVarIDs() {
 					ctx.Aliases.MarkStatic(vid, mut)
 				}
 			}
@@ -1366,7 +1366,7 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 		argSource := determineCheckerAliasSource(callExpr.Args[i])
 		switch argSource.RootKind() {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-			for _, id := range argSource.VarIDs() {
+			for _, id := range argSource.UniqueVarIDs() {
 				if !seen.Contains(id) {
 					seen.Add(id)
 					aggregated = append(aggregated, id)

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -284,9 +284,9 @@ func (c *Checker) attachLifetimeToResult(
 		// converge: on the second pass, peers' lifetimes are visible
 		// here.
 		src := determineCheckerAliasSource(re)
-		switch src.Kind {
+		switch src.Kind() {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-			for _, vid := range src.VarIDs {
+			for _, vid := range src.VarIDs() {
 				idx, ok := leafIndex[vid]
 				if !ok {
 					continue
@@ -604,9 +604,9 @@ func (v *escapingRefsVisitor) EnterExpr(e ast.Expr) bool {
 			// through a call whose callee returns its argument
 			// (`cache = wrap(p)`) is still detected as escaping.
 			src := determineCheckerAliasSource(be.Right)
-			switch src.Kind {
+			switch src.Kind() {
 			case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-				for _, vid := range src.VarIDs {
+				for _, vid := range src.VarIDs() {
 					if idx, ok := v.leafIndex[vid]; ok {
 						v.escaped.Add(idx)
 					}
@@ -710,10 +710,10 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 			}
 			for j := i; j < len(args); j++ {
 				src := determineCheckerAliasSource(args[j])
-				switch src.Kind {
+				switch src.Kind() {
 				case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 					for _, mut := range muts {
-						for _, vid := range src.VarIDs {
+						for _, vid := range src.VarIDs() {
 							ctx.Aliases.MarkStatic(vid, mut)
 						}
 					}
@@ -743,10 +743,10 @@ func (c *Checker) propagateCalleeStaticLifetimes(
 		// liveness helper treats every CallExpr as fresh, hiding such
 		// transitive aliases from the static-escape check.
 		src := determineCheckerAliasSource(args[i])
-		switch src.Kind {
+		switch src.Kind() {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
 			for _, mut := range muts {
-				for _, vid := range src.VarIDs {
+				for _, vid := range src.VarIDs() {
 					ctx.Aliases.MarkStatic(vid, mut)
 				}
 			}
@@ -1212,9 +1212,9 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 			continue
 		}
 		argSource := determineCheckerAliasSource(callExpr.Args[i])
-		switch argSource.Kind {
+		switch argSource.Kind() {
 		case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-			for _, id := range argSource.VarIDs {
+			for _, id := range argSource.VarIDs() {
 				if !seen.Contains(id) {
 					seen.Add(id)
 					aggregated = append(aggregated, id)
@@ -1228,10 +1228,12 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 		// None of the matching arguments could be tracked back to a local
 		// variable — fall back to the default treatment.
 		return liveness.DetermineAliasSource(expr)
-	case 1:
-		return liveness.AliasSource{Kind: liveness.AliasSourceVariable, VarIDs: aggregated}
 	default:
-		return liveness.AliasSource{Kind: liveness.AliasSourceMultiple, VarIDs: aggregated}
+		leaves := make([]liveness.AliasLeaf, len(aggregated))
+		for i, id := range aggregated {
+			leaves[i] = liveness.AliasLeaf{RootVarID: id}
+		}
+		return liveness.AliasSource{Leaves: leaves}
 	}
 }
 

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -532,6 +532,27 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"passThrough": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {head: mut 'a {x: number}, tail: mut 'b {x: number}}",
 			},
 		},
+		"PassThroughCallWithNumericKeyedEmbeddedLifetimes": {
+			// Regression for the walkReturnLifetimeSlots fix: when the
+			// callee's return type embeds lifetimes inside numeric-keyed
+			// slots (`{0: 'a P, 1: 'b P}`), walkReturnLifetimeSlots must
+			// emit PropertyOf steps with FormatNumKey-encoded keys so
+			// that embeddedLifetimeAliasSource can match them back to
+			// the corresponding arg leaves. Before the fix the numeric
+			// keys were skipped, the call's slots were lost, and the
+			// caller's signature collapsed to no inferred lifetimes.
+			input: `
+				fn wrap(a: mut {x: number}, b: mut {x: number}) -> {0: mut {x: number}, 1: mut {x: number}} {
+					return {0: a, 1: b}
+				}
+				fn passThrough(a: mut {x: number}, b: mut {x: number}) -> {0: mut {x: number}, 1: mut {x: number}} {
+					return wrap(a, b)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"passThrough": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {0: mut 'a {x: number}, 1: mut 'b {x: number}}",
+			},
+		},
 		"PropertyAccess_ProjectsPerSlotLifetime_KnownGap": {
 			// Caller-side aliasing precision: accessing a single slot
 			// of a per-property-typed result *should* project only
@@ -593,6 +614,38 @@ func TestInferLifetimeTypes(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"stash": "fn <'a>({a: mut 'static {x: number}, b: mut 'a {x: number}}) -> mut 'a {x: number}",
+			},
+		},
+		"NumericKeyedObjectCapturesParam": {
+			// Regression for the stepIntoSlot fix: when a fresh object
+			// literal uses a numeric key (`{0: p}`), the producer emits
+			// PropertyOf{Key: "0"} on the leaf path. The consumer must
+			// match that string against the corresponding NumObjTypeKeyKind
+			// property on the return type. Before the fix, only
+			// StrObjTypeKeyKind properties matched, so the leaf was
+			// dropped and no lifetime was attached to the `0` slot.
+			input: `
+				fn wrap(p: mut {x: number}) -> {0: mut {x: number}} {
+					return {0: p}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"wrap": "fn <'a>(p: mut 'a {x: number}) -> {0: mut 'a {x: number}}",
+			},
+		},
+		"MixedNumericAndStringKeysCapturesDifferentParams": {
+			// Two params land in two slots of the fresh object, one keyed
+			// numerically and one keyed by name. Each gets its own
+			// lifetime, exercising both the NumObjTypeKeyKind and the
+			// StrObjTypeKeyKind arms of stepIntoSlot.PropertyOf in the
+			// same return type.
+			input: `
+				fn pair(a: mut {x: number}, b: mut {x: number}) -> {0: mut {x: number}, name: mut {x: number}} {
+					return {0: a, name: b}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pair": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {0: mut 'a {x: number}, name: mut 'b {x: number}}",
 			},
 		},
 		"NestedObjectInArray_DescendsTwoSteps": {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -500,6 +500,101 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"wrap": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {head: mut 'a {x: number}, tail: mut 'b {x: number}}",
 			},
 		},
+		"TupleOfTwoParams_PerSlotDistinctLifetimes": {
+			// Tuple-typed return (not Array) preserves per-index
+			// lifetimes — `'a` and `'b` stay separate at slots 0 and
+			// 1 rather than collapsing into a union.
+			input: `
+				fn pair(a: mut {x: number}, b: mut {x: number}) -> [mut {x: number}, mut {x: number}] {
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pair": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> [mut 'a {x: number}, mut 'b {x: number}]",
+			},
+		},
+		"PassThroughCallWithEmbeddedReturnLifetimes": {
+			// Fix from determineCheckerAliasSource: when the callee's
+			// return type embeds lifetimes inside slots (rather than
+			// at the top), the call result surfaces those slots as
+			// fresh-rooted leaves with per-slot paths. The caller's
+			// signature inference uses those leaves to drive per-slot
+			// lifetime attachment in its own return type.
+			input: `
+				fn wrap(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
+					return {head: a, tail: b}
+				}
+				fn passThrough(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
+					return wrap(a, b)
+				}
+			`,
+			expectedTypes: map[string]string{
+				"passThrough": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {head: mut 'a {x: number}, tail: mut 'b {x: number}}",
+			},
+		},
+		"PropertyAccess_ProjectsPerSlotLifetime_KnownGap": {
+			// Caller-side aliasing precision: accessing a single slot
+			// of a per-property-typed result *should* project only
+			// that slot's lifetime — `r.head` would carry `'a`, not
+			// the union, letting the alias tracker distinguish borrows
+			// from `a` vs `b`.
+			//
+			// Today determineCheckerAliasSource only handles top-level
+			// return lifetimes; per-slot projection through a call's
+			// return type isn't threaded yet. Pinning down current
+			// behavior; tracked in the Phase 8.9 follow-up.
+			input: `
+				fn wrap(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
+					return {head: a, tail: b}
+				}
+				fn pickHead(a: mut {x: number}, b: mut {x: number}) -> mut {x: number} {
+					return wrap(a, b).head
+				}
+			`,
+			expectedTypes: map[string]string{
+				// Target: "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}"
+				"pickHead": "fn (a: mut {x: number}, b: mut {x: number}) -> mut {x: number}",
+			},
+		},
+		"IndexAccess_ProjectsPerSlotLifetime_KnownGap": {
+			// Same gap as PropertyAccess_ProjectsPerSlotLifetime_KnownGap
+			// but for tuple slots — `pair(a, b)[0]` should carry only
+			// `'a`. Pinning today's behavior.
+			input: `
+				fn pair(a: mut {x: number}, b: mut {x: number}) -> [mut {x: number}, mut {x: number}] {
+					return [a, b]
+				}
+				fn pickFirst(a: mut {x: number}, b: mut {x: number}) -> mut {x: number} {
+					return pair(a, b)[0]
+				}
+			`,
+			expectedTypes: map[string]string{
+				// Target: "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}"
+				"pickFirst": "fn (a: mut {x: number}, b: mut {x: number}) -> mut {x: number}",
+			},
+		},
+		"PerSlotEscape_OnlyEscapingPropertyGetsStatic": {
+			// Benefit: fewer false-positive escape errors at the
+			// property level. The single object-destructured param
+			// `{a, b}` has two leaves at distinct property slots;
+			// escaping only `a` should pin `'static` onto the `a`
+			// slot of the param's type while leaving the `b` slot
+			// with its own lifetime variable. Without per-property
+			// granularity the whole param object would widen to
+			// `'static`, dragging `b` along with it.
+			input: `
+				var cache: mut {slot: mut {x: number}} = {slot: {x: 0}}
+				fn stash(
+					{a, b}: {a: mut {x: number}, b: mut {x: number}},
+				) -> mut {x: number} {
+					cache.slot = a
+					return b
+				}
+			`,
+			expectedTypes: map[string]string{
+				"stash": "fn <'a>({a: mut 'static {x: number}, b: mut 'a {x: number}}) -> mut 'a {x: number}",
+			},
+		},
 		"NestedObjectInArray_DescendsTwoSteps": {
 			// Phase 8.9: a leaf with path [IndexOf 0, PropertyOf "inner"]
 			// drives lifetime attachment to the inner property of the

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -606,6 +606,72 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"C": 0,
 			},
 		},
+		"CtorStoresTupleOfParams_FieldSlotsCarryLifetimes": {
+			// Phase 8.9 (e) deeper goal: when params escape into a
+			// composite field, the field's per-slot types in the
+			// instance should reflect the per-slot lifetimes — e.g.
+			// `items[0]: mut 'a {...}`, `items[1]: mut 'b {...}` after
+			// `self.items = [a, b]`. Pin down current behavior so we
+			// know whether the class field type tracks slot-level
+			// lifetimes today.
+			input: `
+				class Pair {
+					items: [mut {x: number}, mut {x: number}],
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self.items = [a, b]
+					}
+				}
+				val p = Pair({x: 1}, {x: 2})
+				val items = p.items
+			`,
+			expectedTypes: map[string]string{
+				// Document today's behavior; the fuller Phase 8.9 (e)
+				// would attach per-slot lifetimes here.
+				"items": "[mut {x: number}, mut {x: number}]",
+			},
+		},
+		"CtorStoresTupleOfParams_EscapesBoth": {
+			// Phase 8.9: `self.items = [a, b]` — the RHS is a fresh
+			// tuple whose leaves both escape into self. Both params
+			// must pin lifetimes onto the ctor; today's escape
+			// detector consults src.Kind() which returns Fresh for
+			// fresh-rooted sources, so without path-based escape
+			// recognition only the alias-rooted RHS (e.g. `self.x = a`)
+			// is detected. This case pins down the new behavior.
+			input: `
+				class Pair {
+					items: [mut {x: number}, mut {x: number}],
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self.items = [a, b]
+					}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"Pair": "{new fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> Pair<'a, 'b>}",
+			},
+			expectedInstanceLifetimes: map[string]int{
+				"Pair": 2,
+			},
+		},
+		"CtorStoresObjectOfParams_EscapesBoth": {
+			// Sister case to CtorStoresTupleOfParams: object-literal
+			// RHS leaves are also fresh-rooted with PropertyOf paths.
+			// Both params should pin distinct lifetimes onto the ctor.
+			input: `
+				class Wrap {
+					pair: {head: mut {x: number}, tail: mut {x: number}},
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self.pair = {head: a, tail: b}
+					}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"Wrap": "{new fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> Wrap<'a, 'b>}",
+			},
+			expectedInstanceLifetimes: map[string]int{
+				"Wrap": 2,
+			},
+		},
 		"DestructuredTupleCtorParamCapture": {
 			// A destructured tuple ctor param whose leaves are stored
 			// into self should still pin lifetimes onto the param. (#531)

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -474,6 +474,45 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"odd":  "fn <'a>(q: mut 'a {x: number}, n: number) -> mut 'a {x: number}",
 			},
 		},
+		"TupleOfTwoParams_ElementLevelUnion": {
+			// Phase 8.9: a fresh tuple literal `[a, b]` typed as a
+			// homogeneous Array<T> at the slot — both element-level
+			// lifetimes collapse onto the same Array<T>'s element type
+			// and union there.
+			input: `
+				fn pair(a: mut {x: number}, b: mut {x: number}) -> mut Array<mut {x: number}> {
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pair": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> mut Array<mut ('a | 'b) {x: number}>",
+			},
+		},
+		"ObjectLiteral_PropertyLevelDistinctLifetimes": {
+			// Phase 8.9: object literal with distinct slots produces
+			// distinct property-level lifetimes on the result.
+			input: `
+				fn wrap(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
+					return {head: a, tail: b}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"wrap": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {head: mut 'a {x: number}, tail: mut 'b {x: number}}",
+			},
+		},
+		"NestedObjectInArray_DescendsTwoSteps": {
+			// Phase 8.9: a leaf with path [IndexOf 0, PropertyOf "inner"]
+			// drives lifetime attachment to the inner property of the
+			// array's element type.
+			input: `
+				fn box(p: mut {x: number}) -> Array<{inner: mut {x: number}}> {
+					return [{inner: p}]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"box": "fn <'a>(p: mut 'a {x: number}) -> Array<{inner: mut 'a {x: number}}>",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -706,13 +706,15 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			// composite field, the field's per-slot types in the
 			// instance should reflect the per-slot lifetimes — e.g.
 			// `items[0]: mut 'a {...}`, `items[1]: mut 'b {...}` after
-			// `self.items = [a, b]`. Pin down current behavior so we
-			// know whether the class field type tracks slot-level
-			// lifetimes today.
+			// `self.items = [a, b]`. With per-slot fresh-var tuple
+			// inference (option 1), the constructor's `'a`/`'b` flow
+			// through the `[a, b]` literal's slot vars into the field
+			// type, so each instance's `p.items` carries per-slot
+			// lifetimes from its constructor args.
 			input: `
 				class Pair {
 					items: [mut {x: number}, mut {x: number}],
-					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+					constructor(mut self, a, b) {
 						self.items = [a, b]
 					}
 				}
@@ -720,9 +722,7 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				val items = p.items
 			`,
 			expectedTypes: map[string]string{
-				// Document today's behavior; the fuller Phase 8.9 (e)
-				// would attach per-slot lifetimes here.
-				"items": "[mut {x: number}, mut {x: number}]",
+				"items": "[mut 'a {x: number}, mut 'b {x: number}]",
 			},
 		},
 		"CtorStoresTupleOfParams_EscapesBoth": {
@@ -733,10 +733,12 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			// fresh-rooted sources, so without path-based escape
 			// recognition only the alias-rooted RHS (e.g. `self.x = a`)
 			// is detected. This case pins down the new behavior.
+			// Constructor params are unannotated; their types and
+			// lifetimes are inferred from the field they store into.
 			input: `
 				class Pair {
 					items: [mut {x: number}, mut {x: number}],
-					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+					constructor(mut self, a, b) {
 						self.items = [a, b]
 					}
 				}
@@ -752,10 +754,12 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 			// Sister case to CtorStoresTupleOfParams: object-literal
 			// RHS leaves are also fresh-rooted with PropertyOf paths.
 			// Both params should pin distinct lifetimes onto the ctor.
+			// Constructor params are unannotated; their types and
+			// lifetimes are inferred from the field they store into.
 			input: `
 				class Wrap {
 					pair: {head: mut {x: number}, tail: mut {x: number}},
-					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+					constructor(mut self, a, b) {
 						self.pair = {head: a, tail: b}
 					}
 				}

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -1282,8 +1282,8 @@ func TestRowTypesRowPolymorphism(t *testing.T) {
 				val r = foo({x: 0, extra1: true}, {y: "", extra2: 42})
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0, T1>(a: mut {x: number, ...T0}, b: mut {y: string, ...T1}) -> [{x: number, ...T0}, {y: string, ...T1}]",
-				"r":   "[{x: number, extra1: true}, {y: string, extra2: 42}]",
+				"foo": "fn <'a, 'b, T0, T1>(a: mut 'a {x: number, ...T0}, b: mut 'b {y: string, ...T1}) -> ['a {x: number, ...T0}, 'b {y: string, ...T1}]",
+				"r":   "['a {x: number, extra1: true}, 'b {y: string, extra2: 42}]",
 			},
 		},
 		"NoExtraProperties": {
@@ -1349,7 +1349,7 @@ func TestVariadicTupleTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <R1, R2>(a: [number, ...R1], b: [string, ...R2]) -> [[number, ...R1], [string, ...R2]]",
+				"foo": "fn <'a, 'b, R1, R2>(a: 'a [number, ...R1], b: 'b [string, ...R2]) -> ['a [number, ...R1], 'b [string, ...R2]]",
 			},
 		},
 		"Generalization_VariadicRest": {
@@ -2297,8 +2297,8 @@ func TestTupleRowPolymorphism(t *testing.T) {
 				val r = foo([1, 2], ["a", "b"])
 			`,
 			expectedTypes: map[string]string{
-				"foo": "fn <T0, T1, T2, T3>(a: [T0, ...T1], b: [T2, ...T3]) -> [[T0, ...T1], [T2, ...T3]]",
-				"r":   "[[1, 2], [\"a\", \"b\"]]",
+				"foo": "fn <'a, 'b, T0, T1, T2, T3>(a: 'a [T0, ...T1], b: 'b [T2, ...T3]) -> ['a [T0, ...T1], 'b [T2, ...T3]]",
+				"r":   "['a [1, 2], 'b [\"a\", \"b\"]]",
 			},
 		},
 		"NoExtraElements_RestResolvesToEmptyTuple": {

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -449,13 +449,32 @@ func determineObjectAliasSource(expr *ast.ObjectExpr) AliasSource {
 func leafKey(root VarID, path []ProjectionStep) string {
 	var b strings.Builder
 	b.WriteString(strconv.Itoa(int(root)))
-	for _, step := range path {
-		b.WriteByte('|')
+	b.WriteByte('|')
+	b.WriteString(PathKey(path))
+	return b.String()
+}
+
+// PathKey returns a deterministic, collision-free string encoding of a
+// projection path. Property keys are length-prefixed so user-supplied
+// strings containing the step delimiter ('|') or step-tag prefix ('p:')
+// can't collide with a path of two property steps that happen to render
+// the same when concatenated.
+func PathKey(path []ProjectionStep) string {
+	if len(path) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, step := range path {
+		if i > 0 {
+			b.WriteByte('|')
+		}
 		switch s := step.(type) {
 		case ElementOf:
 			b.WriteString("e")
 		case PropertyOf:
 			b.WriteString("p:")
+			b.WriteString(strconv.Itoa(len(s.Key)))
+			b.WriteByte(':')
 			b.WriteString(s.Key)
 		case IndexOf:
 			b.WriteString("i:")

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -14,14 +14,39 @@ import (
 // expression aliases VarID X" behavior.
 type ProjectionStep interface{ projectionStep() }
 
-// ElementOf is the step into an array literal element ([a, b]).
+// ElementOf is the step into an array element — slot-agnostic, since
+// `Array<T>` has a single element type `T` regardless of position. Use
+// this when the source expression doesn't pin down a specific index
+// (e.g. `arr.map(...)`, iteration, or any operation that yields "some
+// element of an array").
+//
+// NOTE: ElementOf is not currently emitted by any producer. Tuple/array
+// literals always emit IndexOf{Index: i}, and stepIntoSlot collapses
+// IndexOf to element-of-array semantics when the underlying type is
+// Array<T> (see internal/checker/infer_lifetime.go::stepIntoSlot).
+// ElementOf is reserved for future array-iteration / collection-method
+// support, where no specific index is meaningful.
 type ElementOf struct{}
+
+// IndexOf is the step into a specific positional slot — appropriate for
+// tuples, where slot 0 and slot 1 may have distinct types, and for
+// indexed access with a constant integer (`obj[0]`). Carries the slot
+// number as payload.
+//
+// IndexOf is also currently used for *array* literals (`[a, b, c]`
+// emits IndexOf{0}, IndexOf{1}, IndexOf{2}), even though the slot
+// number is semantically irrelevant when the surrounding type resolves
+// to Array<T>. This is because the AST-level producer can't tell
+// whether a literal will be typed as a tuple or an array — that
+// decision happens later. The lifetime-attachment side
+// (stepIntoSlot) handles both: for TupleType it picks the slot at
+// the given index; for Array<T> it ignores the index and returns the
+// element type. Contrast with ElementOf, which is unconditionally
+// slot-agnostic.
+type IndexOf struct{ Index int }
 
 // PropertyOf is the step into an object property ({k: a}).
 type PropertyOf struct{ Key string }
-
-// IndexOf is the step into a fixed tuple slot.
-type IndexOf struct{ Index int }
 
 // AwaitOf is the step through a Promise<T> value (await p).
 type AwaitOf struct{}
@@ -39,6 +64,7 @@ func (CastOf) projectionStep()     {}
 // slot of a surrounding fresh container.
 type AliasLeaf struct {
 	RootVarID VarID
+
 	// Path is the sequence of projection steps from the root into the
 	// freshly-constructed container surrounding this expression. An empty
 	// path means the leaf is the root itself (the legacy single-var case).
@@ -68,11 +94,13 @@ const (
 	// AliasOriginUnknown means the alias status of the value cannot be
 	// determined statically. Zero value.
 	AliasOriginUnknown AliasOrigin = iota
+
 	// AliasOriginFresh means the value's root is brand-new — e.g. a
 	// literal, an array literal, an object literal, a call result, a
 	// function expression. Leaves on a fresh-origin source describe
 	// aliasing of nested slots only; the root itself aliases nothing.
 	AliasOriginFresh
+
 	// AliasOriginAlias means the value is (or projects from) an
 	// existing variable. The root aliases the leaf roots; leaf paths
 	// describe *where in those roots* the value points. A direct
@@ -85,13 +113,15 @@ const (
 // classification) and a *set* of leaves — each leaf names a root variable
 // plus a projection path. The two carry complementary information:
 //
-//   - For Origin=Alias, leaves describe the (root, slot-in-root) the
-//     expression refers to. `obj` is one leaf with empty path; `obj.k`
-//     is one leaf with `[PropertyOf("k")]`.
-//   - For Origin=Fresh, leaves describe (param-root, slot-in-new-container)
-//     that the freshly-constructed root *captures*. `[a, b]` has two
-//     leaves with `[IndexOf(0)]` and `[IndexOf(1)]` rooted at `a`/`b`.
-//     The new container itself aliases nothing at the root.
+//   - For Origin=Alias, each leaf names an existing root variable plus
+//     the path within it that the expression points at. `obj` produces
+//     one leaf rooted at `obj` with an empty path; `obj.k` produces one
+//     leaf rooted at `obj` with path `[PropertyOf("k")]`.
+//   - For Origin=Fresh, the root is a brand-new value that aliases
+//     nothing, but its interior slots may capture references to existing
+//     variables. Each leaf names the captured root variable and the path
+//     *inside the new container* where it lands. `[a, b]` produces two
+//     leaves: `a` at path `[IndexOf(0)]` and `b` at path `[IndexOf(1)]`.
 type AliasSource struct {
 	Origin AliasOrigin
 	Leaves []AliasLeaf
@@ -397,9 +427,8 @@ func determineTupleAliasSource(expr *ast.TupleExpr) AliasSource {
 		}
 		child := DetermineAliasSource(elem)
 		for _, leaf := range child.Leaves {
-			newPath := make([]ProjectionStep, 0, len(leaf.Path)+1)
-			newPath = append(newPath, IndexOf{Index: i})
-			newPath = append(newPath, leaf.Path...)
+			// Build a new path with IndexOf{Index: i} prepended to leaf.Path.
+			newPath := append([]ProjectionStep{IndexOf{Index: i}}, leaf.Path...)
 			key := leafKey(leaf.RootVarID, newPath)
 			if seen.Contains(key) {
 				continue
@@ -428,15 +457,14 @@ func determineObjectAliasSource(expr *ast.ObjectExpr) AliasSource {
 		if !ok || prop.Value == nil {
 			continue
 		}
-		key, ok := staticPropertyKey(prop.Name)
+		key, ok := propertyKeyToString(prop.Name)
 		if !ok {
 			continue
 		}
 		child := DetermineAliasSource(prop.Value)
 		for _, leaf := range child.Leaves {
-			newPath := make([]ProjectionStep, 0, len(leaf.Path)+1)
-			newPath = append(newPath, PropertyOf{Key: key})
-			newPath = append(newPath, leaf.Path...)
+			// Build a new path with PropertyOf{Key: key} prepended to leaf.Path.
+			newPath := append([]ProjectionStep{PropertyOf{Key: key}}, leaf.Path...)
 			leafK := leafKey(leaf.RootVarID, newPath)
 			if seen.Contains(leafK) {
 				continue
@@ -496,9 +524,10 @@ func PathKey(path []ProjectionStep) string {
 	return b.String()
 }
 
-// staticPropertyKey returns the static string form of an object key, or
-// false if the key is computed (and thus not statically known).
-func staticPropertyKey(k ast.ObjKey) (string, bool) {
+// propertyKeyToString returns the string form of an object key when it is
+// statically known (identifier, string literal, or numeric literal), and
+// false for computed keys whose value can't be determined at compile time.
+func propertyKeyToString(k ast.ObjKey) (string, bool) {
 	switch n := k.(type) {
 	case *ast.IdentExpr:
 		return n.Name, true
@@ -508,15 +537,18 @@ func staticPropertyKey(k ast.ObjKey) (string, bool) {
 		// Numeric keys are valid object keys; stringify for the path.
 		// Use Go's default float formatting — adequate for path equality
 		// since both sides go through the same conversion.
-		return formatNumKey(n.Value), true
+		return FormatNumKey(n.Value), true
 	}
 	return "", false
 }
 
-// formatNumKey stringifies a numeric object key. Kept separate so the
-// formatting choice has one place to live if it later needs to align
-// with another stringifier (e.g. printer output).
-func formatNumKey(v float64) string {
+// FormatNumKey stringifies a numeric object key for use as the Key
+// payload of a PropertyOf projection step. Exported so the checker side
+// can produce matching keys when synthesizing PropertyOf steps from a
+// type's NumObjTypeKeyKind property — keeping the exact format choice
+// in one place avoids drift between the producer and consumer of those
+// steps.
+func FormatNumKey(v float64) string {
 	return strconv.FormatFloat(v, 'g', -1, 64)
 }
 

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -5,7 +5,46 @@ import (
 	"github.com/escalier-lang/escalier/internal/set"
 )
 
-// AliasSourceKind describes the kind of alias source an expression represents.
+// ProjectionStep names one step from a root variable to a leaf slot inside
+// a freshly-constructed composite value. The empty-path case (a leaf with
+// no steps) means the leaf is the root itself — this is today's "this
+// expression aliases VarID X" behavior.
+type ProjectionStep interface{ projectionStep() }
+
+// ElementOf is the step into an array literal element ([a, b]).
+type ElementOf struct{}
+
+// PropertyOf is the step into an object property ({k: a}).
+type PropertyOf struct{ Key string }
+
+// IndexOf is the step into a fixed tuple slot.
+type IndexOf struct{ Index int }
+
+// AwaitOf is the step through a Promise<T> value (await p).
+type AwaitOf struct{}
+
+// CastOf is the step through a type cast (p as T) — pass-through.
+type CastOf struct{}
+
+func (ElementOf) projectionStep()  {}
+func (PropertyOf) projectionStep() {}
+func (IndexOf) projectionStep()    {}
+func (AwaitOf) projectionStep()    {}
+func (CastOf) projectionStep()     {}
+
+// AliasLeaf is one (root, path) pair contributing a lifetime to a specific
+// slot of a surrounding fresh container.
+type AliasLeaf struct {
+	RootVarID VarID
+	// Path is the sequence of projection steps from the root into the
+	// freshly-constructed container surrounding this expression. An empty
+	// path means the leaf is the root itself (the legacy single-var case).
+	Path []ProjectionStep
+}
+
+// AliasSourceKind describes the kind of alias source an expression
+// represents. Derived from the (Leaves, Fresh) shape — kept as a typed
+// value so call sites can switch on it.
 type AliasSourceKind int
 
 const (
@@ -15,10 +54,66 @@ const (
 	AliasSourceUnknown                         // cannot determine statically
 )
 
-// AliasSource describes where a value comes from for alias tracking purposes.
+// AliasSource describes where a value comes from for alias tracking
+// purposes. As of Phase 8.9, an alias source is a *set* of leaves — each
+// leaf names a root variable plus the projection path from that root into
+// the freshly-constructed container that wraps the expression. A direct
+// variable reference is a single leaf with empty path; `[a, b]` is two
+// leaves rooted at `a` and `b` with `[ElementOf]` paths.
 type AliasSource struct {
-	Kind   AliasSourceKind
-	VarIDs []VarID // empty for Fresh/Unknown, one for Variable, multiple for Multiple
+	Leaves []AliasLeaf
+	// Fresh is true iff the expression produces a freshly-constructed value
+	// with no aliasing leaves. Distinguishes "definitely fresh" from
+	// "unknown" (the zero value, with no leaves and Fresh==false).
+	Fresh bool
+}
+
+// Kind returns the legacy alias-source kind derived from the leaves.
+func (s AliasSource) Kind() AliasSourceKind {
+	switch len(s.Leaves) {
+	case 0:
+		if s.Fresh {
+			return AliasSourceFresh
+		}
+		return AliasSourceUnknown
+	case 1:
+		return AliasSourceVariable
+	default:
+		return AliasSourceMultiple
+	}
+}
+
+// VarIDs returns the deduplicated list of root variable IDs across all
+// leaves, in leaf order. Provided for callers that only care about the
+// flat root set (e.g. existing alias-set merging in the checker).
+func (s AliasSource) VarIDs() []VarID {
+	if len(s.Leaves) == 0 {
+		return nil
+	}
+	seen := set.NewSet[VarID]()
+	out := make([]VarID, 0, len(s.Leaves))
+	for _, leaf := range s.Leaves {
+		if seen.Contains(leaf.RootVarID) {
+			continue
+		}
+		seen.Add(leaf.RootVarID)
+		out = append(out, leaf.RootVarID)
+	}
+	return out
+}
+
+// freshSource is a small constructor for the common "definitely fresh"
+// case so call sites stay readable.
+func freshSource() AliasSource { return AliasSource{Fresh: true} }
+
+// unknownSource is the zero value — kept as a constructor for parity with
+// freshSource so the intent is explicit at the call site.
+func unknownSource() AliasSource { return AliasSource{} }
+
+// rootSource builds an AliasSource for a single direct variable
+// reference (empty projection path).
+func rootSource(id VarID) AliasSource {
+	return AliasSource{Leaves: []AliasLeaf{{RootVarID: id}}}
 }
 
 // DetermineAliasSource examines an expression and returns its alias source.
@@ -28,39 +123,39 @@ func DetermineAliasSource(expr ast.Expr) AliasSource {
 	switch e := expr.(type) {
 	case *ast.IdentExpr:
 		if e.VarID > 0 {
-			return AliasSource{Kind: AliasSourceVariable, VarIDs: []VarID{VarID(e.VarID)}}
+			return rootSource(VarID(e.VarID))
 		}
 		// Non-local variable (VarID <= 0) — treat as unknown since we
 		// can't track aliases across function boundaries.
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 
 	// Fresh values: literals, object/array construction, function expressions
 	case *ast.LiteralExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.ObjectExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.TupleExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.FuncExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.TemplateLitExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.TaggedTemplateLitExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.JSXElementExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.JSXFragmentExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 
 	// Function calls: treat as fresh for now (Phase 8 adds lifetime-based tracking)
 	case *ast.CallExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 
 	// Unary/binary operations produce fresh primitive values
 	case *ast.UnaryExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.BinaryExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 
 	// Type cast: the alias source is the inner expression
 	case *ast.TypeCastExpr:
@@ -81,32 +176,32 @@ func DetermineAliasSource(expr ast.Expr) AliasSource {
 	case *ast.IfElseExpr:
 		return determineConditionalAliasSource(e)
 	case *ast.IfLetExpr:
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 	case *ast.MatchExpr:
 		return determineMatchAliasSource(e)
 
 	// Do expressions, try-catch: complex control flow, treat as unknown
 	case *ast.DoExpr:
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 	case *ast.TryCatchExpr:
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 
 	// Throw/yield don't produce values that get assigned
 	case *ast.ThrowExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 	case *ast.YieldExpr:
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 
 	// Array spread
 	case *ast.ArraySpreadExpr:
-		return AliasSource{Kind: AliasSourceFresh}
+		return freshSource()
 
 	// Error expression
 	case *ast.ErrorExpr:
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 
 	default:
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 	}
 }
 
@@ -138,44 +233,44 @@ func blockOrExprResultExpr(boe *ast.BlockOrExpr) ast.Expr {
 }
 
 // collectBranchSources collects alias sources from a list of expressions,
-// deduplicating VarIDs across branches. Returns a merged AliasSource.
+// deduplicating leaves across branches by root VarID. Returns a merged
+// AliasSource. Per-branch projection paths are preserved on each leaf;
+// duplicate roots keep the first leaf's path.
 func collectBranchSources(exprs []ast.Expr) AliasSource {
-	varIDs := set.NewOrderedSet[VarID]()
+	seen := set.NewSet[VarID]()
+	var leaves []AliasLeaf
 	allFresh := true
 
 	for _, expr := range exprs {
 		if expr == nil {
-			// A branch with no result expression — treat as unknown
-			return AliasSource{Kind: AliasSourceUnknown}
+			// A branch with no result expression — treat as unknown.
+			return unknownSource()
 		}
 		source := DetermineAliasSource(expr)
-		switch source.Kind {
-		case AliasSourceVariable, AliasSourceMultiple:
+		if len(source.Leaves) > 0 {
 			allFresh = false
-			for _, id := range source.VarIDs {
-				varIDs.Add(id)
+			for _, leaf := range source.Leaves {
+				if seen.Contains(leaf.RootVarID) {
+					continue
+				}
+				seen.Add(leaf.RootVarID)
+				leaves = append(leaves, leaf)
 			}
-		case AliasSourceFresh:
-			// Fresh branch — doesn't contribute alias IDs
-		default:
+		} else if !source.Fresh {
 			// Unknown — treat like fresh for alias purposes. We can't
-			// determine what this branch aliases, but that's no reason to
-			// discard alias info from the branches we DO know about.
+			// determine what this branch aliases, but that's no reason
+			// to discard alias info from the branches we DO know about.
 			allFresh = false
 		}
 	}
 
-	switch varIDs.Len() {
-	case 0:
+	if len(leaves) == 0 {
 		if allFresh {
-			return AliasSource{Kind: AliasSourceFresh}
+			return freshSource()
 		}
-		return AliasSource{Kind: AliasSourceUnknown}
-	case 1:
-		return AliasSource{Kind: AliasSourceVariable, VarIDs: varIDs.ToSlice()}
-	default:
-		return AliasSource{Kind: AliasSourceMultiple, VarIDs: varIDs.ToSlice()}
+		return unknownSource()
 	}
+	return AliasSource{Leaves: leaves}
 }
 
 // determineConditionalAliasSource determines alias sources for an if-else
@@ -197,7 +292,7 @@ func determineConditionalAliasSource(expr *ast.IfElseExpr) AliasSource {
 // by collecting sources from all case bodies.
 func determineMatchAliasSource(expr *ast.MatchExpr) AliasSource {
 	if len(expr.Cases) == 0 {
-		return AliasSource{Kind: AliasSourceUnknown}
+		return unknownSource()
 	}
 
 	branchExprs := make([]ast.Expr, len(expr.Cases))

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -1,6 +1,8 @@
 package liveness
 
 import (
+	"strconv"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/set"
 )
@@ -54,27 +56,60 @@ const (
 	AliasSourceUnknown                         // cannot determine statically
 )
 
+// AliasOrigin classifies whether the *root* of an expression's value is
+// freshly constructed or an alias of an existing value. The leaf set
+// describes nested slot aliases, but the origin determines whether the
+// root itself participates in aliasing — this distinction matters for
+// the alias tracker, which only merges sets at the root level.
+type AliasOrigin int
+
+const (
+	// AliasOriginUnknown means the alias status of the value cannot be
+	// determined statically. Zero value.
+	AliasOriginUnknown AliasOrigin = iota
+	// AliasOriginFresh means the value's root is brand-new — e.g. a
+	// literal, an array literal, an object literal, a call result, a
+	// function expression. Leaves on a fresh-origin source describe
+	// aliasing of nested slots only; the root itself aliases nothing.
+	AliasOriginFresh
+	// AliasOriginAlias means the value is (or projects from) an
+	// existing variable. The root aliases the leaf roots; leaf paths
+	// describe *where in those roots* the value points. A direct
+	// variable reference is the canonical case (single leaf, empty path).
+	AliasOriginAlias
+)
+
 // AliasSource describes where a value comes from for alias tracking
-// purposes. As of Phase 8.9, an alias source is a *set* of leaves — each
-// leaf names a root variable plus the projection path from that root into
-// the freshly-constructed container that wraps the expression. A direct
-// variable reference is a single leaf with empty path; `[a, b]` is two
-// leaves rooted at `a` and `b` with `[ElementOf]` paths.
+// purposes. As of Phase 8.9, an alias source has both an Origin (root
+// classification) and a *set* of leaves — each leaf names a root variable
+// plus a projection path. The two carry complementary information:
+//
+//   - For Origin=Alias, leaves describe the (root, slot-in-root) the
+//     expression refers to. `obj` is one leaf with empty path; `obj.k`
+//     is one leaf with `[PropertyOf("k")]`.
+//   - For Origin=Fresh, leaves describe (param-root, slot-in-new-container)
+//     that the freshly-constructed root *captures*. `[a, b]` has two
+//     leaves with `[IndexOf(0)]` and `[IndexOf(1)]` rooted at `a`/`b`.
+//     The new container itself aliases nothing at the root.
 type AliasSource struct {
+	Origin AliasOrigin
 	Leaves []AliasLeaf
-	// Fresh is true iff the expression produces a freshly-constructed value
-	// with no aliasing leaves. Distinguishes "definitely fresh" from
-	// "unknown" (the zero value, with no leaves and Fresh==false).
-	Fresh bool
 }
 
-// Kind returns the legacy alias-source kind derived from the leaves.
+// Kind returns the legacy alias-source kind. For backward compatibility
+// with consumers that only track root-level aliasing (the alias tracker,
+// transition checking), a fresh-origin value reports Fresh regardless of
+// whether it has nested-slot leaves — only Alias-origin leaves contribute
+// to the legacy Variable/Multiple classification.
 func (s AliasSource) Kind() AliasSourceKind {
+	switch s.Origin {
+	case AliasOriginFresh:
+		return AliasSourceFresh
+	case AliasOriginUnknown:
+		return AliasSourceUnknown
+	}
 	switch len(s.Leaves) {
 	case 0:
-		if s.Fresh {
-			return AliasSourceFresh
-		}
 		return AliasSourceUnknown
 	case 1:
 		return AliasSourceVariable
@@ -104,7 +139,14 @@ func (s AliasSource) VarIDs() []VarID {
 
 // freshSource is a small constructor for the common "definitely fresh"
 // case so call sites stay readable.
-func freshSource() AliasSource { return AliasSource{Fresh: true} }
+func freshSource() AliasSource { return AliasSource{Origin: AliasOriginFresh} }
+
+// freshContainerSource builds a fresh-origin source carrying nested-slot
+// leaves — e.g. `[a, b]` → fresh root, two leaves with paths into the
+// new container.
+func freshContainerSource(leaves []AliasLeaf) AliasSource {
+	return AliasSource{Origin: AliasOriginFresh, Leaves: leaves}
+}
 
 // unknownSource is the zero value — kept as a constructor for parity with
 // freshSource so the intent is explicit at the call site.
@@ -113,7 +155,10 @@ func unknownSource() AliasSource { return AliasSource{} }
 // rootSource builds an AliasSource for a single direct variable
 // reference (empty projection path).
 func rootSource(id VarID) AliasSource {
-	return AliasSource{Leaves: []AliasLeaf{{RootVarID: id}}}
+	return AliasSource{
+		Origin: AliasOriginAlias,
+		Leaves: []AliasLeaf{{RootVarID: id}},
+	}
 }
 
 // DetermineAliasSource examines an expression and returns its alias source.
@@ -133,9 +178,9 @@ func DetermineAliasSource(expr ast.Expr) AliasSource {
 	case *ast.LiteralExpr:
 		return freshSource()
 	case *ast.ObjectExpr:
-		return freshSource()
+		return determineObjectAliasSource(e)
 	case *ast.TupleExpr:
-		return freshSource()
+		return determineTupleAliasSource(e)
 	case *ast.FuncExpr:
 		return freshSource()
 	case *ast.TemplateLitExpr:
@@ -157,20 +202,23 @@ func DetermineAliasSource(expr ast.Expr) AliasSource {
 	case *ast.BinaryExpr:
 		return freshSource()
 
-	// Type cast: the alias source is the inner expression
+	// Type cast: pure pass-through. The Phase 8.9 spec models a CastOf
+	// projection step, but it carries no slot information; treating it as
+	// transparent matches today's behavior and keeps paths shorter.
 	case *ast.TypeCastExpr:
 		return DetermineAliasSource(e.Expr)
 
-	// Await: the alias source is the inner expression
+	// Await: append AwaitOf to each leaf so that lifetime attachment can
+	// descend into Promise<T>'s inner T.
 	case *ast.AwaitExpr:
-		return DetermineAliasSource(e.Arg)
+		return appendStepToLeaves(DetermineAliasSource(e.Arg), AwaitOf{})
 
-	// Property access: the value aliases the object's source.
-	// We treat it as aliasing the object variable (conservative).
+	// Property access: the value projects into the object. Append
+	// PropertyOf(name) so each leaf records the additional descent.
 	case *ast.MemberExpr:
-		return DetermineAliasSource(e.Object)
+		return appendStepToLeaves(DetermineAliasSource(e.Object), PropertyOf{Key: e.Prop.Name})
 	case *ast.IndexExpr:
-		return DetermineAliasSource(e.Object)
+		return determineIndexAliasSource(e)
 
 	// Conditionals: aliases all branches (Phase 7.4).
 	case *ast.IfElseExpr:
@@ -256,7 +304,7 @@ func collectBranchSources(exprs []ast.Expr) AliasSource {
 				seen.Add(leaf.RootVarID)
 				leaves = append(leaves, leaf)
 			}
-		} else if !source.Fresh {
+		} else if source.Origin != AliasOriginFresh {
 			// Unknown — treat like fresh for alias purposes. We can't
 			// determine what this branch aliases, but that's no reason
 			// to discard alias info from the branches we DO know about.
@@ -270,7 +318,12 @@ func collectBranchSources(exprs []ast.Expr) AliasSource {
 		}
 		return unknownSource()
 	}
-	return AliasSource{Leaves: leaves}
+	// Branch arms that bubbled up an alias-of-existing-root contribute
+	// to a merged Alias-origin source. Per-arm Origin distinctions are
+	// not currently tracked at the branch level: if any arm's leaves
+	// reach here, treat the merged source as Alias so callers see the
+	// historical Variable/Multiple kind.
+	return AliasSource{Origin: AliasOriginAlias, Leaves: leaves}
 }
 
 // determineConditionalAliasSource determines alias sources for an if-else
@@ -286,6 +339,145 @@ func determineConditionalAliasSource(expr *ast.IfElseExpr) AliasSource {
 	}
 
 	return collectBranchSources([]ast.Expr{consExpr, altExpr})
+}
+
+// appendStepToLeaves returns a new AliasSource whose leaves each have
+// the given step appended to their projection path. Origin is preserved
+// — descending through `obj.field` keeps the alias-of-existing-root
+// classification, and descending through `await fresh` keeps fresh.
+// Sources with no leaves (Fresh or Unknown with no captures) pass
+// through unchanged.
+func appendStepToLeaves(src AliasSource, step ProjectionStep) AliasSource {
+	if len(src.Leaves) == 0 {
+		return src
+	}
+	out := AliasSource{Origin: src.Origin, Leaves: make([]AliasLeaf, len(src.Leaves))}
+	for i, leaf := range src.Leaves {
+		newPath := make([]ProjectionStep, len(leaf.Path)+1)
+		copy(newPath, leaf.Path)
+		newPath[len(leaf.Path)] = step
+		out.Leaves[i] = AliasLeaf{RootVarID: leaf.RootVarID, Path: newPath}
+	}
+	return out
+}
+
+// determineTupleAliasSource computes the alias source for a tuple/array
+// literal `[e0, e1, ...]`. The root is freshly constructed; each element's
+// leaves are folded in with `IndexOf(i)` prepended to their existing path.
+// The lifetime-attachment side decides whether to interpret these as
+// element-of-array or per-slot tuple positions based on the surrounding
+// type.
+func determineTupleAliasSource(expr *ast.TupleExpr) AliasSource {
+	var leaves []AliasLeaf
+	seen := set.NewSet[VarID]()
+	for i, elem := range expr.Elems {
+		if elem == nil {
+			continue
+		}
+		child := DetermineAliasSource(elem)
+		for _, leaf := range child.Leaves {
+			if seen.Contains(leaf.RootVarID) {
+				continue
+			}
+			seen.Add(leaf.RootVarID)
+			newPath := make([]ProjectionStep, 0, len(leaf.Path)+1)
+			newPath = append(newPath, IndexOf{Index: i})
+			newPath = append(newPath, leaf.Path...)
+			leaves = append(leaves, AliasLeaf{RootVarID: leaf.RootVarID, Path: newPath})
+		}
+	}
+	if len(leaves) == 0 {
+		return freshSource()
+	}
+	return freshContainerSource(leaves)
+}
+
+// determineObjectAliasSource computes the alias source for an object
+// literal `{k0: e0, k1: e1, ...}`. The root is freshly constructed; each
+// property value's leaves are folded in with `PropertyOf(key)` prepended.
+// Spread elements, methods, getters/setters, and computed keys without
+// a static name are skipped — their alias contributions can't be slotted
+// to a known property of the new container.
+func determineObjectAliasSource(expr *ast.ObjectExpr) AliasSource {
+	var leaves []AliasLeaf
+	seen := set.NewSet[VarID]()
+	for _, elem := range expr.Elems {
+		prop, ok := elem.(*ast.PropertyExpr)
+		if !ok || prop.Value == nil {
+			continue
+		}
+		key, ok := staticPropertyKey(prop.Name)
+		if !ok {
+			continue
+		}
+		child := DetermineAliasSource(prop.Value)
+		for _, leaf := range child.Leaves {
+			if seen.Contains(leaf.RootVarID) {
+				continue
+			}
+			seen.Add(leaf.RootVarID)
+			newPath := make([]ProjectionStep, 0, len(leaf.Path)+1)
+			newPath = append(newPath, PropertyOf{Key: key})
+			newPath = append(newPath, leaf.Path...)
+			leaves = append(leaves, AliasLeaf{RootVarID: leaf.RootVarID, Path: newPath})
+		}
+	}
+	if len(leaves) == 0 {
+		return freshSource()
+	}
+	return freshContainerSource(leaves)
+}
+
+// staticPropertyKey returns the static string form of an object key, or
+// false if the key is computed (and thus not statically known).
+func staticPropertyKey(k ast.ObjKey) (string, bool) {
+	switch n := k.(type) {
+	case *ast.IdentExpr:
+		return n.Name, true
+	case *ast.StrLit:
+		return n.Value, true
+	case *ast.NumLit:
+		// Numeric keys are valid object keys; stringify for the path.
+		// Use Go's default float formatting — adequate for path equality
+		// since both sides go through the same conversion.
+		return formatNumKey(n.Value), true
+	}
+	return "", false
+}
+
+// formatNumKey stringifies a numeric object key. Kept separate so the
+// formatting choice has one place to live if it later needs to align
+// with another stringifier (e.g. printer output).
+func formatNumKey(v float64) string {
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}
+
+// determineIndexAliasSource computes the alias source for `obj[i]`. The
+// expression projects into obj; we append `IndexOf(i)` only when the
+// index is a constant integer literal (the only case where we can name
+// the slot statically). Non-constant indexes fall back to a transparent
+// descent into the object — the same conservative approximation as
+// before Phase 8.9.
+func determineIndexAliasSource(expr *ast.IndexExpr) AliasSource {
+	src := DetermineAliasSource(expr.Object)
+	if lit, ok := expr.Index.(*ast.LiteralExpr); ok {
+		if num, ok := lit.Lit.(*ast.NumLit); ok {
+			if i, isInt := floatAsInt(num.Value); isInt {
+				return appendStepToLeaves(src, IndexOf{Index: i})
+			}
+		}
+	}
+	return src
+}
+
+// floatAsInt returns the int form of a float64 if it represents a
+// non-negative integer index, and false otherwise.
+func floatAsInt(v float64) (int, bool) {
+	i := int(v)
+	if float64(i) == v && i >= 0 {
+		return i, true
+	}
+	return 0, false
 }
 
 // determineMatchAliasSource determines alias sources for a match expression

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -97,12 +97,18 @@ type AliasSource struct {
 	Leaves []AliasLeaf
 }
 
-// Kind returns the legacy alias-source kind. For backward compatibility
-// with consumers that only track root-level aliasing (the alias tracker,
-// transition checking), a fresh-origin value reports Fresh regardless of
-// whether it has nested-slot leaves — only Alias-origin leaves contribute
-// to the legacy Variable/Multiple classification.
-func (s AliasSource) Kind() AliasSourceKind {
+// Kind returns a root-level view of the alias source for consumers
+// whose data model is "which variable IDs does this value alias at the
+// root?" — the alias tracker, transition checking, and the static-escape
+// propagation, none of which understand projection paths. A fresh-origin
+// value reports Fresh regardless of whether it has nested-slot leaves
+// (the new container's root aliases nothing, even if `[a, b]` captures
+// `a` and `b` at element slots); only Alias-origin leaves contribute to
+// the Variable/Multiple classification.
+//
+// Lifetime attachment uses the path-aware Origin + Leaves view directly.
+// Both views are load-bearing — neither is a backward-compat shim.
+func (s AliasSource) RootKind() AliasSourceKind {
 	switch s.Origin {
 	case AliasOriginFresh:
 		return AliasSourceFresh

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -125,10 +125,12 @@ func (s AliasSource) RootKind() AliasSourceKind {
 	}
 }
 
-// VarIDs returns the deduplicated list of root variable IDs across all
-// leaves, in leaf order. Provided for callers that only care about the
-// flat root set (e.g. existing alias-set merging in the checker).
-func (s AliasSource) VarIDs() []VarID {
+// UniqueVarIDs returns the deduplicated list of root variable IDs
+// across all leaves, in leaf order. Provided for callers that only
+// care about the flat root set (e.g. alias-set merging in the
+// checker), so they don't have to dedupe themselves when the same
+// root appears under multiple slot paths.
+func (s AliasSource) UniqueVarIDs() []VarID {
 	if len(s.Leaves) == 0 {
 		return nil
 	}

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -2,6 +2,7 @@ package liveness
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/set"
@@ -281,13 +282,16 @@ func blockOrExprResultExpr(boe *ast.BlockOrExpr) ast.Expr {
 }
 
 // collectBranchSources collects alias sources from a list of expressions,
-// deduplicating leaves across branches by root VarID. Returns a merged
-// AliasSource. Per-branch projection paths are preserved on each leaf;
-// duplicate roots keep the first leaf's path.
+// deduplicating leaves across branches by (root, projection path) so that
+// fresh-container shapes like {head:a} vs {tail:a} (same root, different
+// slot) are preserved. The merged Origin is Fresh when every contributing
+// branch's value root is fresh; Alias when at least one branch's root
+// itself aliases an existing variable.
 func collectBranchSources(exprs []ast.Expr) AliasSource {
-	seen := set.NewSet[VarID]()
+	seen := set.NewSet[string]()
 	var leaves []AliasLeaf
 	allFresh := true
+	hasAliasOrigin := false
 
 	for _, expr := range exprs {
 		if expr == nil {
@@ -297,11 +301,15 @@ func collectBranchSources(exprs []ast.Expr) AliasSource {
 		source := DetermineAliasSource(expr)
 		if len(source.Leaves) > 0 {
 			allFresh = false
+			if source.Origin == AliasOriginAlias {
+				hasAliasOrigin = true
+			}
 			for _, leaf := range source.Leaves {
-				if seen.Contains(leaf.RootVarID) {
+				key := leafKey(leaf.RootVarID, leaf.Path)
+				if seen.Contains(key) {
 					continue
 				}
-				seen.Add(leaf.RootVarID)
+				seen.Add(key)
 				leaves = append(leaves, leaf)
 			}
 		} else if source.Origin != AliasOriginFresh {
@@ -318,12 +326,17 @@ func collectBranchSources(exprs []ast.Expr) AliasSource {
 		}
 		return unknownSource()
 	}
-	// Branch arms that bubbled up an alias-of-existing-root contribute
-	// to a merged Alias-origin source. Per-arm Origin distinctions are
-	// not currently tracked at the branch level: if any arm's leaves
-	// reach here, treat the merged source as Alias so callers see the
-	// historical Variable/Multiple kind.
-	return AliasSource{Origin: AliasOriginAlias, Leaves: leaves}
+	// If every contributing branch produced a fresh-rooted value, the
+	// merged result is also fresh-rooted: leaf paths describe descents
+	// into the fresh container, and lifetime attachment must follow them
+	// into the return type. If any branch's root itself aliases an
+	// existing variable, the merged root aliases too — the legacy
+	// Variable/Multiple kind matters there.
+	origin := AliasOriginFresh
+	if hasAliasOrigin {
+		origin = AliasOriginAlias
+	}
+	return AliasSource{Origin: origin, Leaves: leaves}
 }
 
 // determineConditionalAliasSource determines alias sources for an if-else
@@ -369,20 +382,21 @@ func appendStepToLeaves(src AliasSource, step ProjectionStep) AliasSource {
 // type.
 func determineTupleAliasSource(expr *ast.TupleExpr) AliasSource {
 	var leaves []AliasLeaf
-	seen := set.NewSet[VarID]()
+	seen := set.NewSet[string]()
 	for i, elem := range expr.Elems {
 		if elem == nil {
 			continue
 		}
 		child := DetermineAliasSource(elem)
 		for _, leaf := range child.Leaves {
-			if seen.Contains(leaf.RootVarID) {
-				continue
-			}
-			seen.Add(leaf.RootVarID)
 			newPath := make([]ProjectionStep, 0, len(leaf.Path)+1)
 			newPath = append(newPath, IndexOf{Index: i})
 			newPath = append(newPath, leaf.Path...)
+			key := leafKey(leaf.RootVarID, newPath)
+			if seen.Contains(key) {
+				continue
+			}
+			seen.Add(key)
 			leaves = append(leaves, AliasLeaf{RootVarID: leaf.RootVarID, Path: newPath})
 		}
 	}
@@ -400,7 +414,7 @@ func determineTupleAliasSource(expr *ast.TupleExpr) AliasSource {
 // to a known property of the new container.
 func determineObjectAliasSource(expr *ast.ObjectExpr) AliasSource {
 	var leaves []AliasLeaf
-	seen := set.NewSet[VarID]()
+	seen := set.NewSet[string]()
 	for _, elem := range expr.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok || prop.Value == nil {
@@ -412,13 +426,14 @@ func determineObjectAliasSource(expr *ast.ObjectExpr) AliasSource {
 		}
 		child := DetermineAliasSource(prop.Value)
 		for _, leaf := range child.Leaves {
-			if seen.Contains(leaf.RootVarID) {
-				continue
-			}
-			seen.Add(leaf.RootVarID)
 			newPath := make([]ProjectionStep, 0, len(leaf.Path)+1)
 			newPath = append(newPath, PropertyOf{Key: key})
 			newPath = append(newPath, leaf.Path...)
+			leafK := leafKey(leaf.RootVarID, newPath)
+			if seen.Contains(leafK) {
+				continue
+			}
+			seen.Add(leafK)
 			leaves = append(leaves, AliasLeaf{RootVarID: leaf.RootVarID, Path: newPath})
 		}
 	}
@@ -426,6 +441,32 @@ func determineObjectAliasSource(expr *ast.ObjectExpr) AliasSource {
 		return freshSource()
 	}
 	return freshContainerSource(leaves)
+}
+
+// leafKey returns a stable string representation of a (root, path) pair
+// suitable for use as a deduplication key. Two leaves with the same root
+// and equivalent path produce equal keys.
+func leafKey(root VarID, path []ProjectionStep) string {
+	var b strings.Builder
+	b.WriteString(strconv.Itoa(int(root)))
+	for _, step := range path {
+		b.WriteByte('|')
+		switch s := step.(type) {
+		case ElementOf:
+			b.WriteString("e")
+		case PropertyOf:
+			b.WriteString("p:")
+			b.WriteString(s.Key)
+		case IndexOf:
+			b.WriteString("i:")
+			b.WriteString(strconv.Itoa(s.Index))
+		case AwaitOf:
+			b.WriteString("a")
+		case CastOf:
+			b.WriteString("c")
+		}
+	}
+	return b.String()
 }
 
 // staticPropertyKey returns the static string form of an object key, or

--- a/internal/liveness/alias_analysis_test.go
+++ b/internal/liveness/alias_analysis_test.go
@@ -249,6 +249,141 @@ func TestDetermineAliasSource_MatchExpr_SameVariable(t *testing.T) {
 	require.Equal(t, "variable [a]", formatAliasSource(DetermineAliasSource(expr), names))
 }
 
+// formatLeaves returns a compact, deterministic string of an alias
+// source's (root, path) pairs — used by Phase 8.9 path-tracking tests
+// where the legacy Kind/VarIDs view loses the projection structure.
+func formatLeaves(source AliasSource, names map[VarID]string) string {
+	parts := make([]string, len(source.Leaves))
+	for i, leaf := range source.Leaves {
+		name, ok := names[leaf.RootVarID]
+		if !ok {
+			name = fmt.Sprintf("%d", leaf.RootVarID)
+		}
+		parts[i] = name + formatPath(leaf.Path)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatPath(path []ProjectionStep) string {
+	if len(path) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, step := range path {
+		switch s := step.(type) {
+		case ElementOf:
+			b.WriteString(".[]")
+		case PropertyOf:
+			b.WriteString(".")
+			b.WriteString(s.Key)
+		case IndexOf:
+			fmt.Fprintf(&b, "[%d]", s.Index)
+		case AwaitOf:
+			b.WriteString(".await")
+		case CastOf:
+			b.WriteString(".cast")
+		}
+	}
+	return b.String()
+}
+
+func TestDetermineAliasSource_MemberExpr_AppendsProperty(t *testing.T) {
+	expr := parseExpr(t, "obj.field.inner")
+	setVarIDs(expr, map[string]int{"obj": 5})
+	names := map[VarID]string{5: "obj"}
+
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginAlias, src.Origin)
+	require.Equal(t, "obj.field.inner", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_IndexExpr_ConstAppendsIndex(t *testing.T) {
+	expr := parseExpr(t, "obj[2]")
+	setVarIDs(expr, map[string]int{"obj": 5})
+	names := map[VarID]string{5: "obj"}
+
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginAlias, src.Origin)
+	require.Equal(t, "obj[2]", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_IndexExpr_NonConstFallsBack(t *testing.T) {
+	expr := parseExpr(t, "obj[i]")
+	setVarIDs(expr, map[string]int{"obj": 5, "i": 7})
+	names := map[VarID]string{5: "obj"}
+
+	// Non-constant indexes can't be slotted statically — leaf has no
+	// IndexOf step, just the bare root.
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginAlias, src.Origin)
+	require.Equal(t, "obj", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_TupleExpr_ProducesIndexLeaves(t *testing.T) {
+	expr := parseExpr(t, "[a, b]")
+	setVarIDs(expr, map[string]int{"a": 1, "b": 2})
+	names := map[VarID]string{1: "a", 2: "b"}
+
+	src := DetermineAliasSource(expr)
+	// Root is freshly constructed — the alias tracker should still see
+	// "fresh" via the legacy Kind() so it doesn't merge alias sets at
+	// the root level.
+	require.Equal(t, "fresh", formatAliasSource(src, names))
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Equal(t, "a[0], b[1]", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_TupleExpr_AllFreshHasNoLeaves(t *testing.T) {
+	expr := parseExpr(t, "[1, 2]")
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Empty(t, src.Leaves)
+}
+
+func TestDetermineAliasSource_ObjectExpr_ProducesPropertyLeaves(t *testing.T) {
+	expr := parseExpr(t, "{head: a, tail: b}")
+	setVarIDs(expr, map[string]int{"a": 1, "b": 2})
+	names := map[VarID]string{1: "a", 2: "b"}
+
+	src := DetermineAliasSource(expr)
+	require.Equal(t, "fresh", formatAliasSource(src, names))
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Equal(t, "a.head, b.tail", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_NestedTupleInObject(t *testing.T) {
+	expr := parseExpr(t, "{items: [a, b]}")
+	setVarIDs(expr, map[string]int{"a": 1, "b": 2})
+	names := map[VarID]string{1: "a", 2: "b"}
+
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Equal(t, "a.items[0], b.items[1]", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_TupleOfMember(t *testing.T) {
+	expr := parseExpr(t, "[obj.x]")
+	setVarIDs(expr, map[string]int{"obj": 9})
+	names := map[VarID]string{9: "obj"}
+
+	// `[obj.x]` — fresh root, one leaf rooted at obj with path
+	// [IndexOf(0), PropertyOf("x")] describing the slot in the new
+	// container followed by the projection into obj.
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Equal(t, "obj[0].x", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_AwaitExpr_AppendsAwait(t *testing.T) {
+	expr := parseExpr(t, "await p")
+	setVarIDs(expr, map[string]int{"p": 4})
+	names := map[VarID]string{4: "p"}
+
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginAlias, src.Origin)
+	require.Equal(t, "p.await", formatLeaves(src, names))
+}
+
 func TestDetermineAliasSource_MatchExpr_VariableAndFresh(t *testing.T) {
 	expr := parseExpr(t, "match 1 { _ => a, _ => [1] }")
 	setVarIDs(expr, map[string]int{"a": 1})

--- a/internal/liveness/alias_analysis_test.go
+++ b/internal/liveness/alias_analysis_test.go
@@ -21,7 +21,7 @@ func formatAliasSource(source AliasSource, names map[VarID]string) string {
 	case AliasSourceUnknown:
 		return "unknown"
 	case AliasSourceVariable, AliasSourceMultiple:
-		ids := source.VarIDs()
+		ids := source.UniqueVarIDs()
 		varNames := make([]string, len(ids))
 		for i, id := range ids {
 			if name, ok := names[id]; ok {

--- a/internal/liveness/alias_analysis_test.go
+++ b/internal/liveness/alias_analysis_test.go
@@ -374,6 +374,54 @@ func TestDetermineAliasSource_TupleOfMember(t *testing.T) {
 	require.Equal(t, "obj[0].x", formatLeaves(src, names))
 }
 
+func TestDetermineAliasSource_TupleExpr_RepeatedRootKeepsBothSlots(t *testing.T) {
+	expr := parseExpr(t, "[a, a]")
+	setVarIDs(expr, map[string]int{"a": 1})
+	names := map[VarID]string{1: "a"}
+
+	// `[a, a]` — two distinct slots, both rooted at `a`. The dedupe key
+	// must be (RootVarID, Path), not RootVarID alone, otherwise IndexOf(1)
+	// is dropped and the second slot loses its lifetime attachment.
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Equal(t, "a[0], a[1]", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_ObjectExpr_RepeatedRootKeepsBothProps(t *testing.T) {
+	expr := parseExpr(t, "{head: a, tail: a}")
+	setVarIDs(expr, map[string]int{"a": 1})
+	names := map[VarID]string{1: "a"}
+
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Equal(t, "a.head, a.tail", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_IfElseExpr_BothFreshContainersStaysFresh(t *testing.T) {
+	expr := parseExpr(t, "if true { [a] } else { [b] }")
+	setVarIDs(expr, map[string]int{"a": 1, "b": 2})
+	names := map[VarID]string{1: "a", 2: "b"}
+
+	// Both branches produce fresh containers with element-level leaves.
+	// The merged origin should remain Fresh so path-aware lifetime
+	// attachment descends into the array's element type, rather than
+	// attaching at the top.
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginFresh, src.Origin)
+	require.Equal(t, "a[0], b[0]", formatLeaves(src, names))
+}
+
+func TestDetermineAliasSource_IfElseExpr_MixedFreshAndAliasIsAlias(t *testing.T) {
+	expr := parseExpr(t, "if true { [a] } else { b }")
+	setVarIDs(expr, map[string]int{"a": 1, "b": 2})
+
+	// One branch is fresh-rooted with an element leaf; the other is an
+	// alias-rooted bare variable. The merged origin must be Alias because
+	// at least one branch's value root aliases an existing variable.
+	src := DetermineAliasSource(expr)
+	require.Equal(t, AliasOriginAlias, src.Origin)
+}
+
 func TestDetermineAliasSource_AwaitExpr_AppendsAwait(t *testing.T) {
 	expr := parseExpr(t, "await p")
 	setVarIDs(expr, map[string]int{"p": 4})

--- a/internal/liveness/alias_analysis_test.go
+++ b/internal/liveness/alias_analysis_test.go
@@ -432,6 +432,15 @@ func TestDetermineAliasSource_AwaitExpr_AppendsAwait(t *testing.T) {
 	require.Equal(t, "p.await", formatLeaves(src, names))
 }
 
+func TestLeafKey_NoCollisionWithDelimiterInPropertyName(t *testing.T) {
+	// PropertyOf keys are user-supplied (string-keyed object literals can
+	// contain '|' or 'p:'). The dedup key must not collide with a path
+	// where the same characters are split across two property steps.
+	a := leafKey(1, []ProjectionStep{PropertyOf{Key: "foo|p:bar"}})
+	b := leafKey(1, []ProjectionStep{PropertyOf{Key: "foo"}, PropertyOf{Key: "bar"}})
+	require.NotEqual(t, a, b, "different paths must produce different keys")
+}
+
 func TestDetermineAliasSource_MatchExpr_VariableAndFresh(t *testing.T) {
 	expr := parseExpr(t, "match 1 { _ => a, _ => [1] }")
 	setVarIDs(expr, map[string]int{"a": 1})

--- a/internal/liveness/alias_analysis_test.go
+++ b/internal/liveness/alias_analysis_test.go
@@ -14,26 +14,28 @@ import (
 // formatAliasSource formats an AliasSource as a readable string for test assertions.
 // Examples: "fresh", "unknown", "variable [x]", "multiple [a, b]"
 func formatAliasSource(source AliasSource, names map[VarID]string) string {
-	switch source.Kind {
+	kind := source.Kind()
+	switch kind {
 	case AliasSourceFresh:
 		return "fresh"
 	case AliasSourceUnknown:
 		return "unknown"
 	case AliasSourceVariable, AliasSourceMultiple:
-		varNames := make([]string, len(source.VarIDs))
-		for i, id := range source.VarIDs {
+		ids := source.VarIDs()
+		varNames := make([]string, len(ids))
+		for i, id := range ids {
 			if name, ok := names[id]; ok {
 				varNames[i] = name
 			} else {
 				varNames[i] = fmt.Sprintf("%d", id)
 			}
 		}
-		if source.Kind == AliasSourceVariable {
+		if kind == AliasSourceVariable {
 			return "variable [" + strings.Join(varNames, ", ") + "]"
 		}
 		return "multiple [" + strings.Join(varNames, ", ") + "]"
 	default:
-		return fmt.Sprintf("unknown-kind(%d)", source.Kind)
+		return fmt.Sprintf("unknown-kind(%d)", kind)
 	}
 }
 

--- a/internal/liveness/alias_analysis_test.go
+++ b/internal/liveness/alias_analysis_test.go
@@ -14,7 +14,7 @@ import (
 // formatAliasSource formats an AliasSource as a readable string for test assertions.
 // Examples: "fresh", "unknown", "variable [x]", "multiple [a, b]"
 func formatAliasSource(source AliasSource, names map[VarID]string) string {
-	kind := source.Kind()
+	kind := source.RootKind()
 	switch kind {
 	case AliasSourceFresh:
 		return "fresh"


### PR DESCRIPTION
- **Phase 8.9 (a): switch AliasSource to a path-based leaf set**
- **Phase 8.9 (b): descend into composite expressions in DetermineAliasSource**
- **Phase 8.9 (c): path-aware lifetime attachment in result types**
- **Phase 8.9 (e): escape detection sees fresh-rooted RHS leaves**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced lifetime inference for composite types (tuples, objects, arrays) with more precise type tracking per slot.
  * Improved row-polymorphic function type representation with clearer type variable display.
  * Better handling of nested composite literal slots and escape analysis in constructors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->