### PR TITLE
Lifetimes 10: Constrained type parameters that carry a lifetime

### DIFF
--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1511,11 +1511,14 @@ func typeCarriesLifetime(t type_system.Type) bool {
 			// Phase 10.2: walk into the bound. For type-parameter
 			// scope entries, TypeAlias.Type holds the constraint
 			// (or UnknownType for unbounded params, which falls
-			// through to false).
+			// through to false). Use boundCarriesLifetime so a
+			// constraint that itself names an alias resolving to a
+			// primitive (e.g. `type Num = number; T: Num`) returns
+			// false.
 			if ty.TypeAlias.Type == nil {
 				return false
 			}
-			return typeCarriesLifetime(ty.TypeAlias.Type)
+			return boundCarriesLifetime(ty.TypeAlias.Type)
 		}
 		return true
 	case *type_system.ObjectType, *type_system.TupleType:
@@ -1523,6 +1526,36 @@ func typeCarriesLifetime(t type_system.Type) bool {
 		return true
 	case *type_system.MutType:
 		return typeCarriesLifetime(ty.Type)
+	}
+	return false
+}
+
+// boundCarriesLifetime is the constraint-walking variant of
+// typeCarriesLifetime. Unlike the general check, it expands non-type-
+// param TypeRefType bounds to their alias body so that a constraint
+// like `T: Num` (where `type Num = number`) resolves to its primitive
+// body and reports false. Outside the constraint walk we keep the
+// conservative "TypeRefType always carries a lifetime" rule because
+// real reference shapes (classes, parameterized aliases over objects)
+// flow through it.
+func boundCarriesLifetime(t type_system.Type) bool {
+	switch ty := type_system.Prune(t).(type) {
+	case *type_system.TypeRefType:
+		if ty.TypeAlias != nil && ty.TypeAlias.IsTypeParam {
+			if ty.TypeAlias.Type == nil {
+				return false
+			}
+			return boundCarriesLifetime(ty.TypeAlias.Type)
+		}
+		if ty.TypeAlias != nil && ty.TypeAlias.Type != nil {
+			return boundCarriesLifetime(ty.TypeAlias.Type)
+		}
+		return true
+	case *type_system.ObjectType, *type_system.TupleType:
+		_ = ty
+		return true
+	case *type_system.MutType:
+		return boundCarriesLifetime(ty.Type)
 	}
 	return false
 }

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1527,6 +1527,21 @@ func typeCarriesLifetime(t type_system.Type) bool {
 	return false
 }
 
+// cloneLifetimeBearing returns a shallow copy of t suitable for mutating
+// its Lifetime field without affecting the original. Walks past MutType
+// wrappers so the inner TypeRefType/ObjectType/TupleType is copied too.
+// Returns t unchanged for other shapes.
+func cloneLifetimeBearing(t type_system.Type) type_system.Type {
+	switch ty := type_system.Prune(t).(type) {
+	case *type_system.MutType:
+		inner := cloneLifetimeBearing(ty.Type)
+		return type_system.NewMutType(nil, inner)
+	case *type_system.TypeRefType, *type_system.ObjectType, *type_system.TupleType:
+		return ty.Copy()
+	}
+	return t
+}
+
 // lifetimeBearingHasNoLifetime reports whether t can carry a Lifetime
 // field but currently has none. Used by Phase 10.5 substitution to
 // decide whether to transfer the use-site lifetime onto a resolved

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1498,15 +1498,24 @@ func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
 }
 
 // typeCarriesLifetime reports whether the given type can carry a lifetime.
