### PR TITLE
Interop mutability 5.2: extract overrides & signature consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Escalier is a programming language with a Go-based compiler. The compiler pipeli
 - Assert the full error message, not a substring.
 - Write test inputs as Escalier source. Assert inferred types using Escalier type-annotation syntax in strings. See [internal/checker/tests/class_test.go](internal/checker/tests/class_test.go) for the canonical pattern.
 - Prefer table-driven tests.
+- Use `github.com/stretchr/testify` for assertions instead of hand-rolled `if x != y { t.Fatalf(...) }` blocks. Prefer `require.*` (stops on first failure, matching the `t.Fatalf` pattern) over `assert.*`. Common conversions: `require.Equal(t, expected, actual)`, `require.Same(t, expected, actual)` for pointer identity, `require.NotNil(t, x)`, `require.Contains(t, m, k)`, `require.NotContains(t, m, k)`, `require.Empty(t, s)`, `require.Error(t, err)`, `require.NoError(t, err)`. Split compound conditions (`x == nil || x.Type != fn`) into separate `require` calls so failures point at the actual problem.
 
 ## Ephemeral scripts
 

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -204,16 +204,24 @@ type MethodTypeAnn struct {
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
 }
+
+func (m *MethodTypeAnn) Span() Span { return m.Name.Span() }
+
 type GetterTypeAnn struct {
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
 }
+
+func (g *GetterTypeAnn) Span() Span { return g.Name.Span() }
+
 type SetterTypeAnn struct {
 	Name     ObjKey
 	Fn       *FuncTypeAnn
 	Receiver *MethodReceiver // nil if no receiver
 }
+
+func (s *SetterTypeAnn) Span() Span { return s.Name.Span() }
 
 type MappedModifier string
 
@@ -222,13 +230,18 @@ const (
 	MMRemove MappedModifier = "remove"
 )
 
-// TODO: include span
+// TODO: include a dedicated span covering the full property declaration
+// (including modifiers like `readonly`/`?`); for now Span() returns the
+// name's span so callers get a per-member position instead of the
+// enclosing container's span.
 type PropertyTypeAnn struct {
 	Name     ObjKey
 	Optional bool
 	Readonly bool
 	Value    TypeAnn
 }
+
+func (p *PropertyTypeAnn) Span() Span { return p.Name.Span() }
 
 type MappedTypeAnn struct {
 	TypeParam *IndexParamTypeAnn

--- a/internal/interop/consistency.go
+++ b/internal/interop/consistency.go
@@ -1,0 +1,123 @@
+package interop
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// CheckSet verifies overload-set shape: counts match and each override
+// signature is equivalent to the original at the same index. Called
+// from merge.go once per method/function slot.
+//
+// On mismatched counts, no per-signature checks run (there's no
+// defensible pairing) — the user must redeclare the full set.
+func CheckSet(override, original []*type_system.FuncType, path Path, origin Origin) error {
+	if len(override) != len(original) {
+		return &ErrSignatureMismatch{
+			Path:           path,
+			Field:          "overload count",
+			Override:       fmt.Sprintf("%d", len(override)),
+			Original:       fmt.Sprintf("%d", len(original)),
+			OverrideOrigin: origin,
+		}
+	}
+	bracket := len(override) > 1
+	for i := range override {
+		field, ok := funcSignatureEquivalent(override[i], original[i])
+		if ok {
+			continue
+		}
+		if bracket {
+			field = fmt.Sprintf("overload[%d]/%s", i, field)
+		}
+		return &ErrSignatureMismatch{
+			Path:           path,
+			Field:          field,
+			Override:       override[i].String(),
+			Original:       original[i].String(),
+			OverrideOrigin: origin,
+		}
+	}
+	return nil
+}
+
+// Check is the per-signature helper used by CheckSet and exposed
+// directly for the §10 implements check.
+func Check(override, original *type_system.FuncType, path Path, origin Origin) error {
+	field, ok := funcSignatureEquivalent(override, original)
+	if ok {
+		return nil
+	}
+	return &ErrSignatureMismatch{
+		Path:           path,
+		Field:          field,
+		Override:       override.String(),
+		Original:       original.String(),
+		OverrideOrigin: origin,
+	}
+}
+
+// funcSignatureEquivalent compares two FuncTypes for the consistency
+// contract: arity (excluding any `this`/`self` receiver), per-position
+// non-receiver param types and Optional flag, and return type.
+// Parameter names are ignored. SelfParam mode is intentionally excluded — that's the field
+// the override is allowed to change. Type parameters must match in
+// arity, and in the per-pair comparison their declared constraints
+// and defaults are compared structurally. Lifetime parameters are not
+// compared: TypeScript has no lifetime syntax, so overrides will
+// routinely add lifetimes the original lacks.
+func funcSignatureEquivalent(a, b *type_system.FuncType) (field string, ok bool) {
+	if a == nil || b == nil {
+		return "nilFunc", a == b
+	}
+
+	// Per-signature generics arity.
+	if len(a.TypeParams) != len(b.TypeParams) {
+		return "typeParams", false
+	}
+	for i := range a.TypeParams {
+		ap, bp := a.TypeParams[i], b.TypeParams[i]
+		if (ap.Constraint == nil) != (bp.Constraint == nil) {
+			return fmt.Sprintf("typeParam[%d]/constraint", i), false
+		}
+		if ap.Constraint != nil && !ap.Constraint.Equals(bp.Constraint) {
+			return fmt.Sprintf("typeParam[%d]/constraint", i), false
+		}
+		if (ap.Default == nil) != (bp.Default == nil) {
+			return fmt.Sprintf("typeParam[%d]/default", i), false
+		}
+		if ap.Default != nil && !ap.Default.Equals(bp.Default) {
+			return fmt.Sprintf("typeParam[%d]/default", i), false
+		}
+	}
+	if len(a.Params) != len(b.Params) {
+		return "arity", false
+	}
+	// Param types are compared via Type.Equals — which is strict on
+	// lifetime annotations. Overrides that add lifetimes to nested
+	// FuncType-valued params relative to a TS-derived original will
+	// therefore mismatch; a lifetime-erased equivalence variant for
+	// the override path is tracked in §5.13.
+	for i := range a.Params {
+		if a.Params[i].Optional != b.Params[i].Optional {
+			return fmt.Sprintf("param[%d]", i), false
+		}
+		if a.Params[i].Type == nil || b.Params[i].Type == nil {
+			if a.Params[i].Type != b.Params[i].Type {
+				return fmt.Sprintf("param[%d]", i), false
+			}
+			continue
+		}
+		if !a.Params[i].Type.Equals(b.Params[i].Type) {
+			return fmt.Sprintf("param[%d]", i), false
+		}
+	}
+	if (a.Return == nil) != (b.Return == nil) {
+		return "return", false
+	}
+	if a.Return != nil && !a.Return.Equals(b.Return) {
+		return "return", false
+	}
+	return "", true
+}

--- a/internal/interop/consistency.go
+++ b/internal/interop/consistency.go
@@ -2,6 +2,7 @@ package interop
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
@@ -17,8 +18,8 @@ func CheckSet(override, original []*type_system.FuncType, path Path, origin Orig
 		return &ErrSignatureMismatch{
 			Path:           path,
 			Field:          "overload count",
-			Override:       fmt.Sprintf("%d", len(override)),
-			Original:       fmt.Sprintf("%d", len(original)),
+			Override:       strconv.Itoa(len(override)),
+			Original:       strconv.Itoa(len(original)),
 			OverrideOrigin: origin,
 		}
 	}

--- a/internal/interop/consistency.go
+++ b/internal/interop/consistency.go
@@ -34,12 +34,21 @@ func CheckSet(override, original []*type_system.FuncType, path Path, origin Orig
 		return &ErrSignatureMismatch{
 			Path:           path,
 			Field:          field,
-			Override:       override[i].String(),
-			Original:       original[i].String(),
+			Override:       funcString(override[i]),
+			Original:       funcString(original[i]),
 			OverrideOrigin: origin,
 		}
 	}
 	return nil
+}
+
+// funcString renders a FuncType for diagnostics, returning "nilFunc"
+// when the pointer is nil so error construction never panics.
+func funcString(f *type_system.FuncType) string {
+	if f == nil {
+		return "nilFunc"
+	}
+	return f.String()
 }
 
 // Check is the per-signature helper used by CheckSet and exposed
@@ -52,8 +61,8 @@ func Check(override, original *type_system.FuncType, path Path, origin Origin) e
 	return &ErrSignatureMismatch{
 		Path:           path,
 		Field:          field,
-		Override:       override.String(),
-		Original:       original.String(),
+		Override:       funcString(override),
+		Original:       funcString(original),
 		OverrideOrigin: origin,
 	}
 }

