### PR TITLE
Exact Types Planning

### DIFF
--- a/planning/exact-types/builtin-classes.md
+++ b/planning/exact-types/builtin-classes.md
@@ -1,0 +1,2089 @@
+# Classes in TypeScript lib files (Escalier interpretation)
+
+Total: 692 classes
+
+## Hierarchy (roots and their subclasses)
+
+- AbstractRange
+  - Range
+  - StaticRange
+- AnimationEffect
+  - KeyframeEffect
+- AnimationTimeline
+  - DocumentTimeline
+- AuthenticatorResponse
+  - AuthenticatorAssertionResponse
+  - AuthenticatorAttestationResponse
+- Blob
+  - File
+- CSSRule
+  - CSSCounterStyleRule
+  - CSSFontFaceRule
+  - CSSFontFeatureValuesRule
+  - CSSFontPaletteValuesRule
+  - CSSGroupingRule
+    - CSSConditionRule
+      - CSSContainerRule
+      - CSSMediaRule
+      - CSSSupportsRule
+    - CSSLayerBlockRule
+    - CSSPageRule
+    - CSSScopeRule
+    - CSSStartingStyleRule
+    - CSSStyleRule
+  - CSSImportRule
+  - CSSKeyframeRule
+  - CSSKeyframesRule
+  - CSSLayerStatementRule
+  - CSSNamespaceRule
+  - CSSNestedDeclarations
+  - CSSPropertyRule
+  - CSSViewTransitionRule
+- CSSStyleValue
+  - CSSImageValue
+  - CSSKeywordValue
+  - CSSNumericValue
+    - CSSMathValue
+      - CSSMathClamp
+      - CSSMathInvert
+      - CSSMathMax
+      - CSSMathMin
+      - CSSMathNegate
+      - CSSMathProduct
+      - CSSMathSum
+    - CSSUnitValue
+  - CSSTransformValue
+  - CSSUnparsedValue
+- CSSTransformComponent
+  - CSSMatrixComponent
+  - CSSPerspective
+  - CSSRotate
+  - CSSScale
+  - CSSSkew
+  - CSSSkewX
+  - CSSSkewY
+  - CSSTranslate
+- Credential
+  - PublicKeyCredential
+- DOMMatrixReadOnly
+  - DOMMatrix
+- DOMPointReadOnly
+  - DOMPoint
+- DOMRectReadOnly
+  - DOMRect
+- Error
+  - AggregateError
+  - CompileError
+  - DOMException
+    - OverconstrainedError
+    - RTCError
+    - WebTransportError
+  - EvalError
+  - LinkError
+  - RangeError
+  - ReferenceError
+  - RuntimeError
+  - SuppressedError
+  - SyntaxError
+  - TypeError
+  - URIError
+- Event
+  - AnimationEvent
+  - AnimationPlaybackEvent
+  - AudioProcessingEvent
+  - BeforeUnloadEvent
+  - BlobEvent
+  - ClipboardEvent
+  - CloseEvent
+  - ContentVisibilityAutoStateChangeEvent
+  - CustomEvent
+  - DeviceMotionEvent
+  - DeviceOrientationEvent
+  - ErrorEvent
+  - FontFaceSetLoadEvent
+  - FormDataEvent
+  - GamepadEvent
+  - HashChangeEvent
+  - IDBVersionChangeEvent
+  - MIDIConnectionEvent
+  - MIDIMessageEvent
+  - MediaEncryptedEvent
+  - MediaKeyMessageEvent
+  - MediaQueryListEvent
+  - MediaStreamTrackEvent
+  - MessageEvent
+  - OfflineAudioCompletionEvent
+  - PageRevealEvent
+  - PageSwapEvent
+  - PageTransitionEvent
+  - PaymentRequestUpdateEvent
+    - PaymentMethodChangeEvent
+  - PictureInPictureEvent
+  - PopStateEvent
+  - ProgressEvent
+  - PromiseRejectionEvent
+  - RTCDTMFToneChangeEvent
+  - RTCDataChannelEvent
+  - RTCErrorEvent
+  - RTCPeerConnectionIceErrorEvent
+  - RTCPeerConnectionIceEvent
+  - RTCTrackEvent
+  - SecurityPolicyViolationEvent
+  - SpeechSynthesisEvent
+    - SpeechSynthesisErrorEvent
+  - StorageEvent
+  - SubmitEvent
+  - ToggleEvent
+  - TrackEvent
+  - TransitionEvent
+  - UIEvent
+    - CompositionEvent
+    - FocusEvent
+    - InputEvent
+    - KeyboardEvent
+    - MouseEvent
+      - DragEvent
+      - PointerEvent
+      - WheelEvent
+    - TextEvent
+    - TouchEvent
+  - WebGLContextEvent
+- EventTarget
+  - AbortSignal
+  - Animation
+    - CSSAnimation
+    - CSSTransition
+  - AudioDecoder
+  - AudioEncoder
+  - AudioNode
+    - AnalyserNode
+    - AudioDestinationNode
+    - AudioScheduledSourceNode
+      - AudioBufferSourceNode
+      - ConstantSourceNode
+      - OscillatorNode
+    - AudioWorkletNode
+    - BiquadFilterNode
+    - ChannelMergerNode
+    - ChannelSplitterNode
+    - ConvolverNode
+    - DelayNode
+    - DynamicsCompressorNode
+    - GainNode
+    - IIRFilterNode
+    - MediaElementAudioSourceNode
+    - MediaStreamAudioDestinationNode
+    - MediaStreamAudioSourceNode
+    - PannerNode
+    - ScriptProcessorNode
+    - StereoPannerNode
+    - WaveShaperNode
+  - BaseAudioContext
+    - AudioContext
+    - OfflineAudioContext
+  - BroadcastChannel
+  - Clipboard
+  - EventSource
+  - FileReader
+  - FontFaceSet
+  - IDBDatabase
+  - IDBRequest
+    - IDBOpenDBRequest
+  - IDBTransaction
+  - MIDIAccess
+  - MIDIPort
+    - MIDIInput
+    - MIDIOutput
+  - MediaDevices
+  - MediaKeySession
+  - MediaQueryList
+  - MediaRecorder
+  - MediaSource
+  - MediaStream
+  - MediaStreamTrack
+    - CanvasCaptureMediaStreamTrack
+  - MessagePort
+  - NavigationHistoryEntry
+  - Node
+    - Attr
+    - CharacterData
+      - Comment
+      - ProcessingInstruction
+      - Text
+        - CDATASection
+    - Document
+      - HTMLDocument
+      - XMLDocument
+    - DocumentFragment
+      - ShadowRoot
+    - DocumentType
+    - Element
+      - HTMLElement
+        - HTMLAnchorElement
+        - HTMLAreaElement
+        - HTMLBRElement
+        - HTMLBaseElement
+        - HTMLBodyElement
+        - HTMLButtonElement
+        - HTMLCanvasElement
+        - HTMLDListElement
+        - HTMLDataElement
+        - HTMLDataListElement
+        - HTMLDetailsElement
+        - HTMLDialogElement
+        - HTMLDirectoryElement
+        - HTMLDivElement
+        - HTMLEmbedElement
+        - HTMLFieldSetElement
+        - HTMLFontElement
+        - HTMLFormElement
+        - HTMLFrameElement
+        - HTMLFrameSetElement
+        - HTMLHRElement
+        - HTMLHeadElement
+        - HTMLHeadingElement
+        - HTMLHtmlElement
+        - HTMLIFrameElement
+        - HTMLImageElement
+        - HTMLInputElement
+        - HTMLLIElement
+        - HTMLLabelElement
+        - HTMLLegendElement
+        - HTMLLinkElement
+        - HTMLMapElement
+        - HTMLMarqueeElement
+        - HTMLMediaElement
+          - HTMLAudioElement
+          - HTMLVideoElement
+        - HTMLMenuElement
+        - HTMLMetaElement
+        - HTMLMeterElement
+        - HTMLModElement
+        - HTMLOListElement
+        - HTMLObjectElement
+        - HTMLOptGroupElement
+        - HTMLOptionElement
+        - HTMLOutputElement
+        - HTMLParagraphElement
+        - HTMLParamElement
+        - HTMLPictureElement
+        - HTMLPreElement
+        - HTMLProgressElement
+        - HTMLQuoteElement
+        - HTMLScriptElement
+        - HTMLSelectElement
+        - HTMLSlotElement
+        - HTMLSourceElement
+        - HTMLSpanElement
+        - HTMLStyleElement
+        - HTMLTableCaptionElement
+        - HTMLTableCellElement
+        - HTMLTableColElement
+        - HTMLTableElement
+        - HTMLTableRowElement
+        - HTMLTableSectionElement
+        - HTMLTemplateElement
+        - HTMLTextAreaElement
+        - HTMLTimeElement
+        - HTMLTitleElement
+        - HTMLTrackElement
+        - HTMLUListElement
+        - HTMLUnknownElement
+      - MathMLElement
+      - SVGElement
+        - SVGAnimationElement
+          - SVGAnimateElement
+          - SVGAnimateMotionElement
+          - SVGAnimateTransformElement
+          - SVGSetElement
+        - SVGClipPathElement
+        - SVGComponentTransferFunctionElement
+          - SVGFEFuncAElement
+          - SVGFEFuncBElement
+          - SVGFEFuncGElement
+          - SVGFEFuncRElement
+        - SVGDescElement
+        - SVGFEBlendElement
+        - SVGFEColorMatrixElement
+        - SVGFEComponentTransferElement
+        - SVGFECompositeElement
+        - SVGFEConvolveMatrixElement
+        - SVGFEDiffuseLightingElement
+        - SVGFEDisplacementMapElement
+        - SVGFEDistantLightElement
+        - SVGFEDropShadowElement
+        - SVGFEFloodElement
+        - SVGFEGaussianBlurElement
+        - SVGFEImageElement
+        - SVGFEMergeElement
+        - SVGFEMergeNodeElement
+        - SVGFEMorphologyElement
+        - SVGFEOffsetElement
+        - SVGFEPointLightElement
+        - SVGFESpecularLightingElement
+        - SVGFESpotLightElement
+        - SVGFETileElement
+        - SVGFETurbulenceElement
+        - SVGFilterElement
+        - SVGGradientElement
+          - SVGLinearGradientElement
+          - SVGRadialGradientElement
+        - SVGGraphicsElement
+          - SVGAElement
+          - SVGDefsElement
+          - SVGForeignObjectElement
+          - SVGGElement
+          - SVGGeometryElement
+            - SVGCircleElement
+            - SVGEllipseElement
+            - SVGLineElement
+            - SVGPathElement
+            - SVGPolygonElement
+            - SVGPolylineElement
+            - SVGRectElement
+          - SVGImageElement
+          - SVGSVGElement
+          - SVGSwitchElement
+          - SVGTextContentElement
+            - SVGTextPathElement
+            - SVGTextPositioningElement
+              - SVGTSpanElement
+              - SVGTextElement
+          - SVGUseElement
+        - SVGMPathElement
+        - SVGMarkerElement
+        - SVGMaskElement
+        - SVGMetadataElement
+        - SVGPatternElement
+        - SVGScriptElement
+        - SVGStopElement
+        - SVGStyleElement
+        - SVGSymbolElement
+        - SVGTitleElement
+        - SVGViewElement
+  - Notification
+  - OffscreenCanvas
+  - PaymentRequest
+  - PaymentResponse
+  - Performance
+  - PermissionStatus
+  - PictureInPictureWindow
+  - RTCDTMFSender
+  - RTCDataChannel
+  - RTCDtlsTransport
+  - RTCIceTransport
+  - RTCPeerConnection
+  - RTCSctpTransport
+  - RemotePlayback
+  - ScreenOrientation
+  - ServiceWorker
+  - ServiceWorkerContainer
+  - ServiceWorkerRegistration
+  - SharedWorker
+  - SourceBuffer
+  - SourceBufferList
+  - SpeechSynthesis
+  - SpeechSynthesisUtterance
+  - TextTrack
+  - TextTrackCue
+    - VTTCue
+  - TextTrackList
+  - VideoDecoder
+  - VideoEncoder
+  - VisualViewport
+  - WakeLockSentinel
+  - WebSocket
+  - Window
+  - Worker
+  - XMLHttpRequestEventTarget
+    - XMLHttpRequest
+    - XMLHttpRequestUpload
+- FileSystemEntry
+  - FileSystemDirectoryEntry
+  - FileSystemFileEntry
+- FileSystemHandle
+  - FileSystemDirectoryHandle
+  - FileSystemFileHandle
+- IDBCursor
+  - IDBCursorWithValue
+- Map
+  - HighlightRegistry
+- MediaDeviceInfo
+  - InputDeviceInfo
+- NodeList
+  - RadioNodeList
+- PerformanceEntry
+  - LargestContentfulPaint
+  - PerformanceEventTiming
+  - PerformanceMark
+  - PerformanceMeasure
+  - PerformancePaintTiming
+  - PerformanceResourceTiming
+    - PerformanceNavigationTiming
+- Set
+  - CustomStateSet
+  - FontFaceSet
+  - Highlight
+  - ViewTransitionTypeSet
+- StylePropertyMapReadOnly
+  - StylePropertyMap
+- StyleSheet
+  - CSSStyleSheet
+- Worklet
+  - AudioWorklet
+- WritableStream
+  - FileSystemWritableFileStream
+
+## Standalone classes (no subclasses in lib)
+
+- AbortController
+- Array
+- ArrayBuffer
+- AsyncDisposableStack
+- AudioBuffer
+- AudioData
+- AudioListener
+- AudioParam
+- AudioParamMap
+- BarProp
+- BigInt
+- BigInt64Array
+- BigUint64Array
+- Boolean
+- ByteLengthQueuingStrategy
+- CSSNumericArray
+- CSSRuleList
+- CSSStyleDeclaration
+- CSSVariableReferenceValue
+- Cache
+- CacheStorage
+- CanvasGradient
+- CanvasPattern
+- CanvasRenderingContext2D
+- CaretPosition
+- ClipboardItem
+- Collator
+- CompressionStream
+- CountQueuingStrategy
+- CredentialsContainer
+- Crypto
+- CryptoKey
+- CustomElementRegistry
+- DOMImplementation
+- DOMParser
+- DOMQuad
+- DOMRectList
+- DOMStringList
+- DOMStringMap
+- DOMTokenList
+- DataTransfer
+- DataTransferItem
+- DataTransferItemList
+- DataView
+- Date
+- DateTimeFormat
+- DecompressionStream
+- DisplayNames
+- DisposableStack
+- ElementInternals
+- EncodedAudioChunk
+- EncodedVideoChunk
+- Enumerator
+- EventCounts
+- External
+- FileList
+- FileSystem
+- FileSystemDirectoryReader
+- FinalizationRegistry
+- Float16Array
+- Float32Array
+- Float64Array
+- FontFace
+- FormData
+- FragmentDirective
+- Function
+- Gamepad
+- GamepadButton
+- GamepadHapticActuator
+- Geolocation
+- GeolocationCoordinates
+- GeolocationPosition
+- GeolocationPositionError
+- Global
+- HTMLAllCollection
+- HTMLCollection
+- HTMLFormControlsCollection
+- HTMLOptionsCollection
+- Headers
+- History
+- IDBFactory
+- IDBIndex
+- IDBKeyRange
+- IDBObjectStore
+- IdleDeadline
+- ImageBitmap
+- ImageBitmapRenderingContext
+- ImageData
+- ImageDecoder
+- ImageTrack
+- ImageTrackList
+- Instance
+- Int16Array
+- Int32Array
+- Int8Array
+- IntersectionObserver
+- IntersectionObserverEntry
+- Iterator
+- ListFormat
+- Location
+- Lock
+- LockManager
+- MIDIInputMap
+- MIDIOutputMap
+- MediaCapabilities
+- MediaError
+- MediaKeyStatusMap
+- MediaKeySystemAccess
+- MediaKeys
+- MediaList
+- MediaMetadata
+- MediaSession
+- MediaSourceHandle
+- Memory
+- MessageChannel
+- MimeType
+- MimeTypeArray
+- Module
+- MutationObserver
+- MutationRecord
+- NamedNodeMap
+- NavigationActivation
+- NavigationPreloadManager
+- Navigator
+- NodeIterator
+- Number
+- NumberFormat
+- Object
+- OffscreenCanvasRenderingContext2D
+- Path2D
+- PaymentAddress
+- PerformanceNavigation
+- PerformanceObserver
+- PerformanceObserverEntryList
+- PerformanceServerTiming
+- PerformanceTiming
+- PeriodicWave
+- Permissions
+- Plugin
+- PluginArray
+- PluralRules
+- Promise
+- PushManager
+- PushSubscription
+- PushSubscriptionOptions
+- RTCCertificate
+- RTCEncodedAudioFrame
+- RTCEncodedVideoFrame
+- RTCIceCandidate
+- RTCRtpReceiver
+- RTCRtpScriptTransform
+- RTCRtpSender
+- RTCRtpTransceiver
+- RTCSessionDescription
+- RTCStatsReport
+- ReadableByteStreamController
+- ReadableStream
+- ReadableStreamBYOBReader
+- ReadableStreamBYOBRequest
+- ReadableStreamDefaultController
+- ReadableStreamDefaultReader
+- RegExp
+- Report
+- ReportBody
+- ReportingObserver
+- Request
+- ResizeObserver
+- ResizeObserverEntry
+- ResizeObserverSize
+- Response
+- SVGAngle
+- SVGAnimatedAngle
+- SVGAnimatedBoolean
+- SVGAnimatedEnumeration
+- SVGAnimatedInteger
+- SVGAnimatedLength
+- SVGAnimatedLengthList
+- SVGAnimatedNumber
+- SVGAnimatedNumberList
+- SVGAnimatedPreserveAspectRatio
+- SVGAnimatedRect
+- SVGAnimatedString
+- SVGAnimatedTransformList
+- SVGLength
+- SVGLengthList
+- SVGNumber
+- SVGNumberList
+- SVGPointList
+- SVGPreserveAspectRatio
+- SVGStringList
+- SVGTransform
+- SVGTransformList
+- SVGUnitTypes
+- Screen
+- Segmenter
+- Selection
+- SharedArrayBuffer
+- SpeechRecognitionAlternative
+- SpeechRecognitionResult
+- SpeechRecognitionResultList
+- SpeechSynthesisVoice
+- Storage
+- StorageManager
+- String
+- StyleSheetList
+- SubtleCrypto
+- Symbol
+- Table
+- TextDecoder
+- TextDecoderStream
+- TextEncoder
+- TextEncoderStream
+- TextMetrics
+- TextTrackCueList
+- TimeRanges
+- Touch
+- TouchList
+- TransformStream
+- TransformStreamDefaultController
+- TreeWalker
+- URL
+- URLSearchParams
+- Uint16Array
+- Uint32Array
+- Uint8Array
+- Uint8ClampedArray
+- UserActivation
+- VBArray
+- VTTRegion
+- ValidityState
+- VideoColorSpace
+- VideoFrame
+- VideoPlaybackQuality
+- ViewTransition
+- WakeLock
+- WeakMap
+- WeakRef
+- WeakSet
+- WebGL2RenderingContext
+- WebGLActiveInfo
+- WebGLBuffer
+- WebGLFramebuffer
+- WebGLProgram
+- WebGLQuery
+- WebGLRenderbuffer
+- WebGLRenderingContext
+- WebGLSampler
+- WebGLShader
+- WebGLShaderPrecisionFormat
+- WebGLSync
+- WebGLTexture
+- WebGLTransformFeedback
+- WebGLUniformLocation
+- WebGLVertexArrayObject
+- WebTransport
+- WebTransportBidirectionalStream
+- WebTransportDatagramDuplexStream
+- WritableStreamDefaultController
+- WritableStreamDefaultWriter
+- XMLSerializer
+- XPathEvaluator
+- XPathExpression
+- XPathResult
+- XSLTProcessor
+
+## All classes (alphabetical) with parents and source files
+
+- **AbortController** (parents: —)
+    files: lib.dom.d.ts
+- **AbortSignal** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **AbstractRange** (parents: —)
+    files: lib.dom.d.ts
+- **AggregateError** (parents: Error)
+    files: lib.es2021.promise.d.ts
+- **AnalyserNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **Animation** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **AnimationEffect** (parents: —)
+    files: lib.dom.d.ts
+- **AnimationEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **AnimationPlaybackEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **AnimationTimeline** (parents: —)
+    files: lib.dom.d.ts
+- **Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2019.array.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **ArrayBuffer** (parents: —)
+    files: lib.es2015.symbol.wellknown.d.ts, lib.es2024.arraybuffer.d.ts, lib.es5.d.ts
+- **AsyncDisposableStack** (parents: —)
+    files: lib.esnext.disposable.d.ts
+- **Attr** (parents: Node)
+    files: lib.dom.d.ts
+- **AudioBuffer** (parents: —)
+    files: lib.dom.d.ts
+- **AudioBufferSourceNode** (parents: AudioScheduledSourceNode)
+    files: lib.dom.d.ts
+- **AudioContext** (parents: BaseAudioContext)
+    files: lib.dom.d.ts
+- **AudioData** (parents: —)
+    files: lib.dom.d.ts
+- **AudioDecoder** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **AudioDestinationNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **AudioEncoder** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **AudioListener** (parents: —)
+    files: lib.dom.d.ts
+- **AudioNode** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **AudioParam** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **AudioParamMap** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **AudioProcessingEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **AudioScheduledSourceNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **AudioWorklet** (parents: Worklet)
+    files: lib.dom.d.ts
+- **AudioWorkletNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **AuthenticatorAssertionResponse** (parents: AuthenticatorResponse)
+    files: lib.dom.d.ts
+- **AuthenticatorAttestationResponse** (parents: AuthenticatorResponse)
+    files: lib.dom.d.ts
+- **AuthenticatorResponse** (parents: —)
+    files: lib.dom.d.ts
+- **BarProp** (parents: —)
+    files: lib.dom.d.ts
+- **BaseAudioContext** (parents: EventTarget)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **BeforeUnloadEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **BigInt** (parents: —)
+    files: lib.es2020.bigint.d.ts
+- **BigInt64Array** (parents: —)
+    files: lib.es2020.bigint.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts
+- **BigUint64Array** (parents: —)
+    files: lib.es2020.bigint.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts
+- **BiquadFilterNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **Blob** (parents: —)
+    files: lib.dom.d.ts
+- **BlobEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **Boolean** (parents: —)
+    files: lib.es5.d.ts
+- **BroadcastChannel** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **ByteLengthQueuingStrategy** (parents: —)
+    files: lib.dom.d.ts
+- **CDATASection** (parents: Text)
+    files: lib.dom.d.ts
+- **CSSAnimation** (parents: Animation)
+    files: lib.dom.d.ts
+- **CSSConditionRule** (parents: CSSGroupingRule)
+    files: lib.dom.d.ts
+- **CSSContainerRule** (parents: CSSConditionRule)
+    files: lib.dom.d.ts
+- **CSSCounterStyleRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSFontFaceRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSFontFeatureValuesRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSFontPaletteValuesRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSGroupingRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSImageValue** (parents: CSSStyleValue)
+    files: lib.dom.d.ts
+- **CSSImportRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSKeyframeRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSKeyframesRule** (parents: CSSRule)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **CSSKeywordValue** (parents: CSSStyleValue)
+    files: lib.dom.d.ts
+- **CSSLayerBlockRule** (parents: CSSGroupingRule)
+    files: lib.dom.d.ts
+- **CSSLayerStatementRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSMathClamp** (parents: CSSMathValue)
+    files: lib.dom.d.ts
+- **CSSMathInvert** (parents: CSSMathValue)
+    files: lib.dom.d.ts
+- **CSSMathMax** (parents: CSSMathValue)
+    files: lib.dom.d.ts
+- **CSSMathMin** (parents: CSSMathValue)
+    files: lib.dom.d.ts
+- **CSSMathNegate** (parents: CSSMathValue)
+    files: lib.dom.d.ts
+- **CSSMathProduct** (parents: CSSMathValue)
+    files: lib.dom.d.ts
+- **CSSMathSum** (parents: CSSMathValue)
+    files: lib.dom.d.ts
+- **CSSMathValue** (parents: CSSNumericValue)
+    files: lib.dom.d.ts
+- **CSSMatrixComponent** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSMediaRule** (parents: CSSConditionRule)
+    files: lib.dom.d.ts
+- **CSSNamespaceRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSNestedDeclarations** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSNumericArray** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **CSSNumericValue** (parents: CSSStyleValue)
+    files: lib.dom.d.ts
+- **CSSPageRule** (parents: CSSGroupingRule)
+    files: lib.dom.d.ts
+- **CSSPerspective** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSPropertyRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **CSSRotate** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSRule** (parents: —)
+    files: lib.dom.d.ts
+- **CSSRuleList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **CSSScale** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSScopeRule** (parents: CSSGroupingRule)
+    files: lib.dom.d.ts
+- **CSSSkew** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSSkewX** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSSkewY** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSStartingStyleRule** (parents: CSSGroupingRule)
+    files: lib.dom.d.ts
+- **CSSStyleDeclaration** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **CSSStyleRule** (parents: CSSGroupingRule)
+    files: lib.dom.d.ts
+- **CSSStyleSheet** (parents: StyleSheet)
+    files: lib.dom.d.ts
+- **CSSStyleValue** (parents: —)
+    files: lib.dom.d.ts
+- **CSSSupportsRule** (parents: CSSConditionRule)
+    files: lib.dom.d.ts
+- **CSSTransformComponent** (parents: —)
+    files: lib.dom.d.ts
+- **CSSTransformValue** (parents: CSSStyleValue)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **CSSTransition** (parents: Animation)
+    files: lib.dom.d.ts
+- **CSSTranslate** (parents: CSSTransformComponent)
+    files: lib.dom.d.ts
+- **CSSUnitValue** (parents: CSSNumericValue)
+    files: lib.dom.d.ts
+- **CSSUnparsedValue** (parents: CSSStyleValue)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **CSSVariableReferenceValue** (parents: —)
+    files: lib.dom.d.ts
+- **CSSViewTransitionRule** (parents: CSSRule)
+    files: lib.dom.d.ts
+- **Cache** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **CacheStorage** (parents: —)
+    files: lib.dom.d.ts
+- **CanvasCaptureMediaStreamTrack** (parents: MediaStreamTrack)
+    files: lib.dom.d.ts
+- **CanvasGradient** (parents: —)
+    files: lib.dom.d.ts
+- **CanvasPattern** (parents: —)
+    files: lib.dom.d.ts
+- **CanvasRenderingContext2D** (parents: —)
+    files: lib.dom.d.ts
+- **CaretPosition** (parents: —)
+    files: lib.dom.d.ts
+- **ChannelMergerNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **ChannelSplitterNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **CharacterData** (parents: Node)
+    files: lib.dom.d.ts
+- **Clipboard** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **ClipboardEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **ClipboardItem** (parents: —)
+    files: lib.dom.d.ts
+- **CloseEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **Collator** (parents: —)
+    files: lib.es5.d.ts
+- **Comment** (parents: CharacterData)
+    files: lib.dom.d.ts
+- **CompileError** (parents: Error)
+    files: lib.dom.d.ts
+- **CompositionEvent** (parents: UIEvent)
+    files: lib.dom.d.ts
+- **CompressionStream** (parents: —)
+    files: lib.dom.d.ts
+- **ConstantSourceNode** (parents: AudioScheduledSourceNode)
+    files: lib.dom.d.ts
+- **ContentVisibilityAutoStateChangeEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **ConvolverNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **CountQueuingStrategy** (parents: —)
+    files: lib.dom.d.ts
+- **Credential** (parents: —)
+    files: lib.dom.d.ts
+- **CredentialsContainer** (parents: —)
+    files: lib.dom.d.ts
+- **Crypto** (parents: —)
+    files: lib.dom.d.ts
+- **CryptoKey** (parents: —)
+    files: lib.dom.d.ts
+- **CustomElementRegistry** (parents: —)
+    files: lib.dom.d.ts
+- **CustomEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **CustomStateSet** (parents: Set)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **DOMException** (parents: Error)
+    files: lib.dom.d.ts
+- **DOMImplementation** (parents: —)
+    files: lib.dom.d.ts
+- **DOMMatrix** (parents: DOMMatrixReadOnly)
+    files: lib.dom.d.ts
+- **DOMMatrixReadOnly** (parents: —)
+    files: lib.dom.d.ts
+- **DOMParser** (parents: —)
+    files: lib.dom.d.ts
+- **DOMPoint** (parents: DOMPointReadOnly)
+    files: lib.dom.d.ts
+- **DOMPointReadOnly** (parents: —)
+    files: lib.dom.d.ts
+- **DOMQuad** (parents: —)
+    files: lib.dom.d.ts
+- **DOMRect** (parents: DOMRectReadOnly)
+    files: lib.dom.d.ts
+- **DOMRectList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **DOMRectReadOnly** (parents: —)
+    files: lib.dom.d.ts
+- **DOMStringList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **DOMStringMap** (parents: —)
+    files: lib.dom.d.ts
+- **DOMTokenList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **DataTransfer** (parents: —)
+    files: lib.dom.d.ts
+- **DataTransferItem** (parents: —)
+    files: lib.dom.d.ts
+- **DataTransferItemList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **DataView** (parents: —)
+    files: lib.es2015.symbol.wellknown.d.ts, lib.es2020.bigint.d.ts, lib.es5.d.ts, lib.esnext.float16.d.ts
+- **Date** (parents: —)
+    files: lib.es2015.symbol.wellknown.d.ts, lib.es2020.date.d.ts, lib.es5.d.ts, lib.scripthost.d.ts
+- **DateTimeFormat** (parents: —)
+    files: lib.es2017.intl.d.ts, lib.es2021.intl.d.ts, lib.es5.d.ts
+- **DecompressionStream** (parents: —)
+    files: lib.dom.d.ts
+- **DelayNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **DeviceMotionEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **DeviceOrientationEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **DisplayNames** (parents: —)
+    files: lib.es2020.intl.d.ts
+- **DisposableStack** (parents: —)
+    files: lib.esnext.disposable.d.ts
+- **Document** (parents: Node)
+    files: lib.dom.d.ts
+- **DocumentFragment** (parents: Node)
+    files: lib.dom.d.ts
+- **DocumentTimeline** (parents: AnimationTimeline)
+    files: lib.dom.d.ts
+- **DocumentType** (parents: Node)
+    files: lib.dom.d.ts
+- **DragEvent** (parents: MouseEvent)
+    files: lib.dom.d.ts
+- **DynamicsCompressorNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **Element** (parents: Node)
+    files: lib.dom.d.ts
+- **ElementInternals** (parents: —)
+    files: lib.dom.d.ts
+- **EncodedAudioChunk** (parents: —)
+    files: lib.dom.d.ts
+- **EncodedVideoChunk** (parents: —)
+    files: lib.dom.d.ts
+- **Enumerator** (parents: —)
+    files: lib.scripthost.d.ts
+- **Error** (parents: —)
+    files: lib.es2022.error.d.ts, lib.es5.d.ts
+- **ErrorEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **EvalError** (parents: Error)
+    files: lib.es5.d.ts
+- **Event** (parents: —)
+    files: lib.dom.d.ts
+- **EventCounts** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **EventSource** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **EventTarget** (parents: —)
+    files: lib.dom.d.ts
+- **External** (parents: —)
+    files: lib.dom.d.ts
+- **File** (parents: Blob)
+    files: lib.dom.d.ts
+- **FileList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **FileReader** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **FileSystem** (parents: —)
+    files: lib.dom.d.ts
+- **FileSystemDirectoryEntry** (parents: FileSystemEntry)
+    files: lib.dom.d.ts
+- **FileSystemDirectoryHandle** (parents: FileSystemHandle)
+    files: lib.dom.asynciterable.d.ts, lib.dom.d.ts
+- **FileSystemDirectoryReader** (parents: —)
+    files: lib.dom.d.ts
+- **FileSystemEntry** (parents: —)
+    files: lib.dom.d.ts
+- **FileSystemFileEntry** (parents: FileSystemEntry)
+    files: lib.dom.d.ts
+- **FileSystemFileHandle** (parents: FileSystemHandle)
+    files: lib.dom.d.ts
+- **FileSystemHandle** (parents: —)
+    files: lib.dom.d.ts
+- **FileSystemWritableFileStream** (parents: WritableStream)
+    files: lib.dom.d.ts
+- **FinalizationRegistry** (parents: —)
+    files: lib.es2021.weakref.d.ts
+- **Float16Array** (parents: —)
+    files: lib.esnext.float16.d.ts
+- **Float32Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **Float64Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **FocusEvent** (parents: UIEvent)
+    files: lib.dom.d.ts
+- **FontFace** (parents: —)
+    files: lib.dom.d.ts
+- **FontFaceSet** (parents: EventTarget, Set)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **FontFaceSetLoadEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **FormData** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **FormDataEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **FragmentDirective** (parents: —)
+    files: lib.dom.d.ts
+- **Function** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts, lib.esnext.decorators.d.ts
+- **GainNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **Gamepad** (parents: —)
+    files: lib.dom.d.ts
+- **GamepadButton** (parents: —)
+    files: lib.dom.d.ts
+- **GamepadEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **GamepadHapticActuator** (parents: —)
+    files: lib.dom.d.ts
+- **Geolocation** (parents: —)
+    files: lib.dom.d.ts
+- **GeolocationCoordinates** (parents: —)
+    files: lib.dom.d.ts
+- **GeolocationPosition** (parents: —)
+    files: lib.dom.d.ts
+- **GeolocationPositionError** (parents: —)
+    files: lib.dom.d.ts
+- **Global** (parents: —)
+    files: lib.dom.d.ts
+- **HTMLAllCollection** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **HTMLAnchorElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLAreaElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLAudioElement** (parents: HTMLMediaElement)
+    files: lib.dom.d.ts
+- **HTMLBRElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLBaseElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLBodyElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLButtonElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLCanvasElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLCollection** (parents: —)
+    files: lib.dom.d.ts
+- **HTMLDListElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLDataElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLDataListElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLDetailsElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLDialogElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLDirectoryElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLDivElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLDocument** (parents: Document)
+    files: lib.dom.d.ts
+- **HTMLElement** (parents: Element)
+    files: lib.dom.d.ts
+- **HTMLEmbedElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLFieldSetElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLFontElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLFormControlsCollection** (parents: —)
+    files: lib.dom.d.ts
+- **HTMLFormElement** (parents: HTMLElement)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **HTMLFrameElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLFrameSetElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLHRElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLHeadElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLHeadingElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLHtmlElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLIFrameElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLImageElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLInputElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLLIElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLLabelElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLLegendElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLLinkElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLMapElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLMarqueeElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLMediaElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLMenuElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLMetaElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLMeterElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLModElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLOListElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLObjectElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLOptGroupElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLOptionElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLOptionsCollection** (parents: —)
+    files: lib.dom.d.ts
+- **HTMLOutputElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLParagraphElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLParamElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLPictureElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLPreElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLProgressElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLQuoteElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLScriptElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLSelectElement** (parents: HTMLElement)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **HTMLSlotElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLSourceElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLSpanElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLStyleElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTableCaptionElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTableCellElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTableColElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTableElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTableRowElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTableSectionElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTemplateElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTextAreaElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTimeElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTitleElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLTrackElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLUListElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLUnknownElement** (parents: HTMLElement)
+    files: lib.dom.d.ts
+- **HTMLVideoElement** (parents: HTMLMediaElement)
+    files: lib.dom.d.ts
+- **HashChangeEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **Headers** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **Highlight** (parents: Set)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **HighlightRegistry** (parents: Map)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **History** (parents: —)
+    files: lib.dom.d.ts
+- **IDBCursor** (parents: —)
+    files: lib.dom.d.ts
+- **IDBCursorWithValue** (parents: IDBCursor)
+    files: lib.dom.d.ts
+- **IDBDatabase** (parents: EventTarget)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **IDBFactory** (parents: —)
+    files: lib.dom.d.ts
+- **IDBIndex** (parents: —)
+    files: lib.dom.d.ts
+- **IDBKeyRange** (parents: —)
+    files: lib.dom.d.ts
+- **IDBObjectStore** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **IDBOpenDBRequest** (parents: IDBRequest)
+    files: lib.dom.d.ts
+- **IDBRequest** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **IDBTransaction** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **IDBVersionChangeEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **IIRFilterNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **IdleDeadline** (parents: —)
+    files: lib.dom.d.ts
+- **ImageBitmap** (parents: —)
+    files: lib.dom.d.ts
+- **ImageBitmapRenderingContext** (parents: —)
+    files: lib.dom.d.ts
+- **ImageData** (parents: —)
+    files: lib.dom.d.ts
+- **ImageDecoder** (parents: —)
+    files: lib.dom.d.ts
+- **ImageTrack** (parents: —)
+    files: lib.dom.d.ts
+- **ImageTrackList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **InputDeviceInfo** (parents: MediaDeviceInfo)
+    files: lib.dom.d.ts
+- **InputEvent** (parents: UIEvent)
+    files: lib.dom.d.ts
+- **Instance** (parents: —)
+    files: lib.dom.d.ts
+- **Int16Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **Int32Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **Int8Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **IntersectionObserver** (parents: —)
+    files: lib.dom.d.ts
+- **IntersectionObserverEntry** (parents: —)
+    files: lib.dom.d.ts
+- **Iterator** (parents: —)
+    files: lib.es2015.iterable.d.ts, lib.esnext.iterator.d.ts
+- **KeyboardEvent** (parents: UIEvent)
+    files: lib.dom.d.ts
+- **KeyframeEffect** (parents: AnimationEffect)
+    files: lib.dom.d.ts
+- **LargestContentfulPaint** (parents: PerformanceEntry)
+    files: lib.dom.d.ts
+- **LinkError** (parents: Error)
+    files: lib.dom.d.ts
+- **ListFormat** (parents: —)
+    files: lib.es2021.intl.d.ts
+- **Location** (parents: —)
+    files: lib.dom.d.ts
+- **Lock** (parents: —)
+    files: lib.dom.d.ts
+- **LockManager** (parents: —)
+    files: lib.dom.d.ts
+- **MIDIAccess** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MIDIConnectionEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **MIDIInput** (parents: MIDIPort)
+    files: lib.dom.d.ts
+- **MIDIInputMap** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **MIDIMessageEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **MIDIOutput** (parents: MIDIPort)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **MIDIOutputMap** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **MIDIPort** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Map** (parents: —)
+    files: lib.es2015.collection.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts
+- **MathMLElement** (parents: Element)
+    files: lib.dom.d.ts
+- **MediaCapabilities** (parents: —)
+    files: lib.dom.d.ts
+- **MediaDeviceInfo** (parents: —)
+    files: lib.dom.d.ts
+- **MediaDevices** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MediaElementAudioSourceNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **MediaEncryptedEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **MediaError** (parents: —)
+    files: lib.dom.d.ts
+- **MediaKeyMessageEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **MediaKeySession** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MediaKeyStatusMap** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **MediaKeySystemAccess** (parents: —)
+    files: lib.dom.d.ts
+- **MediaKeys** (parents: —)
+    files: lib.dom.d.ts
+- **MediaList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **MediaMetadata** (parents: —)
+    files: lib.dom.d.ts
+- **MediaQueryList** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MediaQueryListEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **MediaRecorder** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MediaSession** (parents: —)
+    files: lib.dom.d.ts
+- **MediaSource** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MediaSourceHandle** (parents: —)
+    files: lib.dom.d.ts
+- **MediaStream** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MediaStreamAudioDestinationNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **MediaStreamAudioSourceNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **MediaStreamTrack** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MediaStreamTrackEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **Memory** (parents: —)
+    files: lib.dom.d.ts
+- **MessageChannel** (parents: —)
+    files: lib.dom.d.ts
+- **MessageEvent** (parents: Event)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **MessagePort** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **MimeType** (parents: —)
+    files: lib.dom.d.ts
+- **MimeTypeArray** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **Module** (parents: —)
+    files: lib.dom.d.ts
+- **MouseEvent** (parents: UIEvent)
+    files: lib.dom.d.ts
+- **MutationObserver** (parents: —)
+    files: lib.dom.d.ts
+- **MutationRecord** (parents: —)
+    files: lib.dom.d.ts
+- **NamedNodeMap** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **NavigationActivation** (parents: —)
+    files: lib.dom.d.ts
+- **NavigationHistoryEntry** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **NavigationPreloadManager** (parents: —)
+    files: lib.dom.d.ts
+- **Navigator** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **Node** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **NodeIterator** (parents: —)
+    files: lib.dom.d.ts
+- **NodeList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **Notification** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Number** (parents: —)
+    files: lib.es2020.number.d.ts, lib.es5.d.ts
+- **NumberFormat** (parents: —)
+    files: lib.es2018.intl.d.ts, lib.es2020.bigint.d.ts, lib.es2023.intl.d.ts, lib.es5.d.ts
+- **Object** (parents: —)
+    files: lib.es5.d.ts
+- **OfflineAudioCompletionEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **OfflineAudioContext** (parents: BaseAudioContext)
+    files: lib.dom.d.ts
+- **OffscreenCanvas** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **OffscreenCanvasRenderingContext2D** (parents: —)
+    files: lib.dom.d.ts
+- **OscillatorNode** (parents: AudioScheduledSourceNode)
+    files: lib.dom.d.ts
+- **OverconstrainedError** (parents: DOMException)
+    files: lib.dom.d.ts
+- **PageRevealEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **PageSwapEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **PageTransitionEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **PannerNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **Path2D** (parents: —)
+    files: lib.dom.d.ts
+- **PaymentAddress** (parents: —)
+    files: lib.dom.d.ts
+- **PaymentMethodChangeEvent** (parents: PaymentRequestUpdateEvent)
+    files: lib.dom.d.ts
+- **PaymentRequest** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **PaymentRequestUpdateEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **PaymentResponse** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Performance** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **PerformanceEntry** (parents: —)
+    files: lib.dom.d.ts
+- **PerformanceEventTiming** (parents: PerformanceEntry)
+    files: lib.dom.d.ts
+- **PerformanceMark** (parents: PerformanceEntry)
+    files: lib.dom.d.ts
+- **PerformanceMeasure** (parents: PerformanceEntry)
+    files: lib.dom.d.ts
+- **PerformanceNavigation** (parents: —)
+    files: lib.dom.d.ts
+- **PerformanceNavigationTiming** (parents: PerformanceResourceTiming)
+    files: lib.dom.d.ts
+- **PerformanceObserver** (parents: —)
+    files: lib.dom.d.ts
+- **PerformanceObserverEntryList** (parents: —)
+    files: lib.dom.d.ts
+- **PerformancePaintTiming** (parents: PerformanceEntry)
+    files: lib.dom.d.ts
+- **PerformanceResourceTiming** (parents: PerformanceEntry)
+    files: lib.dom.d.ts
+- **PerformanceServerTiming** (parents: —)
+    files: lib.dom.d.ts
+- **PerformanceTiming** (parents: —)
+    files: lib.dom.d.ts
+- **PeriodicWave** (parents: —)
+    files: lib.dom.d.ts
+- **PermissionStatus** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Permissions** (parents: —)
+    files: lib.dom.d.ts
+- **PictureInPictureEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **PictureInPictureWindow** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Plugin** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **PluginArray** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **PluralRules** (parents: —)
+    files: lib.es2018.intl.d.ts
+- **PointerEvent** (parents: MouseEvent)
+    files: lib.dom.d.ts
+- **PopStateEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **ProcessingInstruction** (parents: CharacterData)
+    files: lib.dom.d.ts
+- **ProgressEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **Promise** (parents: —)
+    files: lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2018.promise.d.ts, lib.es5.d.ts
+- **PromiseRejectionEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **PublicKeyCredential** (parents: Credential)
+    files: lib.dom.d.ts
+- **PushManager** (parents: —)
+    files: lib.dom.d.ts
+- **PushSubscription** (parents: —)
+    files: lib.dom.d.ts
+- **PushSubscriptionOptions** (parents: —)
+    files: lib.dom.d.ts
+- **RTCCertificate** (parents: —)
+    files: lib.dom.d.ts
+- **RTCDTMFSender** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **RTCDTMFToneChangeEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **RTCDataChannel** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **RTCDataChannelEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **RTCDtlsTransport** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **RTCEncodedAudioFrame** (parents: —)
+    files: lib.dom.d.ts
+- **RTCEncodedVideoFrame** (parents: —)
+    files: lib.dom.d.ts
+- **RTCError** (parents: DOMException)
+    files: lib.dom.d.ts
+- **RTCErrorEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **RTCIceCandidate** (parents: —)
+    files: lib.dom.d.ts
+- **RTCIceTransport** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **RTCPeerConnection** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **RTCPeerConnectionIceErrorEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **RTCPeerConnectionIceEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **RTCRtpReceiver** (parents: —)
+    files: lib.dom.d.ts
+- **RTCRtpScriptTransform** (parents: —)
+    files: lib.dom.d.ts
+- **RTCRtpSender** (parents: —)
+    files: lib.dom.d.ts
+- **RTCRtpTransceiver** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **RTCSctpTransport** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **RTCSessionDescription** (parents: —)
+    files: lib.dom.d.ts
+- **RTCStatsReport** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **RTCTrackEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **RadioNodeList** (parents: NodeList)
+    files: lib.dom.d.ts
+- **Range** (parents: AbstractRange)
+    files: lib.dom.d.ts
+- **RangeError** (parents: Error)
+    files: lib.es5.d.ts
+- **ReadableByteStreamController** (parents: —)
+    files: lib.dom.d.ts
+- **ReadableStream** (parents: —)
+    files: lib.dom.asynciterable.d.ts, lib.dom.d.ts
+- **ReadableStreamBYOBReader** (parents: —)
+    files: lib.dom.d.ts
+- **ReadableStreamBYOBRequest** (parents: —)
+    files: lib.dom.d.ts
+- **ReadableStreamDefaultController** (parents: —)
+    files: lib.dom.d.ts
+- **ReadableStreamDefaultReader** (parents: —)
+    files: lib.dom.d.ts
+- **ReferenceError** (parents: Error)
+    files: lib.es5.d.ts
+- **RegExp** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2018.regexp.d.ts, lib.es2020.symbol.wellknown.d.ts, lib.es2022.regexp.d.ts, lib.es2024.regexp.d.ts, lib.es5.d.ts
+- **RemotePlayback** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Report** (parents: —)
+    files: lib.dom.d.ts
+- **ReportBody** (parents: —)
+    files: lib.dom.d.ts
+- **ReportingObserver** (parents: —)
+    files: lib.dom.d.ts
+- **Request** (parents: —)
+    files: lib.dom.d.ts
+- **ResizeObserver** (parents: —)
+    files: lib.dom.d.ts
+- **ResizeObserverEntry** (parents: —)
+    files: lib.dom.d.ts
+- **ResizeObserverSize** (parents: —)
+    files: lib.dom.d.ts
+- **Response** (parents: —)
+    files: lib.dom.d.ts
+- **RuntimeError** (parents: Error)
+    files: lib.dom.d.ts
+- **SVGAElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGAngle** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimateElement** (parents: SVGAnimationElement)
+    files: lib.dom.d.ts
+- **SVGAnimateMotionElement** (parents: SVGAnimationElement)
+    files: lib.dom.d.ts
+- **SVGAnimateTransformElement** (parents: SVGAnimationElement)
+    files: lib.dom.d.ts
+- **SVGAnimatedAngle** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedBoolean** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedEnumeration** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedInteger** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedLength** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedLengthList** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedNumber** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedNumberList** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedPreserveAspectRatio** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedRect** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedString** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimatedTransformList** (parents: —)
+    files: lib.dom.d.ts
+- **SVGAnimationElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGCircleElement** (parents: SVGGeometryElement)
+    files: lib.dom.d.ts
+- **SVGClipPathElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGComponentTransferFunctionElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGDefsElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGDescElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGElement** (parents: Element)
+    files: lib.dom.d.ts
+- **SVGEllipseElement** (parents: SVGGeometryElement)
+    files: lib.dom.d.ts
+- **SVGFEBlendElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEColorMatrixElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEComponentTransferElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFECompositeElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEConvolveMatrixElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEDiffuseLightingElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEDisplacementMapElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEDistantLightElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEDropShadowElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEFloodElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEFuncAElement** (parents: SVGComponentTransferFunctionElement)
+    files: lib.dom.d.ts
+- **SVGFEFuncBElement** (parents: SVGComponentTransferFunctionElement)
+    files: lib.dom.d.ts
+- **SVGFEFuncGElement** (parents: SVGComponentTransferFunctionElement)
+    files: lib.dom.d.ts
+- **SVGFEFuncRElement** (parents: SVGComponentTransferFunctionElement)
+    files: lib.dom.d.ts
+- **SVGFEGaussianBlurElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEImageElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEMergeElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEMergeNodeElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEMorphologyElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEOffsetElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFEPointLightElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFESpecularLightingElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFESpotLightElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFETileElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFETurbulenceElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGFilterElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGForeignObjectElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGGElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGGeometryElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGGradientElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGGraphicsElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGImageElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGLength** (parents: —)
+    files: lib.dom.d.ts
+- **SVGLengthList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SVGLineElement** (parents: SVGGeometryElement)
+    files: lib.dom.d.ts
+- **SVGLinearGradientElement** (parents: SVGGradientElement)
+    files: lib.dom.d.ts
+- **SVGMPathElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGMarkerElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGMaskElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGMetadataElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGNumber** (parents: —)
+    files: lib.dom.d.ts
+- **SVGNumberList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SVGPathElement** (parents: SVGGeometryElement)
+    files: lib.dom.d.ts
+- **SVGPatternElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGPointList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SVGPolygonElement** (parents: SVGGeometryElement)
+    files: lib.dom.d.ts
+- **SVGPolylineElement** (parents: SVGGeometryElement)
+    files: lib.dom.d.ts
+- **SVGPreserveAspectRatio** (parents: —)
+    files: lib.dom.d.ts
+- **SVGRadialGradientElement** (parents: SVGGradientElement)
+    files: lib.dom.d.ts
+- **SVGRectElement** (parents: SVGGeometryElement)
+    files: lib.dom.d.ts
+- **SVGSVGElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGScriptElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGSetElement** (parents: SVGAnimationElement)
+    files: lib.dom.d.ts
+- **SVGStopElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGStringList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SVGStyleElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGSwitchElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGSymbolElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGTSpanElement** (parents: SVGTextPositioningElement)
+    files: lib.dom.d.ts
+- **SVGTextContentElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGTextElement** (parents: SVGTextPositioningElement)
+    files: lib.dom.d.ts
+- **SVGTextPathElement** (parents: SVGTextContentElement)
+    files: lib.dom.d.ts
+- **SVGTextPositioningElement** (parents: SVGTextContentElement)
+    files: lib.dom.d.ts
+- **SVGTitleElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **SVGTransform** (parents: —)
+    files: lib.dom.d.ts
+- **SVGTransformList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SVGUnitTypes** (parents: —)
+    files: lib.dom.d.ts
+- **SVGUseElement** (parents: SVGGraphicsElement)
+    files: lib.dom.d.ts
+- **SVGViewElement** (parents: SVGElement)
+    files: lib.dom.d.ts
+- **Screen** (parents: —)
+    files: lib.dom.d.ts
+- **ScreenOrientation** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **ScriptProcessorNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **SecurityPolicyViolationEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **Segmenter** (parents: —)
+    files: lib.es2022.intl.d.ts
+- **Selection** (parents: —)
+    files: lib.dom.d.ts
+- **ServiceWorker** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **ServiceWorkerContainer** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **ServiceWorkerRegistration** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Set** (parents: —)
+    files: lib.es2015.collection.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.esnext.collection.d.ts
+- **ShadowRoot** (parents: DocumentFragment)
+    files: lib.dom.d.ts
+- **SharedArrayBuffer** (parents: —)
+    files: lib.es2017.sharedmemory.d.ts, lib.es2024.sharedmemory.d.ts
+- **SharedWorker** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **SourceBuffer** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **SourceBufferList** (parents: EventTarget)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SpeechRecognitionAlternative** (parents: —)
+    files: lib.dom.d.ts
+- **SpeechRecognitionResult** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SpeechRecognitionResultList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SpeechSynthesis** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **SpeechSynthesisErrorEvent** (parents: SpeechSynthesisEvent)
+    files: lib.dom.d.ts
+- **SpeechSynthesisEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **SpeechSynthesisUtterance** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **SpeechSynthesisVoice** (parents: —)
+    files: lib.dom.d.ts
+- **StaticRange** (parents: AbstractRange)
+    files: lib.dom.d.ts
+- **StereoPannerNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **Storage** (parents: —)
+    files: lib.dom.d.ts
+- **StorageEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **StorageManager** (parents: —)
+    files: lib.dom.d.ts
+- **String** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2017.string.d.ts, lib.es2019.string.d.ts, lib.es2020.string.d.ts, lib.es2021.string.d.ts, lib.es2022.string.d.ts, lib.es2024.string.d.ts, lib.es5.d.ts
+- **StylePropertyMap** (parents: StylePropertyMapReadOnly)
+    files: lib.dom.d.ts
+- **StylePropertyMapReadOnly** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **StyleSheet** (parents: —)
+    files: lib.dom.d.ts
+- **StyleSheetList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SubmitEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **SubtleCrypto** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **SuppressedError** (parents: Error)
+    files: lib.esnext.disposable.d.ts
+- **Symbol** (parents: —)
+    files: lib.es2015.symbol.wellknown.d.ts, lib.es2019.symbol.d.ts, lib.es5.d.ts
+- **SyntaxError** (parents: Error)
+    files: lib.es5.d.ts
+- **Table** (parents: —)
+    files: lib.dom.d.ts
+- **Text** (parents: CharacterData)
+    files: lib.dom.d.ts
+- **TextDecoder** (parents: —)
+    files: lib.dom.d.ts
+- **TextDecoderStream** (parents: —)
+    files: lib.dom.d.ts
+- **TextEncoder** (parents: —)
+    files: lib.dom.d.ts
+- **TextEncoderStream** (parents: —)
+    files: lib.dom.d.ts
+- **TextEvent** (parents: UIEvent)
+    files: lib.dom.d.ts
+- **TextMetrics** (parents: —)
+    files: lib.dom.d.ts
+- **TextTrack** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **TextTrackCue** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **TextTrackCueList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **TextTrackList** (parents: EventTarget)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **TimeRanges** (parents: —)
+    files: lib.dom.d.ts
+- **ToggleEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **Touch** (parents: —)
+    files: lib.dom.d.ts
+- **TouchEvent** (parents: UIEvent)
+    files: lib.dom.d.ts
+- **TouchList** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **TrackEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **TransformStream** (parents: —)
+    files: lib.dom.d.ts
+- **TransformStreamDefaultController** (parents: —)
+    files: lib.dom.d.ts
+- **TransitionEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **TreeWalker** (parents: —)
+    files: lib.dom.d.ts
+- **TypeError** (parents: Error)
+    files: lib.es5.d.ts
+- **UIEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **URIError** (parents: Error)
+    files: lib.es5.d.ts
+- **URL** (parents: —)
+    files: lib.dom.d.ts
+- **URLSearchParams** (parents: —)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **Uint16Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **Uint32Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **Uint8Array** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **Uint8ClampedArray** (parents: —)
+    files: lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts
+- **UserActivation** (parents: —)
+    files: lib.dom.d.ts
+- **VBArray** (parents: —)
+    files: lib.scripthost.d.ts
+- **VTTCue** (parents: TextTrackCue)
+    files: lib.dom.d.ts
+- **VTTRegion** (parents: —)
+    files: lib.dom.d.ts
+- **ValidityState** (parents: —)
+    files: lib.dom.d.ts
+- **VideoColorSpace** (parents: —)
+    files: lib.dom.d.ts
+- **VideoDecoder** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **VideoEncoder** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **VideoFrame** (parents: —)
+    files: lib.dom.d.ts
+- **VideoPlaybackQuality** (parents: —)
+    files: lib.dom.d.ts
+- **ViewTransition** (parents: —)
+    files: lib.dom.d.ts
+- **ViewTransitionTypeSet** (parents: Set)
+    files: lib.dom.d.ts, lib.dom.iterable.d.ts
+- **VisualViewport** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **WakeLock** (parents: —)
+    files: lib.dom.d.ts
+- **WakeLockSentinel** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **WaveShaperNode** (parents: AudioNode)
+    files: lib.dom.d.ts
+- **WeakMap** (parents: —)
+    files: lib.es2015.collection.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts
+- **WeakRef** (parents: —)
+    files: lib.es2021.weakref.d.ts
+- **WeakSet** (parents: —)
+    files: lib.es2015.collection.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts
+- **WebGL2RenderingContext** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLActiveInfo** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLBuffer** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLContextEvent** (parents: Event)
+    files: lib.dom.d.ts
+- **WebGLFramebuffer** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLProgram** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLQuery** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLRenderbuffer** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLRenderingContext** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLSampler** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLShader** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLShaderPrecisionFormat** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLSync** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLTexture** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLTransformFeedback** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLUniformLocation** (parents: —)
+    files: lib.dom.d.ts
+- **WebGLVertexArrayObject** (parents: —)
+    files: lib.dom.d.ts
+- **WebSocket** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **WebTransport** (parents: —)
+    files: lib.dom.d.ts
+- **WebTransportBidirectionalStream** (parents: —)
+    files: lib.dom.d.ts
+- **WebTransportDatagramDuplexStream** (parents: —)
+    files: lib.dom.d.ts
+- **WebTransportError** (parents: DOMException)
+    files: lib.dom.d.ts
+- **WheelEvent** (parents: MouseEvent)
+    files: lib.dom.d.ts
+- **Window** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Worker** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **Worklet** (parents: —)
+    files: lib.dom.d.ts
+- **WritableStream** (parents: —)
+    files: lib.dom.d.ts
+- **WritableStreamDefaultController** (parents: —)
+    files: lib.dom.d.ts
+- **WritableStreamDefaultWriter** (parents: —)
+    files: lib.dom.d.ts
+- **XMLDocument** (parents: Document)
+    files: lib.dom.d.ts
+- **XMLHttpRequest** (parents: XMLHttpRequestEventTarget)
+    files: lib.dom.d.ts
+- **XMLHttpRequestEventTarget** (parents: EventTarget)
+    files: lib.dom.d.ts
+- **XMLHttpRequestUpload** (parents: XMLHttpRequestEventTarget)
+    files: lib.dom.d.ts
+- **XMLSerializer** (parents: —)
+    files: lib.dom.d.ts
+- **XPathEvaluator** (parents: —)
+    files: lib.dom.d.ts
+- **XPathExpression** (parents: —)
+    files: lib.dom.d.ts
+- **XPathResult** (parents: —)
+    files: lib.dom.d.ts
+- **XSLTProcessor** (parents: —)
+    files: lib.dom.d.ts

