### PR TITLE
Add SelfParam to FuncType

### DIFF
--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1053,12 +1053,12 @@ func isMemberVisible(elem type_system.ObjTypeElem, mode AccessMode, receiverMut 
 			if receiverMut {
 				return true
 			}
-			return e.MutSelf == nil || !*e.MutSelf
+			return !methodRequiresMutSelf(e.Fn, e.MutSelf)
 		case *type_system.GetterElem:
 			if receiverMut {
 				return true
 			}
-			return e.MutSelf == nil || !*e.MutSelf
+			return !methodRequiresMutSelf(e.Fn, e.MutSelf)
 		default:
 			return true
 		}

--- a/internal/checker/infer_class_ctor.go
+++ b/internal/checker/infer_class_ctor.go
@@ -144,6 +144,11 @@ func (c *Checker) inferConstructorSig(
 		retType,
 		throwsType,
 	)
+	// Note: constructors deliberately do NOT carry SelfParam. A
+	// constructor produces a receiver via its return type — there is no
+	// pre-existing receiver to bind. Callers invoke `C(args)`, not
+	// `instance.constructor(args)`. The validateConstructorSelf check
+	// above still enforces that the AST-level `mut self` is present.
 	return funcType, ctorCtx, paramBindings, errors
 }
 

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -434,6 +434,15 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					methodType, methodCtx, paramBindings, _ := c.inferFuncSig(objCtx, &elem.Fn.FuncSig, elem.Fn)
 					methodCtxs[i] = methodCtx
 					paramBindingsSlice[i] = paramBindings