-// Walks past mutability wrappers. Type parameters (TypeRefType pointing
-// at a TypeAlias with IsTypeParam=true) are excluded, since the parameter
-// might be instantiated to a primitive at the call site, in which case
-// the lifetime would have nowhere to live.
+// Walks past mutability wrappers. Unbounded type parameters are excluded,
+// since the parameter might be instantiated to a primitive at the call
+// site, in which case the lifetime would have nowhere to live. A
+// constrained type parameter is treated as lifetime-bearing iff its
+// constraint is itself lifetime-bearing — every legal instantiation of
+// the parameter will then have a place to attach the lifetime.
 func typeCarriesLifetime(t type_system.Type) bool {
 	switch ty := type_system.Prune(t).(type) {
 	case *type_system.TypeRefType:
 		if ty.TypeAlias != nil && ty.TypeAlias.IsTypeParam {
-			return false
+			// Phase 10.2: walk into the bound. For type-parameter
+			// scope entries, TypeAlias.Type holds the constraint
+			// (or UnknownType for unbounded params, which falls
+			// through to false).
+			if ty.TypeAlias.Type == nil {
+				return false
+			}
+			return typeCarriesLifetime(ty.TypeAlias.Type)
 		}
 		return true
 	case *type_system.ObjectType, *type_system.TupleType:
@@ -1514,6 +1523,25 @@ func typeCarriesLifetime(t type_system.Type) bool {
 		return true
 	case *type_system.MutType:
 		return typeCarriesLifetime(ty.Type)
+	}
+	return false
+}
+
+// lifetimeBearingHasNoLifetime reports whether t can carry a Lifetime
+// field but currently has none. Used by Phase 10.5 substitution to
+// decide whether to transfer the use-site lifetime onto a resolved
+// shape, leaving any pre-existing annotation in place for the caller
+// to unify.
+func lifetimeBearingHasNoLifetime(t type_system.Type) bool {
+	switch ty := type_system.Prune(t).(type) {
+	case *type_system.TypeRefType:
+		return ty.Lifetime == nil
+	case *type_system.ObjectType:
+		return ty.Lifetime == nil
+	case *type_system.TupleType:
+		return ty.Lifetime == nil
+	case *type_system.MutType:
+		return lifetimeBearingHasNoLifetime(ty.Type)
 	}
 	return false
 }

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -1560,19 +1560,29 @@ func boundCarriesLifetime(t type_system.Type) bool {
 	return false
 }
 
-// cloneLifetimeBearing returns a shallow copy of t suitable for mutating
-// its Lifetime field without affecting the original. Walks past MutType
-// wrappers so the inner TypeRefType/ObjectType/TupleType is copied too.
-// Returns t unchanged for other shapes.
+// cloneLifetimeBearing returns a shallow copy of t suitable for
+// mutating its Lifetime field without affecting the original, or nil
+// if t cannot actually carry a lifetime. Walks past MutType wrappers
+// so the inner TypeRefType/ObjectType/TupleType is copied too. A
+// TypeRefType is considered lifetime-bearing only if its alias body
+// resolves to a lifetime-bearing shape (per boundCarriesLifetime), so
+// callers can't accidentally attach a lifetime to e.g. a TypeRefType
+// aliasing a primitive.
 func cloneLifetimeBearing(t type_system.Type) type_system.Type {
+	if !boundCarriesLifetime(t) {
+		return nil
+	}
 	switch ty := type_system.Prune(t).(type) {
 	case *type_system.MutType:
 		inner := cloneLifetimeBearing(ty.Type)
+		if inner == nil {
+			return nil
+		}
 		return type_system.NewMutType(nil, inner)
 	case *type_system.TypeRefType, *type_system.ObjectType, *type_system.TupleType:
 		return ty.Copy()
 	}
-	return t
+	return nil
 }
 
 // lifetimeBearingHasNoLifetime reports whether t can carry a Lifetime

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -60,6 +60,17 @@ func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.
 
 		// Check if this is a type parameter reference that should be substituted
 		if substitute, found := v.substitutions[typeName]; found {
+			// Phase 10.5: when the type-parameter use site carries a
+			// Lifetime annotation (e.g. `mut 'a T`), transfer it onto
+			// the resolved shape so the lifetime survives substitution.
+			// If the resolved shape already carries a Lifetime, leave it
+			// alone — unification of the two lifetimes is the caller's
+			// responsibility (Phase 9.1).
+			if t.Lifetime != nil {
+				if lifetimeBearingHasNoLifetime(substitute) {
+					setLifetimeOnType(substitute, t.Lifetime)
+				}
+			}
 			return substitute
 		}
 

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -65,11 +65,13 @@ func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.
 			// the resolved shape so the lifetime survives substitution.
 			// If the resolved shape already carries a Lifetime, leave it
 			// alone — unification of the two lifetimes is the caller's
-			// responsibility (Phase 9.1).
-			if t.Lifetime != nil {
-				if lifetimeBearingHasNoLifetime(substitute) {
-					setLifetimeOnType(substitute, t.Lifetime)
-				}
+			// responsibility (Phase 9.1). Clone the resolved shape before
+			// mutating so other use sites of the same substitute are not
+			// affected.
+			if t.Lifetime != nil && lifetimeBearingHasNoLifetime(substitute) {
+				cloned := cloneLifetimeBearing(substitute)
+				setLifetimeOnType(cloned, t.Lifetime)
+				return cloned
 			}
 			return substitute
 		}

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -68,10 +68,16 @@ func (v *TypeParamSubstitutionVisitor) ExitType(t type_system.Type) type_system.
 			// responsibility (Phase 9.1). Clone the resolved shape before
 			// mutating so other use sites of the same substitute are not
 			// affected.
+			// cloneLifetimeBearing returns nil when the substitute
+			// can't actually carry a lifetime (e.g. a TypeRefType
+			// aliasing a primitive), so this also guards against
+			// silently minting a lifetime on something that can't
+			// hold one.
 			if t.Lifetime != nil && lifetimeBearingHasNoLifetime(substitute) {
-				cloned := cloneLifetimeBearing(substitute)
-				setLifetimeOnType(cloned, t.Lifetime)
-				return cloned
+				if cloned := cloneLifetimeBearing(substitute); cloned != nil {
+					setLifetimeOnType(cloned, t.Lifetime)
+					return cloned
+				}
 			}
 			return substitute
 		}

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -1372,6 +1372,61 @@ func TestCallSiteNoAliasForFreshReturn(t *testing.T) {
 		"clone returns a fresh value, so r should not alias p")
 }
 