--- a/planning/exact-types/requirements.md
+++ b/planning/exact-types/requirements.md
@@ -1,0 +1,1168 @@
+# Exact Types
+
+## 1. Overview
+
+TypeScript uses structural sub-typing, which means a value conforms to a type as
+long as it has at least the properties (or elements, or parameters) that the
+type requires. Extra properties on objects, extra elements in tuples, and being
+called with fewer arguments than declared are all permitted.
+
+Sometimes it is useful to know that a value has *exactly* a certain shape — no
+extra properties on an object, no extra elements in a tuple, no extra arguments
+passed to a function. **Exact types** are the umbrella term for these. Exact
+types still permit ordinary structural variation on the per-property,
+per-element, or per-parameter basis (a property can still be a subtype, a
+parameter can still be contravariant, etc.), but the **arity must match
+exactly**.
+
+This document specifies exact and inexact variants for four categories of
+types:
+
+1. Object types
+2. Tuple types
+3. Function types
+4. Union types
+
+By default, all four categories are **exact**. The trailing `...` syntax marks
+a type as **inexact**, meaning extra properties / elements / arguments /
+members are permitted.
+
+## 2. Object Types
+
+### 2.1. Syntax
+
+Following [`docs/07_exact_types.md`](../../docs/07_exact_types.md):
+
+```
+type ExactPoint = {x: number, y: number}
+type InexactPoint = {x: number, y: number, ...}
+```
+
+- A bare object type literal `{ ... }` (without trailing `...`) is **exact**.
+- An object type with a trailing `...` is **inexact**.
+
+### 2.2. Semantics
+
+```
+declare val p: ExactPoint
+declare val q: InexactPoint
+
+val a: InexactPoint = p // Okay — exact is a subtype of inexact
+val b: ExactPoint = q   // Error — q may have extra properties
+```
+
+#### 2.2.1. Object Literal Inference
+
+Object literals are inferred as **exact** types:
+
+```
+val p = {x: 1, y: 2}                    // inferred as exact {x: number, y: number}
+val q: InexactPoint = {x: 1, y: 2}      // okay — exact widens to inexact on assignment
+val r: InexactPoint = {x: 1, y: 2, z: 3} // okay — assigning to inexact target
+val s: ExactPoint = {x: 1, y: 2, z: 3}   // Error — extra property `z` on exact target
+```
+
+#### 2.2.2. Spread and Rest
+
+Spreading and resting interact with exactness as described in the original doc:
+
+```
+val {x, ...rest} = p // `rest` will be exact (an exact {y: number})
+val {x, ...rest} = q // `rest` will be inexact
+
+val cp = {color, ...p} // `cp` will be exact
+val cq = {color, ...q} // `cq` will be inexact
+```
+
+In other words, exactness propagates through spread/rest: combining only exact
+inputs yields an exact result; combining anything inexact yields an inexact
+result.
+
+#### 2.2.3. `Object.keys`, `Object.values`, and `Object.entries`
+
+Because exact object types have a known, complete set of keys, all three of
+these built-ins can be given precise types when called on an exact object:
+
+- `Object.keys(o)` for an exact `o` returns an exact tuple of literal-string
+  keys (e.g., `["x", "y"]` for `{x: number, y: number}`).
+- `Object.values(o)` for an exact `o` returns an exact tuple of the
+  corresponding value types (e.g., `[number, number]` for the same object).
+- `Object.entries(o)` for an exact `o` returns an exact tuple of
+  `[key, value]` pairs (e.g., `[["x", number], ["y", number]]`).
+
+For an inexact `o`, all three fall back to TypeScript's permissive types:
+`Object.keys(o): Array<string>`, `Object.values(o): Array<unknown>`, and
+`Object.entries(o): Array<[string, unknown]>` — the unknown extra properties
+prevent any tighter typing.
+
+### 2.3. Type-Checking Rules
+
+Let `E = {p1: T1, ..., pn: Tn}` (exact) and `I = {p1: T1, ..., pn: Tn, ...}`
+(inexact). For object types `A` and `B`:
+
+- **Exact <: Inexact:** An exact type is a subtype of the corresponding inexact
+  type with the same declared properties (assuming each `Ti` is compatible).
+- **Inexact </: Exact:** An inexact type is *not* a subtype of an exact type,
+  because the inexact value may carry extra properties.
+- **Exact <: Exact:** `A <: B` only if both have the *same* set of property
+  names (no missing, no extra) and each property of `A` is a subtype of the
+  matching property of `B`.
+- **Inexact <: Inexact:** Standard structural subtyping — `A` must contain at
+  least every property of `B`, with each property of `A` being a subtype of
+  the matching property of `B`.
+
+Optional properties (`p?: T`) interact with exactness as expected: an exact type
+permits the *absence* of an optional property, but does not permit any
+*additional* properties beyond those declared.
+
+### 2.4. Interfaces
+
+Types declared with the `interface` keyword are **always inexact** object
+types. This matches TypeScript's behavior and supports the common use cases
+that motivated interfaces in the first place:
+
+- **Interface merging.** Multiple `interface` declarations with the same name
+  are merged into a single interface containing the union of all declared
+  members. Because the set of merged declarations is not closed at any single
+  declaration site, an interface cannot meaningfully be exact.
+- **Open extension.** Interfaces are designed to be extended by downstream
+  code (including across module boundaries and via declaration merging in
+  consumer code), so by construction they admit unknown additional
+  properties.
+- **Class instances.** Class instance types are interface-like and inexact
+  by default for the same reason — subclasses may add properties. (See the
+  "Class Instances" subsection below for how to opt into exactness via
+  `final` classes.)
+
+```
+interface Point {
+    x: number,
+    y: number,
+}
+
+interface Point {        // merged with the previous declaration
+    z: number,
+}
+
+// Point is now (inexact) { x: number, y: number, z: number, ... }
+```
+
+Because interfaces are inexact, `keyof SomeInterface` is an inexact union, and
+the same exactness propagation rules apply as for any other inexact object
+type. To get an exact object type, use a `type` alias with an object type
+literal instead of an `interface`.
+
+### 2.5. Namespaces
+
+Namespaces are **always inexact**, for essentially the same reasons as
+interfaces:
+
+- **Declaration merging.** Multiple `namespace` declarations with the same
+  name merge into a single namespace containing the union of their members.
+  As with interfaces, the set of merged declarations is not closed at any
+  single declaration site.
+- **Open extension across modules.** Namespaces can be augmented across
+  module boundaries (especially in TypeScript interop scenarios), so by
+  construction they admit unknown additional members.
+
+Consequently, `keyof SomeNamespace` is an inexact union, and the
+exactness-propagation rules apply just as they do for interface types. There
+is no opt-in to making a namespace type exact; if you need a closed,
+exact-keyed grouping of values, use a `type` alias to an exact object type
+instead.
+
+### 2.6. Class Instances
+
+Class instance types are **inexact by default**: a parameter typed as
+`Animal` should accept any subclass instance (`Dog`, `Cat`, etc.), which is
+exactly the open-extension behavior interfaces have. The instance type for
+a class `C` therefore behaves as `{ ...declared members of C, ... }` for
+subtyping purposes, and `keyof C` is an inexact union.
+
+To tighten this, a class can be declared **`final`**, which forbids subclassing
+and therefore makes its instance type exact.
+
+#### 2.6.1. `final` classes
+
+A class declared `final` cannot be extended. Because no subclass can ever
+exist, the instance type is closed: it has exactly the declared members and
+nothing more. The instance type of a `final` class is therefore **exact**,
+and `keyof` of a final class instance is an exact union.
+
+```
+final class Point {
+    x: number
+    y: number
+}
+
+// Point instances are exact: { x: number, y: number }
+// keyof Point is the exact union "x" | "y"
+
+class BadPoint extends Point { ... }   // Error — Point is final
+```
+
+A primary motivating use case: **enum variants**. In Escalier, enum variants
+are classes under the hood, and a value of an enum type is an instance of
+one of its variant classes. Marking variant classes as `final` (either
+implicitly, by virtue of being declared as enum variants, or explicitly via
+the keyword) means the union of variant instance types is itself an exact
+union — which lets exhaustive `match` over an enum work without a default
+arm even when the match discriminates on the variant's runtime class.
+
+```
+enum Shape {
+    Circle(radius: number),       // implicitly final
+    Square(side: number),         // implicitly final
+}
+
+// Shape ≈ exact (Circle | Square), where each variant is an exact instance type
+```
+
+#### 2.6.2. Per-use exactness for non-final classes
+
+There is **no** per-type-use annotation for narrowing a non-final class
+instance type to "direct instances only." If a class author wants to
+guarantee instance-type exactness to consumers, they declare the class
+`final`. Otherwise, the class's openness is part of its public contract,
+and consumers must accept any subclass instance.
+
+This keeps the type system simple — one less type former, one rule fewer in
+subtyping — and forces the open-vs-closed decision to be made once, at the
+class declaration site, rather than re-litigated at every use site. If we
+later discover a concrete need for consumer-side narrowing, it can be added
+in a backward-compatible way.
+
+### 2.7. Mapped Elements
+
+An object type may contain a **mapped element** (`MappedElem`) — a member
+that iterates an `IndexParam` over a constraint type and produces a property
+per value of the parameter:
+
+```
+type Pick<T, K : keyof T> = {[P]: T[P] for P in K}
+type Record<K : string, V> = {[P]: V for P in K}
+```
+
+The exactness of an object type containing a `MappedElem` is determined by
+the **constraint on the `IndexParam`** (i.e. the type after `in`):
+
+- If the constraint is an **exact union** (e.g. an exact union of string
+  literals like `"x" | "y"`, or `keyof E` where `E` is an exact object
+  type), the set of generated properties is fully known. The object type
+  containing the mapped element is **exact**, provided nothing else in the
+  object type forces inexactness (no trailing `...`, no inexact members
+  combined alongside, no spread of an inexact type).
+- If the constraint is an **inexact union** (e.g. `string`, `keyof I`
+  where `I` is an inexact object type or interface, or any `T | U | ...`),
+  the set of generated properties is open-ended. The object type
+  containing the mapped element is **inexact**.
+
+```
+type Exact   = {x: number, y: number}
+type Inexact = {x: number, y: number, ...}
+
+type EM = {[K]: string for K in keyof Exact}    // exact: keyof Exact is exact "x" | "y"
+// EM is exact { x: string, y: string }
+
+type IM = {[K]: string for K in keyof Inexact}  // inexact: keyof Inexact is inexact "x" | "y" | ...
+// IM is inexact { x: string, y: string, ... }
+
+type Open = {[K]: number for K in string}      // inexact: string is an inexact union of all strings
+// Open is inexact — equivalent to { [k: string]: number, ... }
+```
+
+This rule composes naturally with the other propagation rules: combining a
+mapped element whose constraint is exact with a trailing `...` still yields
+an inexact object type, and intersecting an exact mapped result with an
+inexact object type follows the usual intersection rules above.
+
+## 3. Tuple Types
+
+### 3.1. Syntax
+
+```
+type ExactTuple = [string, number]
+type InexactTuple = [string, number, ...]
+```
+
+- A bare tuple type `[T1, ..., Tn]` is **exact** — it has exactly `n` elements.
+- A tuple type ending in `...` is **inexact** — it has *at least* `n` elements,
+  with the trailing elements of unknown type.
+
+This is distinct from a tuple with an explicit *typed* rest element, which is
+already a TypeScript-style construct:
+
+```
+type Variadic = [string, ...Array<number>]    // exact arity-wise: 1 string then number rest
+type Inexact  = [string, number, ...]          // inexact: extra elements of any type allowed
+```
+
+The difference: `[string, ...Array<number>]` is a precise type whose extra
+elements are constrained to be `number`. `[string, number, ...]` says "at least
+these two elements, and possibly more of any type" — closer in spirit to
+`Array<unknown>` for the tail.
+
+### 3.2. Semantics
+
+```
+declare val t: ExactTuple    // [string, number]
+declare val u: InexactTuple  // [string, number, ...]
+
+val a: InexactTuple = t      // Okay — exact tuple widens to inexact
+val b: ExactTuple = u        // Error — `u` may have extra elements
+```
+
+#### 3.2.1. Tuple Literal Inference
+
+Tuple literals are inferred as **exact**:
+
+```
+val t = ["hello", 42]                // inferred as exact [string, number]
+val u: InexactTuple = ["hello", 42, true] // okay — extra element on inexact target
+val v: ExactTuple = ["hello", 42, true]   // Error — extra element on exact target
+```
+
+#### 3.2.2. Spread and Rest
+
+Tuple spread/rest mirror the object-type rules:
+
+```
+val [first, ...rest] = t   // `rest` is exact [number]
+val [first, ...rest] = u   // `rest` is inexact [number, ...]
+
+val tt = ["pre", ...t]     // exact [string, string, number]
+val uu = ["pre", ...u]     // inexact [string, string, number, ...]
+```
+
+#### 3.2.3. `length`
+
+For an exact tuple, `length` is the literal numeric type (`2` for
+`[string, number]`). For an inexact tuple, `length` is `number` with a known
+lower bound (effectively `number`, with the documented minimum equal to the
+number of declared elements).
+
+### 3.3. Type-Checking Rules
+
+For tuple types `A` and `B`:
+
+- **Exact <: Inexact:** `[T1, ..., Tn] <: [T1, ..., Tn, ...]` (when each `Ti`
+  is compatible).
+- **Inexact </: Exact:** Inexact tuples cannot be assigned to exact tuple types.
+- **Exact <: Exact:** `[T1, ..., Tn] <: [U1, ..., Um]` only if `n == m` and
+  each `Ti <: Ui`.
+- **Inexact <: Inexact:** `[T1, ..., Tn, ...] <: [U1, ..., Um, ...]` only if
+  `n >= m` and the first `m` elements are pairwise compatible.
+
+Optional tuple elements (`[T1, T2?]`) interact with exactness analogously to
+optional object properties: an exact tuple permits absence of optional trailing
+elements but no additional elements beyond the declared ones.
+
+## 4. Function Types
+
+### 4.1. Syntax
+
+```
+type ExactCallback   = fn(x: number, y: number) -> number
+type InexactCallback = fn(x: number, y: number, ...) -> number
+```
+
+- A bare function type `fn(...) -> T` is **exact** — callers may not pass extra
+  arguments beyond those declared.
+- A function type ending in `...` in its parameter list is **inexact** — extra
+  positional arguments are permitted at call sites.
+
+This is distinct from an explicit typed rest parameter:
+
+```
+fn sum(...nums: Array<number>) -> number { ... }   // typed rest — extras must be number
+fn log(msg: string, ...) -> undefined { ... }      // inexact — extras of any type allowed
+```
+
+### 4.2. Semantics
+
+In TypeScript, a function type `(x: number) => void` is assignable to a
+parameter expecting `(x: number, y: number) => void` because the implementation
+may simply ignore extra arguments. This means *callers* of the latter type can
+pass two arguments, and the supplied function will silently discard the second.
+
+In Escalier, with exact function types, **the callee declares how many
+arguments it accepts**, and callers may not pass more than that:
+
+```
+declare val f: ExactCallback     // fn(x: number, y: number) -> number
+declare val g: InexactCallback   // fn(x: number, y: number, ...) -> number
+
+f(1, 2)        // okay
+f(1, 2, 3)     // Error — exact function type accepts exactly 2 arguments
+
+g(1, 2)        // okay
+g(1, 2, 3)     // okay — inexact function accepts extras
+```
+
+#### 4.2.1. Subtyping (Function Compatibility)
+
+Standard function subtyping rules still apply (contravariant parameters,
+covariant returns), with an added arity rule:
+
+**Function arities must match exactly when comparing function types,
+regardless of exact/inexact.** Neither direction (`Exact <: Inexact` nor
+`Inexact <: Exact`) is permitted for function subtyping. Exactness on
+function types governs *call-site* checking only — how many arguments a
+caller may pass — not subtyping between function types themselves.
+
+- **Exact </: Inexact:** An exact function is *not* a subtype of the
+  corresponding inexact function. See "Why exact `</:` inexact for
+  functions" below.
+- **Inexact </: Exact:** An inexact function is not a subtype of an exact
+  function either, because the inexact function "advertises" that callers
+  may pass extras, which the exact callsite would forbid.
+- **Exact <: Exact:** Standard structural rule with arities matching
+  exactly. `fn(a: A, b: B) -> R <: fn(c: C, d: D) -> S` only if both have
+  exactly two parameters, `C <: A`, `D <: B`, and `R <: S`.
+- **Inexact <: Inexact:** The classic "fewer params is okay" rule applies
+  *within* inexact function types: `fn(a: A, ...) -> R <:
+  fn(a: A, b: B, ...) -> R`. Both types permit unbounded extra arguments,
+  so the supplier just needs to handle at least the parameters the
+  consumer's contract requires.
+
+##### 4.2.1.1. Why exact `</:` inexact for functions
+
+Unlike object, tuple, and union types — where exact `<:` inexact is
+straightforwardly sound (an exact value just happens to have no extras and
+trivially satisfies an inexact contract) — function exactness sits on the
+*opposite side* of the call contract from value exactness:
+
+- Object/tuple/union exactness is a property of the **value**: "this value
+  has no more than the declared shape." Widening to inexact loses
+  information but never grants new permissions.
+- Function exactness is a property of what **callers** are allowed to do:
+  "callers may not pass extra arguments." Widening an exact function to an
+  inexact type *grants callers a permission the underlying function never
+  agreed to honor*.
+
+Concretely:
+
+```
+declare val f: fn(a: A, b: B) -> R              // exact: rejects extras
+val g: fn(a: A, b: B, ...) -> R = f             // would advertise extras are okay
+g(1, 2, 3)                                       // type-checks, but f rejects it
+```
+
+We considered three resolutions:
+
+1. **Disallow the direction.** Subtyping requires arities to match; users
+   who genuinely want "exact function used where extras are silently
+   dropped" write a one-line wrapper (`fn(a, b, ...) => f(a, b)`) that
+   makes the lossy step explicit at the source.
+2. **Allow it, drop extras silently at runtime.** This is the TypeScript
+   status quo and is precisely what enables bugs like
+   `["1","2","3"].map(parseInt)` returning `[1, NaN, NaN]` — the bug exact
+   function types exist to prevent. Allowing this coercion would let any
+   exact function silently lose its protection at a widening site,
+   defeating the feature's purpose.
+3. **Allow it, insert a runtime arity check at the boundary.** Sound, but
+   pays a runtime cost in a system that otherwise compiles to zero-cost
+   TypeScript. Boundary wrappers also break referential equality, leak
+   into stack traces, and interfere with `.length` / `.name` /
+   `Function.prototype.bind`. Making the type system's behavior depend on
+   codegen is a smell.
+
+**We chose option 1.** The cases that need this coercion are rare and easy
+to handle explicitly with a wrapper, and the rule that results — "function
+arities must match exactly for subtyping" — is simple and memorable. The
+exact/inexact distinction on functions then governs call-site argument
+counts only, not function-to-function subtyping, keeping the soundness
+story tight.
+
+#### 4.2.2. Optional and Rest Parameters
+
+Optional parameters (`x?: T`) and typed rest parameters (`...xs: Array<T>`)
+remain compatible with both exact and inexact function types. An exact function
+with optional parameters still has a fixed *maximum* arity; an exact function
+with a typed rest parameter accepts any number of trailing arguments, but each
+extra must satisfy the rest element type.
+
+#### 4.2.3. Call-Site Checking
+
+At call sites, the checker enforces:
+
+- For an exact function type, the number of supplied arguments must be `>=` the
+  number of required parameters and `<=` the number of declared parameters
+  (counting optionals and any typed rest as documented).
+- For an inexact function type, the number of supplied arguments must be `>=`
+  the number of required parameters; there is no upper bound.
+
+#### 4.2.4. `Parameters<T>` and `infer` on Function Parameter Lists
+
+The standard `Parameters<T>` utility extracts the parameters of a function
+type as a tuple:
+
+```
+type Parameters<T : fn(...args: any) -> any> =
+    if T : fn(...args: infer P) -> any { P } else { never }
+```
+
+For this to produce the right tuple exactness, two rules apply:
+
+- **`infer` on a function parameter list captures the function's exactness
+  onto the resulting tuple.** When `T` is `fn(a: A, b: B) -> R` (exact),
+  `infer P` binds `P` to the exact tuple `[A, B]`. When `T` is
+  `fn(a: A, b: B, ...) -> R` (inexact), `infer P` binds `P` to the inexact
+  tuple `[A, B, ...]`.
+- **The matcher and the constraint must admit both exact and inexact
+  function types.** Function-type subtyping requires arities to match in
+  both directions (see §4.2.1.1), so a single fixed-exactness pattern
+  would cause the other exactness to fall to the `else` branch. The
+  pattern `fn(...args: infer P) -> any` and the constraint
+  `fn(...args: any) -> any` are therefore treated as exactness-agnostic
+  for matching and constraint-checking purposes — they accept either an
+  exact or an inexact function type, and the captured `infer P`
+  faithfully reflects which one it was.
+
+Consequently:
+
+```
+type F = fn(a: string, b: number) -> boolean         // exact
+type G = fn(a: string, b: number, ...) -> boolean    // inexact
+
+type PF = Parameters<F>    // exact [string, number]
+type PG = Parameters<G>    // inexact [string, number, ...]
+```
+
+Note that `Parameters` is a projection, not a subtyping bridge: even
+though `F` and `G` are not subtype-related as function types (§4.2.1.1),
+their parameter tuples `PF` and `PG` are related via the usual tuple
+rule `[string, number] <: [string, number, ...]`. This is intentional —
+the asymmetry on function-type subtyping reflects the call-contract
+direction, which a tuple of parameter types no longer carries.
+
+## 5. Union Types
+
+### 5.1. Motivation
+
+Exactness for unions captures whether the listed members are *all* the
+inhabitants of the type, or merely a known subset. This shows up in three
+places:
+
+1. **Keys of exact/inexact objects.** For an exact object `{x: number, y:
+   number}`, the type of `keyof` is the **exact** union `"x" | "y"`. For an
+   inexact object `{x: number, y: number, ...}`, `keyof` is the **inexact**
+   union `"x" | "y" | ...` (i.e. at least these, possibly more strings).
+2. **Values/element-types of exact/inexact tuples.** For an exact tuple
+   `[string, number]`, the union of its element types is the **exact**
+   `string | number`. For an inexact tuple `[string, number, ...]`, the union
+   of element types is the **inexact** `string | number | ...`.
+3. **`throws` clauses on function signatures.** If a function body is fully
+   wrapped in `try/catch` with a catch-all that re-throws a known set of
+   error types `E1 | E2`, the function's `throws` clause is the **exact**
+   union `E1 | E2` — those are *exactly* the errors it can throw. If the
+   checker cannot prove the catch is exhaustive (no catch-all, or the body
+   contains calls whose throws clauses are themselves inexact), the inferred
+   `throws` clause is the **inexact** union `E1 | E2 | ...`.
+
+### 5.2. Syntax
+
+```
+type ExactColor   = "red" | "green" | "blue"
+type InexactColor = "red" | "green" | "blue" | ...
+
+type ExactError   = IOError | ParseError
+type InexactError = IOError | ParseError | ...
+```
+
+- A bare union `T1 | T2 | ... | Tn` is **exact**: its inhabitants are exactly
+  the values in `T1 ∪ T2 ∪ ... ∪ Tn`, and nothing else.
+- A union ending in `| ...` is **inexact**: it contains *at least* the values
+  in those members, and possibly more values of unknown type (effectively
+  some unknown additional union members).
+
+### 5.3. Semantics
+
+```
+declare val a: ExactColor
+declare val b: InexactColor
+
+val x: InexactColor = a    // okay — exact widens to inexact
+val y: ExactColor = b      // Error — `b` may be a value outside the listed members
+```
+
+#### 5.3.1. Exhaustiveness Checking
+
+Pattern matching / `switch` on an **exact** union is exhaustive when every
+listed member is handled — no default arm is required:
+
+```
+fn name(c: ExactColor) -> string {
+    match c {
+        "red" => "Red",
+        "green" => "Green",
+        "blue" => "Blue",
+    }   // okay — exact union, all members covered
+}
+```
+
+For an **inexact** union, exhaustiveness requires a default arm because the
+runtime value may fall outside the listed members:
+
+```
+fn name(c: InexactColor) -> string {
+    match c {
+        "red" => "Red",
+        "green" => "Green",
+        "blue" => "Blue",
+        _ => "Unknown",      // required — `c` may be something else
+    }
+}
+```
+
+#### 5.3.2. `keyof` and Tuple Element Unions
+
+Exactness flows naturally from objects and tuples to the unions derived from
+them:
+
+```
+type Exact   = {x: number, y: number}
+type Inexact = {x: number, y: number, ...}
+
+type EK = keyof Exact      // exact union "x" | "y"
+type IK = keyof Inexact    // inexact union "x" | "y" | ...
+
+type ET = [string, number]
+type IT = [string, number, ...]
+
+type EV = ET[number]       // exact union string | number
+type IV = IT[number]       // inexact union string | number | ...
+```
+
+#### 5.3.3. `throws` Clauses
+
+A function's `throws` clause is a union type whose exactness reflects how
+much the checker knows:
+
+- **Exact `throws`:** The body is wholly enclosed in `try/catch` with a
+  catch-all clause, every `throw` reachable from the catch-all has a known
+  type, and every nested call's `throws` clause is itself exact (or its
+  errors are caught locally). The inferred `throws` is the exact union of
+  all error types that escape.
+- **Inexact `throws`:** Otherwise — there is at least one site that may
+  throw an error whose type the checker cannot pin down (e.g., a call to a
+  TypeScript-imported function with no `throws` annotation, or an
+  uncaught dynamic `throw`). The inferred `throws` is the inexact union of
+  all known error types.
+
+```
+fn parse(s: string) throws ParseError | IOError { ... }
+// Exact: parse only ever throws one of these two error types.
+
+fn loadConfig() throws ParseError | IOError | ... { ... }
+// Inexact: loadConfig is known to be able to throw at least these,
+// but may also throw something else (e.g., from an inexact callee).
+```
+
+A caller can rely on an exact `throws` clause to drive exhaustive `catch`
+matching. With an inexact `throws`, a catch-all is required.
+
+### 5.4. Type-Checking Rules
+
+For union types `A` and `B`:
+
+- **Exact <: Inexact:** An exact union `T1 | ... | Tn` is a subtype of any
+  inexact union that lists a (subtype-compatible) superset of those members.
+- **Inexact </: Exact:** An inexact union is *not* a subtype of an exact
+  union, because the inexact value may be a member outside the listed set.
+- **Exact <: Exact:** `A <: B` iff every member of `A` is a subtype of some
+  member of `B`. (Standard union subtyping; no extra arity rule beyond what
+  union subtyping already provides.)
+- **Inexact <: Inexact:** `A <: B` iff every *listed* member of `A` is a
+  subtype of some listed member of `B`, *and* `B`'s "unknown tail" is at
+  least as permissive as `A`'s. In practice, an inexact union is treated as
+  having an implicit `unknown`-like tail member, so `A` and `B` must both
+  permit unknown extras.
+
+### 5.5. Interop
+
+TypeScript has no notion of exact unions. A TypeScript union like
+`"red" | "green" | "blue"` is imported as the **inexact** union
+`"red" | "green" | "blue" | ...`. The reason: TypeScript allows widening
+into and out of unions via casts, index access on inexact objects, and
+assertions, so Escalier cannot prove the tighter "closed set" property
+holds across the boundary. Treating the imported union as exact would let
+downstream Escalier code rely on exhaustive `match` without a default arm,
+and that exhaustiveness would be silently wrong whenever the TypeScript
+side admits an out-of-set value at runtime.
+
+This applies to discriminated unions as well. For a TypeScript type like
+`{kind: "ok", value: number} | {kind: "err", error: string}`, the outer
+union is imported as inexact (so `match` on `kind` requires a default arm),
+and each member object type is also inexact per the existing
+object-import rule.
+
+When a user knows an imported union is actually closed (e.g. a generated
+type, a library they trust, or an enum-like definition), they can opt into
+exactness at the use site with the `Exact<T>` utility type:
+
+```
+import type { Color } from "some-ts-lib"     // inferred inexact
+type StrictColor = Exact<Color>              // opt-in to exact
+```
+
+Escalier-emitted `.d.ts` files preserve exactness via JSDoc annotations
+alongside declarations, so when one Escalier project consumes another
+Escalier project's emitted `.d.ts`, exact unions round-trip correctly. Only
+plain TypeScript-authored declarations (without those JSDoc annotations)
+fall back to the inexact default.
+
+### 5.6. Template Literal Types
+
+A template literal type is a derived union over the strings produced by
+substituting each hole with a value from its hole type. Its exactness is the
+**conjunction** of the exactnesses of its hole types:
+
+- If every hole is an exact union over a finite set of literal types, the
+  resulting set of strings is finite and known, so the template literal
+  type is **exact**.
+- If any hole is `string`, `number`, an inexact union, or any other type
+  with an unknown tail, the resulting set is open, so the template literal
+  type is **inexact**.
+
+```
+type Side = "left" | "right"                       // exact
+type Axis = "x" | "y" | "z"                        // exact
+type Pad  = `pad-${Side}`                          // exact: "pad-left" | "pad-right"
+type Var  = `--${Axis}`                            // exact: "--x" | "--y" | "--z"
+
+type AnySuffix = `pad-${string}`                   // inexact
+type Loose     = `--${"x" | "y" | "z" | ...}`      // inexact (hole is inexact)
+```
+
+This composes with the union rules above: an exact template literal type
+behaves like any other exact union for `match` exhaustiveness, `keyof`
+results, and the `Exact`/`Inexact` utility types.
+
+## 6. Utility Types
+
+Escalier provides two built-in utility types for converting between the exact
+and inexact forms of any type that has a notion of exactness (objects,
+tuples, functions, unions). They are dual: `Exact<T>` tightens, `Inexact<T>`
+loosens.
+
+### 6.1. `Exact<T>`
+
+`Exact<T>` produces the exact form of `T`. Its behavior depends on the kind
+of type `T`:
+
+- **Object types:** `Exact<{x: number, y: number, ...}>` is
+  `{x: number, y: number}`. The set of declared properties is preserved;
+  the trailing `...` is removed.
+- **Tuple types:** `Exact<[string, number, ...]>` is `[string, number]`.
+  The declared elements are kept; the trailing `...` is removed.
+- **Function types:** `Exact<fn(a: A, b: B, ...) -> R>` is
+  `fn(a: A, b: B) -> R`. Callers of the result may not pass extra
+  arguments.
+- **Union types:** `Exact<T1 | T2 | ...>` is `T1 | T2`. The trailing `...`
+  is removed; the result is a closed union.
+- **Already-exact types:** `Exact<T>` is `T` if `T` is already exact (and
+  not an interface or non-final class instance — see below).
+
+For types that **cannot be made exact** at the type level, `Exact<T>` is an
+error:
+
+- `Exact<I>` where `I` is an interface — interfaces are always inexact and
+  cannot be tightened (see the Interfaces subsection).
+- `Exact<C>` where `C` is a non-`final` class instance type — the openness
+  is part of the class's contract; declare the class `final` to obtain an
+  exact instance type instead.
+
+### 6.2. `Inexact<T>`
+
+`Inexact<T>` produces the inexact form of `T`. Its behavior is the dual of
+`Exact<T>`:
+
+- **Object types:** `Inexact<{x: number, y: number}>` is
+  `{x: number, y: number, ...}`.
+- **Tuple types:** `Inexact<[string, number]>` is `[string, number, ...]`.
+- **Function types:** `Inexact<fn(a: A, b: B) -> R>` is
+  `fn(a: A, b: B, ...) -> R`. Callers of the result may pass extra
+  arguments.
+- **Union types:** `Inexact<T1 | T2>` is `T1 | T2 | ...`.
+- **Already-inexact types:** `Inexact<T>` is `T` if `T` is already
+  inexact.
+
+`Inexact<T>` is total — it is defined for every kind of type that has an
+exactness notion, since loosening is always permitted.
+
+### 6.3. Examples
+
+```
+type StrictPoint = {x: number, y: number}
+type LoosePoint  = Inexact<StrictPoint>     // {x: number, y: number, ...}
+
+type LooseHeaders = {"content-type": string, ...}
+type StrictHeaders = Exact<LooseHeaders>    // {"content-type": string}
+
+type Pair        = [string, number]
+type LoosePair   = Inexact<Pair>            // [string, number, ...]
+
+type LooseColor  = "red" | "green" | "blue" | ...
+type StrictColor = Exact<LooseColor>        // "red" | "green" | "blue"
+
+// Round-tripping is the identity:
+type T1 = Exact<Inexact<StrictPoint>>       // StrictPoint
+type T2 = Inexact<Exact<LoosePoint>>        // LoosePoint
+```
+
+### 6.4. Interaction with Mapped Types
+
+`Exact` and `Inexact` distribute through mapped types and most utility
+types in the natural way:
+
+```
+type T = {x: number, y: number, ...}
+type P = Partial<T>                  // {x?: number, y?: number, ...}
+type EP = Exact<P>                   // {x?: number, y?: number}
+```
+
+For container generics, `Exact` and `Inexact` apply only to the top-level
+type, not recursively into the element type. To tighten or loosen nested
+types, compose explicitly:
+
+```
+type T = Array<{x: number, ...}>
+type T2 = Array<Exact<{x: number, ...}>>   // Array<{x: number}>
+```
+
+A deep variant could be added later (e.g. `DeepExact<T>` / `DeepInexact<T>`)
+if a real need emerges; we do not provide one initially.
+
+### 6.5. TypeScript Interop
+
+`Exact<T>` and `Inexact<T>` are Escalier-only constructs. When emitting
+`.d.ts` files:
+
+- The result type (after applying `Exact`/`Inexact`) is what's emitted as a
+  plain TypeScript type — TypeScript itself has no notion of exactness, so
+  the `Exact<...>` / `Inexact<...>` wrapper is erased.
+- The original Escalier form is preserved in the JSDoc annotation alongside
+  the declaration so that other Escalier consumers can recover the precise
+  exactness.
+
+## 7. Type Operators and Exactness Propagation
+
+Most type-level operators produce types whose exactness is *derived* from
+their inputs rather than declared independently. This section spells out
+the propagation rules for each operator so they don't need to be reasoned
+out from first principles each time.
+
+### 7.1. `keyof T`
+
+The exactness of `keyof T` matches the exactness of `T`'s key set:
+- `keyof` of an exact object type is an **exact** union of literal-string
+  keys.
+- `keyof` of an inexact object type, an interface, a namespace, or a
+  non-`final` class instance type is an **inexact** union (those types
+  admit unknown additional keys).
+- `keyof` of an exact tuple is the exact union of its valid index literals
+  plus `Array` member keys; `keyof` of an inexact tuple is inexact.
+
+### 7.2. `typeof v`
+
+`typeof v` produces the inferred type of the expression `v`, with whatever
+exactness that inference yields. There is no exactness adjustment performed
+by the operator itself.
+
+### 7.3. Indexed access `T[K]`
+
+The exactness of `T[K]` follows from `T`:
+- `Exact[K]` where `Exact` is an exact tuple yields a value type whose
+  surrounding union (when `K` is a union of indices) is exact.
+- `Inexact[K]` where `Inexact` is an inexact tuple yields an inexact
+  union, because the unknown tail elements contribute unknown member
+  types.
+- `T[K]` for object types follows the same pattern: exact object →
+  result-of-projection is exact in the same sense; inexact object → the
+  projected union admits unknown member contributions.
+
+### 7.4. Conditional types `if T : U { X } else { Y }`
+
+The conditional type operator does not introduce or remove exactness on
+its own. Exactness affects conditional types in three ways: (1) which
+branch is taken, (2) how the chosen branch's exactness flows out, and
+(3) how distribution behaves over union `T`.
+
+#### 7.4.1. Which branch is taken
+
+A conditional asks "is `T` a subtype of `U`?" using the same subtyping
+rules as everywhere else. Exactness on `T` and `U` therefore changes
+branch selection through the asymmetric rules already documented:
+
+- **Exact `<:` inexact** holds for objects, tuples, and unions, so an
+  exact `T` will satisfy `T : U` whenever `U` is the inexact form of the
+  same shape:
+  ```
+  type T = {x: number, y: number}            // exact
+  type U = {x: number, y: number, ...}       // inexact
+
+  if T : U { X } else { Y }                  // takes the X branch
+  ```
+- **Inexact `</:` exact** does *not* hold, so an inexact `T` will not
+  satisfy `T : U` when `U` is exact, even if their declared shapes match:
+  ```
+  type T = {x: number, y: number, ...}       // inexact
+  type U = {x: number, y: number}            // exact
+
+  if T : U { X } else { Y }                  // takes the Y branch
+  ```
+- **Function types are a special case.** Because function-type subtyping
+  requires matching exactness in *both* directions (see the function
+  subtyping section), a conditional comparing two function types of
+  mismatched exactness always takes the false branch — even when the
+  parameter and return types align.
+
+#### 7.4.2. How the result's exactness is determined
+
+The exactness of the conditional's result comes from the chosen branch
+(`X` or `Y`), not from `T`. There is no "result inherits `T`'s exactness"
+rule.
+
+```
+type Wrap<T> = if T : object { Box<T> } else { never }
+// Result exactness comes from Box<T> or never, not from T's exactness.
+```
+
+`T`'s exactness only flows into the result when `X` or `Y` references
+`T` (or binds it via `infer`):
+
+```
+type Id<T> = if T : unknown { T } else { never }
+// If T is exact, the result is exact. If T is inexact, the result is inexact —
+// because the X branch literally is T.
+
+type Elem<T> = if T : Array<infer E> { E } else { never }
+type A = Elem<Array<{x: number}>>          // E is exact {x: number}
+type B = Elem<Array<{x: number, ...}>>     // E is inexact {x: number, ...}
+```
+
+#### 7.4.3. Distribution over unions
+
+When `T` is a union, the conditional distributes over its members and
+each distributed result has the exactness of its branch:
+
+```
+type Foo<T> = if T : string { "yes" } else { "no" }
+
+type R1 = Foo<"a" | "b">             // exact — distributes to "yes" | "yes" = "yes"
+type R2 = Foo<"a" | "b" | ...>       // inexact — distributes over known members,
+                                     // tail handled conservatively
+```
+
+For an inexact `T`, distribution can only enumerate the listed members.
+The unknown tail must be handled conservatively — typically by widening
+the result to include both branches, or by leaving an inexact result.
+
+#### 7.4.4. Constraints on `T` simplify the picture
+
+Adding a constraint on `T` at the type-parameter level pre-filters what
+arguments are admissible and can collapse the conditional entirely:
+
+```
+type Foo<T : string> = if T : string { "yes" } else { "no" }
+```
+
+With `T : string` enforced at the call site:
+
+- An **exact** union of string literals like `"a" | "b"` satisfies the
+  constraint — all members are subtypes of `string`.
+- An **inexact** union like `"a" | "b" | ...` does *not* satisfy the
+  constraint, because the `...` tail represents members of unknown type
+  which are not proven to be subtypes of `string`. Such a call is
+  **rejected at the call site**.
+
+Once inside `Foo<T>`, the conditional check `T : string` is redundant —
+the constraint guarantees it holds for every admissible `T`. So
+`Foo<T>` reduces to `"yes"` for every legal argument:
+
+| `T` | Admissible under `T : string`? | Result |
+|---|---|---|
+| `"a" \| "b"` (exact) | yes | `"yes"` |
+| `"a" \| "b" \| ...` (inexact, tail unconstrained) | **no — call-site error** | n/a |
+| `string` | yes | `"yes"` |
+| `number` | no — fails constraint | n/a |
+
+This is generally the right way to write conditional generics over
+exactness: a sufficiently strong constraint on `T` removes the "unknown
+extras" worry from the body of the conditional and pushes it up to the
+call site, where it's enforced as a constraint check rather than handled
+defensively inside the conditional.
+
+### 7.5. Mapped types `{[K]: T[K] for K in keyof T}`
+
+Already covered in the **Mapped Elements** subsection: the exactness of
+the resulting object type is determined by the exactness of the
+constraint `Keys`. Exact constraint → exact result; inexact constraint →
+inexact result. (As always, the result can still be forced inexact by
+other elements in the surrounding object type.)
+
+### 7.6. Union types `A | B`
+
+A union preserves exactness per branch:
+
+- Combining two exact union types yields an exact union.
+- Combining any inexact union with anything yields an inexact union.
+- A heterogeneous union like `Exact1 | Exact2` remains a union of two
+  exact types — there is no "merging" that loses per-branch exactness.
+
+### 7.7. Intersection types `A & B`
+
+Intersection inherits exactness from its operands per kind:
+
+- **Object types:** The intersection of two exact object types is exact
+  and contains exactly the union of their declared property names.
+  Intersecting an exact type with an inexact type produces an exact type
+  if the inexact type's declared properties are a subset of the exact
+  type's declared properties; otherwise it is an error (the extra
+  inexact properties cannot be present in an exact value).
+- **Union types:** Intersection distributes over unions as usual; the
+  result's exactness is the conjunction (exact only if both operands are
+  exact and the resulting member set is fully determined).
+- **Across kinds** (e.g. primitive `&` object): the result inherits
+  exactness from the object operand.
+
+### 7.8. Narrowing
+
+Type guards narrow union members the same way regardless of exactness,
+but the *residual* union after narrowing preserves the original
+exactness. Narrowing an exact union by removing a known member yields an
+exact union; narrowing an inexact union still leaves the unknown tail.
+
+### 7.9. Utility types
+
+Built-in utility types preserve exactness in the natural way: the result
+of `Partial<T>`, `Readonly<T>`, `Pick<T, K>`, or `Omit<T, K>` over an
+exact type is exact; the result over an inexact type is inexact. (See
+the **Utility Types** section for `Exact<T>` / `Inexact<T>` themselves,
+which deliberately *change* exactness.)
+
+### 7.10. Type aliases and references
+
+`type Foo = T` and references to `Foo` carry whatever exactness `T` has.
+Aliasing is purely a naming layer and does not adjust exactness.
+
+### 7.11. `MutType`
+
+Mutability is orthogonal to exactness. `mut T` carries the exactness of
+`T`; `mut` neither tightens nor loosens.
+
+### 7.12. Special types
+
+- `never`, `unknown`, `any`, and `void` have no notion of arity and
+  therefore no exactness distinction. They behave as the absorbing or
+  identity elements documented in the intersection/union sections (e.g.
+  `never & T = never`, `unknown & T = T`, `any & T = any`).
+- `PrimType`, `LitType`, `UniqueSymbolType`, and `RegexType` are
+  single-inhabitant or single-kind primitive types with no arity, and
+  therefore no exact/inexact variants.
+
+## 8. Defaults and Migration
+
+- **All newly written object, tuple, function, and union types in Escalier
+  source are exact by default.** Inexactness must be explicitly opted into
+  with `...`.
+- **All types imported from TypeScript** (whether via `.d.ts` files or
+  declarations without Escalier-specific JSDoc annotations) are treated as
+  **inexact** for all four categories — including unions. TypeScript has no
+  notion of an exact/closed union, and admits widening through casts, index
+  access, and assertions, so Escalier cannot prove the closed-set property
+  holds across the boundary. This default preserves TypeScript's permissive
+  behavior across the package boundary and avoids spurious errors when
+  calling into TypeScript libraries. Users who know an imported type is
+  actually closed can opt into exactness at the use site with `Exact<T>`.
+- **Round-tripping:** As described in the original `07_exact_types.md`, when
+  Escalier emits `.d.ts` files for consumption by other Escalier projects, it
+  should preserve exactness via JSDoc annotations on declarations. TypeScript
+  consumers will see the (inexact) erased form; Escalier consumers will
+  recover the precise exactness.
+
+## 9. TypeScript Interop
+
+- Exact object types are emitted as plain TypeScript object types
+  (`{ x: number, y: number }`), losing the exactness annotation. A JSDoc
+  comment carries the original Escalier type for round-trip preservation.
+- Exact tuple types are emitted as plain TypeScript tuple types
+  (`[string, number]`), again with a JSDoc annotation for round-tripping.
+- Exact function types are emitted as plain TypeScript function types. The
+  JSDoc annotation marks the exactness so other Escalier consumers can
+  reconstruct the original type and enforce the arity check.
+- Inexact types are emitted as their natural TypeScript equivalents:
+  `{ x: number, [k: string]: unknown }` for objects (or simply
+  `{ x: number }` if a more faithful encoding is not needed), tuples with a
+  trailing `...Array<unknown>` for tuples, and functions with no arity
+  enforcement.
+
+## 10. Examples
+
+### 10.1. Object: Exhaustive Property Iteration
+
+```
+type Point = {x: number, y: number}     // exact
+val p: Point = {x: 1, y: 2}
+
+for k in Object.keys(p) {
+    // k: "x" | "y" — known precisely because Point is exact
+    console.log(k, p[k])
+}
+```
+
+### 10.2. Tuple: Exact-Arity Pair
+
+```
+type Pair = [string, number]            // exact
+
+fn first(p: Pair) -> string {
+    return p[0]
+}
+
+first(["a", 1])           // okay
+first(["a", 1, true])     // Error — extra element on exact tuple
+```
+
+### 10.3. Function: Forbidding Extra Callback Arguments
+
+A common JavaScript pitfall: `["1", "2", "3"].map(parseInt)` returns
+`[1, NaN, NaN]` because `parseInt` accepts a second `radix` argument and
+`Array.prototype.map` passes the index. With exact function types, the type
+of `parseInt` would be `fn(s: string, radix?: number) -> number` (exact), and
+`Array.prototype.map`'s callback parameter could require an exact unary
+function:
+
+```
+declare fn map<T, U>(arr: Array<T>, f: fn(item: T) -> U) -> Array<U>
+
+map(["1", "2", "3"], parseInt)
+// Error — parseInt's exact arity (1 or 2) doesn't match exact unary `fn(item: T) -> U`
+```
+
+### 10.4. Mixed: An Inexact Object as a Bag
+
+```
+type Headers = {
+    "content-type": string,
+    "content-length": number,
+    ...                            // explicitly inexact: other headers are allowed
+}
+
+val h: Headers = {
+    "content-type": "text/plain",
+    "content-length": 11,
+    "x-custom": "ok",              // okay — inexact permits extras
+}
+```
+
+## 11. Open Questions
+
+1. **Index signatures and exactness.** How does an explicit index signature
+   (`{[k: string]: T}`) interact with exactness? Probably an index signature
+   implies inexactness, but this should be specified.
+2. **Generic constraints.** When a type parameter `T` is constrained by an
+   exact type, can `T` be substituted with an inexact subtype? Likely no
+   (exact constraint forces exact arguments), but this should be specified
+   alongside variance rules.

