### PR TITLE
Interop mutability 5.1: override store types & errors

### DIFF
--- a/internal/interop/errors.go
+++ b/internal/interop/errors.go
@@ -1,0 +1,115 @@
+package interop
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrDuplicateMember reports that two override entries at the same
+// OverrideTier targeted the same slot. Cross-tier shadowing is silent;
+// within-tier duplication is a hard error.
+type ErrDuplicateMember struct {
+	Path          Path
+	First, Second Origin
+}
+
+func (e *ErrDuplicateMember) Error() string {
+	return fmt.Sprintf(
+		"duplicate override entry for %s\n  first defined at %s:%d\n  redefined at %s:%d",
+		pathString(e.Path),
+		e.First.FilePath, e.First.Span.Start.Line,
+		e.Second.FilePath, e.Second.Span.Start.Line,
+	)
+}
+
+// ErrUnknownMember reports an override entry whose target does not
+// exist on the original declaration. `Available` is the list of
+// sibling names on the original's matching MemberSet for did-you-mean
+// suggestions.
+type ErrUnknownMember struct {
+	Path      Path
+	Override  Origin
+	Available []string
+}
+
+func (e *ErrUnknownMember) Error() string {
+	msg := fmt.Sprintf(
+		"override target %s not found on original declaration\n  override at %s:%d",
+		pathString(e.Path),
+		e.Override.FilePath, e.Override.Span.Start.Line,
+	)
+	if len(e.Available) > 0 {
+		msg += "\n  available: " + strings.Join(e.Available, ", ")
+	}
+	return msg
+}
+
+// ErrSignatureMismatch reports that an override signature's shape
+// differs from the original on a non-receiver axis (arity, parameter
+// type, return type, or overload count).
+type ErrSignatureMismatch struct {
+	Path           Path
+	Field          string // "arity" | "param[i]" | "return" | "overload count" | "overload[i]/<field>"
+	Override       string // pretty-printed override side (or count, as string)
+	Original       string // pretty-printed original side
+	OverrideOrigin Origin
+}
+
+func (e *ErrSignatureMismatch) Error() string {
+	return fmt.Sprintf(
+		"override of %s changes signature shape (%s): override=%s, original=%s\n  override at %s:%d",
+		pathString(e.Path), e.Field, e.Override, e.Original,
+		e.OverrideOrigin.FilePath, e.OverrideOrigin.Span.Start.Line,
+	)
+}
+
+// ErrGenericArityMismatch reports that an override class/interface
+// declares a different number of type parameters than the original.
+type ErrGenericArityMismatch struct {
+	Path     Path
+	Override int
+	Original int
+}
+
+func (e *ErrGenericArityMismatch) Error() string {
+	return fmt.Sprintf(
+		"override of %s declares %d type parameter(s); original has %d",
+		pathString(e.Path), e.Override, e.Original,
+	)
+}
+
+// pathString renders a Path for diagnostics. Module-scoped paths print
+// as `module "name"::owner.member`; global paths drop the module prefix.
+func pathString(p Path) string {
+	var b strings.Builder
+	if p.Module != "" {
+		b.WriteString(`module "`)
+		b.WriteString(p.Module)
+		b.WriteString(`"::`)
+	}
+	if p.Owner != nil {
+		for i, seg := range qualIdentSegments(p.Owner) {
+			if i > 0 {
+				b.WriteString(".")
+			}
+			b.WriteString(seg)
+		}
+		switch p.Kind {
+		case KindMethod, KindGetter, KindSetter, KindProperty:
+			if p.Static {
+				b.WriteString(".")
+			} else {
+				b.WriteString(".prototype.")
+			}
+		case KindCtor:
+			b.WriteString(".constructor")
+			return b.String()
+		default:
+			b.WriteString(".")
+		}
+	}
+	if p.Name != nil {
+		b.WriteString(canonicalNameFromPK(p.Name))
+	}
+	return b.String()
+}