+// Phase 10 call-site regression: instantiating a generic function with
+// a `mut` argument unifies the fresh type variable with the concrete
+// argument shape. Before the fix, unifyMut required strict equality
+// and rejected the TypeVar↔ObjectType case.
+func TestCallSite_GenericMut_UnboundedTypeParam(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		fn id<T>(p: mut T) -> mut T { return p }
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			val r: mut {x: number} = id(p)
+			r.x = 5
+		}
+	`)
+	assert.Empty(t, mutErrors)
+}
+
+// Same as above but with a constrained type parameter — exercises both
+// Phase 10 lifetime inference (`'a` attached to `mut T`) and the
+// unifyMut TypeVar-binding fix at the call site.
+func TestCallSite_GenericMut_ConstrainedTypeParam(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		fn id<T: {x: number}>(p: mut T) -> mut T { return p }
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			val r: mut {x: number} = id(p)
+			r.x = 5
+		}
+	`)
+	assert.Empty(t, mutErrors)
+}
+
+// `first<T: {x: number}>(p, other) -> p` lifetime-links only `p` to the
+// return. After the call, the unrelated argument `q` (passed as
+// `other`) must be free to be frozen to an immutable binding even
+// while the result still holds mutable access — i.e. `q` is not
+// silently linked to `p`'s lifetime.
+func TestCallSite_FirstGeneric_OtherArgNotLinked(t *testing.T) {
+	t.Parallel()
+	mutErrors := mustInferScriptMutErrors(t, `
+		fn first<T: {x: number}>(p: mut T, other: mut T) -> mut T { return p }
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			val q: mut {x: number} = {x: 1}
+			val r: mut {x: number} = first(p, q)
+			val frozenQ: {x: number} = q
+			r.x = 5
+			frozenQ
+		}
+	`)
+	assert.Empty(t, mutErrors,
+		"q is not aliased by r, so freezing q should be allowed")
+}
+
 // mustInferAsModule parses and type-checks the given input as a module
 // (so class declarations are accepted), failing the test on any non-
 // mutability error. Returns the top-level namespace.

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -779,6 +779,42 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"id": "fn <T: number>(p: mut T) -> mut T",
 			},
 		},
+		// Alias-bound constraint: the bound is a TypeRefType pointing
+		// at a type alias whose body is lifetime-bearing. Every legal
+		// instantiation of T is still a shape that carries a lifetime,
+		// so the parameter should be lifetime-annotated.
+		"ConstrainedTypeParam_AliasBound": {
+			input: `
+				type Point = {x: number}
+				fn id<T: Point>(p: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <'a, T: Point>(p: mut 'a T) -> mut 'a T",
+			},
+		},
+		// Alias-bound constraint where the alias body is itself a
+		// primitive: the constraint resolves to a non-lifetime-bearing
+		// shape, so no lifetime should be inferred.
+		"ConstrainedTypeParam_AliasBound_Primitive": {
+			input: `
+				type Num = number
+				fn id<T: Num>(p: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <T: Num>(p: mut T) -> mut T",
+			},
+		},
+		// Class-instance constraint: every legal instantiation of T
+		// is a class instance, which carries a lifetime.
+		"ConstrainedTypeParam_ClassInstanceBound": {
+			input: `
+				class Point { x: number, y: number }
+				fn id<T: Point>(p: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <'a, T: Point>(p: mut 'a T) -> mut 'a T",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -729,6 +729,56 @@ func TestInferLifetimeTypes(t *testing.T) {
 				"box": "fn <'a>(p: mut 'a {x: number}) -> Array<{inner: mut 'a {x: number}}>",
 			},
 		},