--- a/planning/exact-types/requirements.md
+++ b/planning/exact-types/requirements.md
@@ -472,6 +472,17 @@ caller may pass — not subtyping between function types themselves.
   so the supplier just needs to handle at least the parameters the
   consumer's contract requires.
 
+**Optional parameters are part of the declared parameter list.** For
+the arity-matching rules above, a function type `fn(a: A, b?: B) -> R`
+has declared parameter list `[a: A, b?: B]` — *not* `[a: A]`. It is
+therefore neither a subtype nor a supertype of `fn(a: A) -> R` under
+exact-to-exact subtyping (declared lists differ), and only inexact
+suppliers with declared list `[a: A]` (or fewer) fit an inexact slot
+whose declared list is `[a: A, b?: B]`. This rule applies uniformly to
+both `Exact <: Exact` and `Inexact <: Inexact`: the optionality marker
+is structural identity of the function type, not a deletion the type
+system silently performs. (See §4.2.1.2 for a worked example.)
+
 ##### 4.2.1.1. Why exact `</:` inexact for functions
 
 Unlike object, tuple, and union types — where exact `<:` inexact is
@@ -520,6 +531,195 @@ arities must match exactly for subtyping" — is simple and memorable. The
 exact/inexact distinction on functions then governs call-site argument
 counts only, not function-to-function subtyping, keeping the soundness
 story tight.
