### PR TITLE
Fix #541

### DIFF
--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1317,6 +1317,30 @@ func setLifetimeArgsOnType(t type_system.Type, args []type_system.Lifetime) {
 // For non-call expressions and calls whose callee has no lifetime
 // information, this falls through to liveness.DetermineAliasSource.
 func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
+	// Recurse through pure projection nodes using the checker-aware
+	// helper so that fresh-rooted leaves produced by an inner CallExpr
+	// (via embeddedLifetimeAliasSource) survive the descent. Falling
+	// through to liveness.DetermineAliasSource would re-derive the
+	// inner alias source without lifetime information and lose the
+	// per-slot leaves.
+	switch e := expr.(type) {
+	case *ast.MemberExpr:
+		return liveness.ProjectStep(determineCheckerAliasSource(e.Object), liveness.PropertyOf{Key: e.Prop.Name})
+	case *ast.IndexExpr:
+		inner := determineCheckerAliasSource(e.Object)
+		if lit, ok := e.Index.(*ast.LiteralExpr); ok {
+			if num, ok := lit.Lit.(*ast.NumLit); ok {
+				i := int(num.Value)
+				if float64(i) == num.Value && i >= 0 {
+					return liveness.ProjectStep(inner, liveness.IndexOf{Index: i})
+				}
+			}
+		}
+		return inner
+	case *ast.TypeCastExpr:
+		return determineCheckerAliasSource(e.Expr)
+	}
+
 	callExpr, ok := expr.(*ast.CallExpr)
 	if !ok {
 		return liveness.DetermineAliasSource(expr)
@@ -1438,11 +1462,9 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 // the plain liveness handling, which classifies the call as fresh with
 // no leaves.
 //
-// TODO(#541): downstream `MemberExpr` / `IndexExpr` projection through
-// the leaves of this source only ever appends to the leaf paths, so
-// `wrap(a, b).head` doesn't yet narrow to the `'a`-only leaf. Adding
-// bidirectional path semantics for fresh-rooted sources is tracked
-// separately.
+// Downstream `MemberExpr` / `IndexExpr` projection consumes the matching
+// front step from each leaf (see liveness.ProjectStep), so
+// `wrap(a, b).head` correctly narrows to the `'a`-only leaf.
 func embeddedLifetimeAliasSource(fnType *type_system.FuncType, callExpr *ast.CallExpr) liveness.AliasSource {
 	slots := collectReturnLifetimeSlots(fnType.Return)
 	if len(slots) == 0 {

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1339,6 +1339,8 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 		return inner
 	case *ast.TypeCastExpr:
 		return determineCheckerAliasSource(e.Expr)
+	case *ast.AwaitExpr:
+		return liveness.ProjectStep(determineCheckerAliasSource(e.Arg), liveness.AwaitOf{})
 	}
 
 	callExpr, ok := expr.(*ast.CallExpr)

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1328,13 +1328,8 @@ func determineCheckerAliasSource(expr ast.Expr) liveness.AliasSource {
 		return liveness.ProjectStep(determineCheckerAliasSource(e.Object), liveness.PropertyOf{Key: e.Prop.Name})
 	case *ast.IndexExpr:
 		inner := determineCheckerAliasSource(e.Object)
-		if lit, ok := e.Index.(*ast.LiteralExpr); ok {
-			if num, ok := lit.Lit.(*ast.NumLit); ok {
-				i := int(num.Value)
-				if float64(i) == num.Value && i >= 0 {
-					return liveness.ProjectStep(inner, liveness.IndexOf{Index: i})
-				}
-			}
+		if step, ok := liveness.IndexLiteralStep(e); ok {
+			return liveness.ProjectStep(inner, step)
 		}
 		return inner
 	case *ast.TypeCastExpr:

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -553,17 +553,15 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"passThrough": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {0: mut 'a {x: number}, 1: mut 'b {x: number}}",
 			},
 		},
-		"PropertyAccess_ProjectsPerSlotLifetime_KnownGap": {
+		"PropertyAccess_ProjectsPerSlotLifetime": {
 			// Caller-side aliasing precision: accessing a single slot
-			// of a per-property-typed result *should* project only
-			// that slot's lifetime — `r.head` would carry `'a`, not
-			// the union, letting the alias tracker distinguish borrows
-			// from `a` vs `b`.
-			//
-			// Today determineCheckerAliasSource only handles top-level
-			// return lifetimes; per-slot projection through a call's
-			// return type isn't threaded yet. Pinning down current
-			// behavior; tracked in the Phase 8.9 follow-up.
+			// of a per-property-typed result projects only that slot's
+			// lifetime — `wrap(a, b).head` carries `'a`, not the union,
+			// so `pickHead`'s signature ties its return to `a` only.
+			// Implemented via bidirectional path semantics in
+			// liveness.ProjectStep: fresh-rooted leaves with per-slot
+			// paths get filtered by the matching front step on
+			// MemberExpr/IndexExpr descent.
 			input: `
 				fn wrap(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
 					return {head: a, tail: b}
@@ -573,14 +571,13 @@ func TestInferLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				// Target: "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}"
-				"pickHead": "fn (a: mut {x: number}, b: mut {x: number}) -> mut {x: number}",
+				"pickHead": "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}",
 			},
 		},
-		"IndexAccess_ProjectsPerSlotLifetime_KnownGap": {
-			// Same gap as PropertyAccess_ProjectsPerSlotLifetime_KnownGap
-			// but for tuple slots — `pair(a, b)[0]` should carry only
-			// `'a`. Pinning today's behavior.
+		"IndexAccess_ProjectsPerSlotLifetime": {
+			// Tuple-slot counterpart to PropertyAccess_ProjectsPerSlotLifetime:
+			// `pair(a, b)[0]` carries only `'a`, so `pickFirst` ties
+			// its return to `a` only.
 			input: `
 				fn pair(a: mut {x: number}, b: mut {x: number}) -> [mut {x: number}, mut {x: number}] {
 					return [a, b]
@@ -590,8 +587,7 @@ func TestInferLifetimeTypes(t *testing.T) {
 				}
 			`,
 			expectedTypes: map[string]string{
-				// Target: "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}"
-				"pickFirst": "fn (a: mut {x: number}, b: mut {x: number}) -> mut {x: number}",
+				"pickFirst": "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}",
 			},
 		},
 		"PerSlotEscape_OnlyEscapingPropertyGetsStatic": {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -574,6 +574,23 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"pickHead": "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}",
 			},
 		},
+		"PropertyAccess_CastedProjection": {
+			// Exercises the TypeCastExpr branch in
+			// determineCheckerAliasSource: a cast on the call result
+			// must pass through the per-slot leaves so the subsequent
+			// `.head` projection still narrows to `'a` only.
+			input: `
+				fn wrap(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
+					return {head: a, tail: b}
+				}
+				fn pickHeadCast(a: mut {x: number}, b: mut {x: number}) -> mut {x: number} {
+					return (wrap(a, b): {head: mut {x: number}, tail: mut {x: number}}).head
+				}
+			`,
+			expectedTypes: map[string]string{
+				"pickHeadCast": "fn <'a>(a: mut 'a {x: number}, b: mut {x: number}) -> mut 'a {x: number}",
+			},
+		},
 		"IndexAccess_ProjectsPerSlotLifetime": {
 			// Tuple-slot counterpart to PropertyAccess_ProjectsPerSlotLifetime:
 			// `pair(a, b)[0]` carries only `'a`, so `pickFirst` ties
@@ -642,6 +659,61 @@ func TestInferLifetimeTypes(t *testing.T) {
 			`,
 			expectedTypes: map[string]string{
 				"pair": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> {0: mut 'a {x: number}, name: mut 'b {x: number}}",
+			},
+		},
+		"AsyncFn_IdentityCarriesLifetimeIntoPromise": {
+			// An async fn that returns its mutable param should infer
+			// a lifetime on that param and propagate it into the
+			// Promise<T> wrapper around the return type. The unwrap
+			// of Promise<T> for inference happens in inferLifetimesCore
+			// based on async mode.
+			input: `
+				async fn identity(p: mut {x: number}) -> mut {x: number} {
+					return p
+				}
+			`,
+			expectedTypes: map[string]string{
+				"identity": "fn <'a>(p: mut 'a {x: number}) -> Promise<mut 'a {x: number}, never>",
+			},
+		},
+		"AsyncFn_ProjectsPerSlotLifetimeIntoPromise": {
+			// Composite-return async fn: the per-slot leaves produced
+			// by the object literal should drive per-property lifetime
+			// attachment inside the Promise<T> wrapper.
+			input: `
+				async fn wrap(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
+					return {head: a, tail: b}
+				}
+			`,
+			expectedTypes: map[string]string{
+				"wrap": "fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> Promise<{head: mut 'a {x: number}, tail: mut 'b {x: number}}, never>",
+			},
+		},
+		"AsyncFn_AwaitedReturnPropagatesLifetime_KnownGap": {
+			// An async caller that returns `await callee(p)` where
+			// callee is `async fn(p: mut T) -> mut T` should — once
+			// Promise<T> descent is implemented in
+			// collectReturnLifetimeSlots — tie the caller's return to
+			// `p`'s lifetime. Today the call's Promise<T> return type
+			// isn't descended into, so no per-slot leaves are produced
+			// and the caller's signature collapses to no inferred
+			// lifetimes. Pinning current behavior; tracked in #544.
+			//
+			// The AwaitExpr branch in determineCheckerAliasSource is
+			// already in place, so once #544 lands and the call
+			// produces leaves, ProjectStep will consume the AwaitOf
+			// step from each leaf and surface the underlying root.
+			input: `
+				async fn identity(p: mut {x: number}) -> mut {x: number} {
+					return p
+				}
+				async fn caller(p: mut {x: number}) -> mut {x: number} {
+					return await identity(p)
+				}
+			`,
+			expectedTypes: map[string]string{
+				// Target (post-#544): "fn <'a>(p: mut 'a {x: number}) -> Promise<mut 'a {x: number}, never>"
+				"caller": "fn (p: mut {x: number}) -> Promise<mut 'a {x: number}, never>",
 			},
 		},
 		"NestedObjectInArray_DescendsTwoSteps": {

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -255,7 +255,7 @@ func DetermineAliasSource(expr ast.Expr) AliasSource {
 	// Property access: the value projects into the object. Append
 	// PropertyOf(name) so each leaf records the additional descent.
 	case *ast.MemberExpr:
-		return appendStepToLeaves(DetermineAliasSource(e.Object), PropertyOf{Key: e.Prop.Name})
+		return ProjectStep(DetermineAliasSource(e.Object), PropertyOf{Key: e.Prop.Name})
 	case *ast.IndexExpr:
 		return determineIndexAliasSource(e)
 
@@ -412,6 +412,54 @@ func appendStepToLeaves(src AliasSource, step ProjectionStep) AliasSource {
 	return out
 }
 
+// ProjectStep applies one descent step to an alias source, with semantics
+// that depend on the source's origin.
+//
+// For Origin=Alias (or Origin=Unknown with leaves), the step appends to
+// each leaf's path — `obj.field.inner` projects deeper into `obj`.
+//
+// For Origin=Fresh with leaves, the leaf paths describe "where in this
+// fresh container the aliasing slot lives," so descending instead
+// *consumes* the matching front step: leaves whose first step doesn't
+// match are dropped, the matching step is stripped, and the origin is
+// reclassified — Alias when any surviving leaf's path becomes empty
+// (the projection lands directly on an existing root), Fresh otherwise
+// (the projection lands inside a still-fresh sub-container). When no
+// leaves match, the result is a plain fresh source.
+//
+// Sources with no leaves pass through unchanged.
+func ProjectStep(src AliasSource, step ProjectionStep) AliasSource {
+	if src.Origin != AliasOriginFresh || len(src.Leaves) == 0 {
+		return appendStepToLeaves(src, step)
+	}
+	var newLeaves []AliasLeaf
+	hasAlias := false
+	for _, leaf := range src.Leaves {
+		if len(leaf.Path) == 0 || !stepsMatch(leaf.Path[0], step) {
+			continue
+		}
+		newPath := append([]ProjectionStep{}, leaf.Path[1:]...)
+		newLeaves = append(newLeaves, AliasLeaf{RootVarID: leaf.RootVarID, Path: newPath})
+		if len(newPath) == 0 {
+			hasAlias = true
+		}
+	}
+	if len(newLeaves) == 0 {
+		return freshSource()
+	}
+	origin := AliasOriginFresh
+	if hasAlias {
+		origin = AliasOriginAlias
+	}
+	return AliasSource{Origin: origin, Leaves: newLeaves}
+}
+
+// stepsMatch reports whether two projection steps refer to the same slot.
+// All step types are value-comparable, so direct equality suffices.
+func stepsMatch(a, b ProjectionStep) bool {
+	return a == b
+}
+
 // determineTupleAliasSource computes the alias source for a tuple/array
 // literal `[e0, e1, ...]`. The root is freshly constructed; each element's
 // leaves are folded in with `IndexOf(i)` prepended to their existing path.
@@ -563,7 +611,7 @@ func determineIndexAliasSource(expr *ast.IndexExpr) AliasSource {
 	if lit, ok := expr.Index.(*ast.LiteralExpr); ok {
 		if num, ok := lit.Lit.(*ast.NumLit); ok {
 			if i, isInt := floatAsInt(num.Value); isInt {
-				return appendStepToLeaves(src, IndexOf{Index: i})
+				return ProjectStep(src, IndexOf{Index: i})
 			}
 		}
 	}

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -435,7 +435,7 @@ func ProjectStep(src AliasSource, step ProjectionStep) AliasSource {
 	var newLeaves []AliasLeaf
 	hasAlias := false
 	for _, leaf := range src.Leaves {
-		if len(leaf.Path) == 0 || !stepsMatch(leaf.Path[0], step) {
+		if len(leaf.Path) == 0 || leaf.Path[0] != step {
 			continue
 		}
 		newPath := append([]ProjectionStep{}, leaf.Path[1:]...)
@@ -452,12 +452,6 @@ func ProjectStep(src AliasSource, step ProjectionStep) AliasSource {
 		origin = AliasOriginAlias
 	}
 	return AliasSource{Origin: origin, Leaves: newLeaves}
-}
-
-// stepsMatch reports whether two projection steps refer to the same slot.
-// All step types are value-comparable, so direct equality suffices.
-func stepsMatch(a, b ProjectionStep) bool {
-	return a == b
 }
 
 // determineTupleAliasSource computes the alias source for a tuple/array
@@ -608,14 +602,25 @@ func FormatNumKey(v float64) string {
 // before Phase 8.9.
 func determineIndexAliasSource(expr *ast.IndexExpr) AliasSource {
 	src := DetermineAliasSource(expr.Object)
+	if step, ok := IndexLiteralStep(expr); ok {
+		return ProjectStep(src, step)
+	}
+	return src
+}
+
+// IndexLiteralStep returns the IndexOf projection step for `obj[i]` when
+// `i` is a constant non-negative integer literal. Non-constant or
+// non-integer indexes return false; callers should treat such cases as
+// a transparent descent into the object.
+func IndexLiteralStep(expr *ast.IndexExpr) (IndexOf, bool) {
 	if lit, ok := expr.Index.(*ast.LiteralExpr); ok {
 		if num, ok := lit.Lit.(*ast.NumLit); ok {
 			if i, isInt := floatAsInt(num.Value); isInt {
-				return ProjectStep(src, IndexOf{Index: i})
+				return IndexOf{Index: i}, true
 			}
 		}
 	}
-	return src
+	return IndexOf{}, false
 }
 
 // floatAsInt returns the int form of a float64 if it represents a


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifetime type inference for property and index access operations. The compiler now correctly infers and tracks lifetime parameters when accessing object properties and array elements, providing more accurate type signatures for complex data access patterns.

* **Tests**
  * Updated test cases to reflect enhanced lifetime type inference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->