--- a/internal/interop/store.go
+++ b/internal/interop/store.go
@@ -1,0 +1,370 @@
+package interop
+
+import (
+	"strconv"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// OverrideStore holds the post-merge module map. Per-tier pre-merge
+// module maps exist only inside Build and are not retained — every
+// diagnostic that needs provenance reads Effective.Provenance, which
+// already carries the contributing Origins.
+//
+// See planning/interop_mutability/implementation_plan.md §5.
+type OverrideStore struct {
+	// Modules keyed by module specifier ("" = global; "lodash", "fs", etc.).
+	Modules map[string]*ModuleScope
+}
+
+// NewOverrideStore returns an empty store.
+func NewOverrideStore() *OverrideStore {
+	return &OverrideStore{Modules: make(map[string]*ModuleScope)}
+}
+
+// Container holds the slots populated by modules and namespaces:
+// free-function-style entries plus a map of nested children. Embedded by
+// both ModuleScope and ChildScope so namespace-nested functions land in
+// the same slot as module-top-level functions.
+type Container struct {
+	Free     map[string]*Effective  // free functions, vals, type aliases
+	Children map[string]*ChildScope // nested namespaces / classes / interfaces
+	Origin   Origin                 // declaring file for diagnostics
+}
+
+// ModuleScope is the per-module root.
+type ModuleScope struct {
+	Container
+	AllPure bool // module-level @all_pure pragma
+	// Tier is the OverrideTier that produced this ModuleScope's AllPure
+	// flag. Meaningful only when AllPure is true.
+	AllPureTier OverrideTier
+}
+
+// ChildScope is a namespace, class, or interface. Namespaces use only
+// Container.Free and Container.Children; classes/interfaces use Instance
+// and Static. A ChildScope with both shapes populated is an upstream
+// ErrDuplicateMember — namespace+class declaration merging is not supported.
+type ChildScope struct {
+	Container
+	Instance *MemberSet // nil for namespaces
+	Static   *MemberSet // nil for namespaces
+}
+
+// MemberSet groups the four independent slots that share a name space
+// within a class/interface, plus the constructor.
+type MemberSet struct {
+	Methods    map[string]*Effective
+	Getters    map[string]*Effective
+	Setters    map[string]*Effective
+	Properties map[string]*Effective
+	Ctor       *Effective // single slot per class
+}
+
+// NewMemberSet returns an empty MemberSet with all maps initialised.
+// Ctor is intentionally left nil — callers nil-check it because there
+// is at most one constructor per class.
+func NewMemberSet() *MemberSet {
+	return &MemberSet{
+		Methods:    make(map[string]*Effective),
+		Getters:    make(map[string]*Effective),
+		Setters:    make(map[string]*Effective),
+		Properties: make(map[string]*Effective),
+	}
+}
+
+// OverrideTier identifies where an override came from. Distinct from
+// ResolutionTier (the 7-tier classification ladder) — OverrideTier is
+// only used inside the override system to drive the internal three-tier
+// collapse (§5.5).
+//
+// Lower integer = higher precedence.
+type OverrideTier int
+
+const (
+	OverrideTierUserProject OverrideTier = iota // requirements tier 1b
+	OverrideTierUserDep                         // requirements tier 1a
+	OverrideTierShipped                         // requirements tier 4
+)
+
+// ResolutionTierFor maps an OverrideTier to the broader ResolutionTier
+// the merge stamps on Effective.Source.
+func (t OverrideTier) ResolutionTierFor() ResolutionTier {
+	switch t {
+	case OverrideTierUserProject, OverrideTierUserDep:
+		return TierUserOverride
+	case OverrideTierShipped:
+		return TierShippedOverride
+	}
+	return TierDefault
+}
+
+// Effective is the merged result for a single member. Receiver shape
+// (no receiver / self / mut self) is encoded structurally on Type's
+// *FuncType.SelfParam — callers use type_system.ReceiverIsMut.
+type Effective struct {
+	Type       type_system.Type
+	Source     ResolutionTier
+	Provenance []Origin
+
+	// Tier records the OverrideTier that produced this leaf in the
+	// collapsed per-tier scope. Set by extract; consumed by merge when
+	// stamping Source. Not meaningful on Effectives after merge — merge
+	// derives Source from this field once and may then clear it.
+	Tier OverrideTier
+}
+
+// OriginKind discriminates the kind of source location.
+type OriginKind int
+
+const (
+	OriginalDTS OriginKind = iota
+	OverrideFile
+)
+
+// Origin is the declaring location of an entry (or the source-side of a
+// merge participant).
+type Origin struct {
+	Kind     OriginKind
+	FilePath string
+	Span     ast.Span
+}
+
+// MemberKind discriminates the slot a Path addresses.
+type MemberKind int
+
+const (
+	KindFree MemberKind = iota
+	KindMethod
+	KindGetter
+	KindSetter
+	KindProperty
+	KindCtor
+)
+
+// Path is the structured address of a member, used for resolver
+// queries and diagnostics. Mirrors the tree walk.
+type Path struct {
+	Module string               // "" for global
+	Owner  dts_parser.QualIdent // nil for module-free / global top-level
+	Name   dts_parser.PropertyKey
+	Kind   MemberKind
+	Static bool
+}
+
+// Resolve walks Modules by Path. Returns nil if no override applies.
+func (s *OverrideStore) Resolve(p Path) *Effective {
+	if s == nil {
+		return nil
+	}
+	mod := s.Modules[p.Module]
+	if mod == nil {
+		return nil
+	}
+
+	container := &mod.Container
+	var child *ChildScope
+	if p.Owner != nil {
+		child = walkChild(mod.Children, p.Owner)
+		if child == nil {
+			return nil
+		}
+		container = &child.Container
+	}
+
+	name := canonicalNameFromPK(p.Name)
+	if p.Kind == KindFree {
+		if container.Free == nil {
+			return nil
+		}
+		return container.Free[name]
+	}
+
+	if child == nil {
+		return nil
+	}
+	set := child.Instance
+	if p.Static {
+		set = child.Static
+	}
+	if set == nil {
+		return nil
+	}
+	switch p.Kind {
+	case KindMethod:
+		return set.Methods[name]
+	case KindGetter:
+		return set.Getters[name]
+	case KindSetter:
+		return set.Setters[name]
+	case KindProperty:
+		return set.Properties[name]
+	case KindCtor:
+		return set.Ctor
+	}
+	return nil
+}
+
+// walkChild descends a Member chain through Container.Children. Returns
+// nil if any segment doesn't resolve.
+func walkChild(children map[string]*ChildScope, qi dts_parser.QualIdent) *ChildScope {
+	segs := qualIdentSegments(qi)
+	if len(segs) == 0 {
+		return nil
+	}
+	var cur *ChildScope
+	for i, seg := range segs {
+		if i == 0 {
+			cur = children[seg]
+		} else {
+			if cur == nil || cur.Children == nil {
+				return nil
+			}
+			cur = cur.Children[seg]
+		}
+		if cur == nil {
+			return nil
+		}
+	}
+	return cur
+}
+
+// qualIdentSegments flattens a QualIdent into its identifier-path segments.
+func qualIdentSegments(qi dts_parser.QualIdent) []string {
+	switch q := qi.(type) {
+	case *dts_parser.Ident:
+		return []string{q.Name}
+	case *dts_parser.Member:
+		return append(qualIdentSegments(q.Left), q.Right.Name)
+	}
+	return nil
+}
+
+// canonicalNameFromPK is the single source of truth for canonicalising
+// a member name into a string map key.
+//
+//   - Plain identifier `foo` → "foo".
+//   - Qualified path `Symbol.iterator` → "[Symbol.iterator]".
+//   - String literal `"foo bar"` → `["foo bar"]` (the inner quotes are
+//     part of the key).
+//   - Numeric literal `42` → "[42]".
+func canonicalNameFromPK(key dts_parser.PropertyKey) string {
+	switch k := key.(type) {
+	case *dts_parser.Ident:
+		return k.Name
+	case *dts_parser.StringLiteral:
+		return "[\"" + k.Value + "\"]"
+	case *dts_parser.NumberLiteral:
+		return "[" + strconv.FormatFloat(k.Value, 'g', -1, 64) + "]"
+	case *dts_parser.ComputedKey:
+		return "[" + computedKeyString(k.Expr) + "]"
+	}
+	return ""
+}
+
+// computedKeyString stringifies the expression inside a ComputedKey.
+// Supports identifier and dotted-member paths (the two accepted forms
+// per §2.2) and string literals.
+func computedKeyString(e dts_parser.Expr) string {
+	switch x := e.(type) {
+	case *dts_parser.IdentExpr:
+		return x.Name
+	case *dts_parser.MemberExpr:
+		return computedKeyString(x.Object) + "." + x.Prop.Name
+	case *dts_parser.LitExpr:
+		if s, ok := x.Lit.(*dts_parser.StringLiteral); ok {
+			return "\"" + s.Value + "\""
+		}
+	}
+	return ""
+}
+
+// CanonicalNameFromObjKey canonicalises an ast.ObjKey to the same string
+// space as canonicalNameFromPK. Used by the shape extractor in
+// extract.go when ingesting override .esc files.
+func CanonicalNameFromObjKey(key ast.ObjKey) string {
+	switch k := key.(type) {
+	case *ast.IdentExpr:
+		return k.Name
+	case *ast.StrLit:
+		return "[\"" + k.Value + "\"]"
+	case *ast.NumLit:
+		return "[" + strconv.FormatFloat(k.Value, 'g', -1, 64) + "]"
+	case *ast.ComputedKey:
+		return "[" + computedKeyStringFromAst(k.Expr) + "]"
+	}
+	return ""
+}
+
+func computedKeyStringFromAst(e ast.Expr) string {
+	switch x := e.(type) {
+	case *ast.IdentExpr:
+		return x.Name
+	case *ast.MemberExpr:
+		return computedKeyStringFromAst(x.Object) + "." + identNameFromAst(x.Prop)
+	case *ast.LiteralExpr:
+		if s, ok := x.Lit.(*ast.StrLit); ok {
+			return "\"" + s.Value + "\""
+		}
+	}
+	return ""
+}
+
+func identNameFromAst(n *ast.Ident) string {
+	if n == nil {
+		return ""
+	}
+	return n.Name
+}
+
+// pathForMember constructs a Path for the member in a ClassifyContext.
+// Returns a zero Path if the member shape is one Classify doesn't query
+// the store for (e.g. unsupported member type).
+func pathForMember(ctx ClassifyContext) Path {
+	if ctx.Member == nil {
+		return Path{}
+	}
+	var owner dts_parser.QualIdent
+	if ctx.ClassName != "" {
+		owner = dts_parser.NewIdent(ctx.ClassName, ast.Span{})
+	}
+	p := Path{
+		Module: ctx.ModulePath,
+		Owner:  owner,
+	}
+	switch m := ctx.Member.(type) {
+	case *dts_parser.MethodDecl:
+		p.Name = m.Name
+		p.Kind = KindMethod
+		p.Static = m.Modifiers.Static
+	case *dts_parser.GetterDecl:
+		p.Name = m.Name
+		p.Kind = KindGetter
+		p.Static = m.Modifiers.Static
+	case *dts_parser.SetterDecl:
+		p.Name = m.Name
+		p.Kind = KindSetter
+		p.Static = m.Modifiers.Static
+	case *dts_parser.PropertyDecl:
+		p.Name = m.Name
+		p.Kind = KindProperty
+		p.Static = m.Modifiers.Static
+	case *dts_parser.ConstructorDecl:
+		p.Kind = KindCtor
+	default:
+		return Path{}
+	}
+	return p
+}
+
+// overrideToResult converts an override hit into a ClassifyResult.
+// Receiver mutability is read off the override's *FuncType.SelfParam.
+func overrideToResult(eff *Effective) ClassifyResult {
+	mut := false
+	if fn, ok := eff.Type.(*type_system.FuncType); ok {
+		mut = type_system.ReceiverIsMut(fn)
+	}
+	return ClassifyResult{Mut: mut, Source: eff.Source}
+}

--- a/internal/interop/store_test.go
+++ b/internal/interop/store_test.go
@@ -1,0 +1,104 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+func ident(name string) *dts_parser.Ident {
+	return dts_parser.NewIdent(name, ast.Span{})
+}
+
+func TestResolveFreeFunctionAtModuleTop(t *testing.T) {
+	fn := type_system.NewFuncType(nil, nil, nil, nil, nil)
+	store := NewOverrideStore()
+	store.Modules["lodash"] = &ModuleScope{
+		Container: Container{
+			Free: map[string]*Effective{
+				"map": {Type: fn, Source: TierShippedOverride},
+			},
+			Children: map[string]*ChildScope{},
+		},
+	}
+	got := store.Resolve(Path{
+		Module: "lodash",
+		Name:   ident("map"),
+		Kind:   KindFree,
+	})
+	if got == nil || got.Type != fn {
+		t.Fatalf("expected free fn lookup to return fn; got %#v", got)
+	}
+}
+
+func TestResolveInstanceMethod(t *testing.T) {
+	fn := type_system.NewFuncType(nil, nil, nil, nil, nil)
+	store := NewOverrideStore()
+	store.Modules[""] = &ModuleScope{
+		Container: Container{
+			Free: map[string]*Effective{},
+			Children: map[string]*ChildScope{
+				"Array": {
+					Container: Container{
+						Free:     map[string]*Effective{},
+						Children: map[string]*ChildScope{},
+					},
+					Instance: &MemberSet{
+						Methods: map[string]*Effective{
+							"map": {Type: fn, Source: TierShippedOverride},
+						},
+						Getters:    map[string]*Effective{},
+						Setters:    map[string]*Effective{},
+						Properties: map[string]*Effective{},
+					},
+					Static: NewMemberSet(),
+				},
+			},
+		},
+	}
+	eff := store.Resolve(Path{
+		Owner:  ident("Array"),
+		Name:   ident("map"),
+		Kind:   KindMethod,
+		Static: false,
+	})
+	if eff == nil || eff.Type != fn {
+		t.Fatalf("expected instance method lookup to return fn; got %#v", eff)
+	}
+	// Static lookup misses.
+	if got := store.Resolve(Path{
+		Owner:  ident("Array"),
+		Name:   ident("map"),
+		Kind:   KindMethod,
+		Static: true,
+	}); got != nil {
+		t.Fatalf("expected static lookup to miss; got %#v", got)
+	}
+}
+
+func TestResolveNilStoreReturnsNil(t *testing.T) {
+	var store *OverrideStore
+	if got := store.Resolve(Path{Module: "anything"}); got != nil {
+		t.Fatalf("nil store should resolve to nil; got %#v", got)
+	}
+}
+
+func TestCanonicalNameFromPK(t *testing.T) {
+	cases := []struct {
+		name string
+		in   dts_parser.PropertyKey
+		want string
+	}{
+		{"plain ident", ident("foo"), "foo"},
+		{"string literal", &dts_parser.StringLiteral{Value: "foo bar"}, `["foo bar"]`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := canonicalNameFromPK(c.in); got != c.want {
+				t.Fatalf("canonicalNameFromPK = %q; want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/planning/interop_mutability/implementation_plan.md
+++ b/planning/interop_mutability/implementation_plan.md
@@ -329,24 +329,74 @@ leaves from a lower-tier `@all_pure`.
 
 ### 5.2 Package layout
 
-The override system lives directly in `internal/interop/`
-alongside the existing `decl.go` / `helper.go` / `mutability.go`
-— no subpackage. New files:
+Override `.esc` files are ordinary Escalier source, so the
+ambient declarations they contain are converted to
+`type_system.Type` values by **reusing the existing checker
+pipeline** (the same pipeline that already handles `.d.ts`
+interop via `interop.ConvertModule` → `Checker.InferModule`).
+No new `ast.Decl → type_system.Type` converter is written: every
+existing inference helper (`inferTypeAnn`, `inferFuncSig`,
+`inferTypeDecl`, `inferInterface`, etc.) applies directly.
 
-- `store.go` — `OverrideStore` type and public lookup API.
-- `loader.go` — discovery walk + filesystem reading.
-- `merge.go` — eager merge of override decls onto the original `.d.ts`.
-- `consistency.go` — signature-shape consistency check (arity /
-  non-receiver param types / return type).
-- `errors.go` — typed merge errors (see "Error categories" below).
-- `store_test.go`, `loader_test.go`, `merge_test.go`,
-  `consistency_test.go` — unit coverage.
+The whole override system lives in `internal/interop/`. Note
+that this is possible because `Build` does *not* import
+`checker` directly — it takes a `TypeChecker` function-type
+callback that the consumer (in `internal/checker/`) plugs in.
+The callback seam sidesteps the cycle that would otherwise
+arise (`checker` already imports `interop` for
+`interop.ConvertModule`), so no subpackage is needed.
 
-All new exported types (`OverrideStore`, `ModuleScope`,
-`ChildScope`, `MemberSet`, `Effective`, `Origin`, `Path`, the
-`Err*` types, the `OverrideTier`/`ResolutionTier` enums, etc.)
-sit in package `interop`; external callers reference them as
-`interop.OverrideStore`, `interop.Origin`, and so on.
+Files added to `internal/interop/`:
+
+- `store.go` — `OverrideStore`, `ModuleScope`, `ChildScope`,
+  `Container`, `MemberSet`, `Effective`, `Origin`, `Path`,
+  `OverrideTier`, `MemberKind` plus `Resolve` (§5.10) and
+  canonical-name helpers (§5.4).
+- `errors.go` — typed merge errors (§5.8).
+- `consistency.go` — signature-shape consistency check
+  (§5.7).
+- `extract.go` — "shape extractor" that walks the parsed
+  override AST alongside the checker-produced
+  `*type_system.Namespace` to build the `ModuleScope` /
+  `ChildScope` / `MemberSet` tree (the namespace alone does
+  not preserve method/getter/setter slot independence — the
+  AST does).
+- `merge.go` — `Collapse` (three-tier shadowing) and `Merge`
+  (eager merge of override scopes onto the original `.d.ts`
+  scope) — §5.6.
+- `loader.go` — `Discover` (filesystem walk + parse) and
+  `Build` (full pipeline: discover → typecheck via injected
+  `TypeChecker` → extract → collapse → merge).
+- `store_test.go`, `consistency_test.go`, `merge_test.go`,
+  `loader_test.go`, `extract_test.go` — unit coverage.
+
+External callers reference `interop.OverrideStore`,
+`interop.Build`, `interop.Origin`, and so on. `Classify` reads
+`*OverrideStore` through `ClassifyContext.Store`; the store
+itself is built by `interop.Build` invoked from
+`internal/checker/`.
+
+**Checker hook.** The checker currently no-ops on
+`*ast.DeclareModuleDecl`, `*ast.DeclareGlobalDecl`, and
+`*ast.NamespaceDecl` (see
+[infer_stmt.go](../../internal/checker/infer_stmt.go) — the
+`return []Error{}` branch). When `Override()` is true on one
+of these, the checker must instead descend into the block
+and infer the contained declarations into the surrounding
+namespace, exactly as it does for top-level declarations. The
+hook is small (one switch arm wired to the existing per-decl
+helpers) and is the only checker change §5 requires.
+
+**Sequencing.** Override decls reference types declared in
+the original `.d.ts` (e.g. an override of `Array.prototype.map`
+mentions `Array<T>`). The loader must therefore run *after*
+the relevant `.d.ts` has been inferred, so the global /
+package scope is populated. Concretely: `interop.Build` is
+invoked from the same call site that wires `.d.ts` inference
+into the checker (today
+[infer_import.go](../../internal/checker/infer_import.go)),
+after the package and global namespaces are in place but
+before user-source inference starts.
 
 ### 5.3 Core data types
 
@@ -357,11 +407,12 @@ map-key problem doesn't arise; lookups walk the tree.
 
 ```go
 // OverrideStore holds the post-merge module map. Per-tier
-// pre-merge module maps exist only inside loader.Load (used to
-// run within-tier duplicate detection and the slot-by-slot
-// collapse of §5.5) and are not retained on the store — every
-// diagnostic that needs provenance reads Effective.Provenance,
-// which already carries the contributing Origins.
+// pre-merge module maps exist only inside Build (used to run
+// within-tier duplicate detection and the slot-by-slot
+// collapse of §5.5) and are not retained on the store —
+// every diagnostic that needs provenance reads
+// Effective.Provenance, which already carries the
+// contributing Origins.
 type OverrideStore struct {
     // Merged across all OverrideTiers + the original. Key is the
     // module specifier ("" = global; "lodash", "fs", etc.).
@@ -479,7 +530,30 @@ all call it.
 
 ### 5.5 Discovery, loading, and three-tier collapse
 
-`loader.Load(root string, deps []DepInfo, shipped fs.FS) (*OverrideStore, []error)`:
+Entry point (in package `interop`):
+
+```go
+// TypeChecker is the dependency-injection seam that lets the
+// loader invoke the checker without importing it (and thereby
+// avoid the cycle that would arise — checker already imports
+// interop). The consumer in internal/checker/ wires up a
+// TypeChecker that runs InferModule against scopes populated
+// with the original .d.ts symbols (§5.2 "Sequencing").
+type TypeChecker func(p *ParsedOverride) (
+    globalNs *type_system.Namespace,
+    namedNs map[string]*type_system.Namespace,
+    errs []error,
+)
+
+func Build(
+    ctx context.Context,
+    tc TypeChecker,
+    root string,
+    deps []DepInfo,
+    shipped fs.FS,
+    originals map[string]*ModuleScope,
+) (*OverrideStore, []error)
+```
 
 1. Walk `shipped` (embedded `fs.FS` populated in §6) — emit
    `Entry`s with `OverrideTier = OverrideTierShipped`.
@@ -488,15 +562,31 @@ all call it.
    directory containing that dep's `package.json`.
 3. Walk `<root>/overrides/**/*.esc` — emit with
    `OverrideTier = OverrideTierUserProject`.
-4. Parse each file via the existing `internal/parser` entry point;
-   reject files with parse errors as hard errors.
-5. Build one `map[string]*ModuleScope` per `OverrideTier` by
-   walking parsed decls and inserting each into the appropriate
-   `MemberSet` slot. Within an `OverrideTier`, inserting into an
-   already-occupied slot is `ErrDuplicateMember` (carries both
-   files' `Origin`s). Cross-tier shadowing is handled by the
-   collapse step below.
-6. Collapse the three per-tier scopes into a single override
+4. Parse each file via the existing `internal/parser` entry point
+   (`parser.ParseLibFiles`); reject files with parse errors as
+   hard errors.
+5. **Type-check.** Drive `Checker.InferModule` (or a
+   per-decl variant) over each parsed override file against
+   the same package/global scopes the `.d.ts` populated in
+   step 0 (the implicit prerequisite per §5.2 "Sequencing").
+   The checker's `Override()`-aware branch (§5.2 "Checker
+   hook") descends into `override declare module "..."`,
+   `override declare global`, and `override declare
+   namespace` blocks and infers the contained decls into a
+   fresh `*type_system.Namespace`. Type-check errors are
+   surfaced as hard errors — overrides whose types don't
+   resolve are not silently dropped.
+6. **Shape-extract.** Walk each override file's parsed AST in
+   lockstep with the checker-produced `*type_system.Namespace`
+   and build one `*ModuleScope` per `OverrideTier`. The AST
+   walk decides which slot a declaration lands in (method vs.
+   getter vs. setter vs. property, static vs. instance, free
+   function vs. nested namespace member); the namespace
+   supplies the typed `type_system.Type` for each slot. Within
+   an `OverrideTier`, inserting into an already-occupied slot
+   is `ErrDuplicateMember` (carries both files' `Origin`s).
+   Cross-tier shadowing is handled by the collapse step below.
+7. Collapse the three per-tier scopes into a single override
    scope by walking all three trees together, slot-by-slot:
 
    ```text
@@ -524,7 +614,9 @@ all call it.
 
 ### 5.6 Eager merge pass
 
-`merge.Apply(original, override map[string]*ModuleScope) (*OverrideStore, []error)`:
+Lives in `internal/interop/merge.go`:
+
+`Merge(original, override map[string]*ModuleScope) (*OverrideStore, []error)`:
 
 The merge is a recursive tree walk: visit the original scope and
 the collapsed override scope together, slot-by-slot (override
@@ -749,6 +841,10 @@ of any `QualIdent` walk.
 
 ### 5.11 `Classify` integration
 
+`Classify` lives in `internal/interop/mutability.go`; the
+store it consults is built upstream by `interop.Build`
+(§5.2) and handed in via `ClassifyContext`.
+
 Extend `ClassifyContext` with `Store *OverrideStore` (nil
 is allowed and means "no overrides registered"). `Classify` calls
 `Store.Resolve(path)` exactly once at the very top of the cascade.
@@ -780,21 +876,87 @@ lives in `decl.go`, not `Classify`.
 
 ### 5.12 Tests
 
-- `loader_test.go`: synthetic fs with files at all three tiers;
-  assert grouping, precedence, duplicate-within-tier error.
-- `merge_test.go`: hand-rolled original + override pairs; assert
-  resulting `Effective`. Cover overload collapsing,
+All tests live in `internal/interop/`:
+
+- `store_test.go`: `OverrideStore.Resolve` walks against
+  hand-built scope trees; verify free-function vs. nested
+  member resolution and the kind/static dispatch.
+- `consistency_test.go`: each of arity, param-type,
+  return-type, and generics-arity mismatches produces the
+  right error. Inputs are hand-built `*type_system.FuncType`
+  pairs — no parser/checker dependency.
+- `extract_test.go`: small Escalier-source snippets parsed
+  and checker-inferred (the real pipeline, driven through
+  the `TypeChecker` callback); assert the resulting
+  `*ModuleScope` shape — method vs. getter vs. setter slot,
+  static/instance separation, namespace nesting, `@all_pure`
+  propagation.
+- `loader_test.go`: synthetic fs with files at all three
+  tiers; assert grouping, precedence,
+  duplicate-within-tier error.
+- `merge_test.go`: hand-rolled original + override pairs;
+  assert resulting `Effective`. Cover overload collapsing,
   override-defined overloads, getter/setter independence,
   static/instance separation, `@all_pure`.
-- `consistency_test.go`: each of arity, param-type, return-type,
-  generics-arity mismatches produces the right error.
 - Integration: a fixture under
   `fixtures/interop_mutability/overrides_loaded/` with a real
-  `package.json` + `overrides/foo.esc` + a `.d.ts` it references.
+  `package.json` + `overrides/foo.esc` + a `.d.ts` it
+  references — exercises the full
+  parse → check → extract → merge → resolve pipeline.
 
 Exit criteria: loader + merge covered by unit tests; `Classify`
 consults the merged store but no overrides are shipped yet
 (§6 ships them).
+
+### 5.13 Deferred to a follow-up PR
+
+The initial landing of §5 (PR #603) plumbs the
+discover → check → extract → merge → resolve pipeline end to
+end and wires `Classify` into the merged store, but several
+threads were left for a follow-up to keep that PR
+reviewable:
+
+- **Static-side method/property types.** `extract.go`
+  `lookupMethodType` and `lookupPropertyType` short-circuit
+  to `nil` when `static == true` because the static side of
+  a class isn't reachable from the instance `ObjectType`
+  exposed by the checker. As a result, static overrides
+  flow through the pipeline structurally but with
+  `Effective.Type == nil`, and the consistency check is
+  silently skipped on the static side. Fix is to surface a
+  separate static-side `ObjectType` (or equivalent
+  member-keyed map) from the checker and have the
+  extractor consult it.
+
+- **Lifetime-erased signature equivalence.** §5.7's
+  `funcSignatureEquivalent` uses the strict
+  `Type.Equals`, which is sensitive to `LifetimeParams`
+  arity on nested `FuncType`-valued parameters. TS-derived
+  originals never carry lifetimes, so overrides that add
+  lifetimes to a nested function-type param will trip the
+  consistency check spuriously. Introduce a
+  lifetime-erased equivalence routine (or a flag on
+  `Equals`) and use it only on the consistency-check path.
+
+- **Property-type consistency.** `mergeLeaf` only runs the
+  consistency check when both `orig` and `over` carry
+  `*FuncType`. Property slots (and any other non-function
+  leaf) can silently diverge in type between override and
+  original. Add a structural-equivalence check on
+  non-function leaves.
+
+- **Namespace-vs-class shape conflict.** `mergeChild`
+  decides namespace-vs-class via `hasMembers` on either
+  side. If the original is a namespace and an override is
+  a class (or vice versa), the merge silently mixes the
+  two shapes instead of reporting an `ErrShapeConflict`.
+
+- **Destructuring `VarDecl` patterns in override files.**
+  `extract.go` `patternNames` only handles `*ast.IdentPat`;
+  destructured bindings in an override file produce no
+  scope entries. Either extend the walk or reject
+  destructured patterns in override files with a clear
+  error.
 
 ## 6. Shipped overrides
 


### PR DESCRIPTION
## Summary
First slice of #603, split into a stack for reviewability.

- Adds `OverrideStore` / `ModuleScope` / `ChildScope` / `MemberSet` / `Container` / `Effective` and associated `Path`, `Origin`, `OriginKind`, `MemberKind`, `OverrideTier` types.
- Adds error types used by later slices: `ErrDuplicateMember`, `ErrUnknownMember`, `ErrSignatureMismatch`, `ErrGenericArityMismatch`.
- Updates the implementation plan describing the override pipeline.

Pure data structures + unit tests. No external callers yet.

## Stack
- **5.1 (this PR)** — store + errors + plan doc
- 5.2 — extract + consistency (#)
- 5.3 — merge + loader (#)
- 5.4 — wire into checker (#)

## Test plan
- [x] go build ./...
- [x] go test ./internal/interop/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for override store symbol resolution, method lookups (instance and static), and canonical naming utilities.

* **Documentation**
  * Updated implementation plan for override system with detailed scaffolding, integration points, and follow-up work items.

* **Chores**
  * Internal improvements to diagnostic error reporting in override processing, including detection of duplicate members, unknown targets, signature mismatches, and type-parameter mismatches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/606)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->