+
+##### 4.2.1.2. A worked example: chained widenings in TypeScript
+
+The principled argument above is best illustrated by a concrete program
+that is sound in Escalier but silently miscompiles in TypeScript. The
+following TypeScript code type-checks and runs without errors, yet
+exhibits a runtime type confusion:
+
+```ts
+function foo(cb: (a: string) => void) {
+    bar(cb);
+}
+
+function bar(cb: (a: string, b: number) => void) {
+    cb("hello", 5);
+}
+
+function cb(a: string, b?: boolean) { /* uses b as a boolean */ }
+
+foo(cb);
+// At runtime, the original `cb` is invoked with ("hello", 5).
+// `b` is bound to the number `5`, but the body trusts `b: boolean`.
+```
+
+The unsoundness chain has three steps:
+
+1. `foo(cb)` — TS allows `(a: string, b?: boolean) => void` to flow into
+   `(a: string) => void` because TS treats the trailing optional as
+   droppable.
+2. `bar(cb)` (inside `foo`) — TS allows `(a: string) => void` to flow
+   into `(a: string, b: number) => void` via the classic "fewer-args is
+   fine" bivariance.
+3. `bar` calls `cb("hello", 5)`. The original `cb`'s `b: boolean`
+   parameter is bound to the number `5`. No runtime error; downstream
+   computations on `b` produce silent garbage.
+
+The literal Escalier translation rejects this at **step 1**:
+
+```
+fn foo(cb: fn(a: string) -> undefined) {
+    bar(cb)
+}
+fn bar(cb: fn(a: string, b: number) -> undefined) {
+    cb("hello", 5)
+}
+fn cb(a: string, b?: boolean) -> undefined { ... }
+
+foo(cb)
+// Error: cb's declared parameter list is [a: string, b?: boolean], which
+// does not match foo's slot [a: string]. Per §4.2.1, exact-to-exact
+// subtyping requires arities to match, with optionality preserved.
+```
+
+The presence of the optional `b` is structural identity of `cb`'s type,
+not a deletion the type system silently performs. Even if step 1 had
+let it through, step 2 would also reject: `fn(a: string) -> undefined`
+has arity 1; `bar`'s slot has arity 2; §4.2.1.1 forbids fewer-args
+bivariance.
+
+###### Variations that look promising but still fail
+
+A reader might try to "rescue" the chain by introducing inexact slots
+or explicit `Inexact<T>` widenings. None of them succeed; each falls to
+a different rule.
+
+**Variation A — inexact slot at `foo`, exact `cb`:**
+
+```
+fn foo(cb: fn(a: string, ...) -> undefined) { bar(cb) }
+foo(cb)
+// Error: exact </: inexact for functions (§4.2.1.1).
+```
+
+**Variation B — inexact slot at `foo`, user widens with `Inexact<T>`:**
+
+```
+fn foo(cb: fn(a: string, ...) -> undefined) { bar(cb) }
+foo(Inexact(cb))
+// Error: Inexact(cb) has declared list [a, b?]; foo's slot has [a].
+// Inexact-to-inexact subtyping requires supplier_arity <= slot_arity
+// (§4.2.1); here the supplier has more declared parameters.
+```
+
+**Variation C — inexact slot at `foo` with matching arity:**
+
+```
+fn foo(cb: fn(a: string, b: number, ...) -> undefined) { bar(cb) }
+foo(Inexact(cb))
+// Error: parameter-type contravariance fails at position 1.
+// Slot demands b: number; supplier offers b?: boolean. number </: boolean.
+```
+
+**Variation D — both `foo` and `bar` inexact, all arities aligned:**
+
+```
+fn foo(cb: fn(a: string, b: number, ...) -> undefined) { bar(cb) }
+fn bar(cb: fn(a: string, b: number, ...) -> undefined) { cb("hello", 5) }
+foo(Inexact(cb))
+// Error: same contravariance failure at position 1.
+```
+
+The parameter-type check at position 1 (`number` vs `boolean`) is the
+ultimate backstop. Even when the user systematically loosens every
+slot to inexact and explicitly widens with `Inexact<T>`, the
+contravariant check on the declared parameter types preserves the
+soundness invariant.
+
+##### 4.2.1.3. Anti-patterns that undermine the soundness story
+
+The §4.2.1.2 analysis shows that pure Escalier source cannot reproduce
+the TypeScript unsoundness. The remaining ways to introduce the
+runtime bug all involve the user explicitly opting out of type
+safety. These are anti-patterns, and code review should flag them.
+
+**A1. `any` in callback parameter types.**
+
+```
+fn cb(a: string, b?: any) -> undefined {
+    if b { ... }   // body treats b as a boolean
+}
+```
+
+Once `b: any` is in the type, contravariance trivially succeeds at every
+boundary (everything `<:` `any`), and the chained-widening unsoundness
+becomes reachable. The escape is not specific to exact types — `any`
+disables every check — but the function-typing rules' soundness
+guarantees no longer apply once it is introduced. **Prefer `unknown`
+plus an explicit narrowing**, which forces the unsafe step to be
+visible at the source.
+
+**A2. Intersection types that promise overloads the implementation
+does not honor.**
+
+```
+val cb: (fn(a: string) -> undefined) & (fn(a: string, b: number) -> undefined)
+    = realImpl                            // realImpl is fn(a, b?: boolean)
+```
+
+A function intersection (§7.7) is a *promise* that the value handles
+each listed arm correctly. Annotating an implementation with an
+intersection it does not actually satisfy is a lie that the type
+system cannot independently verify. The runtime confusion that
+follows is the user's annotation, not a gap in the exactness rules.
+**Construct intersection-typed values only from implementations that
+genuinely handle every arm**, or use a single accurate signature.
+
+**A3. Unverified `.d.ts` declarations from third-party packages.**
+
+A TypeScript-authored `.d.ts` whose declared signature does not match
+its JavaScript implementation can carry the runtime unsoundness into
+Escalier regardless of how carefully the Escalier-side types are
+written. The standard exact/inexact import defaults (§8) cannot
+detect this. **When importing from plain TypeScript, treat the
+declared signature as a claim that requires the same scrutiny as any
+other unverified input.** When the implementation is known to differ
+from the declaration, narrow the declaration to match the implementation
+(via a local override or a wrapper) rather than trusting the published
+type.
+
+**A4. `Inexact<T>` as a habit rather than an interop tool.**
+
+`Inexact<T>` (§6.2) exists for the rare cases where a callback genuinely
+must be passed to a TypeScript API that types it inexact. Using it
+reflexively — for example, to silence a type error without
+understanding why the exact type was rejected — re-introduces exactly
+the widening the §4.2.1.1 argument exists to prevent (modulo the
+parameter-type contravariance check, which remains in force).
+**Reach for `Inexact<T>` only when interop forces it, and prefer a
+hand-written wrapper** (`fn(a, ...) => cb(a)`) when the lossy step
+deserves to be visible at the source. This is the same widening pattern
+recommended in §4.2.1.1 (an exact callable exposed through an
+inexact-facing slot) — the wrapper makes the arity narrowing explicit
+at the source rather than implicit at the type-system level.
+
+**A5. `any`-typed callback parameters in Escalier-authored
+`.d.ts`-equivalents.**
+
+When emitting `.d.ts` for downstream Escalier consumers, the
+`@escalier-type` JSDoc tag carries the original Escalier type
+(§9). Any `any` introduced into a published signature defeats the
+soundness story for every consumer, not just the author. Treat
+published `any` in function types as a soundness-breaking commitment
+that should not be made lightly.
+
+In short: the function-typing rules in §4.2.1 are sound *with respect
+to fully-typed Escalier source*. Each anti-pattern above is a way the
+user explicitly tells the type system "don't check this," and each
+re-opens the door to the bug `parseInt`-in-`map` and the
+optional-trailing-param example were designed to close.
 
 #### 4.2.2. Optional and Rest Parameters
 
