### PR TITLE
Fix #539

### DIFF
--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1289,35 +1289,58 @@ func attachFieldSlotLifetimes(
 	leafIndex map[liveness.VarID]int,
 	leafLV map[int]*type_system.LifetimeVar,
 ) {
+	// Nothing to attach if the body is empty or no escaping param leaf
+	// got a LifetimeVar in the prior allocation pass.
 	if body == nil || len(leafLV) == 0 {
 		return
 	}
+	// The instance type is the class's TypeAlias.Type, which after Prune
+	// is the ObjectType holding the field properties. Anything else (e.g.
+	// a generic instantiation that hasn't resolved yet) is skipped.
 	instanceObj, ok := type_system.Prune(instanceType).(*type_system.ObjectType)
 	if !ok {
 		return
 	}
 
+	// Accumulate per-slot lifetime contributions across all `self.<f> = …`
+	// assignments before writing them out in finalize, so multiple
+	// assignments to the same field union their lifetimes (rather than
+	// overwriting each other) and repeated leaves dedupe.
 	slots := newSlotAccumulator()
 	v := &fieldAssignVisitor{
 		selfVarID: selfVarID,
 		onAssign: func(fieldName string, rhs ast.Expr) {
+			// Map the field name to its slot in the instance type. If
+			// the field doesn't exist or is a primitive (no lifetime to
+			// carry), there's nothing to attach.
 			fieldType := lookupInstanceFieldType(instanceObj, fieldName)
 			if fieldType == nil || !typeCarriesLifetime(fieldType) {
 				return
 			}
+			// Resolve the RHS to its underlying parameter leaves. Using
+			// the checker-aware variant means call results like
+			// `self.f = wrap(p)` propagate through the callee's already-
+			// inferred return-aliases-its-arg lifetimes.
 			src := determineCheckerAliasSource(rhs)
 			if len(src.Leaves) == 0 {
 				return
 			}
 			for _, leaf := range src.Leaves {
+				// Only leaves that map back to one of *this* ctor's
+				// escaping params...
 				idx, ok := leafIndex[leaf.RootVarID]
 				if !ok {
 					continue
 				}
+				// ...and got a LifetimeVar, contribute.
 				lv, ok := leafLV[idx]
 				if !ok {
 					continue
 				}
+				// Decide which slot of the field type the leaf lands on.
+				// Fresh-rooted RHS like `[a, b]` or `{head: a}` carries
+				// per-slot paths; alias-rooted RHS attaches at the top
+				// of the field type. See pickResultSlot for the rule.
 				slot := pickResultSlot(fieldType, src.Origin, leaf.Path)
 				if !typeCarriesLifetime(slot) {
 					continue
@@ -1326,26 +1349,37 @@ func attachFieldSlotLifetimes(
 			}
 		},
 	}
+	// Walk the body to collect contributions, then write the
+	// (possibly-unioned) lifetimes onto each accumulated slot.
 	body.Accept(v)
 	slots.finalize()
 }
 
 // lookupInstanceFieldType returns the type of an instance field by name on
-// a class instance ObjectType, or nil if no matching property exists. Only
-// string-keyed properties are matched: numeric class field syntax (e.g.
-// `0: T`) is rejected by the parser/checker, so numeric keys cannot appear
-// on class instance types.
+// a class instance ObjectType, or nil if no matching property exists. Both
+// string-keyed and number-keyed properties are matched — number keys are
+// compared after formatting via strconv.FormatFloat so the lookup string
+// can come directly from a `self[<numeric-literal>] = …` lvalue.
+//
+// TODO(#543): symbol-keyed properties are not yet handled here. Resolving
+// a symbol key from a `self[<sym>] = …` lvalue requires the same lookup
+// machinery used elsewhere for symbol keys; once that lands, extend this
+// helper to match SymObjTypeKeyKind too.
 func lookupInstanceFieldType(obj *type_system.ObjectType, name string) type_system.Type {
 	for _, elem := range obj.Elems {
 		prop, ok := elem.(*type_system.PropertyElem)
 		if !ok {
 			continue
 		}
-		if prop.Name.Kind != type_system.StrObjTypeKeyKind {
-			continue
-		}
-		if prop.Name.Str == name {
-			return prop.Value
+		switch prop.Name.Kind {
+		case type_system.StrObjTypeKeyKind:
+			if prop.Name.Str == name {
+				return prop.Value
+			}
+		case type_system.NumObjTypeKeyKind:
+			if strconv.FormatFloat(prop.Name.Num, 'f', -1, 64) == name {
+				return prop.Value
+			}
 		}
 	}
 	return nil

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -286,31 +286,7 @@ func (c *Checker) attachLifetimeToResult(
 	// all sourceExprs. Slot identity is the post-Prune Type pointer
 	// returned by descendIntoSlot, so two paths landing on the same
 	// element type of an Array<T> dedupe naturally.
-	type slotEntry struct {
-		members   []type_system.Lifetime
-		hasStatic bool
-	}
-	slotByPtr := map[type_system.Type]*slotEntry{}
-	var slotOrder []type_system.Type
-
-	addToSlot := func(slot type_system.Type, lt type_system.Lifetime) {
-		entry, exists := slotByPtr[slot]
-		if !exists {
-			entry = &slotEntry{}
-			slotByPtr[slot] = entry
-			slotOrder = append(slotOrder, slot)
-		}
-		entry.members = append(entry.members, lt)
-	}
-	markSlotStatic := func(slot type_system.Type) {
-		entry, exists := slotByPtr[slot]
-		if !exists {
-			entry = &slotEntry{}
-			slotByPtr[slot] = entry
-			slotOrder = append(slotOrder, slot)
-		}
-		entry.hasStatic = true
-	}
+	slots := newSlotAccumulator()
 
 	for _, re := range sourceExprs {
 		// Use the checker-aware variant so call expressions whose callee
@@ -333,19 +309,7 @@ func (c *Checker) attachLifetimeToResult(
 				continue
 			}
 
-			// Pick the destination slot in the return type. For
-			// fresh-rooted sources (`[a, b]`, `{k: a}`) the leaf path
-			// describes a descent INTO the new container — walk the
-			// return type along it. For alias-rooted sources (`obj`,
-			// `obj.field`) the path describes a projection into the
-			// source root, not a return-side slot — attach at the top.
-			var slot type_system.Type
-			switch src.Origin {
-			case liveness.AliasOriginFresh:
-				slot = descendIntoSlot(resultType, leaf.Path)
-			default:
-				slot = resultType
-			}
+			slot := pickResultSlot(resultType, src.Origin, leaf.Path)
 
 			// If the destination slot can't carry a lifetime (e.g. the
 			// path landed on a type parameter, void, or a primitive),
@@ -358,7 +322,7 @@ func (c *Checker) attachLifetimeToResult(
 			}
 
 			if escapingLeaves.Contains(idx) {
-				markSlotStatic(slot)
+				slots.markStatic(slot)
 				continue
 			}
 
@@ -378,20 +342,78 @@ func (c *Checker) attachLifetimeToResult(
 				}
 				leafLV[idx] = lv
 			}
-			addToSlot(slot, lv)
+			slots.add(slot, lv)
 		}
 	}
 
-	if len(slotOrder) == 0 {
-		return
-	}
+	slots.finalize()
 
-	// Attach a (possibly-unioned) lifetime to each destination slot.
-	// Members within a slot are deduped by pointer identity — repeating
-	// the same LifetimeVar across multiple sourceExprs is common (e.g.
-	// `return p` in two branches both contribute leaf p).
-	for _, slot := range slotOrder {
-		entry := slotByPtr[slot]
+	if len(newLifetimeParams) > 0 {
+		funcType.LifetimeParams = append(funcType.LifetimeParams, newLifetimeParams...)
+	}
+}
+
+// pickResultSlot chooses the destination slot in a result-side type for a
+// leaf. Fresh-rooted sources (`[a, b]`, `{k: a}`) carry leaf paths that
+// describe a descent INTO the new container — walk the result type along
+// the path. Alias-rooted sources (`obj`, `obj.field`) carry paths that
+// describe a projection into the source root, not a result-side slot —
+// attach at the top.
+func pickResultSlot(resultType type_system.Type, origin liveness.AliasOrigin, path []liveness.ProjectionStep) type_system.Type {
+	switch origin {
+	case liveness.AliasOriginFresh:
+		return descendIntoSlot(resultType, path)
+	default:
+		return resultType
+	}
+}
+
+// slotAccumulator collects per-slot lifetime contributions and applies them
+// in a single finalize pass. Slot identity is by Type pointer (typically
+// the post-Prune type returned by descendIntoSlot), so two paths landing
+// on the same element type of an Array<T> dedupe naturally. Used by both
+// attachLifetimeToResult (function results) and attachFieldSlotLifetimes
+// (constructor field assignments) to share the union-vs-single bookkeeping.
+type slotAccumulator struct {
+	byPtr map[type_system.Type]*slotEntry
+	order []type_system.Type
+}
+
+type slotEntry struct {
+	members   []type_system.Lifetime
+	hasStatic bool
+}
+
+func newSlotAccumulator() *slotAccumulator {
+	return &slotAccumulator{byPtr: map[type_system.Type]*slotEntry{}}
+}
+
+func (s *slotAccumulator) entry(slot type_system.Type) *slotEntry {
+	e, ok := s.byPtr[slot]
+	if !ok {
+		e = &slotEntry{}
+		s.byPtr[slot] = e
+		s.order = append(s.order, slot)
+	}
+	return e
+}
+
+func (s *slotAccumulator) add(slot type_system.Type, lt type_system.Lifetime) {
+	e := s.entry(slot)
+	e.members = append(e.members, lt)
+}
+
+func (s *slotAccumulator) markStatic(slot type_system.Type) {
+	s.entry(slot).hasStatic = true
+}
+
+// finalize attaches a (possibly-unioned) lifetime to each accumulated slot.
+// Members within a slot are deduped by pointer identity — repeating the
+// same LifetimeVar across multiple sources is common (e.g. `return p` in
+// two branches both contribute leaf p).
+func (s *slotAccumulator) finalize() {
+	for _, slot := range s.order {
+		entry := s.byPtr[slot]
 		members := dedupeLifetimes(entry.members)
 		if entry.hasStatic {
 			members = append(members, &type_system.LifetimeValue{
@@ -409,14 +431,11 @@ func (c *Checker) attachLifetimeToResult(
 			lt = &type_system.LifetimeUnion{Lifetimes: members}
 		}
 		// TODO(#507): if slot is pointer-shared with a param leaf
-		// (which happens for unioned yield types and for `yield from`),
+		// (e.g. unioned yield types, `yield from`, or unannotated
+		// constructor params whose leaf type IS the field-slot type),
 		// this write bleeds through to the param. Shallow-clone the
 		// shared type here and substitute the clone back.
 		setLifetimeOnType(slot, lt)
-	}
-
-	if len(newLifetimeParams) > 0 {
-		funcType.LifetimeParams = append(funcType.LifetimeParams, newLifetimeParams...)
 	}
 }
 
@@ -1198,6 +1217,7 @@ func (c *Checker) InferConstructorLifetimes(
 	// sub-position the rename pass bound (e.g. the tuple element type for
 	// `[a, b]: [mut T, mut U]`).
 	var lifetimeParams []*type_system.LifetimeVar
+	leafLV := make(map[int]*type_system.LifetimeVar)
 	for leafIdx, leaf := range leaves {
 		if !escapingLeaves.Contains(leafIdx) {
 			continue
@@ -1208,6 +1228,7 @@ func (c *Checker) InferConstructorLifetimes(
 		lv := c.FreshLifetimeVar(lifetimeParamName(len(lifetimeParams)))
 		lifetimeParams = append(lifetimeParams, lv)
 		setLifetimeOnType(leaf.leafType, lv)
+		leafLV[leafIdx] = lv
 	}
 
 	if len(lifetimeParams) == 0 {
@@ -1224,6 +1245,134 @@ func (c *Checker) InferConstructorLifetimes(
 		lifetimeArgs[i] = lv
 	}
 	setLifetimeArgsOnType(ctorFn.Return, lifetimeArgs)
+
+	// (#539) Walk `self.<field> = expr` assignments and attach per-slot
+	// lifetimes to the field types on the instance. When constructor
+	// params are unannotated, the param type IS the field-slot type
+	// (same pointer) so the setLifetimeOnType call above already
+	// surfaced lifetimes on the instance. With explicit param
+	// annotations the param and field types are distinct, so the field
+	// slots need a separate pass mirroring attachLifetimeToResult.
+	attachFieldSlotLifetimes(ctorElem.Fn.Body, selfVarID, typeAlias.Type, leafIndex, leafLV)
+}
+
+// attachFieldSlotLifetimes walks a constructor body for `self.<field> = expr`
+// assignments and attaches per-slot lifetimes to the corresponding field types
+// on the class instance. Mirrors the slot-accumulation logic in
+// attachLifetimeToResult, except the destination is a class field rather than
+// the function's result type.
+//
+// Only direct `self.<field> = expr` assignments are walked. Nested
+// `self.<f>.<g> = expr` is rejected upstream by the field-initialization
+// checker (every field must be initialized before being read), and class
+// instances are not indexable so `self[i] = expr` does not arise.
+//
+// 'static is intentionally not propagated here. InferConstructorLifetimes
+// allocates a fresh LifetimeVar for every escaping leaf — including leaves
+// that escape into module-level state — rather than pinning 'static, so
+// there are no 'static leaves for this pass to forward. If the upstream
+// allocation is ever taught to distinguish module-level escapes, this
+// helper will need a markStatic path too.
+func attachFieldSlotLifetimes(
+	body *ast.Block,
+	selfVarID liveness.VarID,
+	instanceType type_system.Type,
+	leafIndex map[liveness.VarID]int,
+	leafLV map[int]*type_system.LifetimeVar,
+) {
+	if body == nil || len(leafLV) == 0 {
+		return
+	}
+	instanceObj, ok := type_system.Prune(instanceType).(*type_system.ObjectType)
+	if !ok {
+		return
+	}
+
+	slots := newSlotAccumulator()
+	v := &fieldAssignVisitor{
+		selfVarID: selfVarID,
+		onAssign: func(fieldName string, rhs ast.Expr) {
+			fieldType := lookupInstanceFieldType(instanceObj, fieldName)
+			if fieldType == nil || !typeCarriesLifetime(fieldType) {
+				return
+			}
+			src := determineCheckerAliasSource(rhs)
+			if len(src.Leaves) == 0 {
+				return
+			}
+			for _, leaf := range src.Leaves {
+				idx, ok := leafIndex[leaf.RootVarID]
+				if !ok {
+					continue
+				}
+				lv, ok := leafLV[idx]
+				if !ok {
+					continue
+				}
+				slot := pickResultSlot(fieldType, src.Origin, leaf.Path)
+				if !typeCarriesLifetime(slot) {
+					continue
+				}
+				slots.add(slot, lv)
+			}
+		},
+	}
+	body.Accept(v)
+	slots.finalize()
+}
+
+// lookupInstanceFieldType returns the type of an instance field by name on
+// a class instance ObjectType, or nil if no matching property exists. Only
+// string-keyed properties are matched: numeric class field syntax (e.g.
+// `0: T`) is rejected by the parser/checker, so numeric keys cannot appear
+// on class instance types.
+func lookupInstanceFieldType(obj *type_system.ObjectType, name string) type_system.Type {
+	for _, elem := range obj.Elems {
+		prop, ok := elem.(*type_system.PropertyElem)
+		if !ok {
+			continue
+		}
+		if prop.Name.Kind != type_system.StrObjTypeKeyKind {
+			continue
+		}
+		if prop.Name.Str == name {
+			return prop.Value
+		}
+	}
+	return nil
+}
+
+// fieldAssignVisitor invokes onAssign for every `self.<field> = expr`
+// assignment in a constructor body. Nested function bodies and class/func
+// declarations are skipped so we only see the constructor's own assignments.
+type fieldAssignVisitor struct {
+	ast.DefaultVisitor
+	selfVarID liveness.VarID
+	onAssign  func(fieldName string, rhs ast.Expr)
+}
+
+func (v *fieldAssignVisitor) EnterExpr(e ast.Expr) bool {
+	if be, ok := e.(*ast.BinaryExpr); ok && be.Op == ast.Assign {
+		if me, ok := be.Left.(*ast.MemberExpr); ok {
+			if ident, ok := me.Object.(*ast.IdentExpr); ok &&
+				liveness.VarID(ident.VarID) == v.selfVarID &&
+				me.Prop != nil {
+				v.onAssign(me.Prop.Name, be.Right)
+			}
+		}
+	}
+	if _, ok := e.(*ast.FuncExpr); ok {
+		return false
+	}
+	return true
+}
+
+func (v *fieldAssignVisitor) EnterDecl(d ast.Decl) bool {
+	switch d.(type) {
+	case *ast.FuncDecl, *ast.ClassDecl:
+		return false
+	}
+	return true
 }
 
 // forEachLeafBinding invokes fn for every identifier-binding leaf

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1057,6 +1057,14 @@ func lifetimeContainsStatic(lt type_system.Lifetime) bool {
 // ctor body share the same VarID (assigned as an extra param by
 // `runLivenessPrePass`), so the first match is sufficient. Returns 0
 // when the body has no `self` reference.
+//
+// The visitor descends into nested function expressions, which is
+// safe today because `self` inside a closure within a ctor body
+// captures the outer ctor's `self` and shares its VarID. Nested
+// class declarations are not yet supported by the checker (the body
+// phase panics on them), so a nested class introducing its own
+// `self` is unreachable. If/when nested classes are implemented,
+// this visitor must be hardened to stop at ClassDecl boundaries.
 func findSelfVarID(body *ast.Block) liveness.VarID {
 	if body == nil {
 		return 0

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1270,10 +1270,11 @@ func (c *Checker) InferConstructorLifetimes(
 // attachLifetimeToResult, except the destination is a class field rather than
 // the function's result type.
 //
-// Only direct `self.<field> = expr` assignments are walked. Nested
-// `self.<f>.<g> = expr` is rejected upstream by the field-initialization
-// checker (every field must be initialized before being read), and class
-// instances are not indexable so `self[i] = expr` does not arise.
+// Only direct `self.<field> = expr` and `self[<literal-key>] = expr`
+// assignments are walked. Nested `self.<f>.<g> = expr` is rejected
+// upstream by the field-initialization checker (every field must be
+// initialized before being read), and `self[k] = expr` with a non-literal
+// key cannot be statically resolved to a single field slot.
 //
 // 'static is intentionally not propagated here. InferConstructorLifetimes
 // allocates a fresh LifetimeVar for every escaping leaf — including leaves
@@ -1350,9 +1351,10 @@ func lookupInstanceFieldType(obj *type_system.ObjectType, name string) type_syst
 	return nil
 }
 
-// fieldAssignVisitor invokes onAssign for every `self.<field> = expr`
-// assignment in a constructor body. Nested function bodies and class/func
-// declarations are skipped so we only see the constructor's own assignments.
+// fieldAssignVisitor invokes onAssign for every `self.<field> = expr` or
+// `self[<literal-key>] = expr` assignment in a constructor body. Nested
+// function bodies and class/func declarations are skipped so we only see
+// the constructor's own assignments.
 type fieldAssignVisitor struct {
 	ast.DefaultVisitor
 	selfVarID liveness.VarID
@@ -1361,18 +1363,46 @@ type fieldAssignVisitor struct {
 
 func (v *fieldAssignVisitor) EnterExpr(e ast.Expr) bool {
 	if be, ok := e.(*ast.BinaryExpr); ok && be.Op == ast.Assign {
-		if me, ok := be.Left.(*ast.MemberExpr); ok {
-			if ident, ok := me.Object.(*ast.IdentExpr); ok &&
-				liveness.VarID(ident.VarID) == v.selfVarID &&
-				me.Prop != nil {
-				v.onAssign(me.Prop.Name, be.Right)
-			}
+		if name, ok := selfFieldLValueName(be.Left, v.selfVarID); ok {
+			v.onAssign(name, be.Right)
 		}
 	}
 	if _, ok := e.(*ast.FuncExpr); ok {
 		return false
 	}
 	return true
+}
+
+// selfFieldLValueName returns the field name targeted by an lvalue if and
+// only if it is a direct field assignment on `self` — either `self.<name>`
+// (MemberExpr) or `self[<literal-key>]` (IndexExpr with a string- or
+// number-literal index). Other shapes (chained access, computed keys,
+// non-self objects) return ok=false.
+func selfFieldLValueName(lvalue ast.Expr, selfVarID liveness.VarID) (string, bool) {
+	switch e := lvalue.(type) {
+	case *ast.MemberExpr:
+		ident, ok := e.Object.(*ast.IdentExpr)
+		if !ok || liveness.VarID(ident.VarID) != selfVarID || e.Prop == nil {
+			return "", false
+		}
+		return e.Prop.Name, true
+	case *ast.IndexExpr:
+		ident, ok := e.Object.(*ast.IdentExpr)
+		if !ok || liveness.VarID(ident.VarID) != selfVarID {
+			return "", false
+		}
+		lit, ok := e.Index.(*ast.LiteralExpr)
+		if !ok {
+			return "", false
+		}
+		switch k := lit.Lit.(type) {
+		case *ast.StrLit:
+			return k.Value, true
+		case *ast.NumLit:
+			return strconv.FormatFloat(k.Value, 'f', -1, 64), true
+		}
+	}
+	return "", false
 }
 
 func (v *fieldAssignVisitor) EnterDecl(d ast.Decl) bool {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -930,6 +930,51 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"pair": "{head: mut 'a {x: number}, tail: mut 'b {x: number}}",
 			},
 		},
+		"CtorStoresTupleOfAnnotatedParams_CallResult_FieldSlotsCarryLifetimes": {
+			// (#539) Like CtorStoresTupleOfAnnotatedParams_FieldSlotsCarryLifetimes,
+			// but the RHS of `self.items = …` is a call result rather than
+			// a tuple literal. Exercises the determineCheckerAliasSource
+			// path in attachFieldSlotLifetimes — the call's per-slot leaves
+			// must drive per-slot lifetime attachment on the field type.
+			input: `
+				fn wrap(a: mut {x: number}, b: mut {x: number}) -> [mut {x: number}, mut {x: number}] {
+					return [a, b]
+				}
+				class Pair {
+					items: [mut {x: number}, mut {x: number}],
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self.items = wrap(a, b)
+					}
+				}
+				val p = Pair({x: 1}, {x: 2})
+				val items = p.items
+			`,
+			expectedTypes: map[string]string{
+				"items": "[mut 'a {x: number}, mut 'b {x: number}]",
+			},
+		},
+		"CtorStoresObjectOfAnnotatedParams_CallResult_FieldSlotsCarryLifetimes": {
+			// (#539) Sister case to the tuple call-result variant: the RHS
+			// of `self.pair = …` is a call returning a per-property typed
+			// object, and the call's embedded slot lifetimes must surface
+			// at the corresponding field slots.
+			input: `
+				fn wrap(a: mut {x: number}, b: mut {x: number}) -> {head: mut {x: number}, tail: mut {x: number}} {
+					return {head: a, tail: b}
+				}
+				class Wrap {
+					pair: {head: mut {x: number}, tail: mut {x: number}},
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self.pair = wrap(a, b)
+					}
+				}
+				val w = Wrap({x: 1}, {x: 2})
+				val pair = w.pair
+			`,
+			expectedTypes: map[string]string{
+				"pair": "{head: mut 'a {x: number}, tail: mut 'b {x: number}}",
+			},
+		},
 		"DestructuredTupleCtorParamCapture": {
 			// A destructured tuple ctor param whose leaves are stored
 			// into self should still pin lifetimes onto the param. (#531)

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -975,6 +975,26 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"pair": "{head: mut 'a {x: number}, tail: mut 'b {x: number}}",
 			},
 		},
+		"CtorStoresViaIndexExpr_FieldSlotsCarryLifetimes": {
+			// (#539) `self["items"] = [a, b]` is a valid form of field
+			// assignment when the key is a string literal. The field-slot
+			// pass must recognize IndexExpr lvalues with literal keys, not
+			// just MemberExpr, so per-slot lifetimes still surface on the
+			// stored field's type.
+			input: `
+				class Pair {
+					items: [mut {x: number}, mut {x: number}],
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self["items"] = [a, b]
+					}
+				}
+				val p = Pair({x: 1}, {x: 2})
+				val items = p.items
+			`,
+			expectedTypes: map[string]string{
+				"items": "[mut 'a {x: number}, mut 'b {x: number}]",
+			},
+		},
 		"DestructuredTupleCtorParamCapture": {
 			// A destructured tuple ctor param whose leaves are stored
 			// into self should still pin lifetimes onto the param. (#531)

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -892,6 +892,44 @@ func TestInferConstructorLifetimeTypes(t *testing.T) {
 				"Wrap": 2,
 			},
 		},
+		"CtorStoresTupleOfAnnotatedParams_FieldSlotsCarryLifetimes": {
+			// (#539) When ctor params are explicitly annotated, the param
+			// types and the field-slot types are distinct pointers, so
+			// `setLifetimeOnType` on the param leaf does not surface to
+			// the field. A separate per-slot pass walks `self.<f> = expr`
+			// and attaches lifetimes to the matching slots in the field
+			// type.
+			input: `
+				class Pair {
+					items: [mut {x: number}, mut {x: number}],
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self.items = [a, b]
+					}
+				}
+				val p = Pair({x: 1}, {x: 2})
+				val items = p.items
+			`,
+			expectedTypes: map[string]string{
+				"items": "[mut 'a {x: number}, mut 'b {x: number}]",
+			},
+		},
+		"CtorStoresObjectOfAnnotatedParams_FieldSlotsCarryLifetimes": {
+			// (#539) Sister case for object-literal RHS with explicitly
+			// annotated params.
+			input: `
+				class Wrap {
+					pair: {head: mut {x: number}, tail: mut {x: number}},
+					constructor(mut self, a: mut {x: number}, b: mut {x: number}) {
+						self.pair = {head: a, tail: b}
+					}
+				}
+				val w = Wrap({x: 1}, {x: 2})
+				val pair = w.pair
+			`,
+			expectedTypes: map[string]string{
+				"pair": "{head: mut 'a {x: number}, tail: mut 'b {x: number}}",
+			},
+		},
 		"DestructuredTupleCtorParamCapture": {
 			// A destructured tuple ctor param whose leaves are stored
 			// into self should still pin lifetimes onto the param. (#531)

--- a/internal/liveness/alias_analysis.go
+++ b/internal/liveness/alias_analysis.go
@@ -438,6 +438,9 @@ func ProjectStep(src AliasSource, step ProjectionStep) AliasSource {
 		if len(leaf.Path) == 0 || leaf.Path[0] != step {
 			continue
 		}
+		// Copy rather than reslice: leaf.Path[1:] shares backing storage
+		// with the source leaf, so a later append to the new path could
+		// clobber the original if capacity allows in-place growth.
 		newPath := append([]ProjectionStep{}, leaf.Path[1:]...)
 		newLeaves = append(newLeaves, AliasLeaf{RootVarID: leaf.RootVarID, Path: newPath})
 		if len(newPath) == 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backing-storage clobbering risk in alias analysis path construction.

* **Improvements**
  * Enhanced lifetime inference for instance field assignments in constructors with explicit parameter annotations.

* **Tests**
  * Added regression test coverage for constructor field-lifetime propagation with annotated parameters in tuple and object field assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->