+					// Note: object-literal methods deliberately leave
+					// SelfParam unpopulated. The receiver type is the
+					// surrounding object — represented by `selfType`,
+					// a fresh TypeVar that gets bound to the ObjectType
+					// being constructed. Wiring that back into each
+					// method's SelfParam creates a recursive
+					// `obj→method→obj` cycle that breaks the unifier.
+					// Object-literal receivers are structural anyway;
+					// the MethodElem.MutSelf cache covers visibility.
 					types[i] = methodType
 					typeElems[i] = type_system.NewMethodElem(*key, methodType, elem.MutSelf)
 				}

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -495,6 +495,15 @@ func (c *Checker) InferComponent(
 				instanceSymbolKeyMap := make(map[int]any)
 				staticSymbolKeyMap := make(map[int]any)
 
+				// Build the class instance ref once so each method/getter/setter
+				// can attach it as their FuncType.SelfParam. Mirrors the
+				// retType construction below.
+				classTypeArgs := make([]type_system.Type, len(typeParams))
+				for i := range typeParams {
+					classTypeArgs[i] = type_system.NewTypeRefType(nil, typeParams[i].Name, nil)
+				}
+				classSelfRef := type_system.NewTypeRefType(nil, decl.Name.Name, typeAlias, classTypeArgs...)
+
 				for i, elem := range decl.Body {
 					switch elem := elem.(type) {
 					case *ast.FieldElem:
@@ -570,6 +579,7 @@ func (c *Checker) InferComponent(
 							)
 						} else {
 							// Instance methods go to the instance type
+							methodType.SelfParam = makeSelfParam(classSelfRef, elem.MutSelf)
 							objTypeElems = append(
 								objTypeElems,
 								type_system.NewMethodElem(*key, methodType, elem.MutSelf),
@@ -604,6 +614,7 @@ func (c *Checker) InferComponent(
 							)
 						} else {
 							// Instance getters go to the instance type
+							funcType.SelfParam = makeSelfParam(classSelfRef, elem.MutSelf)
 							objTypeElems = append(
 								objTypeElems,
 								type_system.NewGetterElem(*key, funcType, elem.MutSelf),
@@ -638,6 +649,7 @@ func (c *Checker) InferComponent(
 							)
 						} else {
 							// Instance setters go to the instance type
+							funcType.SelfParam = makeSelfParam(classSelfRef, elem.MutSelf)
 							objTypeElems = append(
 								objTypeElems,
 								type_system.NewSetterElem(*key, funcType, elem.MutSelf),

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -330,8 +330,9 @@ func (c *Checker) inferInterface(
 	for i, typeParam := range decl.TypeParams {
 		typeArgs[i] = type_system.NewTypeRefType(nil, typeParam.Name, nil)
 	}
-	selfType := type_system.NewTypeRefType(nil, decl.Name.Name, nil, typeArgs...)
-	selfTypeAlias := type_system.TypeAlias{Type: selfType, TypeParams: []*type_system.TypeParam{}}
+	selfTypeAlias := type_system.TypeAlias{TypeParams: []*type_system.TypeParam{}}
+	selfType := type_system.NewTypeRefType(nil, decl.Name.Name, &selfTypeAlias, typeArgs...)
+	selfTypeAlias.Type = selfType
 
 	result := c.buildTypeParams(ctx, decl.TypeParams, &selfTypeAlias)
 	errors := result.Errors
@@ -344,6 +345,28 @@ func (c *Checker) inferInterface(
 
 	objType, typeErrors := c.inferObjectTypeAnn(typeCtx, decl.TypeAnn)
 	errors = slices.Concat(errors, typeErrors)
+
+	// Populate SelfParam on each instance method/getter/setter so receiver
+	// lifetimes flow through the same machinery as parameter lifetimes.
+	// inferObjectTypeAnn is generic across object-type contexts (interfaces,
+	// object-type-literals); only here, in the interface entry point, do we
+	// know the receiver type to attach.
+	for _, elem := range objType.Elems {
+		switch e := elem.(type) {
+		case *type_system.MethodElem:
+			if e.Fn != nil && e.Fn.SelfParam == nil {
+				e.Fn.SelfParam = makeSelfParam(selfType, e.MutSelf)
+			}
+		case *type_system.GetterElem:
+			if e.Fn != nil && e.Fn.SelfParam == nil {
+				e.Fn.SelfParam = makeSelfParam(selfType, e.MutSelf)
+			}
+		case *type_system.SetterElem:
+			if e.Fn != nil && e.Fn.SelfParam == nil {
+				e.Fn.SelfParam = makeSelfParam(selfType, e.MutSelf)
+			}
+		}
+	}
 
 	// Infer the Extends clause if present
 	if decl.Extends != nil {

--- a/internal/checker/method_helpers.go
+++ b/internal/checker/method_helpers.go
@@ -1,0 +1,81 @@
+package checker
+
+import "github.com/escalier-lang/escalier/internal/type_system"
+
+// makeSelfParam returns a FuncParam representing an implicit `self` receiver
+// for a method whose containing type is `containingType`. `mutSelf` is the
+// AST-level mutability flag (nil = static / no self, *false = `self`,
+// *true = `mut self`). Returns nil when there is no receiver.
+//
+// The receiver's pattern is always `self`; the type is the containing type,
+// wrapped in MutType when mutSelf points to true. Used during method
+// inference to populate FuncType.SelfParam in lockstep with the existing
+// MutSelf *bool denormalized cache on element nodes.
+func makeSelfParam(containingType type_system.Type, mutSelf *bool) *type_system.FuncParam {
+	if mutSelf == nil || containingType == nil {
+		return nil
+	}
+	t := containingType
+	if *mutSelf {
+		t = type_system.NewMutType(nil, containingType)
+	}
+	return &type_system.FuncParam{
+		Pattern: type_system.NewIdentPat("self"),
+		Type:    t,
+	}
+}
+
+// methodRequiresMutSelf reports whether a method/getter requires a `mut self`
+// receiver. Reads FuncType.SelfParam when populated (single source of truth);
+// falls back to the denormalized MutSelf flag for elements that haven't gone
+// through SelfParam population yet (a defensive fallback — every code path
+// that constructs MethodElem/GetterElem/SetterElem now sets SelfParam, and
+// the prelude backfill covers .d.ts-loaded types).
+func methodRequiresMutSelf(fn *type_system.FuncType, mutSelf *bool) bool {
+	if fn != nil && fn.SelfParam != nil {
+		_, isMut := fn.SelfParam.Type.(*type_system.MutType)
+		return isMut
+	}
+	return mutSelf != nil && *mutSelf
+}
+
+// populateSelfParams backfills FuncType.SelfParam on every instance
+// method/getter/setter in the namespace whose owning type is an
+// ObjectType. Source-inferred types already get SelfParam at inference
+// time (see infer_module.go, infer_stmt.go, infer_expr.go); this pass
+// covers the .d.ts-loaded TypeScript lib types — Array, Map, Set,
+// Promise, etc. — which arrive without a receiver representation. The
+// pass runs in initializeGlobalScope after UpdateMethodMutability has
+// already populated MutSelf on these elements.
+func populateSelfParams(ns *type_system.Namespace) {
+	for name, typeAlias := range ns.Types {
+		objType, ok := type_system.Prune(typeAlias.Type).(*type_system.ObjectType)
+		if !ok {
+			continue
+		}
+		// Build a TypeRef to this alias to use as the receiver type.
+		// Type args mirror the alias's TypeParams in declaration order.
+		typeArgs := make([]type_system.Type, len(typeAlias.TypeParams))
+		for i, tp := range typeAlias.TypeParams {
+			typeArgs[i] = type_system.NewTypeRefType(nil, tp.Name, nil)
+		}
+		selfRef := type_system.NewTypeRefType(nil, name, typeAlias, typeArgs...)
+
+		for _, elem := range objType.Elems {
+			switch e := elem.(type) {
+			case *type_system.MethodElem:
+				if e.Fn != nil && e.Fn.SelfParam == nil {
+					e.Fn.SelfParam = makeSelfParam(selfRef, e.MutSelf)
+				}
+			case *type_system.GetterElem:
+				if e.Fn != nil && e.Fn.SelfParam == nil {
+					e.Fn.SelfParam = makeSelfParam(selfRef, e.MutSelf)
+				}
+			case *type_system.SetterElem:
+				if e.Fn != nil && e.Fn.SelfParam == nil {
+					e.Fn.SelfParam = makeSelfParam(selfRef, e.MutSelf)
+				}
+			}
+		}
+	}
+}

--- a/internal/checker/method_helpers.go
+++ b/internal/checker/method_helpers.go
@@ -46,8 +46,13 @@ func methodRequiresMutSelf(fn *type_system.FuncType, mutSelf *bool) bool {
 // covers the .d.ts-loaded TypeScript lib types — Array, Map, Set,
 // Promise, etc. — which arrive without a receiver representation. The
 // pass runs in initializeGlobalScope after UpdateMethodMutability has
-// already populated MutSelf on these elements.
+// already populated MutSelf on these elements. Recurses into nested
+// namespaces so namespaced lib types (e.g. `Intl.Collator`) are
+// covered too.
 func populateSelfParams(ns *type_system.Namespace) {
+	for _, child := range ns.Namespaces {
+		populateSelfParams(child)
+	}
 	for name, typeAlias := range ns.Types {
 		objType, ok := type_system.Prune(typeAlias.Type).(*type_system.ObjectType)
 		if !ok {

--- a/internal/checker/method_helpers_test.go
+++ b/internal/checker/method_helpers_test.go
@@ -1,0 +1,69 @@
+package checker
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeMethodObjAlias builds a TypeAlias whose Type is an ObjectType
+// containing a single instance MethodElem with the given mutability.
+// The method's FuncType has no SelfParam yet — the shape produced by
+// .d.ts loading, which populateSelfParams should backfill.
+func makeMethodObjAlias(methodName string, mutSelf bool) *type_system.TypeAlias {
+	fn := type_system.NewFuncType(
+		nil, nil, nil,
+		type_system.NewNeverType(nil),
+		type_system.NewNeverType(nil),
+	)
+	method := type_system.NewMethodElem(
+		type_system.NewStrKey(methodName),
+		fn,
+		&mutSelf,
+	)
+	obj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{method})
+	return &type_system.TypeAlias{Type: obj}
+}
+
+// TestPopulateSelfParamsRecursesIntoNestedNamespaces pins that the
+// prelude SelfParam backfill walks child namespaces. .d.ts can define
+// types under a nested namespace (e.g. `Intl.Collator`); without
+// recursion those types' methods would silently miss SelfParam,
+// regressing receiver-lifetime flow for any namespaced lib type.
+func TestPopulateSelfParamsRecursesIntoNestedNamespaces(t *testing.T) {
+	t.Parallel()
+
+	root := type_system.NewNamespace()
+	child := type_system.NewNamespace()
+	grandchild := type_system.NewNamespace()
+
+	root.Types["Top"] = makeMethodObjAlias("topMethod", false)
+	child.Types["Mid"] = makeMethodObjAlias("midMethod", true)
+	grandchild.Types["Leaf"] = makeMethodObjAlias("leafMethod", false)
+
+	require.NoError(t, child.SetNamespace("Grand", grandchild))
+	require.NoError(t, root.SetNamespace("Child", child))
+
+	populateSelfParams(root)
+
+	check := func(alias *type_system.TypeAlias, methodName string, expectMut bool) {
+		obj := type_system.Prune(alias.Type).(*type_system.ObjectType)
+		var fn *type_system.FuncType
+		for _, elem := range obj.Elems {
+			if me, ok := elem.(*type_system.MethodElem); ok && me.Name.Str == methodName {
+				fn = me.Fn
+				break
+			}
+		}
+		require.NotNilf(t, fn, "method %q not found", methodName)
+		require.NotNilf(t, fn.SelfParam, "SelfParam missing for %q", methodName)
+		_, isMut := fn.SelfParam.Type.(*type_system.MutType)
+		assert.Equalf(t, expectMut, isMut, "MutType wrap for %q", methodName)
+	}
+
+	check(root.Types["Top"], "topMethod", false)
+	check(child.Types["Mid"], "midMethod", true)
+	check(grandchild.Types["Leaf"], "leafMethod", false)
+}

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -451,6 +451,7 @@ func (c *Checker) initializeGlobalScope() {
 
 	UpdateMethodMutability(inferCtx, globalNs)
 	UpdateCollectionMutability(globalNs)
+	populateSelfParams(globalNs)
 
 	// Add built-in operator bindings
 	c.addOperatorBindings(globalNs)

--- a/internal/checker/tests/class_test.go
+++ b/internal/checker/tests/class_test.go
@@ -654,6 +654,28 @@ func TestClassMethodSelfParamPopulated(t *testing.T) {
 			methodName:   "make",
 			expectStatic: true,
 		},
+		"GetterImmutableSelf": {
+			input: `
+				class Reader {
+					_value: number,
+					get value(self) -> number { return self._value }
+				}
+			`,
+			className:  "Reader",
+			methodName: "value",
+		},
+		"SetterMutSelf": {
+			input: `
+				class Writer {
+					_value: number,
+					constructor(mut self) { self._value = 0 },
+					set value(mut self, x: number) { self._value = x }
+				}
+			`,
+			className:  "Writer",
+			methodName: "value",
+			expectMut:  true,
+		},
 	}
 
 	for name, test := range tests {
@@ -678,16 +700,32 @@ func TestClassMethodSelfParamPopulated(t *testing.T) {
 
 			var methodFn *type_system.FuncType
 			var methodMutSelf *bool
+			matchKey := func(k type_system.ObjTypeKey) bool {
+				return k.Kind == type_system.StrObjTypeKeyKind && k.Str == test.methodName
+			}
 			for _, elem := range searchObj.Elems {
-				if me, ok := elem.(*type_system.MethodElem); ok {
-					if me.Name.Kind == type_system.StrObjTypeKeyKind && me.Name.Str == test.methodName {
-						methodFn = me.Fn
-						methodMutSelf = me.MutSelf
-						break
+				switch e := elem.(type) {
+				case *type_system.MethodElem:
+					if matchKey(e.Name) {
+						methodFn = e.Fn
+						methodMutSelf = e.MutSelf
+					}
+				case *type_system.GetterElem:
+					if matchKey(e.Name) {
+						methodFn = e.Fn
+						methodMutSelf = e.MutSelf
+					}
+				case *type_system.SetterElem:
+					if matchKey(e.Name) {
+						methodFn = e.Fn
+						methodMutSelf = e.MutSelf
 					}
 				}
+				if methodFn != nil {
+					break
+				}
 			}
-			require.NotNilf(t, methodFn, "method %q not found", test.methodName)
+			require.NotNilf(t, methodFn, "method/accessor %q not found", test.methodName)
 
 			if test.expectStatic {
 				assert.Nil(t, methodFn.SelfParam,

--- a/internal/checker/tests/class_test.go
+++ b/internal/checker/tests/class_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	. "github.com/escalier-lang/escalier/internal/checker"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -599,6 +600,113 @@ func TestClassImplementsLifetimeConformance(t *testing.T) {
 			} else {
 				assert.Equal(t, test.expectedErrors, actualMsgs)
 			}
+		})
+	}
+}
+
+// TestClassMethodSelfParamPopulated pins that class method/getter/setter
+// inference populates FuncType.SelfParam with a receiver whose type is
+// the class instance ref (wrapped in MutType for `mut self`). This is
+// the type-system-level invariant the checker relies on once
+// receiver-lifetime work goes downstream of method-call typing.
+func TestClassMethodSelfParamPopulated(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		className    string
+		methodName   string
+		expectMut    bool
+		expectStatic bool
+	}{
+		"ImmutableSelf": {
+			input: `
+				class Box {
+					value: number,
+					read(self) -> number { return self.value }
+				}
+			`,
+			className:  "Box",
+			methodName: "read",
+		},
+		"MutSelf": {
+			input: `
+				class Counter {
+					n: number,
+					constructor(mut self) { self.n = 0 },
+					bump(mut self) -> number {
+						self.n = self.n + 1
+						return self.n
+					}
+				}
+			`,
+			className:  "Counter",
+			methodName: "bump",
+			expectMut:  true,
+		},
+		"StaticHasNoSelfParam": {
+			// Static methods must NOT carry a SelfParam — they have no
+			// receiver to bind. The method elem's MutSelf is nil.
+			input: `
+				class Boxer {
+					static make() -> number { return 0 }
+				}
+			`,
+			className:    "Boxer",
+			methodName:   "make",
+			expectStatic: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ns := mustInferAsModule(t, test.input)
+
+			classAlias := ns.Types[test.className]
+			require.NotNilf(t, classAlias, "class type alias %q not found", test.className)
+
+			searchObj := type_system.Prune(classAlias.Type).(*type_system.ObjectType)
+			if test.expectStatic {
+				// Static methods live on the class object's value
+				// binding, not on the instance type. Look up the
+				// constructor type alias for the class to inspect them.
+				ctorBinding := ns.Values[test.className]
+				require.NotNil(t, ctorBinding, "constructor binding not found")
+				if obj, ok := type_system.Prune(ctorBinding.Type).(*type_system.ObjectType); ok {
+					searchObj = obj
+				}
+			}
+
+			var methodFn *type_system.FuncType
+			var methodMutSelf *bool
+			for _, elem := range searchObj.Elems {
+				if me, ok := elem.(*type_system.MethodElem); ok {
+					if me.Name.Kind == type_system.StrObjTypeKeyKind && me.Name.Str == test.methodName {
+						methodFn = me.Fn
+						methodMutSelf = me.MutSelf
+						break
+					}
+				}
+			}
+			require.NotNilf(t, methodFn, "method %q not found", test.methodName)
+
+			if test.expectStatic {
+				assert.Nil(t, methodFn.SelfParam,
+					"static methods must not carry SelfParam")
+				assert.Nil(t, methodMutSelf,
+					"static methods' MutSelf must be nil")
+				return
+			}
+
+			require.NotNil(t, methodFn.SelfParam,
+				"instance methods must carry SelfParam")
+			require.NotNil(t, methodMutSelf,
+				"instance methods' MutSelf must be set")
+
+			_, isMut := methodFn.SelfParam.Type.(*type_system.MutType)
+			assert.Equalf(t, test.expectMut, isMut,
+				"SelfParam.Type wrap-in-MutType should reflect MutSelf=%v", *methodMutSelf)
+			assert.Equalf(t, test.expectMut, *methodMutSelf,
+				"MutSelf should match the test expectation")
 		})
 	}
 }

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -412,6 +412,14 @@ func printFuncType(t *FuncType, pt func(Type) string) string {
 		result += ">"
 	}
 	result += "("
+	// Note: SelfParam is intentionally NOT printed here. printFuncType
+	// is shared between (a) bare function values and (b) the inner
+	// signature of method elements. Method elements emit `self` /
+	// `mut self` themselves at the printObjectType level; printing
+	// SelfParam here would duplicate it for methods AND, more
+	// problematically, attach a phantom `self` to function values
+	// extracted from a method (`val f = obj.method`), where the
+	// receiver is already bound and shouldn't surface.
 	if len(t.Params) > 0 {
 		for i, param := range t.Params {
 			if i > 0 {

--- a/internal/type_system/self_param_test.go
+++ b/internal/type_system/self_param_test.go
@@ -1,0 +1,50 @@
+package type_system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingVisitor collects every Type its EnterType is called on. Lets
+// us assert that FuncType.Accept walks SelfParam.Type as part of
+// normal traversal — required so receiver-attached lifetimes flow
+// through substitution and lifetime machinery automatically.
+type recordingVisitor struct{ visited []Type }
+
+func (v *recordingVisitor) EnterType(t Type) EnterResult {
+	v.visited = append(v.visited, t)
+	return EnterResult{}
+}
+func (v *recordingVisitor) ExitType(t Type) Type { return nil }
+
+// TestFuncTypeAcceptVisitsSelfParam pins that FuncType.Accept traverses
+// SelfParam.Type so any visitor (substitution, lifetime walks, etc.)
+// sees the receiver's inner types. Without this, receiver-attached
+// lifetimes would be invisible to the lifetime substitution pass.
+func TestFuncTypeAcceptVisitsSelfParam(t *testing.T) {
+	receiverInner := NewTypeRefType(nil, "Receiver", nil)
+	paramInner := NewTypeRefType(nil, "Param", nil)
+	returnType := NewTypeRefType(nil, "Ret", nil)
+
+	fn := NewFuncType(
+		nil, nil,
+		[]*FuncParam{{Pattern: NewIdentPat("p"), Type: paramInner}},
+		returnType,
+		NewNeverType(nil),
+	)
+	fn.SelfParam = &FuncParam{
+		Pattern: NewIdentPat("self"),
+		Type:    receiverInner,
+	}
+
+	v := &recordingVisitor{}
+	fn.Accept(v)
+
+	assert.Contains(t, v.visited, Type(receiverInner),
+		"FuncType.Accept must visit SelfParam.Type")
+	assert.Contains(t, v.visited, Type(paramInner),
+		"FuncType.Accept must visit Params[].Type (regression check)")
+	assert.Contains(t, v.visited, Type(returnType),
+		"FuncType.Accept must visit Return (regression check)")
+}

--- a/internal/type_system/self_param_test.go
+++ b/internal/type_system/self_param_test.go
@@ -48,3 +48,53 @@ func TestFuncTypeAcceptVisitsSelfParam(t *testing.T) {
 	assert.Contains(t, v.visited, Type(returnType),
 		"FuncType.Accept must visit Return (regression check)")
 }
+
+// TestFuncTypeEqualsConsidersSelfParam pins that FuncType.Equals compares
+// SelfParam. Without this, a method's `(self) -> T` and `(mut self) -> T`
+// FuncTypes are structurally equal — which would let normalization or
+// any equality-keyed cache silently merge them, dropping receiver-mutability
+// information from method-call typing.
+func TestFuncTypeEqualsConsidersSelfParam(t *testing.T) {
+	mkFn := func() *FuncType {
+		return NewFuncType(nil, nil, nil, NewNeverType(nil), NewNeverType(nil))
+	}
+	receiver := NewTypeRefType(nil, "Receiver", nil)
+
+	bare := mkFn()
+
+	withImmutSelf := mkFn()
+	withImmutSelf.SelfParam = &FuncParam{
+		Pattern: NewIdentPat("self"),
+		Type:    receiver,
+	}
+
+	withMutSelf := mkFn()
+	withMutSelf.SelfParam = &FuncParam{
+		Pattern: NewIdentPat("self"),
+		Type:    NewMutType(nil, receiver),
+	}
+
+	otherReceiver := NewTypeRefType(nil, "Other", nil)
+	withOtherSelf := mkFn()
+	withOtherSelf.SelfParam = &FuncParam{
+		Pattern: NewIdentPat("self"),
+		Type:    otherReceiver,
+	}
+
+	assert.False(t, bare.Equals(withImmutSelf),
+		"bare FuncType must not equal one with a SelfParam")
+	assert.False(t, withImmutSelf.Equals(bare),
+		"FuncType with SelfParam must not equal a bare one (symmetry)")
+	assert.False(t, withImmutSelf.Equals(withMutSelf),
+		"`self` and `mut self` FuncTypes must not be equal")
+	assert.False(t, withImmutSelf.Equals(withOtherSelf),
+		"FuncTypes with different SelfParam types must not be equal")
+
+	withImmutSelf2 := mkFn()
+	withImmutSelf2.SelfParam = &FuncParam{
+		Pattern: NewIdentPat("self"),
+		Type:    receiver,
+	}
+	assert.True(t, withImmutSelf.Equals(withImmutSelf2),
+		"FuncTypes with structurally-equal SelfParams must be equal")
+}

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -947,6 +947,21 @@ func (t *FuncType) Equals(other Type) bool {
 		if len(t.LifetimeParams) != len(other.LifetimeParams) {
 			return false
 		}
+		// Compare SelfParam — receiver presence and mutability is part
+		// of a method's identity. The MutType wrapper on the receiver
+		// type carries `mut self` vs `self`, so a structural equals on
+		// SelfParam.Type covers both.
+		if (t.SelfParam == nil) != (other.SelfParam == nil) {
+			return false
+		}
+		if t.SelfParam != nil {
+			if !equals(t.SelfParam.Type, other.SelfParam.Type) {
+				return false
+			}
+			if t.SelfParam.Optional != other.SelfParam.Optional {
+				return false
+			}
+		}
 		// Compare Params
 		if len(t.Params) != len(other.Params) {
 			return false

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -812,10 +812,19 @@ func NewFuncParam(pattern Pat, t Type) *FuncParam {
 type FuncType struct {
 	LifetimeParams []*LifetimeVar // e.g. ['a, 'b]
 	TypeParams     []*TypeParam
-	Params         []*FuncParam
-	Return         Type
-	Throws         Type
-	provenance     Provenance
+	// SelfParam carries the implicit `self` receiver of a method when this
+	// FuncType belongs to a MethodElem/GetterElem/SetterElem. It is nil for
+	// plain functions and static methods. The receiver type lives in
+	// SelfParam.Type — wrapped in MutType for `mut self` — so receiver
+	// lifetimes flow through the visitor / substitution / lifetime
+	// machinery the same way parameter lifetimes do. Element-level
+	// MutSelf *bool is a denormalized cache that mirrors whether
+	// SelfParam.Type is a MutType wrapper.
+	SelfParam  *FuncParam
+	Params     []*FuncParam
+	Return     Type
+	Throws     Type
+	provenance Provenance
 }
 
 func NewFuncType(provenance Provenance, typeParams []*TypeParam, params []*FuncParam, returnType Type, throws Type) *FuncType {
@@ -840,6 +849,20 @@ func (t *FuncType) Accept(v TypeVisitor) Type {
 	}
 
 	changed := false
+
+	var newSelfParam *FuncParam
+	if t.SelfParam != nil {
+		newSelfType := t.SelfParam.Type.Accept(v)
+		if newSelfType != t.SelfParam.Type {
+			changed = true
+			newSelfParam = &FuncParam{
+				Pattern:  t.SelfParam.Pattern,
+				Type:     newSelfType,
+				Optional: t.SelfParam.Optional,
+			}
+		}
+	}
+
 	var newParams []*FuncParam
 	for i, param := range t.Params {
 		newType := param.Type.Accept(v)
@@ -881,6 +904,10 @@ func (t *FuncType) Accept(v TypeVisitor) Type {
 		if newParams != nil {
 			params = newParams
 		}
+		selfParam := t.SelfParam
+		if newSelfParam != nil {
+			selfParam = newSelfParam
+		}
 		r := NewFuncType(
 			t.provenance,
 			t.TypeParams,
@@ -889,6 +916,7 @@ func (t *FuncType) Accept(v TypeVisitor) Type {
 			newThrows,
 		)
 		r.LifetimeParams = t.LifetimeParams
+		r.SelfParam = selfParam
 		result = r
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal method receiver type handling to use explicit type specifications instead of flag-based approaches, enhancing consistency and maintainability across the type system.

* **Tests**
  * Added tests validating method receiver typing correctness for instance and static methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->