@@ -959,6 +1159,183 @@ if a real need emerges; we do not provide one initially.
   declaration so that other Escalier consumers can recover the precise
   exactness. See §9.
 
+### 6.6. Value-Level Conversion: `exact<T>(v)`
+
+The `Exact<T>` / `Inexact<T>` utilities in §6.1 and §6.2 are
+*type-level* operators — they change a type without producing any
+runtime code. Sometimes a program also needs to convert a *value* from
+the inexact form to the exact form (e.g. to call into Escalier code
+that requires an exact-typed argument with a TS-imported inexact
+value). This subsection specifies a built-in `exact<T>(v)` operator
+for that purpose, and explicitly documents the categories where it is
+*not* available.
+
+#### 6.6.1. Semantics by category
+
+`exact<T>(v)` is a compile-time-resolved built-in. The checker
+inspects the target type `T`, validates that the input type `typeof v`
+is the corresponding inexact form (or already exact), and lowers the
+call to the appropriate runtime expression. There is no generic
+"convert anything" implementation — each category gets its own
+lowering, and some categories have no lowering at all.
+
+| Category | Lowering | Cost |
+|---|---|---|
+| Object | Property pick into a fresh object: `{ k1: v.k1, ..., kn: v.kn }` | One allocation, `O(n)` in declared keys |
+| Tuple | `v.slice(0, n)` (where `n` is the declared length) | One allocation, `O(n)` |
+| Union (discriminable) | A `match` over the listed members, emitting a `RuntimeError` for unhandled tails | `O(1)` per call (one discrimination check) |
+| Function | **Not supported** — compile error directs the user to a manual wrapper. See §6.6.3. |
+
+##### Runtime type information
+
+`exact<T>(v)` is deliberately designed not to depend on reified
+types. The object and tuple lowerings are pure property access and
+slicing — the declared keys and length are known to the compiler from
+`T`, so the emitted JavaScript only manipulates values it can already
+see. No type tags or runtime type descriptors are introduced.
+
+The union lowering does require some runtime cooperation, but only
+in the form of mechanisms JavaScript already exposes: value equality
+for primitive-literal unions, discriminator-field equality for
+tagged unions, and `instanceof` for unions of class instances. The
+checker selects the appropriate discrimination strategy from `T`'s
+structure and emits the corresponding JS check. Each strategy uses
+ordinary JS values (string literals, the class objects themselves)
+rather than a separate runtime type system.
+
+| Union shape | Discrimination strategy | Example |
+|---|---|---|
+| Primitive literals (`"a" \| "b" \| ...`, `1 \| 2 \| ...`, `true \| false \| ...`) | Value equality (`v === "a"`) | exact color, exact bit flag |
+| Discriminated objects (`{kind: "ok", ...} \| {kind: "err", ...}`) | Discriminator-field equality (`v.kind === "ok"`) | Result types, tagged AST nodes |
+| Class instances (`Circle \| Square`) where each member is a `final` class instance type | `instanceof` against the class object (`v instanceof Circle`) | enum variants (§2.6.1), exception hierarchies |
+| Mixed primitive/class (`string \| Date \| RegExp`) | `typeof` for primitives, `instanceof` for the rest | rarely needed, but supported |
+
+Unions whose members can only be told apart by **structural property
+shape** — e.g., `{x: number} | {y: string}` with no shared discriminator
+— are **rejected at compile time**. JavaScript has no built-in way to
+inspect arbitrary structural shapes at runtime, and adding one would
+require exactly the reified-type machinery the rest of this design
+avoids. Users in this position must either add a discriminator field
+to their union members or write a manual converter with explicit
+predicates.
+
+Examples:
+
+```
+val inexactPoint: {x: number, y: number, ...} = importedFromTS()
+val p: {x: number, y: number} = exact(inexactPoint)
+// lowers to: val p = { x: inexactPoint.x, y: inexactPoint.y }
+
+val inexactPair: [string, number, ...] = importedFromTS()
+val pair: [string, number] = exact(inexactPair)
+// lowers to: val pair = inexactPair.slice(0, 2)
+
+val inexactColor: "red" | "green" | "blue" | ... = importedFromTS()
+val color: "red" | "green" | "blue" = exact(inexactColor)
+// lowers to: val color = match (inexactColor) {
+//     "red" => "red", "green" => "green", "blue" => "blue",
+//     _ => throw RuntimeError("exact: value outside listed members"),
+// }
+```
+
+For object and tuple lowerings, extras present on the input are
+silently dropped: an inexact object with a `z` property converted to
+exact `{x, y}` produces an object without `z`. This matches the §6.1
+*type-level* semantics — `Exact<T>` over an inexact type removes the
+trailing `...`, not the extra members the runtime value happened to
+carry. For union lowerings, the runtime error makes the alternative
+explicit: an inexact value that does not match any listed member
+throws rather than silently slipping through.
+
+#### 6.6.2. Conditions on `T` and `v`
+
+For `exact<T>(v)` to type-check:
+
+- `T` must be in a category where the operator has a lowering (object,
+  tuple, or union — see §6.6.3 for the excluded categories).
+- `typeof v` must be assignable to `Inexact<T>`. In particular, `v`
+  must have at least the declared members of `T` (with each
+  member-type covariantly compatible). For unions, every listed member
+  of `T` must be assignable to some listed member of `v`'s type.
+- `T` must itself be a concrete enough shape that the lowering has
+  something to enumerate. `exact<Inexact>(v)` (with `Inexact` being a
+  pure interface or non-`final` class instance type) is rejected —
+  there is no closed set of members to pick.
+- **For union targets:** every listed member of `T` must be
+  *discriminable at runtime* using one of the strategies in §6.6.1
+  (value equality for primitive literals, discriminator-field equality
+  for tagged objects, or `instanceof` for `final` class instance
+  types). Unions whose members can only be told apart by structural
+  property shape are rejected — JavaScript has no general way to
+  inspect arbitrary structural shapes at runtime, and `exact<T>(v)`
+  is designed not to introduce reified-type machinery to fill that
+  gap.
+
+If `T` is already exact, `exact<T>(v)` is the identity: the checker
+emits `v` unchanged. This is convenient for generic code that should
+not have to case-split on whether the input type happens to be exact
+or inexact.
+
+#### 6.6.3. Why functions are excluded
+
+Function types have no `exact<...>` lowering for the same reason
+§4.2.1.1 rejects the implicit exact `<:` inexact widening: converting
+an inexact function to an exact one is either **unsafe** (a pure type
+cast that re-introduces the `parseInt`-style bug) or **expensive** (a
+runtime arity-check wrapper that breaks referential equality, mutates
+`.length` / `.name`, and adds a stack frame). Neither option is
+acceptable as a built-in.
+
+Users who need this conversion at a specific interop site should
+write the wrapper explicitly:
+
+```
+declare val f: fn(a: A, b: B, ...) -> R   // inexact, from TS interop
+
+val g: fn(a: A, b: B) -> R = fn(a, b) => f(a, b)
+// g calls f with exactly two args; if f's underlying implementation
+// looked at a third positional arg, it now reliably receives undefined.
+```
+
+The explicit wrapper has the same runtime cost as a boundary check
+would, but the cost is *visible at the source* — the reader can see
+that arity narrowing is happening and can reason about whether `f`'s
+behavior on `(a, b, undefined)` is what they want. The hidden
+`exact<...>` form would silently impose the same wrapper everywhere
+without surfacing the soundness-relevant question.
+
+The class instance form is excluded for the same reason expressed in
+type-level terms (§6.1): a non-`final` class instance type cannot be
+tightened because the class's openness is part of its public contract.
+Declare the class `final` if you need exact instance types.
+
+#### 6.6.4. TypeScript interop
+
+`exact<T>(v)` has no TypeScript equivalent. When emitting `.d.ts`,
+calls to `exact<...>` are erased to their lowered form — TypeScript
+consumers see the property-pick / slice / match expression directly,
+with the inexact-to-exact step recorded only in the `@escalier-type`
+JSDoc payload (§9). Escalier consumers re-importing the declaration
+recover the original `exact<T>(v)` form.
+
+A common pattern at the TS-interop boundary: wrap an imported value
+once at the boundary and pass the exact form through the rest of the
+program.
+
+```
+import { getConfig } from "some-ts-lib"
+// `getConfig` declared as returning {host: string, port: number}
+// (imported as inexact per §8).
+
+fn loadConfig() -> {host: string, port: number} {
+    return exact(getConfig())
+}
+```
+
+The boundary `exact(...)` makes the trust decision explicit at the
+source — every downstream consumer of `loadConfig` works with a
+genuinely exact value, with no further conversion needed.
+
 ## 7. Type Operators and Exactness Propagation
 
 Most type-level operators produce types whose exactness is *derived* from