--- a/internal/interop/consistency_test.go
+++ b/internal/interop/consistency_test.go
@@ -1,0 +1,135 @@
+package interop
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+func mkParam(t type_system.Type) *type_system.FuncParam {
+	return &type_system.FuncParam{Type: t}
+}
+
+func mkOptionalParam(t type_system.Type) *type_system.FuncParam {
+	return &type_system.FuncParam{Type: t, Optional: true}
+}
+
+func mkFunc(params []type_system.Type, ret type_system.Type) *type_system.FuncType {
+	fps := make([]*type_system.FuncParam, len(params))
+	for i, t := range params {
+		fps[i] = mkParam(t)
+	}
+	return type_system.NewFuncType(nil, nil, fps, ret, nil)
+}
+
+func mkFuncParams(params []*type_system.FuncParam, ret type_system.Type) *type_system.FuncType {
+	return type_system.NewFuncType(nil, nil, params, ret, nil)
+}
+
+var (
+	stringPrim = type_system.NewStrPrimType(nil)
+	numberPrim = type_system.NewNumPrimType(nil)
+)
+
+// expectedSigMismatch builds the full error message produced by
+// ErrSignatureMismatch.Error() so tests assert the complete diagnostic
+// text rather than just the Field axis.
+func expectedSigMismatch(field, override, original string) string {
+	return fmt.Sprintf(
+		"override of  changes signature shape (%s): override=%s, original=%s\n  override at :0",
+		field, override, original,
+	)
+}
+
+func TestCheckArityMismatch(t *testing.T) {
+	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
+	original := mkFunc([]type_system.Type{stringPrim, numberPrim}, numberPrim)
+	err := Check(override, original, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected arity mismatch error; got nil")
+	}
+	want := expectedSigMismatch("arity", override.String(), original.String())
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+func TestCheckReturnMismatch(t *testing.T) {
+	override := mkFunc([]type_system.Type{stringPrim}, stringPrim)
+	original := mkFunc([]type_system.Type{stringPrim}, numberPrim)
+	err := Check(override, original, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected return mismatch error")
+	}
+	want := expectedSigMismatch("return", override.String(), original.String())
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+func TestCheckParamMismatch(t *testing.T) {
+	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
+	original := mkFunc([]type_system.Type{numberPrim}, numberPrim)
+	err := Check(override, original, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected param mismatch error")
+	}
+	want := expectedSigMismatch("param[0]", override.String(), original.String())
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+func TestCheckParamOptionalMismatch(t *testing.T) {
+	override := mkFuncParams([]*type_system.FuncParam{mkOptionalParam(stringPrim)}, numberPrim)
+	original := mkFuncParams([]*type_system.FuncParam{mkParam(stringPrim)}, numberPrim)
+	err := Check(override, original, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected optionality mismatch error; got nil")
+	}
+	want := expectedSigMismatch("param[0]", override.String(), original.String())
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+func TestCheckEquivalentSignatures(t *testing.T) {
+	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
+	original := mkFunc([]type_system.Type{stringPrim}, numberPrim)
+	if err := Check(override, original, Path{}, Origin{}); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+}
+
+func TestCheckSetOverloadCountMismatch(t *testing.T) {
+	o := []*type_system.FuncType{mkFunc(nil, numberPrim)}
+	orig := []*type_system.FuncType{mkFunc(nil, numberPrim), mkFunc(nil, stringPrim)}
+	err := CheckSet(o, orig, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected overload count mismatch error")
+	}
+	want := expectedSigMismatch("overload count", "1", "2")
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+func TestCheckSetPerSignatureMismatchAnnotatesIndex(t *testing.T) {
+	override := []*type_system.FuncType{
+		mkFunc([]type_system.Type{stringPrim}, numberPrim),
+		mkFunc([]type_system.Type{stringPrim}, numberPrim),
+	}
+	original := []*type_system.FuncType{
+		mkFunc([]type_system.Type{stringPrim}, numberPrim),
+		mkFunc([]type_system.Type{numberPrim}, numberPrim),
+	}
+	err := CheckSet(override, original, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected per-signature mismatch error")
+	}
+	want := expectedSigMismatch("overload[1]/param[0]", override[1].String(), original[1].String())
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}

--- a/internal/interop/consistency_test.go
+++ b/internal/interop/consistency_test.go
@@ -115,6 +115,43 @@ func TestCheckSetOverloadCountMismatch(t *testing.T) {
 	}
 }
 
+func TestCheckNilOverride(t *testing.T) {
+	original := mkFunc([]type_system.Type{stringPrim}, numberPrim)
+	err := Check(nil, original, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected nilFunc mismatch error; got nil")
+	}
+	want := expectedSigMismatch("nilFunc", "nilFunc", original.String())
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+func TestCheckNilOriginal(t *testing.T) {
+	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
+	err := Check(override, nil, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected nilFunc mismatch error; got nil")
+	}
+	want := expectedSigMismatch("nilFunc", override.String(), "nilFunc")
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
+func TestCheckSetNilSignature(t *testing.T) {
+	override := []*type_system.FuncType{nil}
+	original := []*type_system.FuncType{mkFunc([]type_system.Type{stringPrim}, numberPrim)}
+	err := CheckSet(override, original, Path{}, Origin{})
+	if err == nil {
+		t.Fatal("expected nilFunc mismatch error; got nil")
+	}
+	want := expectedSigMismatch("nilFunc", "nilFunc", original[0].String())
+	if err.Error() != want {
+		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
 func TestCheckSetPerSignatureMismatchAnnotatesIndex(t *testing.T) {
 	override := []*type_system.FuncType{
 		mkFunc([]type_system.Type{stringPrim}, numberPrim),

--- a/internal/interop/consistency_test.go
+++ b/internal/interop/consistency_test.go
@@ -37,7 +37,7 @@ var (
 // text rather than just the Field axis.
 func expectedSigMismatch(field, override, original string) string {
 	return fmt.Sprintf(
-		"override of  changes signature shape (%s): override=%s, original=%s\n  override at :0",
+		"override of <unknown> changes signature shape (%s): override=%s, original=%s\n  override at :0",
 		field, override, original,
 	)
 }

--- a/internal/interop/consistency_test.go
+++ b/internal/interop/consistency_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
 )
 
 func mkParam(t type_system.Type) *type_system.FuncParam {
@@ -46,110 +47,68 @@ func TestCheckArityMismatch(t *testing.T) {
 	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
 	original := mkFunc([]type_system.Type{stringPrim, numberPrim}, numberPrim)
 	err := Check(override, original, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected arity mismatch error; got nil")
-	}
-	want := expectedSigMismatch("arity", override.String(), original.String())
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected arity mismatch error")
+	require.Equal(t, expectedSigMismatch("arity", override.String(), original.String()), err.Error())
 }
 
 func TestCheckReturnMismatch(t *testing.T) {
 	override := mkFunc([]type_system.Type{stringPrim}, stringPrim)
 	original := mkFunc([]type_system.Type{stringPrim}, numberPrim)
 	err := Check(override, original, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected return mismatch error")
-	}
-	want := expectedSigMismatch("return", override.String(), original.String())
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected return mismatch error")
+	require.Equal(t, expectedSigMismatch("return", override.String(), original.String()), err.Error())
 }
 
 func TestCheckParamMismatch(t *testing.T) {
 	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
 	original := mkFunc([]type_system.Type{numberPrim}, numberPrim)
 	err := Check(override, original, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected param mismatch error")
-	}
-	want := expectedSigMismatch("param[0]", override.String(), original.String())
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected param mismatch error")
+	require.Equal(t, expectedSigMismatch("param[0]", override.String(), original.String()), err.Error())
 }
 
 func TestCheckParamOptionalMismatch(t *testing.T) {
 	override := mkFuncParams([]*type_system.FuncParam{mkOptionalParam(stringPrim)}, numberPrim)
 	original := mkFuncParams([]*type_system.FuncParam{mkParam(stringPrim)}, numberPrim)
 	err := Check(override, original, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected optionality mismatch error; got nil")
-	}
-	want := expectedSigMismatch("param[0]", override.String(), original.String())
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected optionality mismatch error")
+	require.Equal(t, expectedSigMismatch("param[0]", override.String(), original.String()), err.Error())
 }
 
 func TestCheckEquivalentSignatures(t *testing.T) {
 	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
 	original := mkFunc([]type_system.Type{stringPrim}, numberPrim)
-	if err := Check(override, original, Path{}, Origin{}); err != nil {
-		t.Fatalf("expected no error; got %v", err)
-	}
+	require.NoError(t, Check(override, original, Path{}, Origin{}))
 }
 
 func TestCheckSetOverloadCountMismatch(t *testing.T) {
 	o := []*type_system.FuncType{mkFunc(nil, numberPrim)}
 	orig := []*type_system.FuncType{mkFunc(nil, numberPrim), mkFunc(nil, stringPrim)}
 	err := CheckSet(o, orig, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected overload count mismatch error")
-	}
-	want := expectedSigMismatch("overload count", "1", "2")
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected overload count mismatch error")
+	require.Equal(t, expectedSigMismatch("overload count", "1", "2"), err.Error())
 }
 
 func TestCheckNilOverride(t *testing.T) {
 	original := mkFunc([]type_system.Type{stringPrim}, numberPrim)
 	err := Check(nil, original, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected nilFunc mismatch error; got nil")
-	}
-	want := expectedSigMismatch("nilFunc", "nilFunc", original.String())
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected nilFunc mismatch error")
+	require.Equal(t, expectedSigMismatch("nilFunc", "nilFunc", original.String()), err.Error())
 }
 
 func TestCheckNilOriginal(t *testing.T) {
 	override := mkFunc([]type_system.Type{stringPrim}, numberPrim)
 	err := Check(override, nil, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected nilFunc mismatch error; got nil")
-	}
-	want := expectedSigMismatch("nilFunc", override.String(), "nilFunc")
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected nilFunc mismatch error")
+	require.Equal(t, expectedSigMismatch("nilFunc", override.String(), "nilFunc"), err.Error())
 }
 
 func TestCheckSetNilSignature(t *testing.T) {
 	override := []*type_system.FuncType{nil}
 	original := []*type_system.FuncType{mkFunc([]type_system.Type{stringPrim}, numberPrim)}
 	err := CheckSet(override, original, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected nilFunc mismatch error; got nil")
-	}
-	want := expectedSigMismatch("nilFunc", "nilFunc", original[0].String())
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected nilFunc mismatch error")
+	require.Equal(t, expectedSigMismatch("nilFunc", "nilFunc", original[0].String()), err.Error())
 }
 
 func TestCheckSetPerSignatureMismatchAnnotatesIndex(t *testing.T) {
@@ -162,11 +121,6 @@ func TestCheckSetPerSignatureMismatchAnnotatesIndex(t *testing.T) {
 		mkFunc([]type_system.Type{numberPrim}, numberPrim),
 	}
 	err := CheckSet(override, original, Path{}, Origin{})
-	if err == nil {
-		t.Fatal("expected per-signature mismatch error")
-	}
-	want := expectedSigMismatch("overload[1]/param[0]", override[1].String(), original[1].String())
-	if err.Error() != want {
-		t.Fatalf("error mismatch\n got: %q\nwant: %q", err.Error(), want)
-	}
+	require.Error(t, err, "expected per-signature mismatch error")
+	require.Equal(t, expectedSigMismatch("overload[1]/param[0]", override[1].String(), original[1].String()), err.Error())
 }

--- a/internal/interop/errors.go
+++ b/internal/interop/errors.go
@@ -82,6 +82,9 @@ func (e *ErrGenericArityMismatch) Error() string {
 // as `module "name"::owner.member`; global paths drop the module prefix.
 func pathString(p Path) string {
 	var b strings.Builder
+	if p.Module == "" && p.Owner == nil && p.Name == nil {
+		return "<unknown>"
+	}
 	if p.Module != "" {
 		b.WriteString(`module "`)
 		b.WriteString(p.Module)

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -1,0 +1,467 @@
+package interop
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// Extract walks a parsed override file's declarations alongside the
+// checker-produced namespace and returns a per-module map of override
+// ModuleScopes the file contributes to. The shape decisions (which
+// MemberSet slot a member lands in, instance vs. static, namespace vs.
+// class) come from the AST; the actual `type_system.Type` values come
+// from the namespace.
+//
+// `globalNs` is the namespace the checker populated when inferring the
+// override file's `override declare global { ... }` block contents
+// (and any top-level sugar that desugars to it). It MAY be nil for
+// files that only target named modules.
+//
+// `namedNs` maps module-specifier string → namespace, populated by the
+// checker from each `override declare module "name" { ... }` block.
+//
+// Top-level sugar (`override declare class Foo { ... }` etc.) is
+// expected to have been desugared by the parser per
+// implementation_plan.md §2.2, so each top-level decl in `decls` is
+// either a DeclareModuleDecl or a DeclareGlobalDecl whose Override()
+// reports true. Anything else is ignored (returned as a parse-shape
+// error in §5.5 step 4 — this extractor trusts its input).
+func Extract(
+	decls []ast.Decl,
+	globalNs *type_system.Namespace,
+	namedNs map[string]*type_system.Namespace,
+	filePath string,
+	tier OverrideTier,
+) map[string]*ModuleScope {
+	out := make(map[string]*ModuleScope)
+	origin := Origin{Kind: OverrideFile, FilePath: filePath}
+
+	for _, d := range decls {
+		switch decl := d.(type) {
+		case *ast.DeclareGlobalDecl:
+			if !decl.Override() {
+				continue
+			}
+			ms := ensureModule(out, "", origin)
+			extractIntoContainer(decl.Decls, globalNs, &ms.Container, filePath, tier)
+		case *ast.DeclareModuleDecl:
+			if !decl.Override() || decl.Name == nil {
+				continue
+			}
+			modName := decl.Name.Value
+			ms := ensureModule(out, modName, origin)
+			extractIntoContainer(decl.Decls, namedNs[modName], &ms.Container, filePath, tier)
+		}
+	}
+	return out
+}
+
+func ensureModule(out map[string]*ModuleScope, name string, origin Origin) *ModuleScope {
+	if ms, ok := out[name]; ok {
+		return ms
+	}
+	ms := &ModuleScope{
+		Container: Container{
+			Free:     make(map[string]*Effective),
+			Children: make(map[string]*ChildScope),
+			Origin:   origin,
+		},
+	}
+	out[name] = ms
+	return ms
+}
+
+// extractIntoContainer walks a list of declarations and places each
+// into the appropriate Container/ChildScope slot, pulling typed values
+// out of ns.
+func extractIntoContainer(
+	decls []ast.Decl,
+	ns *type_system.Namespace,
+	container *Container,
+	filePath string,
+	tier OverrideTier,
+) {
+	for _, d := range decls {
+		switch decl := d.(type) {
+		case *ast.FuncDecl:
+			if decl.Name == nil {
+				continue
+			}
+			eff := buildLeafFromValue(ns, decl.Name.Name, filePath, decl.Span(), tier)
+			if eff != nil {
+				container.Free[decl.Name.Name] = eff
+			}
+		case *ast.VarDecl:
+			for _, name := range patternNames(decl.Pattern) {
+				eff := buildLeafFromValue(ns, name, filePath, decl.Span(), tier)
+				if eff != nil {
+					container.Free[name] = eff
+				}
+			}
+		case *ast.TypeDecl:
+			if decl.Name == nil {
+				continue
+			}
+			eff := buildLeafFromTypeAlias(ns, decl.Name.Name, filePath, decl.Span(), tier)
+			if eff != nil {
+				container.Free[decl.Name.Name] = eff
+			}
+		case *ast.ClassDecl:
+			if decl.Name == nil {
+				continue
+			}
+			child := buildClassChild(decl, ns, filePath, tier)
+			if child != nil {
+				container.Children[decl.Name.Name] = child
+			}
+		case *ast.InterfaceDecl:
+			if decl.Name == nil {
+				continue
+			}
+			child := buildInterfaceChild(decl, ns, filePath, tier)
+			if child != nil {
+				container.Children[decl.Name.Name] = child
+			}
+		case *ast.NamespaceDecl:
+			if decl.Name == nil {
+				continue
+			}
+			subNs, _ := nsLookupNamespace(ns, decl.Name.Name)
+			child := &ChildScope{
+				Container: Container{
+					Free:     make(map[string]*Effective),
+					Children: make(map[string]*ChildScope),
+					Origin:   Origin{Kind: OverrideFile, FilePath: filePath, Span: decl.Span()},
+				},
+			}
+			extractIntoContainer(decl.Decls, subNs, &child.Container, filePath, tier)
+			container.Children[decl.Name.Name] = child
+		}
+	}
+}
+
+func buildLeafFromValue(ns *type_system.Namespace, name, filePath string, span ast.Span, tier OverrideTier) *Effective {
+	if ns == nil {
+		return nil
+	}
+	b, ok := ns.Values[name]
+	if !ok || b == nil {
+		return nil
+	}
+	return &Effective{
+		Type:       b.Type,
+		Source:     tier.ResolutionTierFor(),
+		Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+		Tier:       tier,
+	}
+}
+
+func buildLeafFromTypeAlias(ns *type_system.Namespace, name, filePath string, span ast.Span, tier OverrideTier) *Effective {
+	if ns == nil {
+		return nil
+	}
+	ta, ok := ns.Types[name]
+	if !ok || ta == nil {
+		return nil
+	}
+	return &Effective{
+		Type:       ta.Type,
+		Source:     tier.ResolutionTierFor(),
+		Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+		Tier:       tier,
+	}
+}
+
+// buildClassChild builds a ChildScope for a class declaration. Methods,
+// getters, setters, property fields and the constructor are routed
+// into the appropriate MemberSet slot; their types come from the class
+// type recorded in `ns`.
+//
+// The class type lookup is best-effort: when the checker hasn't
+// produced a typed object/class for the override (e.g. the override
+// references a TypeScript symbol that wasn't pre-loaded), the leaf
+// types fall back to nil and the merge will skip the consistency check
+// for that slot.
+func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath string, tier OverrideTier) *ChildScope {
+	origin := Origin{Kind: OverrideFile, FilePath: filePath, Span: decl.Span()}
+	child := &ChildScope{
+		Container: Container{
+			Free:     make(map[string]*Effective),
+			Children: make(map[string]*ChildScope),
+			Origin:   origin,
+		},
+		Instance: NewMemberSet(),
+		Static:   NewMemberSet(),
+	}
+
+	classType := lookupClassObject(ns, decl.Name.Name)
+
+	for _, elem := range decl.Body {
+		switch e := elem.(type) {
+		case *ast.MethodElem:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			t := lookupMethodType(classType, name, e.Static)
+			eff := &Effective{
+				Type:       t,
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:       tier,
+			}
+			set := child.Instance
+			if e.Static {
+				set = child.Static
+			}
+			set.Methods[name] = eff
+		case *ast.GetterElem:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			eff := &Effective{
+				Type:       lookupMethodType(classType, name, e.Static),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:       tier,
+			}
+			set := child.Instance
+			if e.Static {
+				set = child.Static
+			}
+			set.Getters[name] = eff
+		case *ast.SetterElem:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			eff := &Effective{
+				Type:       lookupMethodType(classType, name, e.Static),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:       tier,
+			}
+			set := child.Instance
+			if e.Static {
+				set = child.Static
+			}
+			set.Setters[name] = eff
+		case *ast.FieldElem:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			eff := &Effective{
+				Type:       lookupPropertyType(classType, name, e.Static),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:       tier,
+			}
+			set := child.Instance
+			if e.Static {
+				set = child.Static
+			}
+			set.Properties[name] = eff
+		case *ast.ConstructorElem:
+			eff := &Effective{
+				Type:       lookupCtorType(classType),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:       tier,
+			}
+			child.Instance.Ctor = eff
+		}
+	}
+	return child
+}
+
+// buildInterfaceChild mirrors buildClassChild for interfaces. Same
+// slot routing; types come from the interface's object type in `ns`.
+// Interfaces have no static side — only Instance is populated.
+func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, filePath string, tier OverrideTier) *ChildScope {
+	origin := Origin{Kind: OverrideFile, FilePath: filePath, Span: decl.Span()}
+	child := &ChildScope{
+		Container: Container{
+			Free:     make(map[string]*Effective),
+			Children: make(map[string]*ChildScope),
+			Origin:   origin,
+		},
+		Instance: NewMemberSet(),
+	}
+	if decl.TypeAnn == nil {
+		return child
+	}
+	classType := lookupClassObject(ns, decl.Name.Name)
+	span := decl.Span()
+	for _, elem := range decl.TypeAnn.Elems {
+		switch e := elem.(type) {
+		case *ast.MethodTypeAnn:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			child.Instance.Methods[name] = &Effective{
+				Type:       lookupMethodType(classType, name, false),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Tier:       tier,
+			}
+		case *ast.GetterTypeAnn:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			child.Instance.Getters[name] = &Effective{
+				Type:       lookupMethodType(classType, name, false),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Tier:       tier,
+			}
+		case *ast.SetterTypeAnn:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			child.Instance.Setters[name] = &Effective{
+				Type:       lookupMethodType(classType, name, false),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Tier:       tier,
+			}
+		case *ast.PropertyTypeAnn:
+			name := CanonicalNameFromObjKey(e.Name)
+			if name == "" {
+				continue
+			}
+			child.Instance.Properties[name] = &Effective{
+				Type:       lookupPropertyType(classType, name, false),
+				Source:     tier.ResolutionTierFor(),
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Tier:       tier,
+			}
+		}
+	}
+	return child
+}
+
+// nsLookupNamespace returns the sub-namespace bound to `name` in `ns`,
+// or nil/false if not found.
+func nsLookupNamespace(ns *type_system.Namespace, name string) (*type_system.Namespace, bool) {
+	if ns == nil {
+		return nil, false
+	}
+	sub, ok := ns.Namespaces[name]
+	return sub, ok
+}
+
+// lookupClassObject returns the *type_system.ObjectType corresponding
+// to the class/interface named `name` in `ns`, or nil if not found.
+// Classes typically land in `ns.Types[name].Type` (the TypeAlias points
+// at the instance shape) or in `ns.Values[name].Type` (the constructor
+// function whose Return is the instance type). The shape used by
+// downstream interop is implementation-specific; we try both.
+func lookupClassObject(ns *type_system.Namespace, name string) *type_system.ObjectType {
+	if ns == nil {
+		return nil
+	}
+	if ta, ok := ns.Types[name]; ok && ta != nil {
+		if obj := unwrapToObject(ta.Type); obj != nil {
+			return obj
+		}
+	}
+	if b, ok := ns.Values[name]; ok && b != nil {
+		if fn, ok := b.Type.(*type_system.FuncType); ok && fn.Return != nil {
+			if obj := unwrapToObject(fn.Return); obj != nil {
+				return obj
+			}
+		}
+	}
+	return nil
+}
+
+func unwrapToObject(t type_system.Type) *type_system.ObjectType {
+	for {
+		switch x := t.(type) {
+		case *type_system.ObjectType:
+			return x
+		case *type_system.TypeRefType:
+			if x.TypeAlias == nil {
+				return nil
+			}
+			t = x.TypeAlias.Type
+		default:
+			return nil
+		}
+	}
+}
+
+// lookupMethodType finds a method/getter/setter type on an ObjectType
+// by canonical name. Returns nil if no matching element is present.
+//
+// TODO(#interop-static): static lookup is not yet wired — the class
+// statics aren't reachable from the instance ObjectType, and the
+// checker has no separate static-object representation here. Static
+// callers receive nil and the consistency check is skipped on the
+// static side until that gap is filled.
+func lookupMethodType(obj *type_system.ObjectType, name string, static bool) type_system.Type {
+	if obj == nil || static {
+		return nil
+	}
+	for _, elem := range obj.Elems {
+		t, n, ok := objElemMatch(elem)
+		if !ok {
+			continue
+		}
+		if n == name {
+			return t
+		}
+	}
+	return nil
+}
+
+func lookupPropertyType(obj *type_system.ObjectType, name string, static bool) type_system.Type {
+	return lookupMethodType(obj, name, static)
+}
+
+func lookupCtorType(obj *type_system.ObjectType) type_system.Type {
+	if obj == nil {
+		return nil
+	}
+	for _, elem := range obj.Elems {
+		if c, ok := elem.(*type_system.ConstructorElem); ok {
+			return c.Fn
+		}
+	}
+	return nil
+}
+
+// objElemMatch extracts (type, name, ok) from an object-type element.
+// Names come from the ObjTypeKey carried on each element kind. Returns
+// ok=false when the element has no addressable name (e.g.
+// callable/constructor/index signature). All members on ObjectType are
+// instance-side; static-side lookup is handled by lookupMethodType
+// returning nil up front (see its TODO).
+func objElemMatch(elem type_system.ObjTypeElem) (type_system.Type, string, bool) {
+	switch e := elem.(type) {
+	case *type_system.MethodElem:
+		return e.Fn, e.Name.String(), true
+	case *type_system.GetterElem:
+		return e.Fn, e.Name.String(), true
+	case *type_system.SetterElem:
+		return e.Fn, e.Name.String(), true
+	case *type_system.PropertyElem:
+		return e.Value, e.Name.String(), true
+	}
+	return nil, "", false
+}
+
+// patternNames returns the surface identifier names a VarDecl pattern
+// binds — the keys used to look up checker-produced bindings in `ns`.
+func patternNames(p ast.Pat) []string {
+	switch x := p.(type) {
+	case *ast.IdentPat:
+		return []string{x.Name}
+	}
+	return nil
+}

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -293,7 +293,6 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 		return child
 	}
 	classType := lookupClassObject(ns, decl.Name.Name)
-	span := decl.Span()
 	for _, elem := range decl.TypeAnn.Elems {
 		switch e := elem.(type) {
 		case *ast.MethodTypeAnn:
@@ -304,7 +303,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 			child.Instance.Methods[name] = &Effective{
 				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
 		case *ast.GetterTypeAnn:
@@ -315,7 +314,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 			child.Instance.Getters[name] = &Effective{
 				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
 		case *ast.SetterTypeAnn:
@@ -326,7 +325,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 			child.Instance.Setters[name] = &Effective{
 				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
 		case *ast.PropertyTypeAnn:
@@ -337,7 +336,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 			child.Instance.Properties[name] = &Effective{
 				Type:       lookupPropertyType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
 		}
@@ -458,10 +457,40 @@ func objElemMatch(elem type_system.ObjTypeElem) (type_system.Type, string, bool)
 
 // patternNames returns the surface identifier names a VarDecl pattern
 // binds — the keys used to look up checker-produced bindings in `ns`.
+// Recurses into destructuring patterns (object/tuple/rest) so nested
+// IdentPat bindings aren't silently dropped.
+//
+// TODO: ExtractorPat and InstancePat aren't handled — they bind names
+// from arbitrary class extractor signatures and aren't currently used
+// at module scope in interop override files. LitPat and WildcardPat
+// bind no names and are intentionally skipped.
 func patternNames(p ast.Pat) []string {
 	switch x := p.(type) {
 	case *ast.IdentPat:
 		return []string{x.Name}
+	case *ast.ObjectPat:
+		var names []string
+		for _, elem := range x.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjKeyValuePat:
+				names = append(names, patternNames(e.Value)...)
+			case *ast.ObjShorthandPat:
+				if e.Key != nil {
+					names = append(names, e.Key.Name)
+				}
+			case *ast.ObjRestPat:
+				names = append(names, patternNames(e.Pattern)...)
+			}
+		}
+		return names
+	case *ast.TuplePat:
+		var names []string
+		for _, elem := range x.Elems {
+			names = append(names, patternNames(elem)...)
+		}
+		return names
+	case *ast.RestPat:
+		return patternNames(x.Pattern)
 	}
 	return nil
 }

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -116,18 +116,12 @@ func extractIntoContainer(
 			if decl.Name == nil {
 				continue
 			}
-			child := buildClassChild(decl, ns, filePath, tier)
-			if child != nil {
-				container.Children[decl.Name.Name] = child
-			}
+			container.Children[decl.Name.Name] = buildClassChild(decl, ns, filePath, tier)
 		case *ast.InterfaceDecl:
 			if decl.Name == nil {
 				continue
 			}
-			child := buildInterfaceChild(decl, ns, filePath, tier)
-			if child != nil {
-				container.Children[decl.Name.Name] = child
-			}
+			container.Children[decl.Name.Name] = buildInterfaceChild(decl, ns, filePath, tier)
 		case *ast.NamespaceDecl:
 			if decl.Name == nil {
 				continue
@@ -261,7 +255,7 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Properties[name] = &Effective{
-				Type:       lookupPropertyType(classType, name, false),
+				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -337,7 +331,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Properties[name] = &Effective{
-				Type:       lookupPropertyType(classType, name, false),
+				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -420,10 +414,6 @@ func lookupMethodType(obj *type_system.ObjectType, name string, static bool) typ
 		}
 	}
 	return nil
-}
-
-func lookupPropertyType(obj *type_system.ObjectType, name string, static bool) type_system.Type {
-	return lookupMethodType(obj, name, static)
 }
 
 func lookupCtorType(obj *type_system.ObjectType) type_system.Type {

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -56,6 +56,12 @@ func Extract(
 	return out
 }
 
+// ensureModule returns the ModuleScope for `name`, creating it on first
+// touch. When the module already exists, `origin` is ignored — the
+// first-seen file's origin wins for Container.Origin. This is fine for
+// diagnostics because each leaf carries its own Provenance; the
+// Container.Origin is only used as a fallback when no leaf-level origin
+// is available.
 func ensureModule(out map[string]*ModuleScope, name string, origin Origin) *ModuleScope {
 	if ms, ok := out[name]; ok {
 		return ms
@@ -196,73 +202,70 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 
 	classType := lookupClassObject(ns, decl.Name.Name)
 
+	// Static-side members are intentionally dropped until #interop-static
+	// wires up static lookup. Recording them with Type=nil here would let
+	// the merge step's "override wins" branch clobber the original's
+	// typed static slot with a nil-typed entry, corrupting the store.
+	// Dropping is silent for now — surfacing as a diagnostic is tracked
+	// alongside the static-lookup work.
 	for _, elem := range decl.Body {
 		switch e := elem.(type) {
 		case *ast.MethodElem:
+			if e.Static {
+				continue
+			}
 			name := CanonicalNameFromObjKey(e.Name)
 			if name == "" {
 				continue
 			}
-			t := lookupMethodType(classType, name, e.Static)
-			eff := &Effective{
-				Type:       t,
+			child.Instance.Methods[name] = &Effective{
+				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
-			set := child.Instance
-			if e.Static {
-				set = child.Static
-			}
-			set.Methods[name] = eff
 		case *ast.GetterElem:
+			if e.Static {
+				continue
+			}
 			name := CanonicalNameFromObjKey(e.Name)
 			if name == "" {
 				continue
 			}
-			eff := &Effective{
-				Type:       lookupMethodType(classType, name, e.Static),
+			child.Instance.Getters[name] = &Effective{
+				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
-			set := child.Instance
-			if e.Static {
-				set = child.Static
-			}
-			set.Getters[name] = eff
 		case *ast.SetterElem:
+			if e.Static {
+				continue
+			}
 			name := CanonicalNameFromObjKey(e.Name)
 			if name == "" {
 				continue
 			}
-			eff := &Effective{
-				Type:       lookupMethodType(classType, name, e.Static),
+			child.Instance.Setters[name] = &Effective{
+				Type:       lookupMethodType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
-			set := child.Instance
-			if e.Static {
-				set = child.Static
-			}
-			set.Setters[name] = eff
 		case *ast.FieldElem:
+			if e.Static {
+				continue
+			}
 			name := CanonicalNameFromObjKey(e.Name)
 			if name == "" {
 				continue
 			}
-			eff := &Effective{
-				Type:       lookupPropertyType(classType, name, e.Static),
+			child.Instance.Properties[name] = &Effective{
+				Type:       lookupPropertyType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
 			}
-			set := child.Instance
-			if e.Static {
-				set = child.Static
-			}
-			set.Properties[name] = eff
 		case *ast.ConstructorElem:
 			eff := &Effective{
 				Type:       lookupCtorType(classType),

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -20,6 +20,11 @@ import (
 // `namedNs` maps module-specifier string → namespace, populated by the
 // checker from each `override declare module "name" { ... }` block.
 //
+// `filePath` is the locator for the override file being extracted. It
+// is stamped on every Origin produced by this call (always with
+// Kind=OverrideFile) and surfaced in diagnostics. See Origin.FilePath
+// for the locator-string convention.
+//
 // Top-level sugar (`override declare class Foo { ... }` etc.) is
 // expected to have been desugared by the parser per
 // implementation_plan.md §2.2, so each top-level decl in `decls` is
@@ -98,7 +103,7 @@ func extractIntoContainer(
 				container.Free[decl.Name.Name] = eff
 			}
 		case *ast.VarDecl:
-			for _, name := range patternNames(decl.Pattern) {
+			for name := range ast.FindBindings(decl.Pattern) {
 				eff := buildLeafFromValue(ns, name, filePath, decl.Span(), tier)
 				if eff != nil {
 					container.Free[name] = eff
@@ -108,6 +113,12 @@ func extractIntoContainer(
 			if decl.Name == nil {
 				continue
 			}
+			// TODO(#interop-type-value-namespace): types and values live
+			// in separate namespaces, so a module may legitimately declare
+			// both `type Foo = …` and `val Foo = …` (or `class Foo { … }`)
+			// with the same identifier. Container.Free keys by string,
+			// which collapses the two into one slot — whichever loses the
+			// race is silently dropped. Tracked in §5.13.
 			eff := buildLeafFromTypeAlias(ns, decl.Name.Name, filePath, decl.Span(), tier)
 			if eff != nil {
 				container.Free[decl.Name.Name] = eff
@@ -177,11 +188,14 @@ func buildLeafFromTypeAlias(ns *type_system.Namespace, name, filePath string, sp
 // into the appropriate MemberSet slot; their types come from the class
 // type recorded in `ns`.
 //
-// The class type lookup is best-effort: when the checker hasn't
-// produced a typed object/class for the override (e.g. the override
-// references a TypeScript symbol that wasn't pre-loaded), the leaf
-// types fall back to nil and the merge will skip the consistency check
-// for that slot.
+// The class type lookup is best-effort: if the checker couldn't
+// produce a typed binding for the class itself (e.g. a member body
+// references an unresolvable type, an annotation is malformed, or the
+// enclosing module's inference failed wholesale), the leaf types fall
+// back to nil and the merge will skip the consistency check for that
+// slot. References to upstream base classes in `extends` clauses are
+// not a concern — those resolve through the checker's outer scope,
+// which already contains the .d.ts symbols (§5.2 sequencing).
 func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath string, tier OverrideTier) *ChildScope {
 	origin := Origin{Kind: OverrideFile, FilePath: filePath, Span: decl.Span()}
 	child := &ChildScope{
@@ -213,7 +227,7 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Methods[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -227,7 +241,7 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Getters[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -241,7 +255,7 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Setters[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -255,7 +269,7 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Properties[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -298,7 +312,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Methods[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -309,7 +323,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Getters[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -320,7 +334,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Setters[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -331,7 +345,7 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Properties[name] = &Effective{
-				Type:       lookupMethodType(classType, name, false),
+				Type:       lookupObjElemType(classType, name, false),
 				Source:     tier.ResolutionTierFor(),
 				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
 				Tier:       tier,
@@ -392,15 +406,16 @@ func unwrapToObject(t type_system.Type) *type_system.ObjectType {
 	}
 }
 
-// lookupMethodType finds a method/getter/setter type on an ObjectType
-// by canonical name. Returns nil if no matching element is present.
+// lookupObjElemType finds a method, getter, setter, or property type on
+// an ObjectType by canonical name. Returns nil if no matching element
+// is present.
 //
 // TODO(#interop-static): static lookup is not yet wired — the class
 // statics aren't reachable from the instance ObjectType, and the
 // checker has no separate static-object representation here. Static
 // callers receive nil and the consistency check is skipped on the
 // static side until that gap is filled.
-func lookupMethodType(obj *type_system.ObjectType, name string, static bool) type_system.Type {
+func lookupObjElemType(obj *type_system.ObjectType, name string, static bool) type_system.Type {
 	if obj == nil || static {
 		return nil
 	}
@@ -432,7 +447,7 @@ func lookupCtorType(obj *type_system.ObjectType) type_system.Type {
 // Names come from the ObjTypeKey carried on each element kind. Returns
 // ok=false when the element has no addressable name (e.g.
 // callable/constructor/index signature). All members on ObjectType are
-// instance-side; static-side lookup is handled by lookupMethodType
+// instance-side; static-side lookup is handled by lookupObjElemType
 // returning nil up front (see its TODO).
 func objElemMatch(elem type_system.ObjTypeElem) (type_system.Type, string, bool) {
 	switch e := elem.(type) {
@@ -448,42 +463,3 @@ func objElemMatch(elem type_system.ObjTypeElem) (type_system.Type, string, bool)
 	return nil, "", false
 }
 
-// patternNames returns the surface identifier names a VarDecl pattern
-// binds — the keys used to look up checker-produced bindings in `ns`.
-// Recurses into destructuring patterns (object/tuple/rest) so nested
-// IdentPat bindings aren't silently dropped.
-//
-// TODO: ExtractorPat and InstancePat aren't handled — they bind names
-// from arbitrary class extractor signatures and aren't currently used
-// at module scope in interop override files. LitPat and WildcardPat
-// bind no names and are intentionally skipped.
-func patternNames(p ast.Pat) []string {
-	switch x := p.(type) {
-	case *ast.IdentPat:
-		return []string{x.Name}
-	case *ast.ObjectPat:
-		var names []string
-		for _, elem := range x.Elems {
-			switch e := elem.(type) {
-			case *ast.ObjKeyValuePat:
-				names = append(names, patternNames(e.Value)...)
-			case *ast.ObjShorthandPat:
-				if e.Key != nil {
-					names = append(names, e.Key.Name)
-				}
-			case *ast.ObjRestPat:
-				names = append(names, patternNames(e.Pattern)...)
-			}
-		}
-		return names
-	case *ast.TuplePat:
-		var names []string
-		for _, elem := range x.Elems {
-			names = append(names, patternNames(elem)...)
-		}
-		return names
-	case *ast.RestPat:
-		return patternNames(x.Pattern)
-	}
-	return nil
-}

--- a/internal/interop/extract_test.go
+++ b/internal/interop/extract_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
 )
 
 // These tests drive Extract directly with hand-built AST + Namespace
@@ -33,20 +34,11 @@ func TestExtractFreeFunctionFromDeclareGlobal(t *testing.T) {
 		"shipped:/test.esc",
 		OverrideTierShipped,
 	)
-	ms, ok := out[""]
-	if !ok {
-		t.Fatalf("expected entry under \"\" (global); got %#v", out)
-	}
-	eff := ms.Free["foo"]
-	if eff == nil {
-		t.Fatalf("expected Free[foo] to be set; got nil")
-	}
-	if eff.Type != fn {
-		t.Fatalf("expected eff.Type to be the func from the namespace; got %#v", eff.Type)
-	}
-	if eff.Tier != OverrideTierShipped {
-		t.Fatalf("expected Tier=Shipped; got %v", eff.Tier)
-	}
+	require.Contains(t, out, "", "expected entry under \"\" (global)")
+	eff := out[""].Free["foo"]
+	require.NotNil(t, eff, "expected Free[foo] to be set")
+	require.Same(t, fn, eff.Type, "expected eff.Type to be the func from the namespace")
+	require.Equal(t, OverrideTierShipped, eff.Tier)
 }
 
 func TestExtractFreeFunctionFromDeclareModule(t *testing.T) {
@@ -75,13 +67,10 @@ func TestExtractFreeFunctionFromDeclareModule(t *testing.T) {
 		"shipped:/lodash.esc",
 		OverrideTierShipped,
 	)
-	ms, ok := out["lodash"]
-	if !ok {
-		t.Fatalf("expected entry under \"lodash\"; got %#v", out)
-	}
-	if eff := ms.Free["map"]; eff == nil || eff.Type != fn {
-		t.Fatalf("expected Free[map] to carry func type; got %#v", eff)
-	}
+	require.Contains(t, out, "lodash")
+	eff := out["lodash"].Free["map"]
+	require.NotNil(t, eff)
+	require.Same(t, fn, eff.Type)
 }
 
 func TestExtractSkipsNonOverrideBlocks(t *testing.T) {
@@ -103,9 +92,7 @@ func TestExtractSkipsNonOverrideBlocks(t *testing.T) {
 		"test.esc",
 		OverrideTierUserProject,
 	)
-	if len(out) != 0 {
-		t.Fatalf("non-override blocks must produce no scope contributions; got %#v", out)
-	}
+	require.Empty(t, out, "non-override blocks must produce no scope contributions")
 }
 
 func TestExtractTypeAlias(t *testing.T) {
@@ -129,13 +116,10 @@ func TestExtractTypeAlias(t *testing.T) {
 		OverrideTierUserProject,
 	)
 	ms := out[""]
-	if ms == nil {
-		t.Fatalf("expected global scope contribution")
-	}
+	require.NotNil(t, ms, "expected global scope contribution")
 	eff := ms.Free["MyNum"]
-	if eff == nil || eff.Type != alias.Type {
-		t.Fatalf("expected MyNum leaf carrying the alias type; got %#v", eff)
-	}
+	require.NotNil(t, eff)
+	require.Same(t, alias.Type, eff.Type, "expected MyNum leaf carrying the alias type")
 }
 
 func TestExtractInterfaceInstanceMethod(t *testing.T) {
@@ -166,20 +150,13 @@ func TestExtractInterfaceInstanceMethod(t *testing.T) {
 		OverrideTierShipped,
 	)
 	ms := out[""]
-	if ms == nil {
-		t.Fatalf("expected global contribution")
-	}
+	require.NotNil(t, ms, "expected global contribution")
 	child := ms.Children["Pinger"]
-	if child == nil {
-		t.Fatalf("expected Children[Pinger]; got %#v", ms.Children)
-	}
-	if child.Instance == nil {
-		t.Fatalf("expected Instance MemberSet populated on interface child")
-	}
+	require.NotNil(t, child, "expected Children[Pinger]")
+	require.NotNil(t, child.Instance, "expected Instance MemberSet populated on interface child")
 	eff := child.Instance.Methods["ping"]
-	if eff == nil || eff.Type != methodFn {
-		t.Fatalf("expected ping method to carry its FuncType from the namespace; got %#v", eff)
-	}
+	require.NotNil(t, eff)
+	require.Same(t, methodFn, eff.Type, "expected ping method to carry its FuncType from the namespace")
 }
 
 func TestExtractNamespaceNesting(t *testing.T) {
@@ -209,19 +186,14 @@ func TestExtractNamespaceNesting(t *testing.T) {
 		OverrideTierUserProject,
 	)
 	ms := out[""]
-	if ms == nil {
-		t.Fatalf("expected global contribution")
-	}
+	require.NotNil(t, ms, "expected global contribution")
 	child := ms.Children["Util"]
-	if child == nil {
-		t.Fatalf("expected Children[Util] for nested namespace")
-	}
-	if child.Instance != nil || child.Static != nil {
-		t.Fatalf("namespace child should not have Instance/Static populated")
-	}
-	if eff := child.Free["inner"]; eff == nil || eff.Type != fn {
-		t.Fatalf("expected nested namespace fn; got %#v", eff)
-	}
+	require.NotNil(t, child, "expected Children[Util] for nested namespace")
+	require.Nil(t, child.Instance, "namespace child should not have Instance populated")
+	require.Nil(t, child.Static, "namespace child should not have Static populated")
+	eff := child.Free["inner"]
+	require.NotNil(t, eff, "expected nested namespace fn")
+	require.Same(t, fn, eff.Type)
 }
 
 func TestExtractDestructuredVarDecl(t *testing.T) {
@@ -252,15 +224,11 @@ func TestExtractDestructuredVarDecl(t *testing.T) {
 		OverrideTierShipped,
 	)
 	ms := out[""]
-	if ms == nil {
-		t.Fatalf("expected global contribution")
-	}
-	if eff := ms.Free["a"]; eff == nil || eff.Type != fnA {
-		t.Fatalf("expected Free[a] to carry fnA; got %#v", eff)
-	}
-	if eff := ms.Free["b"]; eff == nil || eff.Type != fnB {
-		t.Fatalf("expected Free[b] to carry fnB; got %#v", eff)
-	}
+	require.NotNil(t, ms, "expected global contribution")
+	require.NotNil(t, ms.Free["a"])
+	require.Same(t, fnA, ms.Free["a"].Type, "expected Free[a] to carry fnA")
+	require.NotNil(t, ms.Free["b"])
+	require.Same(t, fnB, ms.Free["b"].Type, "expected Free[b] to carry fnB")
 }
 
 func TestExtractClassDropsStaticMembers(t *testing.T) {
@@ -304,19 +272,13 @@ func TestExtractClassDropsStaticMembers(t *testing.T) {
 		OverrideTierShipped,
 	)
 	ms := out[""]
+	require.NotNil(t, ms)
 	child := ms.Children["Widget"]
-	if child == nil {
-		t.Fatalf("expected Children[Widget]")
-	}
-	if child.Instance == nil || child.Instance.Methods["inst"] == nil {
-		t.Fatalf("expected instance method inst recorded; got %#v", child.Instance)
-	}
-	if child.Static == nil {
-		t.Fatalf("expected Static MemberSet allocated (class shape signal)")
-	}
-	if _, present := child.Static.Methods["doStatic"]; present {
-		t.Fatalf("expected static methods to be dropped during extraction; got %#v", child.Static.Methods)
-	}
+	require.NotNil(t, child, "expected Children[Widget]")
+	require.NotNil(t, child.Instance)
+	require.NotNil(t, child.Instance.Methods["inst"], "expected instance method inst recorded")
+	require.NotNil(t, child.Static, "expected Static MemberSet allocated (class shape signal)")
+	require.NotContains(t, child.Static.Methods, "doStatic", "expected static methods to be dropped during extraction")
 }
 
 func TestExtractMissingNamespaceEntryProducesNilType(t *testing.T) {
@@ -340,10 +302,6 @@ func TestExtractMissingNamespaceEntryProducesNilType(t *testing.T) {
 		OverrideTierShipped,
 	)
 	ms := out[""]
-	if ms == nil {
-		t.Fatalf("expected module scope created even when bindings missing")
-	}
-	if _, present := ms.Free["orphan"]; present {
-		t.Fatalf("expected no leaf for binding the checker didn't produce")
-	}
+	require.NotNil(t, ms, "expected module scope created even when bindings missing")
+	require.NotContains(t, ms.Free, "orphan", "expected no leaf for binding the checker didn't produce")
 }

--- a/internal/interop/extract_test.go
+++ b/internal/interop/extract_test.go
@@ -224,6 +224,101 @@ func TestExtractNamespaceNesting(t *testing.T) {
 	}
 }
 
+func TestExtractDestructuredVarDecl(t *testing.T) {
+	// Object-pattern destructuring binds two names; each should be
+	// resolved against the checker-produced namespace and surface as
+	// Free leaves.
+	fnA := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	fnB := type_system.NewFuncType(nil, nil, nil, type_system.NewStrPrimType(nil), nil)
+
+	objPat := ast.NewObjectPat(
+		[]ast.ObjPatElem{
+			ast.NewObjShorthandPat(ast.NewIdentifier("a", emptySpan()), false, nil, nil, emptySpan()),
+			ast.NewObjShorthandPat(ast.NewIdentifier("b", emptySpan()), false, nil, nil, emptySpan()),
+		},
+		emptySpan(),
+	)
+	varDecl := ast.NewVarDecl(ast.ValKind, objPat, nil, nil, false, true, emptySpan())
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{varDecl}, true, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+	globalNs.Values["a"] = &type_system.Binding{Type: fnA}
+	globalNs.Values["b"] = &type_system.Binding{Type: fnB}
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"test.esc",
+		OverrideTierShipped,
+	)
+	ms := out[""]
+	if ms == nil {
+		t.Fatalf("expected global contribution")
+	}
+	if eff := ms.Free["a"]; eff == nil || eff.Type != fnA {
+		t.Fatalf("expected Free[a] to carry fnA; got %#v", eff)
+	}
+	if eff := ms.Free["b"]; eff == nil || eff.Type != fnB {
+		t.Fatalf("expected Free[b] to carry fnB; got %#v", eff)
+	}
+}
+
+func TestExtractClassDropsStaticMembers(t *testing.T) {
+	// Static-side overrides are intentionally dropped until static
+	// lookup is wired (see comment in buildClassChild). Without the
+	// skip, Extract would record a static method with Type=nil and the
+	// merge step's "override wins" branch would clobber the original's
+	// typed static slot. This test pins the drop behavior.
+	instanceFn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	cls := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+		type_system.NewMethodElem(type_system.NewStrKey("inst"), instanceFn),
+	})
+
+	instMethod := &ast.MethodElem{
+		Name:   ast.NewIdent("inst", emptySpan()),
+		Fn:     nil,
+		Static: false,
+		Span_:  emptySpan(),
+	}
+	staticMethod := &ast.MethodElem{
+		Name:   ast.NewIdent("doStatic", emptySpan()),
+		Fn:     nil,
+		Static: true,
+		Span_:  emptySpan(),
+	}
+	classDecl := ast.NewClassDecl(
+		ast.NewIdentifier("Widget", emptySpan()),
+		nil, nil, nil, nil,
+		[]ast.ClassElem{instMethod, staticMethod},
+		false, true, emptySpan(),
+	)
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{classDecl}, true, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+	globalNs.Types["Widget"] = &type_system.TypeAlias{Type: cls}
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"test.esc",
+		OverrideTierShipped,
+	)
+	ms := out[""]
+	child := ms.Children["Widget"]
+	if child == nil {
+		t.Fatalf("expected Children[Widget]")
+	}
+	if child.Instance == nil || child.Instance.Methods["inst"] == nil {
+		t.Fatalf("expected instance method inst recorded; got %#v", child.Instance)
+	}
+	if child.Static == nil {
+		t.Fatalf("expected Static MemberSet allocated (class shape signal)")
+	}
+	if _, present := child.Static.Methods["doStatic"]; present {
+		t.Fatalf("expected static methods to be dropped during extraction; got %#v", child.Static.Methods)
+	}
+}
+
 func TestExtractMissingNamespaceEntryProducesNilType(t *testing.T) {
 	// When the checker hasn't populated a binding for a declared name
 	// (e.g. a typo override), the extractor should not insert a Free

--- a/internal/interop/extract_test.go
+++ b/internal/interop/extract_test.go
@@ -1,0 +1,254 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// These tests drive Extract directly with hand-built AST + Namespace
+// pairs. The full parse → check → extract flow is exercised by the
+// integration fixture under fixtures/interop_mutability/.
+
+func emptySpan() ast.Span { return ast.Span{} }
+
+func TestExtractFreeFunctionFromDeclareGlobal(t *testing.T) {
+	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+
+	funcDecl := ast.NewFuncDecl(
+		ast.NewIdentifier("foo", emptySpan()),
+		nil, nil, nil, nil, nil, nil,
+		false, true, false,
+		emptySpan(),
+	)
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{funcDecl}, true, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+	globalNs.Values["foo"] = &type_system.Binding{Type: fn}
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"shipped:/test.esc",
+		OverrideTierShipped,
+	)
+	ms, ok := out[""]
+	if !ok {
+		t.Fatalf("expected entry under \"\" (global); got %#v", out)
+	}
+	eff := ms.Free["foo"]
+	if eff == nil {
+		t.Fatalf("expected Free[foo] to be set; got nil")
+	}
+	if eff.Type != fn {
+		t.Fatalf("expected eff.Type to be the func from the namespace; got %#v", eff.Type)
+	}
+	if eff.Tier != OverrideTierShipped {
+		t.Fatalf("expected Tier=Shipped; got %v", eff.Tier)
+	}
+}
+
+func TestExtractFreeFunctionFromDeclareModule(t *testing.T) {
+	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+
+	funcDecl := ast.NewFuncDecl(
+		ast.NewIdentifier("map", emptySpan()),
+		nil, nil, nil, nil, nil, nil,
+		false, true, false,
+		emptySpan(),
+	)
+	declareModule := ast.NewDeclareModuleDecl(
+		&ast.StrLit{Value: "lodash"},
+		[]ast.Decl{funcDecl},
+		true,
+		emptySpan(),
+	)
+
+	modNs := type_system.NewNamespace()
+	modNs.Values["map"] = &type_system.Binding{Type: fn}
+
+	out := Extract(
+		[]ast.Decl{declareModule},
+		nil,
+		map[string]*type_system.Namespace{"lodash": modNs},
+		"shipped:/lodash.esc",
+		OverrideTierShipped,
+	)
+	ms, ok := out["lodash"]
+	if !ok {
+		t.Fatalf("expected entry under \"lodash\"; got %#v", out)
+	}
+	if eff := ms.Free["map"]; eff == nil || eff.Type != fn {
+		t.Fatalf("expected Free[map] to carry func type; got %#v", eff)
+	}
+}
+
+func TestExtractSkipsNonOverrideBlocks(t *testing.T) {
+	funcDecl := ast.NewFuncDecl(
+		ast.NewIdentifier("foo", emptySpan()),
+		nil, nil, nil, nil, nil, nil,
+		false, true, false,
+		emptySpan(),
+	)
+	// override=false on the wrapper.
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{funcDecl}, false, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+	globalNs.Values["foo"] = &type_system.Binding{Type: type_system.NewNumPrimType(nil)}
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"test.esc",
+		OverrideTierUserProject,
+	)
+	if len(out) != 0 {
+		t.Fatalf("non-override blocks must produce no scope contributions; got %#v", out)
+	}
+}
+
+func TestExtractTypeAlias(t *testing.T) {
+	alias := &type_system.TypeAlias{Type: type_system.NewNumPrimType(nil)}
+
+	typeDecl := ast.NewTypeDecl(
+		ast.NewIdentifier("MyNum", emptySpan()),
+		nil, nil,
+		false, true,
+		emptySpan(),
+	)
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{typeDecl}, true, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+	globalNs.Types["MyNum"] = alias
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"test.esc",
+		OverrideTierUserProject,
+	)
+	ms := out[""]
+	if ms == nil {
+		t.Fatalf("expected global scope contribution")
+	}
+	eff := ms.Free["MyNum"]
+	if eff == nil || eff.Type != alias.Type {
+		t.Fatalf("expected MyNum leaf carrying the alias type; got %#v", eff)
+	}
+}
+
+func TestExtractInterfaceInstanceMethod(t *testing.T) {
+	methodFn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	iface := type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+		type_system.NewMethodElem(type_system.NewStrKey("ping"), methodFn),
+	})
+
+	methodAnn := &ast.MethodTypeAnn{
+		Name: ast.NewIdent("ping", emptySpan()),
+		Fn:   nil,
+	}
+	objTypeAnn := ast.NewObjectTypeAnn([]ast.ObjTypeAnnElem{methodAnn}, emptySpan())
+	interfaceDecl := ast.NewInterfaceDecl(
+		ast.NewIdentifier("Pinger", emptySpan()),
+		nil, nil, nil, objTypeAnn,
+		false, true, emptySpan(),
+	)
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{interfaceDecl}, true, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+	globalNs.Types["Pinger"] = &type_system.TypeAlias{Type: iface}
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"test.esc",
+		OverrideTierShipped,
+	)
+	ms := out[""]
+	if ms == nil {
+		t.Fatalf("expected global contribution")
+	}
+	child := ms.Children["Pinger"]
+	if child == nil {
+		t.Fatalf("expected Children[Pinger]; got %#v", ms.Children)
+	}
+	if child.Instance == nil {
+		t.Fatalf("expected Instance MemberSet populated on interface child")
+	}
+	eff := child.Instance.Methods["ping"]
+	if eff == nil || eff.Type != methodFn {
+		t.Fatalf("expected ping method to carry its FuncType from the namespace; got %#v", eff)
+	}
+}
+
+func TestExtractNamespaceNesting(t *testing.T) {
+	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	innerFunc := ast.NewFuncDecl(
+		ast.NewIdentifier("inner", emptySpan()),
+		nil, nil, nil, nil, nil, nil,
+		false, true, false,
+		emptySpan(),
+	)
+	innerNs := ast.NewNamespaceDecl(
+		ast.NewIdentifier("Util", emptySpan()),
+		[]ast.Decl{innerFunc},
+		false, false, emptySpan(),
+	)
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{innerNs}, true, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+	utilNs := type_system.NewNamespace()
+	utilNs.Values["inner"] = &type_system.Binding{Type: fn}
+	globalNs.Namespaces["Util"] = utilNs
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"test.esc",
+		OverrideTierUserProject,
+	)
+	ms := out[""]
+	if ms == nil {
+		t.Fatalf("expected global contribution")
+	}
+	child := ms.Children["Util"]
+	if child == nil {
+		t.Fatalf("expected Children[Util] for nested namespace")
+	}
+	if child.Instance != nil || child.Static != nil {
+		t.Fatalf("namespace child should not have Instance/Static populated")
+	}
+	if eff := child.Free["inner"]; eff == nil || eff.Type != fn {
+		t.Fatalf("expected nested namespace fn; got %#v", eff)
+	}
+}
+
+func TestExtractMissingNamespaceEntryProducesNilType(t *testing.T) {
+	// When the checker hasn't populated a binding for a declared name
+	// (e.g. a typo override), the extractor should not insert a Free
+	// leaf — the slot simply doesn't appear.
+	funcDecl := ast.NewFuncDecl(
+		ast.NewIdentifier("orphan", emptySpan()),
+		nil, nil, nil, nil, nil, nil,
+		false, true, false,
+		emptySpan(),
+	)
+	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{funcDecl}, true, emptySpan())
+
+	globalNs := type_system.NewNamespace()
+
+	out := Extract(
+		[]ast.Decl{declareGlobal},
+		globalNs, nil,
+		"test.esc",
+		OverrideTierShipped,
+	)
+	ms := out[""]
+	if ms == nil {
+		t.Fatalf("expected module scope created even when bindings missing")
+	}
+	if _, present := ms.Free["orphan"]; present {
+		t.Fatalf("expected no leaf for binding the checker didn't produce")
+	}
+}

--- a/internal/interop/store.go
+++ b/internal/interop/store.go
@@ -127,7 +127,20 @@ const (
 // Origin is the declaring location of an entry (or the source-side of a
 // merge participant).
 type Origin struct {
-	Kind     OriginKind
+	Kind OriginKind
+	// FilePath is an opaque, human-readable locator surfaced in
+	// diagnostics as "<FilePath>:<line>". It is never opened, parsed,
+	// or matched against — purely a label.
+	//
+	// Conventions used by the loader (and expected by any caller):
+	//   - Real on-disk files: an absolute path (so diagnostics don't
+	//     depend on the compiler's CWD). Use the path the user typed
+	//     where possible; don't normalize or symlink-resolve.
+	//   - Sources with no real path (embedded FS, synthetic input):
+	//     a "scheme:/path" form, e.g. "shipped:/data/libs/lodash.esc".
+	//     The colon-prefix disambiguates from a real path.
+	//   - Empty string is legal but renders as ":<line>" in diagnostics
+	//     and should be avoided outside tests.
 	FilePath string
 	Span     ast.Span
 }

--- a/planning/interop_mutability/implementation_plan.md
+++ b/planning/interop_mutability/implementation_plan.md
@@ -917,16 +917,62 @@ threads were left for a follow-up to keep that PR
 reviewable:
 
 - **Static-side method/property types.** `extract.go`
-  `lookupMethodType` and `lookupPropertyType` short-circuit
-  to `nil` when `static == true` because the static side of
-  a class isn't reachable from the instance `ObjectType`
-  exposed by the checker. As a result, static overrides
-  flow through the pipeline structurally but with
-  `Effective.Type == nil`, and the consistency check is
-  silently skipped on the static side. Fix is to surface a
-  separate static-side `ObjectType` (or equivalent
-  member-keyed map) from the checker and have the
-  extractor consult it.
+  `lookupObjElemType` short-circuits to `nil` when
+  `static == true`, and `buildClassChild` currently drops
+  static-side override entries entirely to avoid corrupting
+  the merge store with nil-typed slots. The user-visible
+  effect is that static overrides are silently no-ops.
+
+  The static-side ObjectType is *already in the namespace*
+  — no checker change is needed. Both Escalier's own
+  `class Foo { … static bar() }` and the TS trio
+  (`interface Foo + interface FooConstructor +
+  declare var Foo: FooConstructor`) park the static
+  ObjectType under `ns.Values["Foo"].Type`:
+  - Escalier class: `Values["Foo"].Type` is the static
+    `ObjectType` directly (containing `ConstructorElem`
+    + statics).
+  - TS trio: `Values["Foo"].Type` is
+    `TypeRef("FooConstructor")` whose alias resolves to
+    the same shape.
+
+  Fix: teach `lookupObjElemType` (when `static == true`)
+  to look up `ns.Values[name]`, peel any `TypeRefType`
+  layer via `unwrapToObject`, and search the resulting
+  ObjectType's non-`ConstructorElem` members. Then lift
+  the `buildClassChild` skip so static overrides flow
+  through the pipeline like instance ones. The
+  `ArrayConstructor` exception encoded in
+  `UpdateMethodMutability` (prelude.go) should be carried
+  over.
+
+- **Original-side ModuleScope must fuse the TS
+  class-via-trio pattern.** TypeScript's lib files declare
+  what is conceptually a class as a trio:
+  `interface Foo { … }`,
+  `interface FooConstructor { new (…); /* statics */ }`,
+  `declare var Foo: FooConstructor`. An override author
+  writing `override declare class Foo { … }` expresses one
+  unit of intent — overriding "the Foo class." For that
+  override to land on all three original-side slots, the
+  `.d.ts` → `ModuleScope` builder must recognise the trio
+  pattern and emit a single class-shaped
+  `Children["Foo"]` populated from `Types["Foo"]`
+  (instance), `Types["FooConstructor"]` (statics +
+  constructor), and `Values["Foo"]` (the value binding).
+  Without trio-fusion the user would need three
+  separate override declarations to cover one
+  conceptual class, which defeats the ergonomic goal.
+
+  Recommended approach: a name-based heuristic. A
+  `Types["X"]` with a sibling `Types["XConstructor"]` and
+  a `Values["X"]: TypeRef("XConstructor")` collapses to
+  one class-shaped Child; otherwise fall back to literal
+  mapping. Mirror the `ArrayConstructor` exception from
+  prelude.go. Note that the override side already
+  produces this shape uniformly (Escalier's own
+  `class Foo { … }` does the same), so once the original
+  side fuses, the merge is symmetric.
 
 - **Lifetime-erased signature equivalence.** §5.7's
   `funcSignatureEquivalent` uses the strict
@@ -945,11 +991,39 @@ reviewable:
   original. Add a structural-equivalence check on
   non-function leaves.
 
+  Note: property type overrides are a first-class use case,
+  not a forgotten corner of the merge. Per requirements
+  principle #7, a property has three independent axes — slot
+  reassignability (`readonly`), referent mutability (the type's
+  `Mut[…]` wrapping), and borrow scope (property-level
+  lifetimes) — and overrides legitimately need to change any
+  combination of them. The most common drivers are:
+  *Mut wrapping* (recording that `Container<T>.items: T[]`
+  is actually `Mut[Array[T]]`); *precision tightening*
+  (refining a TS-side `any`/`object`/sloppy union to the
+  runtime shape); and *brand narrowing* (`id: string` →
+  `id: UserId`). The structural-equivalence check should
+  permit these directions of refinement while still catching
+  outright shape mismatches; the exact rule (full equality
+  vs. subtype-on-`Mut`-axis vs. opt-in via a `@checked` tag)
+  is open and worth resolving as part of this item.
+
 - **Namespace-vs-class shape conflict.** `mergeChild`
   decides namespace-vs-class via `hasMembers` on either
   side. If the original is a namespace and an override is
   a class (or vice versa), the merge silently mixes the
   two shapes instead of reporting an `ErrShapeConflict`.
+
+- **Type and value namespace collision in `Container.Free`.**
+  `extract.go` routes type aliases and values (var/func/class)
+  into the same `Container.Free` map keyed by string. Escalier
+  keeps types and values in separate namespaces, so a module
+  may legitimately declare `type Foo = …` alongside
+  `val Foo = …` or `class Foo { … }`. Today the second-seen
+  entry silently overwrites the first. Split `Container.Free`
+  into `FreeValues` and `FreeTypes` (or wrap each `Effective`
+  with a namespace tag) and update the resolver/merge to
+  route lookups accordingly.
 
 - **Destructuring `VarDecl` patterns in override files.**
   `extract.go` `patternNames` only handles `*ast.IdentPat`;

--- a/planning/interop_mutability/requirements.md
+++ b/planning/interop_mutability/requirements.md
@@ -49,6 +49,40 @@ We bias toward soundness: when in doubt, assume mutating.
    `foo`. (Mutable references can still call mutating methods that modify
    non-`readonly` fields.)
 
+7. **Property type, slot, and lifetime are independent axes.** A class
+   or interface property has three orthogonal aspects, each addressed
+   by a different mechanism:
+
+   - **Slot reassignability** — whether `obj.foo = …` is legal. Carried
+     by the `readonly` modifier on the field (principle #6).
+   - **Referent mutability** — whether mutation *through* `obj.foo` is
+     legal (e.g. `obj.foo.push(x)` on an array-valued field). Carried
+     by the property's type itself: `Mut[Array[T]]` permits in-place
+     mutation; `Array[T]` does not. TypeScript has no direct equivalent;
+     the type `T[]` in `.d.ts` is silent on this question and the
+     override mechanism is the canonical way to record it.
+   - **Borrow scope** — how long the referent is valid relative to the
+     host. Carried by property-level lifetime annotations
+     (`foo: &'self T`, etc.) for properties that expose internal
+     references rather than independently-owned values.
+
+   These three axes do not subsume each other. `readonly` does not
+   imply non-`Mut` of the referent; `Mut` wrapping does not imply
+   anything about lifetimes; and a lifetime annotation does not decide
+   mutability. An override may need to change one, two, or all three on
+   a single property.
+
+   Property type overrides are therefore a first-class use case for the
+   override mechanism — not only for toggling `Mut` wrapping but also
+   for:
+   - **Precision tightening** — narrowing a TS-side `any`, `object`,
+     `unknown`, or sloppy union to the actual runtime shape.
+   - **Generic substitution** — recording that a class's own methods
+     mutate its `T[]` field by exposing it as `Mut[Array[T]]`.
+   - **Brand narrowing** — refining `id: string` in `.d.ts` to
+     `id: UserId` where `UserId` is a branded type declared in
+     user code.
+
 ## Round-tripping via `@esctype`
 
 When Escalier emits `.d.ts` for `.esc` source, the compiler embeds the


### PR DESCRIPTION
## Summary
Second slice of the #603 stack.

- `extract.go` — parses override file AST into `ModuleScope` contributions (uses types from 5.1).
- `consistency.go` — signature equivalence check (standalone; consumed by 5.3's merge step).

## Stack
- 5.1 — store + errors + plan doc (#606)
- **5.2 (this PR)** — extract + consistency
- 5.3 — merge + loader (#)
- 5.4 — wire into checker (#)

## Test plan
- [x] go build ./...
- [x] go test ./internal/interop/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for function override signatures to ensure compatibility with originals, with detailed error reporting for mismatches.
  * Added support for extracting and processing override declarations from separate files.

* **Tests**
  * Comprehensive test coverage for signature consistency validation and override declaration extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/607)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->