+		// Phase 10: a type parameter constrained to a lifetime-bearing
+		// shape carries a lifetime — every legal instantiation has a
+		// place to attach the borrow.
+		"ConstrainedTypeParam_FirstOfTwo": {
+			input: `
+				fn first<T: {x: number}>(p: mut T, other: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"first": "fn <'a, T: {x: number}>(p: mut 'a T, other: mut T) -> mut 'a T",
+			},
+		},
+		"ConstrainedTypeParam_Identity": {
+			input: `
+				fn id<T: {x: number}>(p: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <'a, T: {x: number}>(p: mut 'a T) -> mut 'a T",
+			},
+		},
+		// Regression guard for the pre-Phase-10 behavior: an unbounded
+		// type parameter has no guaranteed lifetime-bearing shape, so
+		// no lifetime is inferred.
+		"UnboundedTypeParam_NoLifetime": {
+			input: `
+				fn id<T>(p: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <T>(p: mut T) -> mut T",
+			},
+		},
+		// Tuple-bound constraint: every instantiation is a tuple, which
+		// carries a lifetime.
+		"ConstrainedTypeParam_TupleBound": {
+			input: `
+				fn id<T: [number, number]>(p: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <'a, T: [number, number]>(p: mut 'a T) -> mut 'a T",
+			},
+		},
+		// Primitive-bound constraint: the constraint is not lifetime-
+		// bearing, so the type parameter stays unannotated.
+		"ConstrainedTypeParam_PrimitiveBound": {
+			input: `
+				fn id<T: number>(p: mut T) -> mut T { return p }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <T: number>(p: mut T) -> mut T",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/checker/tests/substitute_test.go
+++ b/internal/checker/tests/substitute_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/test_util"
 	"github.com/escalier-lang/escalier/internal/type_system"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypeParamSubstitutionVisitor(t *testing.T) {
@@ -409,4 +410,46 @@ func TestSubstituteTypeParamsInObjElem(t *testing.T) {
 
 	assert.Equal(t, "{readonly test?: T, method(self, x: T) -> U, get getter(self) -> T, set setter(mut self, value: V) -> undefined, fn (x: T) -> U, new fn (init: V) -> U, ...T}", objType.String())
 	assert.Equal(t, "{readonly test?: number, method(self, x: number) -> string, get getter(self) -> number, set setter(mut self, value: boolean) -> undefined, fn (x: number) -> string, new fn (init: boolean) -> string, ...number}", result.String())
+}
+
+// Phase 10.5 regression: when the same type-parameter substitute is used
+// at multiple use sites with distinct lifetime annotations, the substituter
+// must not mutate the shared substitute. Each visit should produce its own
+// copy carrying that use site's lifetime; otherwise the second visit
+// would either see a stale annotation or overwrite the first.
+func TestSubstituteTypeParams_DoesNotMutateSharedSubstitute(t *testing.T) {
+	ltA := &type_system.LifetimeValue{ID: 1, Name: "a"}
+	ltB := &type_system.LifetimeValue{ID: 2, Name: "b"}
+
+	// Constraint shape used as the type-param's bound — this is what
+	// the use-site TypeRefType resolves to when substituted with a
+	// concrete shape.
+	objType := type_system.NewObjectType(nil, nil)
+
+	// Build two type-param uses of T, each with a distinct lifetime.
+	typeAlias := &type_system.TypeAlias{Type: objType, IsTypeParam: true}
+	useA := type_system.NewTypeRefType(nil, "T", typeAlias)
+	useA.Lifetime = ltA
+	useB := type_system.NewTypeRefType(nil, "T", typeAlias)
+	useB.Lifetime = ltB
+
+	tuple := type_system.NewTupleType(nil, useA, useB)
+
+	subs := map[string]type_system.Type{"T": objType}
+	result := SubstituteTypeParams[type_system.Type](tuple, subs)
+
+	resTuple, ok := result.(*type_system.TupleType)
+	require.True(t, ok, "expected tuple result, got %T", result)
+	require.Len(t, resTuple.Elems, 2)
+
+	first, ok := type_system.Prune(resTuple.Elems[0]).(*type_system.ObjectType)
+	require.True(t, ok)
+	second, ok := type_system.Prune(resTuple.Elems[1]).(*type_system.ObjectType)
+	require.True(t, ok)
+
+	assert.Equal(t, ltA, first.Lifetime, "first slot should carry 'a")
+	assert.Equal(t, ltB, second.Lifetime, "second slot should carry 'b — distinct from 'a")
+
+	// And the original constraint object must not have been mutated.
+	assert.Nil(t, objType.Lifetime, "shared substitute must not be mutated")
 }

--- a/internal/checker/tests/substitute_test.go
+++ b/internal/checker/tests/substitute_test.go
@@ -417,6 +417,13 @@ func TestSubstituteTypeParamsInObjElem(t *testing.T) {
 // must not mutate the shared substitute. Each visit should produce its own
 // copy carrying that use site's lifetime; otherwise the second visit
 // would either see a stale annotation or overwrite the first.
+//
+// Example: substituting `T -> {x: number}` in `[mut 'a T, mut 'b T]`
+// should produce `[mut 'a {x: number}, mut 'b {x: number}]`. With a
+// shared substitute, the first slot would set `{x: number}.Lifetime
+// = 'a`, then the second visit would see the existing 'a annotation,
+// skip its own write, and end up with `'a` in both slots — collapsing
+// `'a` and `'b` into one lifetime.
 func TestSubstituteTypeParams_DoesNotMutateSharedSubstitute(t *testing.T) {
 	ltA := &type_system.LifetimeValue{ID: 1, Name: "a"}
 	ltB := &type_system.LifetimeValue{ID: 2, Name: "b"}

--- a/internal/checker/unify_mut.go
+++ b/internal/checker/unify_mut.go
@@ -18,6 +18,18 @@ func (c *Checker) unifyMut(ctx Context, mut1, mut2 *type_system.MutType) []Error
 	t1 = type_system.Prune(t1)
 	t2 = type_system.Prune(t2)
 
+	// For invariant unification, the types must be exactly equal —
+	// except when one side is an unbound TypeVar (e.g. a fresh
+	// instantiation of a generic type parameter), in which case we
+	// bind it to the other side. After binding, both sides resolve
+	// to the same type, satisfying invariance.
+	if _, ok := t1.(*type_system.TypeVarType); ok {
+		return c.bind(ctx, t1, t2, nil)
+	}
+	if _, ok := t2.(*type_system.TypeVarType); ok {
+		return c.bind(ctx, t2, t1, nil)
+	}
+
 	// For invariant unification, the types must be exactly equal
 	if type_system.Equals(t1, t2) {
 		return nil

--- a/internal/checker/unify_mut.go
+++ b/internal/checker/unify_mut.go
@@ -30,7 +30,7 @@ func (c *Checker) unifyMut(ctx Context, mut1, mut2 *type_system.MutType) []Error
 		return c.bind(ctx, t2, t1, nil)
 	}
 
-	// For invariant unification, the types must be exactly equal
+	// Otherwise require exact equality.
 	if type_system.Equals(t1, t2) {
 		return nil
 	}

--- a/planning/lifetimes/implementation_plan.md
+++ b/planning/lifetimes/implementation_plan.md
@@ -29,9 +29,9 @@ into phases that build incrementally, each producing a testable milestone.
 |     5 | Alias tracking (local variables)                     | 3          | Done   |
 |     6 | Mutability transition checking                       | 4, 5       | Done   |
 |     7 | Alias tracking (properties, closures, destructuring) | 5, 6       | Done   |
-|     8 | Lifetime annotations and inference                   | 6, 7       |        |
-|     9 | Lifetime unification                                  | 8          |        |
-|    10 | Constrained type parameters that carry a lifetime     | 9          |        |
+|     8 | Lifetime annotations and inference                   | 6, 7       | Done   |
+|     9 | Lifetime unification                                  | 8          | Done   |
+|    10 | Constrained type parameters that carry a lifetime     | 9          | Done   |
 |    11 | Lifetime elision rules                               | 8, 9       |        |
 |    12 | TypeScript interop                                   | 11         |        |
 |    13 | Error messages                                       | 6–12       |        |
@@ -1366,7 +1366,7 @@ Additional tests beyond the original plan:
 
 ---
 
-## Phase 8: Lifetime Annotations and Inference
+## Phase 8: Lifetime Annotations and Inference (Done)
 
 **Goal:** Add lifetime annotations to function signatures and infer them from
 function bodies.
@@ -2359,7 +2359,7 @@ class Pair(a: mut Point, b: mut Point) {
 
 ---
 
-## Phase 9: Lifetime Unification
+## Phase 9: Lifetime Unification (Done)
 
 **Goal:** Integrate lifetime variables into the type unification engine so
 that lifetimes are propagated through type inference.
@@ -2756,7 +2756,7 @@ so the diagnostic only fires for user-typed names.
 
 ---
 
-## Phase 10: Constrained Type Parameters That Carry a Lifetime
+## Phase 10: Constrained Type Parameters That Carry a Lifetime (Done)
 
 **Goal:** Allow lifetime inference and annotations on type parameters whose
 constraint is itself a lifetime-bearing shape, so generic functions over
@@ -3492,10 +3492,10 @@ implementation is stable. These are explicitly **not part of Phases 1–14**:
         └── 5. Alias tracking (local) ✅
             ├── 6. Transition checking ✅
             │   └── 7. Advanced alias tracking (properties, closures, destructuring) ✅
-            │       └── 8. Lifetime annotations, inference, & constructors
-            │           └── 9. Lifetime unification ('static, conflict detection,
+            │       └── 8. Lifetime annotations, inference, & constructors ✅
+            │           └── 9. Lifetime unification ('static, conflict detection, ✅
             │               │  higher-order function threading)
-            │               ├── 10. Constrained type parameters that carry a lifetime
+            │               ├── 10. Constrained type parameters that carry a lifetime ✅
             │               └── 11. Elision rules & interface lifetime verification
             │                   └── 12. TypeScript interop
             └── 7. Advanced alias tracking ✅


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifetime inference for constrained type parameters with lifetime-bearing constraints
  * Enhanced preservation of lifetime annotations during type parameter substitution

* **Tests**
  * Added comprehensive test coverage for constrained type parameter lifetime behavior

* **Documentation**
  * Updated implementation roadmap marking phases 8–10 as complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->