@@ -1083,20 +1460,68 @@ The general rule, of which §4.2.4 is the function-pattern instance:
 
 #### 7.4.3. Distribution over unions
 
-When `T` is a union, the conditional distributes over its members and
-each distributed result has the exactness of its branch:
+When `T` is a union, the conditional distributes over its members:
+each listed member is checked against `U` individually, and the
+per-member results are unioned.
+
+For an **exact** union, every member is enumerated by name, so the
+distribution is complete:
 
 ```
 type Foo<T> = if T : string { "yes" } else { "no" }
 
-type R1 = Foo<"a" | "b">             // exact — distributes to "yes" | "yes" = "yes"
-type R2 = Foo<"a" | "b" | ...>       // inexact — distributes over known members,
-                                     // tail handled conservatively
+type R1 = Foo<"a" | "b">             // exact: "yes" | "yes" = "yes"
 ```
 
-For an inexact `T`, distribution can only enumerate the listed members.
-The unknown tail must be handled conservatively — typically by widening
-the result to include both branches, or by leaving an inexact result.
+The exactness of the result follows the standard union-combining
+rules (§7.6): if every distributed branch result is exact, the
+overall result is exact.
+
+For an **inexact** union `M1 | ... | Mn | ...`, distribution can
+enumerate only the listed members `M1..Mn`. The unknown tail is
+`unknown`-typed (§5.2), and for any `U` other than `unknown` the
+predicate `unknown : U` is **undecidable** — the tail may at runtime
+contain values that satisfy `U` (sending them to the `Then` branch)
+or values that do not (sending them to the `Else` branch).
+
+The checker handles this conservatively by **widening the tail's
+contribution to include both branch results** and **marking the
+overall result inexact**. Concretely, the distributed type is:
+
+```
+Distributed(M1) | ... | Distributed(Mn) | Then | Else | ...
+```
+
+where `Then` and `Else` are the conditional's branch result types
+(evaluated at the worst-case input for any `T`-dependent
+computation in the branch — typically `unknown` for `infer`-bound
+positions). The trailing `...` records that conservative widening
+occurred and that downstream consumers cannot rely on the result
+being a closed set even when `Then` and `Else` are themselves exact.
+
+```
+type R2 = Foo<"a" | "b" | ...>       // inexact: "yes" | "no" | ...
+                                     //   "yes" — distributed from "a" and "b"
+                                     //   "no"  — Else branch widened for the
+                                     //           undecidable unknown tail
+                                     //   ...   — marker that widening occurred
+```
+
+##### Exactness rule for conditional results
+
+The conditional's result is **exact** iff *both* of the following hold:
+
+1. The predicate `T : U` is decidable for every member of `T`
+   (including the unknown tail, if any).
+2. Each contributing branch's result type is itself exact.
+
+Otherwise the result is **inexact**. For an exact `T`, condition (1)
+is automatic — every member is named and the predicate is decided
+per-member. For an inexact `T`, condition (1) holds only when `U` is
+`unknown` (so the tail trivially routes to `Then`) or under a
+sufficiently strong constraint on `T` at the type-parameter level
+(§7.4.4) that prevents inexact arguments from reaching the
+conditional in the first place.
 
 #### 7.4.4. Constraints on `T` simplify the picture
 
