### PR TITLE
Implement let-generalization for functions defined inside function bodies

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -165,6 +165,16 @@ type Context struct {
 	// bind it when resolving call sites. Pointer for the same reason as CallSites.
 	CallSiteTypeVars *map[int]*type_system.TypeVarType
 
+	// GeneralizeFuncExpr armed by `inferVarDecl` when a VarDecl's pattern/init
+	// shapes align so FuncExpr values flow into named bindings (IdentPat +
+	// FuncExpr, ObjectPat + ObjectExpr, TuplePat + TupleExpr). Observed and
+	// consumed by `inferExpr`'s FuncExpr branch, which let-generalizes the
+	// FuncType while filtering out the enclosing environment's free type
+	// variables (so captured outer-scope TVs stay owned by the outer
+	// function). Propagated only through ObjectExpr and TupleExpr literal
+	// subexpressions; every other expression kind is a barrier.
+	GeneralizeFuncExpr bool
+
 	// Liveness stores the results of liveness analysis for the current function body.
 	// Set after running AnalyzeBlock (Phase 3) or AnalyzeFunction (Phase 4).
 	Liveness *liveness.LivenessInfo

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -165,14 +165,19 @@ type Context struct {
 	// bind it when resolving call sites. Pointer for the same reason as CallSites.
 	CallSiteTypeVars *map[int]*type_system.TypeVarType
 
-	// GeneralizeFuncExpr armed by `inferVarDecl` when a VarDecl's pattern/init
-	// shapes align so FuncExpr values flow into named bindings (IdentPat +
-	// FuncExpr, ObjectPat + ObjectExpr, TuplePat + TupleExpr). Observed and
-	// consumed by `inferExpr`'s FuncExpr branch, which let-generalizes the
-	// FuncType while filtering out the enclosing environment's free type
-	// variables (so captured outer-scope TVs stay owned by the outer
-	// function). Propagated only through ObjectExpr and TupleExpr literal
-	// subexpressions; every other expression kind is a barrier.
+	// GeneralizeFuncExpr is set by `inferVarDecl` when a VarDecl's
+	// pattern/init shapes align so FuncExpr values flow into named bindings
+	// (IdentPat + FuncExpr, ObjectPat + ObjectExpr, TuplePat + TupleExpr).
+	// Observed and cleared by `inferExpr`'s FuncExpr branch, which
+	// let-generalizes the FuncType while filtering out the enclosing
+	// environment's free type variables (so captured outer-scope TVs stay
+	// owned by the outer function). Propagated only through ObjectExpr and
+	// TupleExpr literal subexpressions; every other expression kind clears
+	// it.
+	//
+	// TODO(#593): remove this field. The (pattern, init) dispatch belongs in
+	// `inferVarDecl` via a binding-aware `inferExprForBinding` entry point,
+	// not as a flag threaded through `inferExpr`.
 	GeneralizeFuncExpr bool
 
 	// Liveness stores the results of liveness analysis for the current function body.

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -551,7 +551,12 @@ func GeneralizeFuncTypeWithEnv(funcType *type_system.FuncType, envTVs set.Set[in
 // value binding's type. These are the TVs that belong to outer (or sibling)
 // constructs and must NOT be generalized by an inner function that captures
 // them.
-func CollectEnvUnresolvedTypeVars(scope *Scope) set.Set[int] {
+//
+// The walk stops at `stopAt` (exclusive). Callers pass `c.GlobalScope` so we
+// don't traverse the prelude — its bindings are fully constructed and have no
+// unresolved TVs, and walking them on every body-level generalization is
+// pure overhead.
+func CollectEnvUnresolvedTypeVars(scope *Scope, stopAt *Scope) set.Set[int] {
 	envTVs := set.NewSet[int]()
 	if scope == nil {
 		return envTVs
@@ -560,7 +565,7 @@ func CollectEnvUnresolvedTypeVars(scope *Scope) set.Set[int] {
 	// `collectUnresolvedTypeVars` requires a non-nil *[]int but its order
 	// information is irrelevant here — we only need the set of IDs.
 	var orderSink []int
-	for s := scope; s != nil; s = s.Parent {
+	for s := scope; s != nil && s != stopAt; s = s.Parent {
 		if s.Namespace == nil {
 			continue
 		}
@@ -592,12 +597,6 @@ func CollectEnvUnresolvedTypeVars(scope *Scope) set.Set[int] {
 // the throws-only-default-to-never or return-only-simplify-to-void
 // transformations either. A nil `excluded` means "no exclusions".
 func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int]) {
-	isExcluded := func(id int) bool {
-		if excluded == nil {
-			return false
-		}
-		return excluded.Contains(id)
-	}
 	// Finalize open object mutability for each func. If any property on an
 	// open object was written during inference, wrap the object in `mut`.
 	for _, funcType := range funcTypes {
@@ -679,7 +678,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int
 		throwsOrder := []int{}
 		collectUnresolvedTypeVars(funcType.Throws, throwsVars, &throwsOrder)
 		for id, tv := range throwsVars {
-			if isExcluded(id) {
+			if excluded.Contains(id) {
 				continue
 			}
 			if _, inParamsOrReturn := sigVars[id]; !inParamsOrReturn {
@@ -706,7 +705,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int
 	// than producing a phantom `T0` no caller can supply or observe.
 	simplifyToVoid := set.NewSet[int]()
 	for _, id := range sigOrder {
-		if isExcluded(id) {
+		if excluded.Contains(id) {
 			continue
 		}
 		if paramVarIDs.Contains(id) {
@@ -768,7 +767,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int
 		if simplifyToVoid.Contains(id) {
 			continue
 		}
-		if isExcluded(id) {
+		if excluded.Contains(id) {
 			continue
 		}
 		tv := sigVars[id]
@@ -812,7 +811,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int
 		added := set.NewSet[int]()
 		var newTypeParams []*type_system.TypeParam
 		appendVar := func(id int) {
-			if simplifyToVoid.Contains(id) || added.Contains(id) || isExcluded(id) {
+			if simplifyToVoid.Contains(id) || added.Contains(id) || excluded.Contains(id) {
 				return
 			}
 			added.Add(id)

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -534,7 +534,47 @@ func finalizeOpenObject(openObj *type_system.ObjectType) bool {
 // and converts them into proper type parameters. This must be called after type
 // inference completes for the function body.
 func GeneralizeFuncType(funcType *type_system.FuncType) {
-	generalizeFuncTypes([]*type_system.FuncType{funcType})
+	generalizeFuncTypes([]*type_system.FuncType{funcType}, nil)
+}
+
+// GeneralizeFuncTypeWithEnv is like GeneralizeFuncType, but excludes any
+// unresolved type variables in `envTVs` (free type variables of the enclosing
+// type environment) from generalization. Captured outer-function TVs must
+// stay unresolved so the outer function continues to own them — generalizing
+// or simplifying them on the inner function would leak the outer scope.
+func GeneralizeFuncTypeWithEnv(funcType *type_system.FuncType, envTVs set.Set[int]) {
+	generalizeFuncTypes([]*type_system.FuncType{funcType}, envTVs)
+}
+
+// CollectEnvUnresolvedTypeVars walks the scope chain rooted at `scope` and
+// collects the set of unresolved TypeVar IDs reachable from every in-scope
+// value binding's type. These are the TVs that belong to outer (or sibling)
+// constructs and must NOT be generalized by an inner function that captures
+// them.
+func CollectEnvUnresolvedTypeVars(scope *Scope) set.Set[int] {
+	envTVs := set.NewSet[int]()
+	if scope == nil {
+		return envTVs
+	}
+	vars := map[int]*type_system.TypeVarType{}
+	// `collectUnresolvedTypeVars` requires a non-nil *[]int but its order
+	// information is irrelevant here — we only need the set of IDs.
+	var orderSink []int
+	for s := scope; s != nil; s = s.Parent {
+		if s.Namespace == nil {
+			continue
+		}
+		for _, binding := range s.Namespace.Values {
+			if binding == nil {
+				continue
+			}
+			collectUnresolvedTypeVars(binding.Type, vars, &orderSink)
+		}
+	}
+	for id := range vars {
+		envTVs.Add(id)
+	}
+	return envTVs
 }
 
 // generalizeFuncTypes generalizes a group of function types together. Unresolved
@@ -545,7 +585,19 @@ func GeneralizeFuncType(funcType *type_system.FuncType) {
 // type var from one declaration into another.
 //
 // For a single FuncType, this behaves identically to GeneralizeFuncType.
-func generalizeFuncTypes(funcTypes []*type_system.FuncType) {
+//
+// `excluded` is an optional set of unresolved TypeVar IDs that must NOT be
+// generalized — typically the free type variables of the enclosing type
+// environment. TVs in `excluded` are left unresolved and are not subject to
+// the throws-only-default-to-never or return-only-simplify-to-void
+// transformations either. A nil `excluded` means "no exclusions".
+func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int]) {
+	isExcluded := func(id int) bool {
+		if excluded == nil {
+			return false
+		}
+		return excluded.Contains(id)
+	}
 	// Finalize open object mutability for each func. If any property on an
 	// open object was written during inference, wrap the object in `mut`.
 	for _, funcType := range funcTypes {
@@ -627,6 +679,9 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType) {
 		throwsOrder := []int{}
 		collectUnresolvedTypeVars(funcType.Throws, throwsVars, &throwsOrder)
 		for id, tv := range throwsVars {
+			if isExcluded(id) {
+				continue
+			}
 			if _, inParamsOrReturn := sigVars[id]; !inParamsOrReturn {
 				tv.Instance = type_system.NewNeverType(nil)
 			}
@@ -651,6 +706,9 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType) {
 	// than producing a phantom `T0` no caller can supply or observe.
 	simplifyToVoid := set.NewSet[int]()
 	for _, id := range sigOrder {
+		if isExcluded(id) {
+			continue
+		}
 		if paramVarIDs.Contains(id) {
 			continue
 		}
@@ -710,6 +768,9 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType) {
 		if simplifyToVoid.Contains(id) {
 			continue
 		}
+		if isExcluded(id) {
+			continue
+		}
 		tv := sigVars[id]
 		name := fmt.Sprintf("T%d", nameIndex)
 		for existingNames.Contains(name) {
@@ -751,7 +812,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType) {
 		added := set.NewSet[int]()
 		var newTypeParams []*type_system.TypeParam
 		appendVar := func(id int) {
-			if simplifyToVoid.Contains(id) || added.Contains(id) {
+			if simplifyToVoid.Contains(id) || added.Contains(id) || isExcluded(id) {
 				return
 			}
 			added.Add(id)

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -21,6 +21,12 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 	var exprType type_system.Type
 	var errors []Error
 
+	// Snapshot and clear the GeneralizeFuncExpr signal — see its Context
+	// doc. ObjectExpr and TupleExpr re-arm it on recursive descent; every
+	// other expression kind is a barrier.
+	generalizeFuncExpr := ctx.GeneralizeFuncExpr
+	ctx.GeneralizeFuncExpr = false
+
 	provenance := &ast.NodeProvenance{Node: expr}
 
 	switch expr := expr.(type) {
@@ -388,7 +394,11 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				// would expose the unannotated-param var to the
 				// `_, MutType` unwrap rule and silently strip `mut`.
 				slotVar := c.FreshVar(&ast.NodeProvenance{Node: elem})
-				elemType, elemErrors := c.inferExpr(ctx, elem)
+				// Re-arm GeneralizeFuncExpr so a FuncExpr at this tuple
+				// slot is recognized as flowing into a named binding.
+				elemCtx := ctx
+				elemCtx.GeneralizeFuncExpr = generalizeFuncExpr
+				elemType, elemErrors := c.inferExpr(elemCtx, elem)
 				unifyErrors := c.Unify(ctx, elemType, slotVar)
 				elemTypes = append(elemTypes, slotVar)
 				errors = slices.Concat(errors, elemErrors, unifyErrors)
@@ -437,7 +447,13 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			switch elem := exprElem.(type) {
 			case *ast.PropertyExpr:
 				if elem.Value != nil {
-					valueType, valueErrors := c.inferExpr(ctx, elem.Value)
+					// Re-arm GeneralizeFuncExpr so a FuncExpr at this
+					// property value is recognized as flowing into a
+					// named binding (either via shorthand or via a
+					// key-value destructuring pattern).
+					valueCtx := ctx
+					valueCtx.GeneralizeFuncExpr = generalizeFuncExpr
+					valueType, valueErrors := c.inferExpr(valueCtx, elem.Value)
 					unifyErrors := c.Unify(ctx, valueType, t)
 
 					errors = slices.Concat(errors, valueErrors, unifyErrors)
@@ -469,9 +485,12 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 		funcType, funcCtx, paramBindings, sigErrors := c.inferFuncSig(ctx, &expr.FuncSig, expr, nil)
 		errors = slices.Concat(errors, sigErrors)
 
-		// Allocate call-site maps for outermost FuncExprs. Nested FuncExprs
-		// inherit the parent's maps via Context copying.
-		if !ctx.InFuncBody {
+		// Allocate call-site maps for outermost FuncExprs and for body-level
+		// FuncExprs that are about to be let-generalized. Other nested
+		// FuncExprs inherit the parent's maps via Context copying so their
+		// call sites accumulate at the outermost function.
+		isolateCallSites := !ctx.InFuncBody || generalizeFuncExpr
+		if isolateCallSites {
 			callSites := make(map[int][]*type_system.FuncType)
 			callSiteTypeVars := make(map[int]*type_system.TypeVarType)
 			funcCtx.CallSites = &callSites
@@ -485,12 +504,24 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 		)
 		errors = slices.Concat(errors, inferErrors)
 
-		// Only generalize top-level FuncExprs. Nested FuncExprs (inside function
-		// bodies) share type variables with outer functions, so their generalization
-		// is deferred to the outermost function.
-		if !ctx.InFuncBody {
+		// Generalize when this FuncExpr is either top-level (the original
+		// case) or armed for let-generalization by an enclosing VarDecl
+		// with aligned pattern/init shape. In the body-level case, env-FTV
+		// filtering keeps captured outer-scope TVs unresolved so the outer
+		// function continues to own them.
+		switch {
+		case !ctx.InFuncBody:
 			c.resolveCallSites(funcCtx)
 			GeneralizeFuncType(funcType)
+		case generalizeFuncExpr:
+			c.resolveCallSites(funcCtx)
+			// Recompute env-FTV at generalize time so we follow the
+			// Instance chains established during this inner function's
+			// body inference. If a captured outer TV was unified with one
+			// of inner's own TVs during the body, Prune will resolve to
+			// the post-unification ID — which is what we need to exclude.
+			envTVs := CollectEnvUnresolvedTypeVars(ctx.Scope)
+			GeneralizeFuncTypeWithEnv(funcType, envTVs)
 		}
 
 		exprType = funcType

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -22,8 +22,8 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 	var errors []Error
 
 	// Snapshot and clear the GeneralizeFuncExpr signal — see its Context
-	// doc. ObjectExpr and TupleExpr re-arm it on recursive descent; every
-	// other expression kind is a barrier.
+	// doc. ObjectExpr and TupleExpr restore it on recursive descent; every
+	// other expression kind leaves it cleared.
 	generalizeFuncExpr := ctx.GeneralizeFuncExpr
 	ctx.GeneralizeFuncExpr = false
 
@@ -394,7 +394,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				// would expose the unannotated-param var to the
 				// `_, MutType` unwrap rule and silently strip `mut`.
 				slotVar := c.FreshVar(&ast.NodeProvenance{Node: elem})
-				// Re-arm GeneralizeFuncExpr so a FuncExpr at this tuple
+				// Restore GeneralizeFuncExpr so a FuncExpr at this tuple
 				// slot is recognized as flowing into a named binding.
 				elemCtx := ctx
 				elemCtx.GeneralizeFuncExpr = generalizeFuncExpr
@@ -447,7 +447,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			switch elem := exprElem.(type) {
 			case *ast.PropertyExpr:
 				if elem.Value != nil {
-					// Re-arm GeneralizeFuncExpr so a FuncExpr at this
+					// Restore GeneralizeFuncExpr so a FuncExpr at this
 					// property value is recognized as flowing into a
 					// named binding (either via shorthand or via a
 					// key-value destructuring pattern).
@@ -505,7 +505,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 		errors = slices.Concat(errors, inferErrors)
 
 		// Generalize when this FuncExpr is either top-level (the original
-		// case) or armed for let-generalization by an enclosing VarDecl
+		// case) or signaled for let-generalization by an enclosing VarDecl
 		// with aligned pattern/init shape. In the body-level case, env-FTV
 		// filtering keeps captured outer-scope TVs unresolved so the outer
 		// function continues to own them.
@@ -520,7 +520,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			// body inference. If a captured outer TV was unified with one
 			// of inner's own TVs during the body, Prune will resolve to
 			// the post-unification ID — which is what we need to exclude.
-			envTVs := CollectEnvUnresolvedTypeVars(ctx.Scope)
+			envTVs := CollectEnvUnresolvedTypeVars(ctx.Scope, c.GlobalScope)
 			GeneralizeFuncTypeWithEnv(funcType, envTVs)
 		}
 

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1700,7 +1700,7 @@ func (c *Checker) InferComponent(
 	// but *before* the Phase 8.7 lifetime fixed-point loop below — that
 	// loop's ReinferLifetimes calls expect peer signatures to already be
 	// generalized. Don't move this call.
-	generalizeFuncTypes(pendingFuncTypes)
+	generalizeFuncTypes(pendingFuncTypes, nil)
 
 	// Phase 8.7: for SCCs of size > 1 (mutually recursive function
 	// groups), iterate lifetime inference to a fixed point. Each pass

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -114,6 +114,11 @@ func (c *Checker) inferVarDecl(
 		errors = slices.Concat(errors, unifyErrors)
 
 		if decl.Init != nil {
+			// Intentionally do NOT arm GeneralizeFuncExpr here: the user's
+			// annotation determines the binding's scheme, and unifying a
+			// generalized init against a monomorphic annotation would
+			// either over-constrain or silently widen. Generalization
+			// happens only on the no-annotation branch below.
 			initType, initErrors := c.inferExpr(ctx, decl.Init)
 			errors = slices.Concat(errors, initErrors)
 
@@ -125,7 +130,13 @@ func (c *Checker) inferVarDecl(
 			// TODO: report an error, but set initType to be `unknown`
 			panic("Expected either a type annotation or an initializer expression")
 		}
-		initType, initErrors := c.inferExpr(ctx, decl.Init)
+		initCtx := ctx
+		// Arm GeneralizeFuncExpr when pattern/init shapes align — see
+		// `shouldArmGeneralizeFuncExpr` and the Context doc.
+		if shouldArmGeneralizeFuncExpr(decl.Pattern, decl.Init) {
+			initCtx.GeneralizeFuncExpr = true
+		}
+		initType, initErrors := c.inferExpr(initCtx, decl.Init)
 		errors = slices.Concat(errors, initErrors)
 
 		unifyErrors := c.Unify(ctx, initType, patType)
@@ -205,9 +216,19 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 		errors = slices.Concat(errors, inferErrors)
 	}
 
-	// Resolve deferred call sites and generalize type variables into type parameters
+	// Resolve deferred call sites and generalize type variables into type
+	// parameters. Compute env-FTV at this point — AFTER body inference —
+	// so that we follow any Instance chains established by unifications
+	// during the body, ensuring captured outer-scope TVs are identified by
+	// their current (post-pruning) IDs rather than pre-unification ones.
+	//
+	// `inferFuncDecl` is only reached via `inferDecl` -> `inferStmt`, so it
+	// always runs for body-level FuncDecls. Top-level FuncDecls are handled
+	// by `InferComponent` and never come through here, so the env-FTV walk
+	// doesn't pay for prelude bindings at the module top level.
 	c.resolveCallSites(ctx)
-	GeneralizeFuncType(funcType)
+	envTVs := CollectEnvUnresolvedTypeVars(ctx.Scope)
+	GeneralizeFuncTypeWithEnv(funcType, envTVs)
 
 	binding := type_system.Binding{
 		Source:     &ast.NodeProvenance{Node: decl},
@@ -217,6 +238,32 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 	}
 	ctx.Scope.setValue(decl.Name.Name, &binding)
 	return errors
+}
+
+// shouldArmGeneralizeFuncExpr decides whether the GeneralizeFuncExpr signal
+// should be set when inferring a VarDecl's init expression. The trigger
+// requires that the pattern and init shapes align so that FuncExpr values
+// flow directly into named bindings: IdentPat + FuncExpr, ObjectPat +
+// ObjectExpr, or TuplePat + TupleExpr. When aligned, propagation through
+// inferExpr's ObjectExpr/TupleExpr branches reaches every FuncExpr that
+// occupies a destructurable slot (recursively for nested literals).
+//
+// IdentPat + non-FuncExpr (e.g. `val o = { f: fn(x){x} }`) does NOT arm the
+// signal — `o` is bound as an object value, and making its field
+// polymorphic would require first-class polymorphism on object fields.
+func shouldArmGeneralizeFuncExpr(pat ast.Pat, init ast.Expr) bool {
+	switch pat.(type) {
+	case *ast.IdentPat:
+		_, ok := init.(*ast.FuncExpr)
+		return ok
+	case *ast.ObjectPat:
+		_, ok := init.(*ast.ObjectExpr)
+		return ok
+	case *ast.TuplePat:
+		_, ok := init.(*ast.TupleExpr)
+		return ok
+	}
+	return false
 }
 
 // TypeParamsResult contains the result of processing type parameters.

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -114,7 +114,7 @@ func (c *Checker) inferVarDecl(
 		errors = slices.Concat(errors, unifyErrors)
 
 		if decl.Init != nil {
-			// Intentionally do NOT arm GeneralizeFuncExpr here: the user's
+			// Intentionally do NOT set GeneralizeFuncExpr here: the user's
 			// annotation determines the binding's scheme, and unifying a
 			// generalized init against a monomorphic annotation would
 			// either over-constrain or silently widen. Generalization
@@ -131,9 +131,9 @@ func (c *Checker) inferVarDecl(
 			panic("Expected either a type annotation or an initializer expression")
 		}
 		initCtx := ctx
-		// Arm GeneralizeFuncExpr when pattern/init shapes align — see
-		// `shouldArmGeneralizeFuncExpr` and the Context doc.
-		if shouldArmGeneralizeFuncExpr(decl.Pattern, decl.Init) {
+		// Set GeneralizeFuncExpr when pattern/init shapes align — see
+		// `shouldGeneralizeFuncExpr` and the Context doc.
+		if shouldGeneralizeFuncExpr(decl.Pattern, decl.Init) {
 			initCtx.GeneralizeFuncExpr = true
 		}
 		initType, initErrors := c.inferExpr(initCtx, decl.Init)
@@ -227,7 +227,7 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 	// by `InferComponent` and never come through here, so the env-FTV walk
 	// doesn't pay for prelude bindings at the module top level.
 	c.resolveCallSites(ctx)
-	envTVs := CollectEnvUnresolvedTypeVars(ctx.Scope)
+	envTVs := CollectEnvUnresolvedTypeVars(ctx.Scope, c.GlobalScope)
 	GeneralizeFuncTypeWithEnv(funcType, envTVs)
 
 	binding := type_system.Binding{
@@ -240,7 +240,7 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 	return errors
 }
 
-// shouldArmGeneralizeFuncExpr decides whether the GeneralizeFuncExpr signal
+// shouldGeneralizeFuncExpr decides whether the GeneralizeFuncExpr signal
 // should be set when inferring a VarDecl's init expression. The trigger
 // requires that the pattern and init shapes align so that FuncExpr values
 // flow directly into named bindings: IdentPat + FuncExpr, ObjectPat +
@@ -248,10 +248,10 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 // inferExpr's ObjectExpr/TupleExpr branches reaches every FuncExpr that
 // occupies a destructurable slot (recursively for nested literals).
 //
-// IdentPat + non-FuncExpr (e.g. `val o = { f: fn(x){x} }`) does NOT arm the
+// IdentPat + non-FuncExpr (e.g. `val o = { f: fn(x){x} }`) does NOT set the
 // signal — `o` is bound as an object value, and making its field
 // polymorphic would require first-class polymorphism on object fields.
-func shouldArmGeneralizeFuncExpr(pat ast.Pat, init ast.Expr) bool {
+func shouldGeneralizeFuncExpr(pat ast.Pat, init ast.Expr) bool {
 	switch pat.(type) {
 	case *ast.IdentPat:
 		_, ok := init.(*ast.FuncExpr)

--- a/internal/checker/tests/let_generalize_test.go
+++ b/internal/checker/tests/let_generalize_test.go
@@ -1,0 +1,337 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	. "github.com/escalier-lang/escalier/internal/checker"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBodyLetGeneralization exercises let-generalization for functions
+// declared inside other function bodies — both `fn name(...)` (FuncDecl) and
+// `val name = fn(...)` / destructured-FuncExpr (VarDecl) forms. The outer
+// function's inferred type is checked; a polymorphic inner function lets the
+// outer body use it at multiple incompatible types without unification errors,
+// and the resulting tuple's element types reflect each call's argument type.
+func TestBodyLetGeneralization(t *testing.T) {
+	tests := map[string]struct {
+		input         string
+		expectedTypes map[string]string
+	}{
+		"BodyVarDecl_IdentPat_FuncExpr": {
+			input: `
+				fn outer() {
+					val id = fn (x) { return x }
+					val a = id("hello")
+					val b = id(5)
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5]",
+			},
+		},
+		"BodyFuncDecl_Polymorphic": {
+			input: `
+				fn outer() {
+					fn id(x) { return x }
+					val a = id("hello")
+					val b = id(5)
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5]",
+			},
+		},
+		"BodyVarDecl_TupleDestructure_FuncExprs": {
+			input: `
+				fn outer() {
+					val [f, g] = [fn (x) { return x }, fn (y) { return y }]
+					val a = f("hello")
+					val b = f(5)
+					val c = g(true)
+					val d = g(1.5)
+					return [a, b, c, d]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5, true, 1.5]",
+			},
+		},
+		"BodyVarDecl_ObjectDestructure_FuncExprs": {
+			input: `
+				fn outer() {
+					val {f, g} = {f: fn (x) { return x }, g: fn (y) { return y }}
+					val a = f("hello")
+					val b = f(5)
+					val c = g(true)
+					val d = g(1.5)
+					return [a, b, c, d]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5, true, 1.5]",
+			},
+		},
+		"BodyVarDecl_NestedDestructure_FuncExprs": {
+			input: `
+				fn outer() {
+					val {a: [f, g]} = {a: [fn (x) { return x }, fn (y) { return y }]}
+					val p = f("hello")
+					val q = f(5)
+					val r = g(true)
+					val s = g(1.5)
+					return [p, q, r, s]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5, true, 1.5]",
+			},
+		},
+		"BodyVarDecl_DeeplyNested": {
+			input: `
+				fn outer() {
+					fn middle() {
+						fn inner() {
+							val id = fn (x) { return x }
+							val a = id("hello")
+							val b = id(5)
+							return [a, b]
+						}
+						return inner()
+					}
+					return middle()
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5]",
+			},
+		},
+		"BodyVarDecl_SiblingInnerDecls": {
+			input: `
+				fn outer() {
+					val f = fn (x) { return x }
+					val g = fn (y) { return y }
+					val a = f("hello")
+					val b = g(5)
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5]",
+			},
+		},
+		"BodyFuncDecl_SiblingInnerDecls": {
+			input: `
+				fn outer() {
+					fn f(x) { return x }
+					fn g(y) { return y }
+					val a = f("hello")
+					val b = g(5)
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> [\"hello\", 5]",
+			},
+		},
+		// Inner function captures an outer-scope param `y`. The env-FTV
+		// filter must keep `y`'s TV unresolved on `inner`'s signature, so
+		// `inner` reads as `fn<T>(x: T) -> <outer_y_tv>` rather than
+		// generalizing the captured TV into a fresh TypeParam. The outer
+		// function then owns that TV and generalizes it itself, producing
+		// `fn<T0, T1>(y: T0) -> [T0, T0]`. Without the filter, `inner`
+		// would over-generalize and `outer`'s return would lose the tie to
+		// `y`'s type — the two `[T0, T0]` slots would diverge or collapse
+		// to void.
+		"BodyVarDecl_InnerCapturesOuterParam": {
+			input: `
+				fn outer(y) {
+					val inner = fn (x) { return y }
+					val a = inner(1)
+					val b = inner("a")
+					return [a, b]
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn <T0>(y: T0) -> [T0, T0]",
+			},
+		},
+		"TopLevelLetPolymorphismUnchanged": {
+			input: `
+				val id = fn (x) { return x }
+			`,
+			expectedTypes: map[string]string{
+				"id": "fn <T0>(x: T0) -> T0",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := &ast.Source{
+				ID:       0,
+				Path:     "input.esc",
+				Contents: test.input,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+
+			if len(errors) > 0 {
+				for i, err := range errors {
+					fmt.Printf("Error[%d]: %#v\n", i, err)
+				}
+			}
+			assert.Len(t, errors, 0)
+
+			c := NewChecker(ctx)
+			inferCtx := Context{
+				Scope:      Prelude(c),
+				IsAsync:    false,
+				IsPatMatch: false,
+			}
+			inferErrors := c.InferModule(inferCtx, module)
+			scope := inferCtx.Scope.Namespace
+			if len(inferErrors) > 0 {
+				for i, err := range inferErrors {
+					fmt.Printf("Infer Error[%d]: %s\n", i, err.Message())
+				}
+				assert.Equal(t, inferErrors, []*Error{})
+			}
+
+			actualTypes := make(map[string]string)
+			for name, binding := range scope.Values {
+				assert.NotNil(t, binding)
+				actualTypes[name] = binding.Type.String()
+			}
+
+			for expectedName, expectedType := range test.expectedTypes {
+				actualType, exists := actualTypes[expectedName]
+				assert.True(t, exists, "Expected variable %s to be declared", expectedName)
+				if exists {
+					assert.Equal(t, expectedType, actualType, "Type mismatch for variable %s", expectedName)
+				}
+			}
+		})
+	}
+}
+
+// TestBodyLetGeneralizationNegatives ensures generalization does NOT happen in
+// positions where the FuncExpr's value does not flow into a named binding.
+// In each case the inner FuncExpr's parameter type must be unified across
+// uses, so calling it at two incompatible types reports a unification error.
+func TestBodyLetGeneralizationNegatives(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		expectedErrors []string
+	}{
+		// FuncExpr appears inside an object literal at an IdentPat-bound
+		// slot. Generalizing the field would require first-class
+		// polymorphism on object fields, which is out of scope. `o.f`
+		// must be monomorphic, so calling it at two incompatible
+		// literal types errors.
+		"ObjectFieldFuncExpr_NotGeneralized": {
+			input: `
+				fn outer() {
+					val o = {f: fn (x) { return x }}
+					val a = o.f("hello")
+					val b = o.f(5)
+					return [a, b]
+				}
+			`,
+			expectedErrors: []string{`5 cannot be assigned to "hello"`},
+		},
+		// IdentPat + TupleExpr is a pattern/init shape mismatch: the
+		// VarDecl binds a single name to the tuple value, so the inner
+		// FuncExprs are not in destructurable positions. They must stay
+		// monomorphic; destructuring the tuple later into per-slot names
+		// does not re-trigger generalization (the FuncTypes were already
+		// inferred without the let-generalize signal). Calling the
+		// destructured `a` at two incompatible literal types must error.
+		"IdentPatTupleInit_ShapeMismatch_NotGeneralized": {
+			input: `
+				fn outer() {
+					val pair = [fn (x) { return x }, fn (y) { return y }]
+					val [a, b] = pair
+					val r1 = a("hello")
+					val r2 = a(5)
+					return [r1, r2]
+				}
+			`,
+			expectedErrors: []string{`5 cannot be assigned to "hello"`},
+		},
+		// FuncExpr passed as a call argument. The CallExpr branch in
+		// inferExpr does not re-arm the let-generalize signal, so the
+		// inner FuncExpr is inferred monomorphically. The returned
+		// FuncType is bound to a single param TV; calling it at two
+		// incompatible literal types must error.
+		"FuncExprAsCallArg_NotGeneralized": {
+			input: `
+				fn outer() {
+					fn apply(f) { return f }
+					val g = apply(fn (x) { return x })
+					val a = g("hello")
+					val b = g(5)
+					return [a, b]
+				}
+			`,
+			expectedErrors: []string{`5 cannot be assigned to "hello"`},
+		},
+		// `val id = fn(x) { return id(x) }` — recursive self-reference
+		// via `val` binding. The init is inferred before `id`'s binding
+		// is finalized, so `id` inside its own body resolves to `never`
+		// rather than the polymorphic outer binding. This pins the
+		// current limitation; if the language later supports recursive
+		// `val` for function values, this test should move to the
+		// positive suite.
+		"BodyVarDecl_RecursiveSelfReference": {
+			input: `
+				fn outer() {
+					val id = fn (x) { return id(x) }
+					val a = id("hello")
+					val b = id(5)
+					return [a, b]
+				}
+			`,
+			expectedErrors: []string{"Callee is not callable: never"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := &ast.Source{
+				ID:       0,
+				Path:     "input.esc",
+				Contents: test.input,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			module, errors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+			assert.Len(t, errors, 0)
+
+			c := NewChecker(ctx)
+			inferCtx := Context{
+				Scope:      Prelude(c),
+				IsAsync:    false,
+				IsPatMatch: false,
+			}
+			inferErrors := c.InferModule(inferCtx, module)
+			actualMessages := make([]string, len(inferErrors))
+			for i, e := range inferErrors {
+				actualMessages[i] = e.Message()
+			}
+			assert.Equal(t, test.expectedErrors, actualMessages)
+		})
+	}
+}

--- a/internal/checker/tests/let_generalize_test.go
+++ b/internal/checker/tests/let_generalize_test.go
@@ -163,6 +163,20 @@ func TestBodyLetGeneralization(t *testing.T) {
 				"outer": "fn <T0>(y: T0) -> [T0, T0]",
 			},
 		},
+		// `outer` returns the polymorphic `id` itself. The returned
+		// function value must preserve its generalized scheme so callers
+		// of `outer()(...)` can use it at multiple incompatible types.
+		"BodyVarDecl_ReturnPolymorphicFunc": {
+			input: `
+				fn outer() {
+					val id = fn (x) { return x }
+					return id
+				}
+			`,
+			expectedTypes: map[string]string{
+				"outer": "fn () -> fn <T0>(x: T0) -> T0",
+			},
+		},
 		"TopLevelLetPolymorphismUnchanged": {
 			input: `
 				val id = fn (x) { return x }
@@ -201,12 +215,10 @@ func TestBodyLetGeneralization(t *testing.T) {
 			}
 			inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
-			if len(inferErrors) > 0 {
-				for i, err := range inferErrors {
-					fmt.Printf("Infer Error[%d]: %s\n", i, err.Message())
-				}
-				assert.Equal(t, inferErrors, []*Error{})
+			for i, err := range inferErrors {
+				fmt.Printf("Infer Error[%d]: %s\n", i, err.Message())
 			}
+			assert.Empty(t, inferErrors)
 
 			actualTypes := make(map[string]string)
 			for name, binding := range scope.Values {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type inference for function expressions in variable declarations, enabling better polymorphism when variable pattern and initializer shapes align (e.g., simple binding, object destructuring, tuple destructuring).

* **Tests**
  * Added comprehensive tests for nested function expression type generalization, covering both positive cases and scenarios where generalization should not apply.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/592)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->