@@ -1354,7 +1779,538 @@ val h: Headers = {
 }
 ```
 
-## 11. Open Questions
+## 11. `std:*` and `dom:*` Module Adjustments
+
+Exact function types change what idiomatic JavaScript APIs look like when
+wrapped for Escalier. Several built-in JS APIs invoke their callbacks with
+"bonus" arguments that are rarely used in practice and that, under
+TypeScript's permissive callback compatibility, enable bugs like
+`["1","2","3"].map(parseInt)`. With exact callbacks, those bonus arguments
+become a usability problem: either every callback must declare every
+parameter, or we relax to inexact and lose the safety guarantee.
+
+The resolution is to design the `std:*` (and where relevant, `dom:*`)
+wrappers around **exact, minimal callback signatures**, and to expose
+secondary methods for the less common cases where the extra arguments are
+genuinely wanted. The runtime cost is zero — extras are dropped at the JS
+boundary as they already are today — and the type-level cost is one extra
+method per affected operation.
+
+### 11.1. `std:array`
+
+The iteration methods on `std:array` follow the split below. Each `map`-
+style method takes an **exact unary** callback; the `-i` variant takes an
+exact binary callback that also receives the index.
+
+| Method | Callback type | Notes |
+|---|---|---|
+| `map<T, U>(arr, f)` | `fn(elem: T) -> U` | The default; rejects `parseInt`-style misuse. |
+| `mapi<T, U>(arr, f)` | `fn(elem: T, index: number) -> U` | Use when the index is needed. |
+| `filter<T>(arr, p)` | `fn(elem: T) -> boolean` | |
+| `filteri<T>(arr, p)` | `fn(elem: T, index: number) -> boolean` | |
+| `forEach<T>(arr, f)` | `fn(elem: T) -> undefined` | |
+| `forEachi<T>(arr, f)` | `fn(elem: T, index: number) -> undefined` | |
+| `find<T>(arr, p)` | `fn(elem: T) -> boolean` | |
+| `findi<T>(arr, p)` | `fn(elem: T, index: number) -> boolean` | |
+| `findIndex<T>(arr, p)` | `fn(elem: T) -> boolean` | Returns `number`. |
+| `some<T>(arr, p)` | `fn(elem: T) -> boolean` | |
+| `every<T>(arr, p)` | `fn(elem: T) -> boolean` | |
+| `reduce<T, A>(arr, f, init)` | `fn(acc: A, elem: T) -> A` | No index variant by default. |
+| `reducei<T, A>(arr, f, init)` | `fn(acc: A, elem: T, index: number) -> A` | When the index is needed. |
+
+The third "source array" argument that `Array.prototype.{map,filter,...}`
+passes is **not** exposed by any `std:array` method. In the rare case where
+a callback genuinely needs the source array, the caller already has it in
+scope and can close over it explicitly.
+
+Users who want the index *and* something more (e.g. both index and source)
+should fall back to a `for` loop or `arr.entries()` rather than reach for
+an ever-wider callback. The split stops at adding at most one context
+parameter (the index) beyond the callback's intrinsic shape — so
+`map`/`filter`/`forEach`/`find` cap out at two-parameter callbacks
+(elem + index), and `reduce` caps out at three (acc + elem + index in
+`reducei`).
+
+### 11.2. Other `std:*` callback-taking APIs
+
+A survey of the non-DOM `lib.es*.d.ts` surface area shows that
+callback-taking methods fall into three patterns. Each has a fixed
+treatment.
+
+**Pattern 1 — Bonus-arg callbacks (the `-i` split).** Apply the §11.1
+rule to every method whose JS callback receives a fixed but mostly
+unused trailing argument:
+
+- `std:typedArray.{map,filter,forEach,find,findIndex,reduce,sort,...}` —
+  same shape as `std:array`, including the `-i` variants.
+- `std:iterator.{map,filter,flatMap,reduce,forEach,some,every,find}`
+  (the ES2024 Iterator helpers) — exact unary + `-i` binary.
+- `std:map.groupBy`, and other ES2024+ `Map`/`Set` callback methods —
+  the key (for maps) or value (for sets) replaces "index" in the `-i`
+  variant.
+
+**Pattern 2 — Fixed-arity callbacks (no split needed).** Some callbacks
+have a known, useful arity with no bonus args; these are exposed as a
+single exact signature:
+
+- `std:array.sort`, `std:typedArray.sort` — `fn(a: T, b: T) -> number`.
+- `std:json.parse` reviver — `fn(key: string, value: unknown) -> unknown`.
+- `std:json.stringify` replacer — `fn(key: string, value: unknown) -> unknown`.
+- `Promise` executor — `fn(resolve, reject) -> undefined`.
+- `Promise.then/catch/finally` callbacks — exact unary on the
+  fulfillment/rejection value, or exact nullary for `finally`.
+- All `ProxyHandler` traps — each trap has a fixed, documented arity.
+
+**Pattern 3 — Genuinely variadic callbacks.** Only one method in the
+core lib surface qualifies: `String.prototype.replace` with a function
+replacement, where the callback is invoked with
+`(match, p1, …, pN, offset, fullString)` and `N` depends on the regex.
+An inexact callback type is **not** the right tool here — the §4.2.1.1
+rule that function-type subtyping requires arities to match in *both*
+directions means an inexact callback slot would actually *reject* the
+ordinary exact functions users naturally write. Instead, `std:string`
+exposes two specialized methods, each with an exact callback:
+
+```
+fn replace(s: string, pattern: string | RegExp, f: fn(match: string) -> string) -> string
+fn replaceWithGroups(
+    s: string,
+    re: RegExp,
+    f: fn(match: string, groups: Array<string>, offset: number) -> string,
+) -> string
+```
+
+The simple `replace` accepts either a string or a RegExp as the search
+pattern and exposes only the matched substring to the callback — for
+the string-search case there are no capture groups, and for the
+RegExp case the groups are discarded. The `replaceWithGroups` form is
+RegExp-only (a string search would always yield an empty `groups`
+array) and exposes the capture groups and offset.
+
+The `std:string` implementation collects the variadic capture-group
+arguments into a single `groups` array before calling the user's
+function, so the variadic shape is handled at the boundary, not in the
+type system.
+
+### 11.3. Non-callback variadic functions
+
+A separate cluster of built-ins takes a variable number of *values*
+(not callbacks). These use **typed rest parameters**, which are exact
+(§4.2.2):
+
+- `std:math.max`, `std:math.min` — `fn(...nums: Array<number>) -> number`.
+- `std:console.log` and peers — `fn(...args: Array<unknown>) -> undefined`.
+
+The §4.2.2 rule explicitly forbids combining a typed rest parameter
+with the inexact `...` sentinel, so there is no ambiguity here: typed
+rest is always the correct spelling for "any number of values of a
+known element type."
+
+A handful of TS-surface APIs use an *untyped* variadic passthrough
+(`setTimeout(fn, ms, ...args)`, `Function.prototype.bind` partial
+application). `std:*` does not reproduce these signatures. Instead:
+
+- `std:timer.setTimeout(cb: fn() -> undefined, ms: number) -> TimerHandle` —
+  users close over any extra state explicitly.
+- No `std:*` equivalent of `Function.prototype.bind`'s partial
+  application — arrow functions and explicit closures replace it
+  cleanly.
+
+### 11.4. When inexact function types are appropriate
+
+The survey above produces no case where `std:*` should expose an
+inexact function type, in either parameter or return position. This is
+not a coincidence: the §4.2.1.1 asymmetry means inexact function types
+only make sense for values whose *call contract* genuinely permits
+extra positional arguments — and Escalier-authored functions, by
+default, never have such a contract.
+
+Inexact function types are therefore principally an **interop
+construct**:
+
+- TS-imported functions are inexact by default (§8), because we
+  cannot trust the TS-side arity contract.
+- The `Inexact<T>` utility (§6.2) is the explicit way to widen an
+  exact function type when interop genuinely requires it.
+
+Escalier source code — including the entire `std:*` and `dom:*`
+surface — should be written with exact function types throughout. If
+a future `std:*` or `dom:*` API appears to call for an inexact
+function type, that's a strong signal the surface should be
+restructured (split into multiple exact methods, switched to a typed
+rest parameter, or dropped entirely) rather than reaching for `...`.
+
+### 11.5. `dom:*` modules
+
+A survey of `lib.dom.d.ts`, `lib.dom.iterable.d.ts`, and the worker
+variants confirms that the §11.2 patterns cover the DOM surface as
+well. The §11.4 conclusion — inexact function types have no place in
+Escalier-authored wrappers — applies here without modification. The
+specifics below show how each pattern maps to DOM APIs.
+
+#### 11.5.1. Event listeners (Pattern 2 — fixed-arity)
+
+`addEventListener` and the `on*` event-handler properties take exact
+unary callbacks. The event argument *is* the callback's purpose, and
+there are no JS-level bonus arguments to discard:
+
+```
+fn addEventListener<K : keyof HTMLElementEventMap>(
+    target: EventTarget,
+    type: K,
+    handler: fn(event: HTMLElementEventMap[K]) -> undefined,
+) -> undefined
+```
+
+#### 11.5.2. Observer callbacks (Pattern 1 — drop the bonus arg)
+
+Every modern observer constructor invokes its callback with
+`(entries, observer)`, where the `observer` argument is the same value
+the user just constructed and has in scope. It's pure bonus; the
+`dom:*` wrapper drops it and exposes an exact unary callback. This
+applies uniformly to:
+
+- `MutationObserver` — `fn(mutations: Array<MutationRecord>) -> undefined`
+- `IntersectionObserver` — `fn(entries: Array<IntersectionObserverEntry>) -> undefined`
+- `ResizeObserver` — `fn(entries: Array<ResizeObserverEntry>) -> undefined`
+- `PerformanceObserver` — `fn(entries: PerformanceObserverEntryList) -> undefined`
+- `ReportingObserver` — `fn(reports: Array<Report>) -> undefined`
+
+Unlike `std:array`'s `-i` split, there is no observer-receiving
+variant: the user already has the observer reference in scope, so the
+second method would be pure noise.
+
+#### 11.5.3. Array-like `forEach` (Pattern 1 — `-i`/`-k` split)
+
+A large number of DOM collection types expose `Array.forEach`-shaped
+callbacks with `(value, key, parent)`. Each gets the `-i`/`-k` split
+following §11.1:
+
+- Index-keyed: `NodeList`, `NodeListOf<T>`, `DOMTokenList`,
+  `CSSNumericArray`, `CSSTransformValue`, `CSSUnparsedValue`,
+  `EventCounts`.
+- String-keyed: `FormData`, `Headers`, `URLSearchParams`,
+  `HighlightRegistry`, `AudioParamMap`, `CustomStateSet`,
+  `RTCStatsReport`.
+
+The "parent collection" third argument is dropped in every case,
+matching the §11.1 rule for `std:array`.
+
+#### 11.5.4. Scheduling, filter, and one-shot callbacks (Pattern 2)
+
+These are already fixed-arity with no bonus args, and the `dom:*`
+wrapper preserves the natural exact signature unchanged:
+
+- `requestAnimationFrame(cb: fn(time: DOMHighResTimeStamp) -> undefined)`
+- `requestIdleCallback(cb: fn(deadline: IdleDeadline) -> undefined, options?)`
+- `queueMicrotask(cb: fn() -> undefined)`
+- `NodeFilter` (used by `createNodeIterator` / `createTreeWalker`) —
+  `fn(node: Node) -> number`
+- `Geolocation.{getCurrentPosition, watchPosition}` success/error
+  callbacks
+- `MediaSession.setActionHandler` — `fn(details: MediaSessionActionDetails) -> undefined`
+- `HTMLVideoElement.requestVideoFrameCallback` —
+  `fn(now: DOMHighResTimeStamp, metadata: VideoFrameCallbackMetadata) -> undefined`
+- WebCodecs output and error callbacks
+- `DataTransferItem.getAsString` callback
+
+`setTimeout` and `setInterval` follow §11.3: the `...arguments: any[]`
+passthrough is dropped, and the `dom:*` (or `std:timer`) wrapper
+exposes `fn(cb: fn() -> undefined, ms: number) -> TimerHandle`. Users
+close over any extra state.
+
+#### 11.5.5. Stream controllers are *not* bonus args
+
+`ReadableStream`, `WritableStream`, and `TransformStream` source/sink/
+transformer callbacks take a `controller` parameter that superficially
+looks like a bonus argument but is essential: the callback's whole job
+is to call `controller.enqueue(...)`, `controller.terminate()`, etc.
+The `dom:*` wrappers therefore preserve the natural exact signatures
+without splitting:
+
+```
+fn(chunk: I, controller: TransformStreamDefaultController<O>) -> Promise<undefined> | undefined
+fn(controller: ReadableStreamDefaultController<R>) -> Promise<undefined> | undefined
+```
+
+This is the one DOM pattern that *looks* like Pattern 1 but isn't — a
+useful reminder that "second argument" is not the same as "bonus
+argument." The test is whether the argument carries information the
+callback can't obtain from its enclosing scope.
+
+#### 11.5.6. Non-callback variadics
+
+DOM has many variadic-value APIs, all of which use typed rest
+parameters (§11.3) and pose no challenge:
+
+- `Element.{append, prepend, after, before, replaceWith, replaceChildren}`
+- `DOMTokenList.{add, remove}` and `Element.classList` operations
+- `Document.{write, writeln}`
+- `Console.{log, error, warn, info, debug, trace, group, ...}`
+- `CSSNumericValue.{add, sub, mul, div, min, max, equals, toSum}` and
+  the `CSSMath*` constructors
+- `RTCRtpSender.{addTrack, setStreams}`
+- `Highlight` constructor
+
+None require inexact function types; all are well-served by
+`fn(...args: Array<T>) -> R` with a known element type.
+
+### 11.6. TypeScript interop
+
+The native callback-taking methods on `Array.prototype` (`map`, `filter`,
+`forEach`, `find`, `findIndex`, `some`, `every`, `reduce`, `reduceRight`,
+and `flatMap`) are **not exposed** in Escalier. Allowing them via direct
+TypeScript import would reintroduce the `parseInt`-style misuse the
+`std:array` wrappers exist to prevent, and would give users two
+near-identical APIs with different safety properties — exactly the kind
+of footgun the exact-types feature is designed to eliminate.
+
+Concretely, the Escalier prelude's `Array<T>` type omits these methods
+from the instance interface. Non-callback methods on `Array.prototype`
+(`length`, `push`, `pop`, `slice`, `concat`, indexing, `includes`,
+`indexOf`, `join`, etc.) remain available unchanged; only the
+callback-taking subset is removed in favor of the `std:array`
+free-function equivalents.
+
+The same rule applies to any other built-in JS type whose native
+callback-taking methods have a corresponding `std:*` wrapper: the
+wrapper is the supported surface, and the native method is hidden at
+the type level even though it still exists at runtime.
+
+### 11.7. Class finality for `std:*` and `dom:*` wrappers
+
+Per §2.6, class instance types are inexact by default; per §2.6.1,
+declaring a class `final` makes its instance type exact and disallows
+subclassing. This subsection specifies which built-in classes in the
+`std:*` and `dom:*` wrappers are declared `final` and which are not.
+
+The analysis below is grounded in an enumeration of all class-like
+declarations in TypeScript's bundled `lib.*.d.ts` files. Under
+Escalier's interpretation of `interface Foo` + `var Foo: FooConstructor`
+(the es-lib pattern) and `interface Foo` + `var Foo: { prototype: Foo;
+new(): Foo; ... }` (the dom-lib pattern), TypeScript's lib declares 692
+classes. The full enumeration with parents and source files is saved
+as [`builtin-classes.md`](./builtin-classes.md) alongside this document.
+
+#### 11.7.1. The mechanical rule: lib subclasses imply non-final
+
+Any class that has at least one subclass declared in the TypeScript lib
+itself is exposed as **non-final** by the corresponding wrapper.
+Declaring such a class `final` would forbid lib-declared subclasses,
+which is incoherent.
+
+This rule alone forces roughly 110 classes non-final. The major
+non-final bases are:
+
+- **`Error`** — 12 direct subclasses (`EvalError`, `RangeError`,
+  `ReferenceError`, `SyntaxError`, `TypeError`, `URIError`,
+  `AggregateError`, `SuppressedError`, `DOMException`, plus the
+  WebAssembly `CompileError` / `LinkError` / `RuntimeError`).
+- **`Event` → `UIEvent` → `MouseEvent`** — each non-leaf level in the
+  event hierarchy is non-final because of its lib subclasses.
+- **`EventTarget`** — ~70 lib subclasses (`Node`, `Window`,
+  `AbortSignal`, `XMLHttpRequest`, `WebSocket`, all `AudioNode`s, all
+  IDB and Media* types, etc.).
+- **`Node` → `Element` → `HTMLElement` / `SVGElement` / `MathMLElement`** —
+  the DOM element tree. `HTMLElement` and `SVGElement` are also the
+  documented web-platform extension points (§11.7.2).
+- **`AudioNode` → `AudioScheduledSourceNode`** — Web Audio.
+- **`CSSRule` → `CSSGroupingRule` → `CSSConditionRule`** — CSS OM.
+- **`CSSStyleValue` → `CSSNumericValue` → `CSSMathValue`** — CSS Typed OM.
+- **The `*ReadOnly` / `*Mutable` pairs**: `DOMMatrixReadOnly`,
+  `DOMPointReadOnly`, `DOMRectReadOnly` — each non-final because the
+  mutable variant extends it.
+- **Other base classes with lib subclasses**: `Blob` (→ `File`),
+  `CharacterData`, `Document`, `DocumentFragment`, `Text`, `IDBRequest`,
+  `MIDIPort`, `MediaStreamTrack`, `XMLHttpRequestEventTarget`,
+  `BaseAudioContext`, `Animation`, `AnimationEffect`,
+  `AnimationTimeline`, `AbstractRange`, `Credential`,
+  `AuthenticatorResponse`, `PaymentRequestUpdateEvent`,
+  `SpeechSynthesisEvent`, `TextTrackCue`.
+
+#### 11.7.2. Documented extension points stay non-final at the leaves
+
+Some lib non-leaves are also documented *extension points*: the web
+platform expects user code to subclass them. They are already non-final
+by §11.7.1, but the rationale is independent and worth stating
+explicitly so the choice survives any future lib reshuffling:
+
+- **`HTMLElement`** is the canonical custom-elements extension point
+  (`class MyEl extends HTMLElement { ... }`, registered via
+  `customElements.define`).
+- **`SVGElement`** and **`MathMLElement`** are the analogous extension
+  points for custom SVG and MathML elements.
+- **`Error`** is the canonical extension point for user-defined error
+  hierarchies (`class NotFoundError extends Error { ... }`).
+- **`Event`** is the standard pattern for custom event subclasses, used
+  alongside `CustomEvent` for typed-payload events.
+
+No other DOM extension points exist that the §11.7.1 rule does not
+already cover.
+
+#### 11.7.3. Library-leaf classes: `final` by default
+
+Every concrete class with no lib subclass and no platform expectation of
+subclassing is exposed as `final`. This covers the bulk of the lib —
+roughly 580 of the 692 classes. Representative groups:
+
+- **All concrete `HTMLXxxElement` leaves** — `HTMLDivElement`,
+  `HTMLAnchorElement`, `HTMLInputElement`, ..., ~85 classes.
+- **All concrete `SVGXxxElement` leaves** — `SVGCircleElement`,
+  `SVGPathElement`, ..., ~50 classes.
+- **All concrete `*Event` leaves** — `KeyboardEvent`, `WheelEvent`,
+  `CustomEvent`, `PointerEvent`, `DragEvent`, ..., ~40 classes.
+- **All concrete `AudioNode` leaves** — `GainNode`, `OscillatorNode`,
+  `AnalyserNode`, etc.
+- **All observers** — `MutationObserver`, `IntersectionObserver`,
+  `ResizeObserver`, `PerformanceObserver`, `ReportingObserver`.
+- **All typed arrays** — `Int8Array` through `Float64Array`,
+  `Float16Array`, `BigInt64Array`, `BigUint64Array`,
+  `Uint8ClampedArray`.
+- **ES wrapper types** — `Date`, `RegExp`, `ArrayBuffer`,
+  `SharedArrayBuffer`, `DataView`, `WeakRef`, `FinalizationRegistry`,
+  `DisposableStack`, `AsyncDisposableStack`, `Symbol`, `BigInt`,
+  `Number`, `String`, `Boolean`.
+- **DOM utility classes** — `URL`, `URLSearchParams`, `Headers`,
+  `FormData`, `AbortController`, `Request`, `Response`, `FileReader`,
+  `Blob` *as constructed* (the `File` subclass exists, so `Blob`
+  itself is non-final; see §11.7.1).
+- **Stream classes** — `ReadableStream`, `WritableStream`,
+  `TransformStream`, and their controllers/readers/writers.
+- **Promise** — see §11.7.4.
+
+The payoff: `keyof HTMLDivElement` is the *exact* set of properties
+HTML defines for `<div>`; `match` over a known union of `*Event`
+subclasses can be exhaustive without a default arm; and reading
+`.fooo` on an `HTMLDivElement` is a type error rather than "well, a
+subclass might define it."
+
+#### 11.7.4. Leaf exceptions: classes users genuinely subclass
+
+A small number of leaves have a real-world subclassing pattern common
+enough that the wrapper should accommodate it. These are exposed as
+**non-final** despite having no lib subclasses:
+
+- **`Array`** — subclassed for typed collections, observable arrays,
+  custom iteration wrappers. The exact-instance benefit is small
+  (most `Array` properties are well-known anyway) and the ergonomic
+  cost of `final` is high.
+- **`Map`** — subclassed for LRU caches, ordered maps, multi-maps,
+  weak-keyed caches.
+- **`Set`** — subclassed for ordered sets, sets-with-default, bag-like
+  collections.
+
+A second motivation for keeping `Array`, `Map`, and `Set` non-final is
+**third-party TypeScript interop**. These three classes are the ones
+TS libraries most commonly subclass (e.g. `NonEmptyArray`, `LRUCache
+extends Map`, ordered-set wrappers). Marking them `final` would force a
+boundary conversion at every interop site that produced or consumed
+such a subclass — either an `Array.from(...)`-style copy or a wrapper
+module. The downstream gains from exact instance types are not large
+enough on these specific classes to justify that tax. For other final
+classes the same interop hazard is present in principle but rare in
+practice; see §11.7.7.
+
+Other leaves that *appear* to invite subclassing are nonetheless
+**final**. These already appear in §11.7.3's list; called out here to
+explain why each one stays in the default-final bucket despite a
+plausible-sounding case for subclassing:
+
+- **`Promise`** — subclassing is spec-supported via `Symbol.species`
+  but rare, bug-prone, and breaks common library patterns.
+- **`Function`** — subclassing has no sensible runtime semantics
+  beyond what arrow functions and ordinary closures already provide.
+- **`WeakMap`, `WeakSet`, `WeakRef`, `FinalizationRegistry`** — same
+  reasoning as `Promise`; no observed real-world subclassing demand.
+
+The primitive wrapper types **`Number`**, **`String`**, and
+**`Boolean`** are also final (per §11.7.3) and warrant no special
+justification — they are essentially never subclassed in practice.
+
+#### 11.7.5. Why default-final, not default-non-final
+
+`final` is the right default for leaves because the benefit accrues to
+*every* downstream use site, not just the declaration site:
+
+- **Exact instance types** mean `keyof T` and property access on `T`
+  are precise. Downstream code does not have to defensively handle
+  "what if a subclass added a property."
+- **Exhaustive `match` over class unions** works without a default
+  arm — relevant for the DOM event union, the error hierarchy, and
+  any user-defined enum-like union of variant classes (§2.6.1).
+- **Better error messages**: a typo accessing `.fooo` on an
+  `HTMLDivElement` is rejected immediately rather than treated as
+  "perhaps a subclass defined `fooo`."
+
+The cost of `final` — forbidding subclassing — is bounded by being
+**reversible** in a backward-compatible way. Loosening a class from
+`final` to non-`final` is a widening change (exact `<:` inexact for
+objects/instance types), so we can start a class `final` and relax it
+later if a genuine subclassing need emerges. The reverse direction
+(non-`final` → `final`) is breaking. The conservative initial position
+is therefore `final` on every leaf, with the §11.7.4 exceptions
+explicitly carved out where current real-world usage justifies the
+weaker contract.
+
+#### 11.7.6. Round-tripping through `.d.ts`
+
+When emitting `.d.ts` files, `final` is an Escalier-only annotation:
+TypeScript has no equivalent. Per §9, the `@escalier-type` JSDoc tag
+carries the original Escalier declaration (including the `final`
+modifier), so other Escalier consumers recover the exactness of the
+instance type. Plain TypeScript consumers see the erased class
+declaration and lose nothing — TypeScript already allows subclassing
+anything, and subclasses introduced on the TS side cannot leak back
+into Escalier as instance values of the `final` type, because the
+Escalier-side type only admits direct instances.
+
+#### 11.7.7. Importing third-party subclasses of final classes
+
+A TS library may declare `class Foo extends Bar` where `Bar` is a class
+that the `std:*` or `dom:*` wrapper exposes as `final`. The `extends`
+clause cannot be honored as a subtype relationship in Escalier without
+contradicting the `final` modifier — `final` guarantees that values
+typed `Bar` have *exactly* `Bar`'s declared members, and admitting an
+`extends Bar` subclass would silently widen every consumer of `Bar`.
+
+The importer therefore **strips the `extends` clause** when the parent
+is a final wrapper class. The imported `Foo` is treated as an
+independent, inexact class instance type that inherits `Bar`'s methods
+into its own interface (flattened from the TS declaration) but is
+**not** a subtype of `Bar`. Concretely, after import:
+
+- `Foo`'s own methods and `Bar`'s inherited methods are both callable
+  on values of type `Foo`.
+- `val x: Bar = someFoo` is rejected — `Foo </: Bar`.
+- `val x: Bar = Bar.from(someFoo)` (or whatever the analogous
+  conversion is for the specific `Bar`) succeeds, with an explicit,
+  runtime-visible boundary conversion.
+
+This contains the impact of the mismatch: the third-party subclass is
+usable through its own type, the user pays a conversion only when they
+actually need to cross into a `Bar`-typed slot, and Escalier's
+`final`-instance guarantees remain intact for all downstream consumers
+of `Bar`.
+
+**Residual unsoundness risk.** A `.d.ts` whose function signature
+claims to return `Bar` but actually returns a subclass instance at
+runtime can still produce a value that violates the `final` contract.
+The exact-types system has no way to detect this; it is an instance of
+the lying-`.d.ts` anti-pattern (§4.2.1.3 A3), made slightly more
+consequential by `final` because consumers now actively rely on the
+absence of extra members. The recommended defense is the same as for
+any other lying `.d.ts`: wrap the suspect import in a local module
+that converts at the boundary, and treat libraries that hide
+subclasses behind base-class signatures as needing scrutiny.
+
+This is part of the trade-off justifying the §11.7.4 carve-out for
+`Array`, `Map`, and `Set`: those three are the classes where TS-side
+subclassing is common enough that the boundary-conversion tax and the
+lying-`.d.ts` exposure would be noticeable. For the other ~580 final
+leaves, third-party subclassing is rare enough that the residual risk
+is acceptable.
+
+## 12. Open Questions
 
 *(None at present — previously open questions about index signatures and
 generic constraints are resolved in §2.7.1 and §7.12 respectively.)*

--- a/planning/exact-types/requirements.md
+++ b/planning/exact-types/requirements.md
@@ -84,7 +84,9 @@ Because exact object types have a known, complete set of keys, all three of
 these built-ins can be given precise types when called on an exact object:
 
 - `Object.keys(o)` for an exact `o` returns an exact tuple of literal-string
-  keys (e.g., `["x", "y"]` for `{x: number, y: number}`).
+  keys (e.g., `["x", "y"]: ["x", "y"]` for `{x: number, y: number}`). Its
+  element-type union is `keyof typeof o`, so iterating the tuple yields a
+  binding of type `keyof typeof o`.
 - `Object.values(o)` for an exact `o` returns an exact tuple of the
   corresponding value types (e.g., `[number, number]` for the same object).
 - `Object.entries(o)` for an exact `o` returns an exact tuple of
@@ -267,9 +269,35 @@ type EM = {[K]: string for K in keyof Exact}    // exact: keyof Exact is exact "
 type IM = {[K]: string for K in keyof Inexact}  // inexact: keyof Inexact is inexact "x" | "y" | ...
 // IM is inexact { x: string, y: string, ... }
 
-type Open = {[K]: number for K in string}      // inexact: string is an inexact union of all strings
-// Open is inexact — equivalent to { [k: string]: number, ... }
+type Open = {[K]: number for K in string}       // inexact: string is an inexact union of all strings
+// Open is inexact, and is exactly the desugaring of the TypeScript-style
+// index signature `{ [k: string]: number }` — see the note below.
 ```
+
+#### 2.7.1. Index signatures as sugar for mapped elements
+
+> **Note.** This subsection resolves what was previously an open
+> question about how index signatures interact with exactness.
+
+A TypeScript-style index signature `{[k: K]: V}` is **surface syntax for
+the mapped element** `{[P]: V for P in K}` — the index parameter is
+renamed and its constraint is lifted into the `for ... in ...` clause.
+The two spellings produce the same type:
+
+```
+{[k: string]: number}    ≡    {[K]: number for K in string}
+{[k: keyof E]: number}   ≡    {[K]: number for K in keyof E}
+```
+
+Consequently, the exactness of an object type containing an index
+signature is determined by the constraint on its key, by exactly the
+rule above:
+
+- `{[k: string]: number}` — constraint `string` is an inexact union, so
+  the object type is **inexact**.
+- `{[k: keyof E]: number}` for an exact `E` — constraint is an exact
+  union, so the object type is **exact** (assuming nothing else in the
+  surrounding object forces inexactness).
 
 This rule composes naturally with the other propagation rules: combining a
 mapped element whose constraint is exact with a trailing `...` still yields
@@ -293,8 +321,8 @@ This is distinct from a tuple with an explicit *typed* rest element, which is
 already a TypeScript-style construct:
 
 ```
-type Variadic = [string, ...Array<number>]    // exact arity-wise: 1 string then number rest
-type Inexact  = [string, number, ...]          // inexact: extra elements of any type allowed
+type Variadic     = [string, ...Array<number>]   // exact arity-wise: 1 string then number rest
+type InexactTail  = [string, number, ...]        // inexact: extra elements of any type allowed
 ```
 
 The difference: `[string, ...Array<number>]` is a precise type whose extra
@@ -357,6 +385,25 @@ Optional tuple elements (`[T1, T2?]`) interact with exactness analogously to
 optional object properties: an exact tuple permits absence of optional trailing
 elements but no additional elements beyond the declared ones.
 
+A tuple with a typed rest element and **no trailing `...` sentinel** —
+e.g. `[string, ...Array<number>]` — is **exact**: its shape is fully
+determined by the declaration, and any extras must satisfy the rest
+element type. For subtyping:
+
+- `[string, ...Array<number>] <: [string, ...Array<number>]` (reflexive).
+- `[string, number] <: [string, ...Array<number>]` (the rest element
+  permits zero `number`s).
+- `[string, number, number] <: [string, ...Array<number>]` (any
+  non-negative count of trailing `number`s).
+- `[string, ...Array<number>] </: [string, number]` (the rest tuple may
+  carry more elements than the fixed exact tuple admits).
+- `[string, ...Array<number>] <: [string, number, ...]` (the rest tuple
+  is at least one element with a string head, satisfying the inexact
+  tuple's lower bound).
+- `[string, ...Array<number>] <: [string, ...]` (same idea with a
+  weaker lower bound: one `string` head plus any number of trailing
+  elements, which the unknown-typed inexact tail trivially admits).
+
 ## 4. Function Types
 
 ### 4.1. Syntax
@@ -368,8 +415,8 @@ type InexactCallback = fn(x: number, y: number, ...) -> number
 
 - A bare function type `fn(...) -> T` is **exact** — callers may not pass extra
   arguments beyond those declared.
-- A function type ending in `...` in its parameter list is **inexact** — extra
-  positional arguments are permitted at call sites.
+- A function type whose parameter list ends with a trailing `...` is
+  **inexact** — extra positional arguments are permitted at call sites.
 
 This is distinct from an explicit typed rest parameter:
 
@@ -482,6 +529,18 @@ with optional parameters still has a fixed *maximum* arity; an exact function
 with a typed rest parameter accepts any number of trailing arguments, but each
 extra must satisfy the rest element type.
 
+A function type with a typed rest parameter — e.g.
+`fn(a: A, ...rest: Array<B>) -> R` — consumes *all* trailing arguments,
+each of which must be a `B`. There is no JavaScript-level way to have a
+typed rest parameter coexist with additional positional parameters after
+it, and the same restriction applies in Escalier. Combining a typed rest
+parameter with the inexact `...` sentinel
+(`fn(a: A, ...rest: Array<B>, ...) -> R`) is therefore **disallowed**:
+either the rest type already specifies what the trailing arguments must
+be (no need for the sentinel), or the sentinel is used on its own to
+admit untyped extras (no typed rest). A function with a typed rest
+parameter is always exact in the §4.2.1 sense.
+
 #### 4.2.3. Call-Site Checking
 
 At call sites, the checker enforces:
@@ -536,6 +595,28 @@ rule `[string, number] <: [string, number, ...]`. This is intentional —
 the asymmetry on function-type subtyping reflects the call-contract
 direction, which a tuple of parameter types no longer carries.
 
+#### 4.2.5. `ReturnType<T>` and Other Function Utility Types
+
+The remaining function-shaped utility types are derived analogously, and
+each carries the natural exactness:
+
+- **`ReturnType<T>`** is the declared return type of `T`. Its exactness
+  is whatever exactness the return type has — `ReturnType<fn(...) -> R>`
+  is `R`, with `R`'s exactness preserved.
+- **`Awaited<T>`** unwraps `Promise<T>` chains. Exactness of the result
+  is the exactness of the resolved type at the bottom of the chain.
+- **`ConstructorParameters<T>`** is the `Parameters`-analog for
+  constructor signatures and follows the same rules as §4.2.4.
+- **`InstanceType<T>`** is the instance type produced by a constructor.
+  Its exactness follows §2.6 (exact only if the underlying class is
+  `final`).
+- **`ThisParameterType<T>`** extracts the type of the explicit `this`
+  parameter, with that type's exactness preserved.
+
+The matcher and constraint for each of these utility types are
+exactness-agnostic on the function/constructor type they accept, for the
+same reason as `Parameters` (§4.2.4).
+
 ## 5. Union Types
 
 ### 5.1. Motivation
@@ -573,8 +654,11 @@ type InexactError = IOError | ParseError | ...
 - A bare union `T1 | T2 | ... | Tn` is **exact**: its inhabitants are exactly
   the values in `T1 ∪ T2 ∪ ... ∪ Tn`, and nothing else.
 - A union ending in `| ...` is **inexact**: it contains *at least* the values
-  in those members, and possibly more values of unknown type (effectively
-  some unknown additional union members).
+  in those members, plus an implicit `unknown`-typed tail standing in for
+  zero or more additional union members of unknown type. The tail is always
+  `unknown`-typed; it is not constrained by surrounding context (so e.g.
+  `"a" | "b" | ...` does *not* satisfy a `: string` constraint, since the
+  tail is not proven to be a string — see §7.4.4).
 
 ### 5.3. Semantics
 
@@ -671,13 +755,15 @@ For union types `A` and `B`:
 - **Inexact </: Exact:** An inexact union is *not* a subtype of an exact
   union, because the inexact value may be a member outside the listed set.
 - **Exact <: Exact:** `A <: B` iff every member of `A` is a subtype of some
-  member of `B`. (Standard union subtyping; no extra arity rule beyond what
-  union subtyping already provides.)
+  member of `B`. (Standard union subtyping. There is no "arity" requirement
+  beyond covering every member — the count of listed members on the two
+  sides need not match, only the coverage relation.)
 - **Inexact <: Inexact:** `A <: B` iff every *listed* member of `A` is a
-  subtype of some listed member of `B`, *and* `B`'s "unknown tail" is at
-  least as permissive as `A`'s. In practice, an inexact union is treated as
-  having an implicit `unknown`-like tail member, so `A` and `B` must both
-  permit unknown extras.
+  subtype of some listed member of `B`, and both `A` and `B` are inexact.
+  The `...` tail on each side is implicitly `unknown`-typed, so the tails
+  always match — the only check that matters is that the listed members
+  on the supplier side are covered by the listed members on the consumer
+  side.
 
 ### 5.5. Interop
 
@@ -706,11 +792,26 @@ import type { Color } from "some-ts-lib"     // inferred inexact
 type StrictColor = Exact<Color>              // opt-in to exact
 ```
 
-Escalier-emitted `.d.ts` files preserve exactness via JSDoc annotations
-alongside declarations, so when one Escalier project consumes another
-Escalier project's emitted `.d.ts`, exact unions round-trip correctly. Only
-plain TypeScript-authored declarations (without those JSDoc annotations)
-fall back to the inexact default.
+Escalier-emitted `.d.ts` files preserve the original Escalier type via
+an `@escalier-type` JSDoc tag alongside each declaration (see §9), so
+when one Escalier project consumes another Escalier project's emitted
+`.d.ts`, exact unions round-trip correctly. Only plain
+TypeScript-authored declarations (without an `@escalier-type` tag) fall
+back to the inexact default.
+
+##### Provably-closed primitive unions
+
+A small set of TypeScript types are *provably* closed at the language
+level and are imported as **exact** unions:
+
+- `boolean` is imported as the exact union `true | false`.
+- `null | undefined` (as a TypeScript type) is imported as exact, since
+  TypeScript guarantees no other values inhabit it.
+
+These are the only exceptions to the inexact-by-default rule for
+TypeScript-imported unions; any other imported union (including the
+nominal `Color`-style alias unions, discriminated unions, etc.) follows
+the inexact rule above.
 
 ### 5.6. Template Literal Types
 
@@ -746,6 +847,12 @@ and inexact forms of any type that has a notion of exactness (objects,
 tuples, functions, unions). They are dual: `Exact<T>` tightens, `Inexact<T>`
 loosens.
 
+The function-shaped utility types (`Parameters<T>`, `ReturnType<T>`,
+`ConstructorParameters<T>`, `InstanceType<T>`, `ThisParameterType<T>`,
+`Awaited<T>`) are documented alongside function-type semantics in §4.2.4
+and §4.2.5, since their exactness behavior is bound up with how `infer`
+captures function parameter lists.
+
 ### 6.1. `Exact<T>`
 
 `Exact<T>` produces the exact form of `T`. Its behavior depends on the kind
@@ -761,8 +868,7 @@ of type `T`:
   arguments.
 - **Union types:** `Exact<T1 | T2 | ...>` is `T1 | T2`. The trailing `...`
   is removed; the result is a closed union.
-- **Already-exact types:** `Exact<T>` is `T` if `T` is already exact (and
-  not an interface or non-final class instance — see below).
+- **Already-exact types:** `Exact<T>` is `T` if `T` is already exact.
 
 For types that **cannot be made exact** at the type level, `Exact<T>` is an
 error:
@@ -783,7 +889,9 @@ error:
 - **Tuple types:** `Inexact<[string, number]>` is `[string, number, ...]`.
 - **Function types:** `Inexact<fn(a: A, b: B) -> R>` is
   `fn(a: A, b: B, ...) -> R`. Callers of the result may pass extra
-  arguments.
+  arguments. Note this is the one direction users *cannot* obtain via
+  function-type subtyping (§4.2.1.1) — `Inexact<F>` exists precisely to
+  express it explicitly.
 - **Union types:** `Inexact<T1 | T2>` is `T1 | T2 | ...`.
 - **Already-inexact types:** `Inexact<T>` is `T` if `T` is already
   inexact.
@@ -820,6 +928,10 @@ types in the natural way:
 type T = {x: number, y: number, ...}
 type P = Partial<T>                  // {x?: number, y?: number, ...}
 type EP = Exact<P>                   // {x?: number, y?: number}
+// Note: applying `Exact` here drops the `...` tail — values of type EP
+// may omit `x` or `y` (they're optional), but they may not carry any
+// other property, even though the original `T` admitted arbitrary
+// extras.
 ```
 
 For container generics, `Exact` and `Inexact` apply only to the top-level
@@ -842,9 +954,10 @@ if a real need emerges; we do not provide one initially.
 - The result type (after applying `Exact`/`Inexact`) is what's emitted as a
   plain TypeScript type — TypeScript itself has no notion of exactness, so
   the `Exact<...>` / `Inexact<...>` wrapper is erased.
-- The original Escalier form is preserved in the JSDoc annotation alongside
-  the declaration so that other Escalier consumers can recover the precise
-  exactness.
+- The original Escalier form (including the `Exact<...>` / `Inexact<...>`
+  wrapper) is preserved in the `@escalier-type` JSDoc tag alongside the
+  declaration so that other Escalier consumers can recover the precise
+  exactness. See §9.
 
 ## 7. Type Operators and Exactness Propagation
 
@@ -861,8 +974,16 @@ The exactness of `keyof T` matches the exactness of `T`'s key set:
 - `keyof` of an inexact object type, an interface, a namespace, or a
   non-`final` class instance type is an **inexact** union (those types
   admit unknown additional keys).
-- `keyof` of an exact tuple is the exact union of its valid index literals
-  plus `Array` member keys; `keyof` of an inexact tuple is inexact.
+- `keyof` of a tuple yields the union of its index literals only —
+  `Array` prototype keys are *not* included (this differs from
+  TypeScript). For an exact tuple `[T0, ..., Tn-1]`, `keyof` is the
+  exact union `"0" | ... | "n-1"`. For an inexact tuple
+  `[T0, ..., Tn-1, ...]`, `keyof` is the inexact union
+  `"0" | ... | "n-1" | ...`, since the unknown trailing positions
+  contribute unknown additional index literals.
+
+NOTE: The behaviour of `keyof` in Escalier does not include `Array` prototype
+keys like it does in TypeScript.
 
 ### 7.2. `typeof v`
 
@@ -942,6 +1063,24 @@ type A = Elem<Array<{x: number}>>          // E is exact {x: number}
 type B = Elem<Array<{x: number, ...}>>     // E is inexact {x: number, ...}
 ```
 
+##### `infer` over object, tuple, and function patterns
+
+The general rule, of which §4.2.4 is the function-pattern instance:
+
+- An `infer` binding inside an object, tuple, or function-parameter
+  pattern captures the exactness of the corresponding part of the
+  matched type. `if T : {x: infer X, ...} { X }` against an exact
+  `{x: P, y: Q}` binds `X` to `P` (with `P`'s exactness preserved); the
+  pattern's own `...` says only what the pattern requires of `T`, not
+  what is captured.
+- The pattern itself is matched against `T` using the standard
+  subtyping rules (§2.3, §3.3, §4.2.1) with one exception: patterns
+  built solely to extract via `infer` (e.g. `fn(...args: infer P)`,
+  `Array<infer E>`) are treated as exactness-agnostic on the matched
+  shape, so a single pattern matches both exact and inexact `T`. This
+  matches the rule already given for function patterns in §4.2.4 and
+  generalizes it to object/tuple patterns used for inference.
+
 #### 7.4.3. Distribution over unions
 
 When `T` is a union, the conditional distributes over its members and
@@ -996,11 +1135,12 @@ defensively inside the conditional.
 
 ### 7.5. Mapped types `{[K]: T[K] for K in keyof T}`
 
-Already covered in the **Mapped Elements** subsection: the exactness of
-the resulting object type is determined by the exactness of the
-constraint `Keys`. Exact constraint → exact result; inexact constraint →
-inexact result. (As always, the result can still be forced inexact by
-other elements in the surrounding object type.)
+Already covered in §2.7 **Mapped Elements**: the exactness of the
+resulting object type is determined by the exactness of the constraint
+on the `IndexParam` (the type after `in`). Exact constraint → exact
+result; inexact constraint → inexact result. (As always, the result can
+still be forced inexact by other elements in the surrounding object
+type.)
 
 ### 7.6. Union types `A | B`
 
@@ -1021,6 +1161,17 @@ Intersection inherits exactness from its operands per kind:
   if the inexact type's declared properties are a subset of the exact
   type's declared properties; otherwise it is an error (the extra
   inexact properties cannot be present in an exact value).
+- **Tuple types:** Intersection of two tuple types is well-defined only
+  when their declared lengths agree (or when one is inexact and the
+  other has at least as many declared elements as it does). The result
+  is exact iff both operands are exact, and each element type is the
+  intersection of the corresponding element types from each side.
+- **Function types:** Intersection of function types models overload —
+  `(fn(A) -> R) & (fn(B) -> S)` is callable as either signature.
+  Because function-type subtyping requires arities (and exactness) to
+  match in both directions, the operands' exactnesses do not need to
+  agree; each call site is checked against the matching overload's
+  exactness.
 - **Union types:** Intersection distributes over unions as usual; the
   result's exactness is the conjunction (exact only if both operands are
   exact and the resulting member set is fully determined).
@@ -1052,7 +1203,32 @@ Aliasing is purely a naming layer and does not adjust exactness.
 Mutability is orthogonal to exactness. `mut T` carries the exactness of
 `T`; `mut` neither tightens nor loosens.
 
-### 7.12. Special types
+### 7.12. Generic constraints
+
+When a type parameter is constrained by an exact type, only exact
+arguments may be substituted. An inexact subtype is *not* admissible at
+the call site, even if its declared shape would otherwise satisfy the
+constraint, because the inexact tail represents members the constraint
+cannot prove are present.
+
+```
+fn dump<T : {x: number, y: number}>(t: T) -> string { ... }
+
+dump({x: 1, y: 2})                 // okay — exact argument
+declare val q: {x: number, y: number, ...}
+dump(q)                            // Error — inexact argument fails exact constraint
+```
+
+The dual rule already follows from §2.3: an inexact constraint admits
+both exact and inexact arguments, since exact `<:` inexact for objects,
+tuples, and unions. (Function-type constraints follow the stricter
+arities-must-match-in-both-directions rule of §4.2.1.1.)
+
+In short: the exactness of the *constraint* fixes the exactness of the
+admissible arguments — exact constraints reject inexact arguments;
+inexact constraints accept either.
+
+### 7.13. Special types
 
 - `never`, `unknown`, `any`, and `void` have no notion of arity and
   therefore no exactness distinction. They behave as the absorbing or
@@ -1068,7 +1244,7 @@ Mutability is orthogonal to exactness. `mut T` carries the exactness of
   source are exact by default.** Inexactness must be explicitly opted into
   with `...`.
 - **All types imported from TypeScript** (whether via `.d.ts` files or
-  declarations without Escalier-specific JSDoc annotations) are treated as
+  declarations without an `@escalier-type` JSDoc tag) are treated as
   **inexact** for all four categories — including unions. TypeScript has no
   notion of an exact/closed union, and admits widening through casts, index
   access, and assertions, so Escalier cannot prove the closed-set property
@@ -1076,27 +1252,47 @@ Mutability is orthogonal to exactness. `mut T` carries the exactness of
   behavior across the package boundary and avoids spurious errors when
   calling into TypeScript libraries. Users who know an imported type is
   actually closed can opt into exactness at the use site with `Exact<T>`.
-- **Round-tripping:** As described in the original `07_exact_types.md`, when
-  Escalier emits `.d.ts` files for consumption by other Escalier projects, it
-  should preserve exactness via JSDoc annotations on declarations. TypeScript
+- **Round-tripping:** When Escalier emits `.d.ts` files for consumption by
+  other Escalier projects, it preserves the original Escalier type via an
+  `@escalier-type` JSDoc tag on each declaration (see §9). TypeScript
   consumers will see the (inexact) erased form; Escalier consumers will
-  recover the precise exactness.
+  recover the precise exactness from the JSDoc payload.
 
 ## 9. TypeScript Interop
 
-- Exact object types are emitted as plain TypeScript object types
-  (`{ x: number, y: number }`), losing the exactness annotation. A JSDoc
-  comment carries the original Escalier type for round-trip preservation.
-- Exact tuple types are emitted as plain TypeScript tuple types
-  (`[string, number]`), again with a JSDoc annotation for round-tripping.
-- Exact function types are emitted as plain TypeScript function types. The
-  JSDoc annotation marks the exactness so other Escalier consumers can
-  reconstruct the original type and enforce the arity check.
-- Inexact types are emitted as their natural TypeScript equivalents:
-  `{ x: number, [k: string]: unknown }` for objects (or simply
-  `{ x: number }` if a more faithful encoding is not needed), tuples with a
-  trailing `...Array<unknown>` for tuples, and functions with no arity
-  enforcement.
+This section consolidates the interop story spread across §5.5 (union
+import), §6.5 (`Exact`/`Inexact` erasure), and the per-category emission
+rules. The summary table below shows how each kind of Escalier type
+round-trips through `.d.ts`:
+
+| Escalier kind | Emitted TS form | JSDoc annotation | Round-trip back to Escalier |
+|---|---|---|---|
+| Exact object `{x: T, y: U}` | `{ x: T, y: U }` | `@escalier-type {x: T, y: U}` | exact |
+| Inexact object `{x: T, ...}` | `{ x: T }` | `@escalier-type {x: T, ...}` | inexact |
+| Exact tuple `[T, U]` | `[T, U]` | `@escalier-type [T, U]` | exact |
+| Inexact tuple `[T, U, ...]` | `[T, U, ...Array<unknown>]` | `@escalier-type [T, U, ...]` | inexact |
+| Exact function `fn(a: A) -> R` | `(a: A) => R` | `@escalier-type fn(a: A) -> R` | exact (arity enforced) |
+| Inexact function `fn(a: A, ...) -> R` | `(a: A, ...rest: Array<unknown>) => R` | `@escalier-type fn(a: A, ...) -> R` | inexact |
+| Exact union `A \| B` | `A \| B` | `@escalier-type A \| B` | exact |
+| Inexact union `A \| B \| ...` | `A \| B \| unknown` (i.e. `unknown`) or just `A \| B` | `@escalier-type A \| B \| ...` | inexact |
+| `Exact<T>` / `Inexact<T>` wrappers | erased to the result type | `@escalier-type Exact<T>` / `@escalier-type Inexact<T>` | wrapper recovered |
+
+A single `@escalier-type` JSDoc tag, whose payload is the original
+Escalier type annotation in source form, carries everything needed to
+round-trip the declaration. The emitted TypeScript form is a best-effort
+erasure for plain TS consumers; the JSDoc payload is the source of truth
+for Escalier consumers re-importing the declaration.
+
+**Imports from plain TypeScript** (declarations *without* an
+`@escalier-type` annotation) default to the inexact form for every
+category, with the `boolean` and `null | undefined` exceptions noted in
+§5.5. Users who know an imported type is actually closed can opt in
+explicitly with `Exact<T>`.
+
+**Round-tripping between Escalier projects** is driven entirely by the
+`@escalier-type` annotations above. Plain TypeScript consumers ignore
+the JSDoc payload and see only the erased form (with the inexact
+default).
 
 ## 10. Examples
 
@@ -1106,8 +1302,9 @@ Mutability is orthogonal to exactness. `mut T` carries the exactness of
 type Point = {x: number, y: number}     // exact
 val p: Point = {x: 1, y: 2}
 
+// Object.keys(p) is the exact tuple ["x", "y"]: ["x", "y"]
 for k in Object.keys(p) {
-    // k: "x" | "y" — known precisely because Point is exact
+    // k: keyof Point — i.e. the exact union "x" | "y", since Point is exact
     console.log(k, p[k])
 }
 ```
@@ -1159,10 +1356,5 @@ val h: Headers = {
 
 ## 11. Open Questions
 
-1. **Index signatures and exactness.** How does an explicit index signature
-   (`{[k: string]: T}`) interact with exactness? Probably an index signature
-   implies inexactness, but this should be specified.
-2. **Generic constraints.** When a type parameter `T` is constrained by an
-   exact type, can `T` be substituted with an inexact subtype? Likely no
-   (exact constraint forces exact arguments), but this should be specified
-   alongside variance rules.
+*(None at present — previously open questions about index signatures and
+generic constraints are resolved in §2.7.1 and §7.12 respectively.)*


### PR DESCRIPTION
- **Requirements doc for planning out exact/inexact types**
- **initial revisions**

TODO:
- [x] add a function that converts an inexact object/tuple to an exact one
- [ ] consider what primitives would be necessary to allow us to define `Exact<T>` and `Inexact<T>` as regular utility types, e.g.

<img width="2114" height="410" alt="image" src="https://github.com/user-attachments/assets/59b9be3f-9a59-49ff-ab32-0f747f303644" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Exact Types Specification**
  * Added comprehensive documentation defining exact vs inexact type variants across object, tuple, function, and union types.
  * Includes syntax specifications, semantic subtyping rules, propagation behavior through type operators, utility types, TypeScript interoperability, and practical usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->