### PR TITLE
Interop mutability 5.3: override merge & loader pipeline

### DIFF
--- a/internal/interop/errors.go
+++ b/internal/interop/errors.go
@@ -22,6 +22,25 @@ func (e *ErrDuplicateMember) Error() string {
 	)
 }
 
+// ErrShapeConflict reports two declarations at the same Path with
+// incompatible variants — e.g. one declares `Foo` as a namespace and
+// the other as a class. Distinct from ErrDuplicateMember (which is for
+// same-shape collisions within a tier) so callers can render a more
+// specific diagnostic.
+type ErrShapeConflict struct {
+	Path          Path
+	First, Second Origin
+}
+
+func (e *ErrShapeConflict) Error() string {
+	return fmt.Sprintf(
+		"shape conflict for %s\n  first defined at %s:%d\n  redefined at %s:%d",
+		pathString(e.Path),
+		e.First.FilePath, e.First.Span.Start.Line,
+		e.Second.FilePath, e.Second.Span.Start.Line,
+	)
+}
+
 // ErrUnknownMember reports an override entry whose target does not
 // exist on the original declaration. `Available` is the list of
 // sibling names on the original's matching MemberSet for did-you-mean

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -47,14 +47,18 @@ func Extract(
 			if !decl.Override() {
 				continue
 			}
-			ms := ensureModule(out, "", origin)
+			declOrigin := origin
+			declOrigin.Span = decl.Span()
+			ms := ensureModule(out, "", declOrigin)
 			extractIntoContainer(decl.Decls, globalNs, &ms.Container, filePath, tier)
 		case *ast.DeclareModuleDecl:
 			if !decl.Override() || decl.Name == nil {
 				continue
 			}
 			modName := decl.Name.Value
-			ms := ensureModule(out, modName, origin)
+			declOrigin := origin
+			declOrigin.Span = decl.Span()
+			ms := ensureModule(out, modName, declOrigin)
 			extractIntoContainer(decl.Decls, namedNs[modName], &ms.Container, filePath, tier)
 		}
 	}

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -21,7 +21,7 @@ import (
 // checker from each `override declare module "name" { ... }` block.
 //
 // `filePath` is the locator for the override file being extracted. It
-// is stamped on every Origin produced by this call (always with
+// is set on every Origin produced by this call (always with
 // Kind=OverrideFile) and surfaced in diagnostics. See Origin.FilePath
 // for the locator-string convention.
 //
@@ -64,7 +64,7 @@ func Extract(
 // ensureModule returns the ModuleScope for `name`, creating it on first
 // touch. When the module already exists, `origin` is ignored — the
 // first-seen file's origin wins for Container.Origin. This is fine for
-// diagnostics because each leaf carries its own Provenance; the
+// diagnostics because each leaf carries its own Origins; the
 // Container.Origin is only used as a fallback when no leaf-level origin
 // is available.
 func ensureModule(out map[string]*ModuleScope, name string, origin Origin) *ModuleScope {
@@ -74,7 +74,7 @@ func ensureModule(out map[string]*ModuleScope, name string, origin Origin) *Modu
 	ms := &ModuleScope{
 		Container: Container{
 			Free:     make(map[string]*Effective),
-			Children: make(map[string]*ChildScope),
+			Children: make(map[string]ChildScope),
 			Origin:   origin,
 		},
 	}
@@ -138,10 +138,10 @@ func extractIntoContainer(
 				continue
 			}
 			subNs, _ := nsLookupNamespace(ns, decl.Name.Name)
-			child := &ChildScope{
+			child := &NamespaceScope{
 				Container: Container{
 					Free:     make(map[string]*Effective),
-					Children: make(map[string]*ChildScope),
+					Children: make(map[string]ChildScope),
 					Origin:   Origin{Kind: OverrideFile, FilePath: filePath, Span: decl.Span()},
 				},
 			}
@@ -160,10 +160,10 @@ func buildLeafFromValue(ns *type_system.Namespace, name, filePath string, span a
 		return nil
 	}
 	return &Effective{
-		Type:       b.Type,
-		Source:     tier.ResolutionTierFor(),
-		Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
-		Tier:       tier,
+		Type:    b.Type,
+		Source:  tier.ResolutionTierFor(),
+		Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+		Tier:    tier,
 	}
 }
 
@@ -176,10 +176,10 @@ func buildLeafFromTypeAlias(ns *type_system.Namespace, name, filePath string, sp
 		return nil
 	}
 	return &Effective{
-		Type:       ta.Type,
-		Source:     tier.ResolutionTierFor(),
-		Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
-		Tier:       tier,
+		Type:    ta.Type,
+		Source:  tier.ResolutionTierFor(),
+		Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: span}},
+		Tier:    tier,
 	}
 }
 
@@ -196,14 +196,10 @@ func buildLeafFromTypeAlias(ns *type_system.Namespace, name, filePath string, sp
 // slot. References to upstream base classes in `extends` clauses are
 // not a concern — those resolve through the checker's outer scope,
 // which already contains the .d.ts symbols (§5.2 sequencing).
-func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath string, tier OverrideTier) *ChildScope {
+func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath string, tier OverrideTier) *ClassScope {
 	origin := Origin{Kind: OverrideFile, FilePath: filePath, Span: decl.Span()}
-	child := &ChildScope{
-		Container: Container{
-			Free:     make(map[string]*Effective),
-			Children: make(map[string]*ChildScope),
-			Origin:   origin,
-		},
+	child := &ClassScope{
+		Origin:   origin,
 		Instance: NewMemberSet(),
 		Static:   NewMemberSet(),
 	}
@@ -227,10 +223,10 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Methods[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		case *ast.GetterElem:
 			if e.Static {
@@ -241,10 +237,10 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Getters[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		case *ast.SetterElem:
 			if e.Static {
@@ -255,10 +251,10 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Setters[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		case *ast.FieldElem:
 			if e.Static {
@@ -269,17 +265,17 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 				continue
 			}
 			child.Instance.Properties[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		case *ast.ConstructorElem:
 			eff := &Effective{
-				Type:       lookupCtorType(classType),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupCtorType(classType),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 			child.Instance.Ctor = eff
 		}
@@ -290,14 +286,10 @@ func buildClassChild(decl *ast.ClassDecl, ns *type_system.Namespace, filePath st
 // buildInterfaceChild mirrors buildClassChild for interfaces. Same
 // slot routing; types come from the interface's object type in `ns`.
 // Interfaces have no static side — only Instance is populated.
-func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, filePath string, tier OverrideTier) *ChildScope {
+func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, filePath string, tier OverrideTier) *InterfaceScope {
 	origin := Origin{Kind: OverrideFile, FilePath: filePath, Span: decl.Span()}
-	child := &ChildScope{
-		Container: Container{
-			Free:     make(map[string]*Effective),
-			Children: make(map[string]*ChildScope),
-			Origin:   origin,
-		},
+	child := &InterfaceScope{
+		Origin:   origin,
 		Instance: NewMemberSet(),
 	}
 	if decl.TypeAnn == nil {
@@ -312,10 +304,10 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Methods[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		case *ast.GetterTypeAnn:
 			name := CanonicalNameFromObjKey(e.Name)
@@ -323,10 +315,10 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Getters[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		case *ast.SetterTypeAnn:
 			name := CanonicalNameFromObjKey(e.Name)
@@ -334,10 +326,10 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Setters[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		case *ast.PropertyTypeAnn:
 			name := CanonicalNameFromObjKey(e.Name)
@@ -345,10 +337,10 @@ func buildInterfaceChild(decl *ast.InterfaceDecl, ns *type_system.Namespace, fil
 				continue
 			}
 			child.Instance.Properties[name] = &Effective{
-				Type:       lookupObjElemType(classType, name, false),
-				Source:     tier.ResolutionTierFor(),
-				Provenance: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
-				Tier:       tier,
+				Type:    lookupObjElemType(classType, name, false),
+				Source:  tier.ResolutionTierFor(),
+				Origins: []Origin{{Kind: OverrideFile, FilePath: filePath, Span: e.Span()}},
+				Tier:    tier,
 			}
 		}
 	}
@@ -462,4 +454,3 @@ func objElemMatch(elem type_system.ObjTypeElem) (type_system.Type, string, bool)
 	}
 	return nil, "", false
 }
-

--- a/internal/interop/extract_test.go
+++ b/internal/interop/extract_test.go
@@ -31,14 +31,14 @@ func TestExtractFreeFunctionFromDeclareGlobal(t *testing.T) {
 	out := Extract(
 		[]ast.Decl{declareGlobal},
 		globalNs, nil,
-		"shipped:/test.esc",
-		OverrideTierShipped,
+		"builtin:/test.esc",
+		OverrideTierBuiltin,
 	)
 	require.Contains(t, out, "", "expected entry under \"\" (global)")
 	eff := out[""].Free["foo"]
 	require.NotNil(t, eff, "expected Free[foo] to be set")
 	require.Same(t, fn, eff.Type, "expected eff.Type to be the func from the namespace")
-	require.Equal(t, OverrideTierShipped, eff.Tier)
+	require.Equal(t, OverrideTierBuiltin, eff.Tier)
 }
 
 func TestExtractFreeFunctionFromDeclareModule(t *testing.T) {
@@ -64,8 +64,8 @@ func TestExtractFreeFunctionFromDeclareModule(t *testing.T) {
 		[]ast.Decl{declareModule},
 		nil,
 		map[string]*type_system.Namespace{"lodash": modNs},
-		"shipped:/lodash.esc",
-		OverrideTierShipped,
+		"builtin:/lodash.esc",
+		OverrideTierBuiltin,
 	)
 	require.Contains(t, out, "lodash")
 	eff := out["lodash"].Free["map"]
@@ -147,12 +147,12 @@ func TestExtractInterfaceInstanceMethod(t *testing.T) {
 		[]ast.Decl{declareGlobal},
 		globalNs, nil,
 		"test.esc",
-		OverrideTierShipped,
+		OverrideTierBuiltin,
 	)
 	ms := out[""]
 	require.NotNil(t, ms, "expected global contribution")
-	child := ms.Children["Pinger"]
-	require.NotNil(t, child, "expected Children[Pinger]")
+	child, ok := ms.Children["Pinger"].(*InterfaceScope)
+	require.True(t, ok, "expected Children[Pinger] to be *InterfaceScope")
 	require.NotNil(t, child.Instance, "expected Instance MemberSet populated on interface child")
 	eff := child.Instance.Methods["ping"]
 	require.NotNil(t, eff)
@@ -187,11 +187,9 @@ func TestExtractNamespaceNesting(t *testing.T) {
 	)
 	ms := out[""]
 	require.NotNil(t, ms, "expected global contribution")
-	child := ms.Children["Util"]
-	require.NotNil(t, child, "expected Children[Util] for nested namespace")
-	require.Nil(t, child.Instance, "namespace child should not have Instance populated")
-	require.Nil(t, child.Static, "namespace child should not have Static populated")
-	eff := child.Free["inner"]
+	child, ok := ms.Children["Util"].(*NamespaceScope)
+	require.True(t, ok, "expected Children[Util] to be *NamespaceScope")
+	eff := child.Container.Free["inner"]
 	require.NotNil(t, eff, "expected nested namespace fn")
 	require.Same(t, fn, eff.Type)
 }
@@ -221,7 +219,7 @@ func TestExtractDestructuredVarDecl(t *testing.T) {
 		[]ast.Decl{declareGlobal},
 		globalNs, nil,
 		"test.esc",
-		OverrideTierShipped,
+		OverrideTierBuiltin,
 	)
 	ms := out[""]
 	require.NotNil(t, ms, "expected global contribution")
@@ -269,12 +267,12 @@ func TestExtractClassDropsStaticMembers(t *testing.T) {
 		[]ast.Decl{declareGlobal},
 		globalNs, nil,
 		"test.esc",
-		OverrideTierShipped,
+		OverrideTierBuiltin,
 	)
 	ms := out[""]
 	require.NotNil(t, ms)
-	child := ms.Children["Widget"]
-	require.NotNil(t, child, "expected Children[Widget]")
+	child, ok := ms.Children["Widget"].(*ClassScope)
+	require.True(t, ok, "expected Children[Widget] to be *ClassScope")
 	require.NotNil(t, child.Instance)
 	require.NotNil(t, child.Instance.Methods["inst"], "expected instance method inst recorded")
 	require.NotNil(t, child.Static, "expected Static MemberSet allocated (class shape signal)")
@@ -299,7 +297,7 @@ func TestExtractMissingNamespaceEntryProducesNilType(t *testing.T) {
 		[]ast.Decl{declareGlobal},
 		globalNs, nil,
 		"test.esc",
-		OverrideTierShipped,
+		OverrideTierBuiltin,
 	)
 	ms := out[""]
 	require.NotNil(t, ms, "expected module scope created even when bindings missing")

--- a/internal/interop/loader.go
+++ b/internal/interop/loader.go
@@ -113,6 +113,9 @@ func parseFromFS(
 		errs []error
 	)
 	walkErr := fs.WalkDir(fsys, root, func(p string, d fs.DirEntry, err error) error {
+		if cErr := ctx.Err(); cErr != nil {
+			return cErr
+		}
 		if err != nil {
 			errs = append(errs, fmt.Errorf("walking %s%s: %w", pathPrefix, p, err))
 			return nil
@@ -253,6 +256,11 @@ func mergeWithinContainer(
 			continue
 		}
 		mergeWithinContainer(&existing.Container, &child.Container, appendChild(owner, name), errs)
+		// Adoption happens after the merge: when existing's shape is
+		// nil, mergeWithinMemberSet no-ops and we then take child's set
+		// wholesale. Hoisting the adoption would alias existing and
+		// child onto the same map and trigger spurious duplicate-member
+		// errors in the call below.
 		mergeWithinMemberSet(existing.Instance, child.Instance, appendChild(owner, name), false, errs)
 		mergeWithinMemberSet(existing.Static, child.Static, appendChild(owner, name), true, errs)
 		if existing.Instance == nil && child.Instance != nil {

--- a/internal/interop/loader.go
+++ b/internal/interop/loader.go
@@ -15,15 +15,26 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
-// DepInfo describes one dependency that may carry overrides. `Dir` is
-// the directory containing that dep's package.json — `Dir`/overrides
+// DepInfo describes one dependency that may carry overrides. `PkgDir`
+// is the directory containing that dep's package.json — `PkgDir`/overrides
 // is scanned recursively for .esc files.
 type DepInfo struct {
-	Name string
-	Dir  string
+	Name   string
+	PkgDir string
 }
 
 // ParsedOverride is a single override .esc file after parsing.
+//
+// Decls is the list of top-level declarations as produced by
+// parser.ParseDecls. Per the override grammar
+// (planning/interop_mutability/implementation_plan.md §2.2), each entry
+// is either a *ast.DeclareGlobalDecl (`override declare global { ... }`)
+// or a *ast.DeclareModuleDecl (`override declare module "name" { ... }`),
+// in both cases with Override() == true. A single file may contain any
+// number of these blocks in any order; Extract routes each into its own
+// scope bucket keyed by module name ("" for global). Lexical
+// `namespace Foo { ... }` nesting inside a block is preserved by
+// Extract — it is not flattened here.
 type ParsedOverride struct {
 	Tier     OverrideTier
 	FilePath string
@@ -47,7 +58,7 @@ type TypeChecker func(p *ParsedOverride) (
 	errs []error,
 )
 
-// Discover walks the three override locations (shipped FS, deps, user
+// Discover walks the three override locations (builtin FS, deps, user
 // project) and returns the parsed override files grouped by tier.
 //
 // Parse errors are returned alongside any successfully-parsed files —
@@ -56,21 +67,21 @@ func Discover(
 	ctx context.Context,
 	root string,
 	deps []DepInfo,
-	shipped fs.FS,
+	builtin fs.FS,
 ) ([]*ParsedOverride, []error) {
 	var (
 		out  []*ParsedOverride
 		errs []error
 	)
 
-	if shipped != nil {
-		shippedFiles, sErrs := parseFromFS(ctx, shipped, ".", "shipped:/", OverrideTierShipped)
-		out = append(out, shippedFiles...)
+	if builtin != nil {
+		builtinFiles, sErrs := parseFromFS(ctx, builtin, ".", "builtin:/", OverrideTierBuiltin)
+		out = append(out, builtinFiles...)
 		errs = append(errs, sErrs...)
 	}
 
 	for _, dep := range deps {
-		depRoot := filepath.Join(dep.Dir, "overrides")
+		depRoot := filepath.Join(dep.PkgDir, "overrides")
 		if !dirExists(depRoot) {
 			continue
 		}
@@ -133,14 +144,13 @@ func parseFromFS(
 		}
 		fullPath := pathPrefix + p
 		src := &ast.Source{Path: fullPath, Contents: string(contents)}
-		mod, pErrs := parser.ParseLibFiles(ctx, []*ast.Source{src})
+		decls, pErrs := parser.ParseDecls(ctx, src)
 		if len(pErrs) > 0 {
 			for _, pe := range pErrs {
 				errs = append(errs, fmt.Errorf("parsing %s: %s", fullPath, pe.String()))
 			}
 			return nil
 		}
-		decls := collectDecls(mod)
 		out = append(out, &ParsedOverride{
 			Tier:     tier,
 			FilePath: fullPath,
@@ -156,7 +166,7 @@ func parseFromFS(
 }
 
 // Build is the full §5.5 pipeline: discover override files, run the
-// provided `tc` over each to obtain typed namespaces, extract scope
+// provided `checker` over each to obtain typed namespaces, extract scope
 // contributions, collapse three tiers, and merge against `originals`.
 //
 // `originals` is the post-inference original-side scope keyed by
@@ -167,44 +177,37 @@ func parseFromFS(
 // type-checking, or merge.
 func Build(
 	ctx context.Context,
-	tc TypeChecker,
+	checker TypeChecker,
 	root string,
 	deps []DepInfo,
-	shipped fs.FS,
+	builtin fs.FS,
 	originals map[string]*ModuleScope,
 ) (*OverrideStore, []error) {
-	files, errs := Discover(ctx, root, deps, shipped)
+	files, errs := Discover(ctx, root, deps, builtin)
 
 	// Per-tier per-file extraction → one scope map per tier.
 	tierMaps := map[OverrideTier]map[string]*ModuleScope{
 		OverrideTierUserProject: {},
 		OverrideTierUserDep:     {},
-		OverrideTierShipped:     {},
+		OverrideTierBuiltin:     {},
 	}
 
-	if tc == nil && len(files) > 0 {
+	if checker == nil && len(files) > 0 {
 		errs = append(errs, fmt.Errorf("interop.Build: nil TypeChecker, cannot type-check %d override file(s)", len(files)))
 		return NewOverrideStore(), errs
 	}
 
 	for _, f := range files {
-		globalNs, namedNs, tcErrs := tc(f)
+		globalNs, namedNs, tcErrs := checker(f)
 		errs = append(errs, tcErrs...)
 		contributions := Extract(f.Decls, globalNs, namedNs, f.FilePath, f.Tier)
 		mergeWithinTier(tierMaps[f.Tier], contributions, &errs)
 	}
 
 	collapsed := Collapse(
-		[]map[string]*ModuleScope{
-			tierMaps[OverrideTierUserProject],
-			tierMaps[OverrideTierUserDep],
-			tierMaps[OverrideTierShipped],
-		},
-		[]OverrideTier{
-			OverrideTierUserProject,
-			OverrideTierUserDep,
-			OverrideTierShipped,
-		},
+		tierMaps[OverrideTierUserProject],
+		tierMaps[OverrideTierUserDep],
+		tierMaps[OverrideTierBuiltin],
 	)
 	store, mErrs := Merge(originals, collapsed)
 	errs = append(errs, mErrs...)
@@ -242,8 +245,8 @@ func mergeWithinContainer(
 		if existing, present := dst.Free[name]; present {
 			*errs = append(*errs, &ErrDuplicateMember{
 				Path:   withFreeName(owner, name),
-				First:  firstOrigin(existing.Provenance),
-				Second: firstOrigin(eff.Provenance),
+				First:  headOrigin(existing.Origins),
+				Second: headOrigin(eff.Origins),
 			})
 			continue
 		}
@@ -255,20 +258,72 @@ func mergeWithinContainer(
 			dst.Children[name] = child
 			continue
 		}
-		mergeWithinContainer(&existing.Container, &child.Container, appendChild(owner, name), errs)
-		// Adoption happens after the merge: when existing's shape is
-		// nil, mergeWithinMemberSet no-ops and we then take child's set
-		// wholesale. Hoisting the adoption would alias existing and
-		// child onto the same map and trigger spurious duplicate-member
-		// errors in the call below.
-		mergeWithinMemberSet(existing.Instance, child.Instance, appendChild(owner, name), false, errs)
-		mergeWithinMemberSet(existing.Static, child.Static, appendChild(owner, name), true, errs)
-		if existing.Instance == nil && child.Instance != nil {
-			existing.Instance = child.Instance
+		mergeWithinChildScope(existing, child, owner.withChild(name), errs)
+	}
+}
+
+// mergeWithinChildScope folds `incoming` into `existing` for the
+// within-tier accumulator. Same-variant merges are recursive; a
+// shape mismatch (e.g. namespace + class at the same name) is reported
+// as ErrDuplicateMember and the first-seen variant is kept.
+func mergeWithinChildScope(existing, incoming ChildScope, childOwner Path, errs *[]error) {
+	switch e := existing.(type) {
+	case *NamespaceScope:
+		i, ok := incoming.(*NamespaceScope)
+		if !ok {
+			reportChildShapeConflict(existing, incoming, childOwner, errs)
+			return
 		}
-		if existing.Static == nil && child.Static != nil {
-			existing.Static = child.Static
+		mergeWithinContainer(&e.Container, &i.Container, childOwner, errs)
+	case *ClassScope:
+		i, ok := incoming.(*ClassScope)
+		if !ok {
+			reportChildShapeConflict(existing, incoming, childOwner, errs)
+			return
 		}
+		mergeWithinMemberSet(e.Instance, i.Instance, childOwner, false, errs)
+		mergeWithinMemberSet(e.Static, i.Static, childOwner, true, errs)
+	case *InterfaceScope:
+		i, ok := incoming.(*InterfaceScope)
+		if !ok {
+			reportChildShapeConflict(existing, incoming, childOwner, errs)
+			return
+		}
+		mergeWithinMemberSet(e.Instance, i.Instance, childOwner, false, errs)
+	}
+}
+
+func reportChildShapeConflict(existing, incoming ChildScope, childOwner Path, errs *[]error) {
+	*errs = append(*errs, &ErrDuplicateMember{
+		Path:   childOwner,
+		First:  existing.ChildOrigin(),
+		Second: incoming.ChildOrigin(),
+	})
+}
+
+// mergeWithinKind folds src's entries for one MemberKind slot into dst.
+// Same-name collisions are reported as ErrDuplicateMember; new entries
+// move over by reference.
+func mergeWithinKind(
+	dst, src map[string]*Effective,
+	owner Path,
+	kind MemberKind,
+	static bool,
+	errs *[]error,
+) {
+	for name, eff := range src {
+		if existing, present := dst[name]; present {
+			p := owner
+			p.Kind = kind
+			p.Static = static
+			*errs = append(*errs, &ErrDuplicateMember{
+				Path:   p,
+				First:  headOrigin(existing.Origins),
+				Second: headOrigin(eff.Origins),
+			})
+			continue
+		}
+		dst[name] = eff
 	}
 }
 
@@ -276,30 +331,10 @@ func mergeWithinMemberSet(dst, src *MemberSet, owner Path, static bool, errs *[]
 	if src == nil || dst == nil {
 		return
 	}
-	for _, pair := range []struct {
-		dst, src map[string]*Effective
-		kind     MemberKind
-	}{
-		{dst.Methods, src.Methods, KindMethod},
-		{dst.Getters, src.Getters, KindGetter},
-		{dst.Setters, src.Setters, KindSetter},
-		{dst.Properties, src.Properties, KindProperty},
-	} {
-		for name, eff := range pair.src {
-			if existing, present := pair.dst[name]; present {
-				p := owner
-				p.Kind = pair.kind
-				p.Static = static
-				*errs = append(*errs, &ErrDuplicateMember{
-					Path:   p,
-					First:  firstOrigin(existing.Provenance),
-					Second: firstOrigin(eff.Provenance),
-				})
-				continue
-			}
-			pair.dst[name] = eff
-		}
-	}
+	mergeWithinKind(dst.Methods, src.Methods, owner, KindMethod, static, errs)
+	mergeWithinKind(dst.Getters, src.Getters, owner, KindGetter, static, errs)
+	mergeWithinKind(dst.Setters, src.Setters, owner, KindSetter, static, errs)
+	mergeWithinKind(dst.Properties, src.Properties, owner, KindProperty, static, errs)
 	if dst.Ctor == nil && src.Ctor != nil {
 		dst.Ctor = src.Ctor
 	} else if src.Ctor != nil {
@@ -308,8 +343,8 @@ func mergeWithinMemberSet(dst, src *MemberSet, owner Path, static bool, errs *[]
 		p.Static = static
 		*errs = append(*errs, &ErrDuplicateMember{
 			Path:   p,
-			First:  firstOrigin(dst.Ctor.Provenance),
-			Second: firstOrigin(src.Ctor.Provenance),
+			First:  headOrigin(dst.Ctor.Origins),
+			Second: headOrigin(src.Ctor.Origins),
 		})
 	}
 }
@@ -323,33 +358,7 @@ func withFreeName(owner Path, name string) Path {
 	return cp
 }
 
-func appendChild(owner Path, name string) Path {
-	cp := owner
-	cp.Owner = appendOwner(owner.Owner, name)
-	return cp
-}
-
-// collectDecls flattens all declarations across all namespaces of a
-// parsed module. Override files are single-file modules, so namespace
-// grouping (by directory) is incidental — the override format treats
-// the file's top-level decls as a flat list.
-func collectDecls(m *ast.Module) []ast.Decl {
-	if m == nil {
-		return nil
-	}
-	var out []ast.Decl
-	iter := m.Namespaces.Iter()
-	for ok := iter.First(); ok; ok = iter.Next() {
-		ns := iter.Value()
-		if ns == nil {
-			continue
-		}
-		out = append(out, ns.Decls...)
-	}
-	return out
-}
-
-func firstOrigin(ps []Origin) Origin {
+func headOrigin(ps []Origin) Origin {
 	if len(ps) == 0 {
 		return Origin{}
 	}

--- a/internal/interop/loader.go
+++ b/internal/interop/loader.go
@@ -200,6 +200,10 @@ func Build(
 	for _, f := range files {
 		globalNs, namedNs, tcErrs := checker(f)
 		errs = append(errs, tcErrs...)
+		// Checker errors do not short-circuit extraction: any namespaces
+		// the checker did populate still contribute to the store, with
+		// the errors flowing back alongside. Extract is nil-safe per
+		// name, so partial namespaces just produce partial overrides.
 		contributions := Extract(f.Decls, globalNs, namedNs, f.FilePath, f.Tier)
 		mergeWithinTier(tierMaps[f.Tier], contributions, &errs)
 	}
@@ -230,8 +234,9 @@ func mergeWithinTier(
 		// Module-level @all_pure: if either side claims it, the
 		// merged scope claims it. Same-tier duplicate isn't reported —
 		// the pragma is module-level metadata, not a slot.
-		if srcMod.AllPure {
+		if srcMod.AllPure && !dstMod.AllPure {
 			dstMod.AllPure = true
+			dstMod.AllPureTier = srcMod.AllPureTier
 		}
 	}
 }
@@ -265,7 +270,7 @@ func mergeWithinContainer(
 // mergeWithinChildScope folds `incoming` into `existing` for the
 // within-tier accumulator. Same-variant merges are recursive; a
 // shape mismatch (e.g. namespace + class at the same name) is reported
-// as ErrDuplicateMember and the first-seen variant is kept.
+// as ErrShapeConflict and the first-seen variant is kept.
 func mergeWithinChildScope(existing, incoming ChildScope, childOwner Path, errs *[]error) {
 	switch e := existing.(type) {
 	case *NamespaceScope:
@@ -294,7 +299,7 @@ func mergeWithinChildScope(existing, incoming ChildScope, childOwner Path, errs 
 }
 
 func reportChildShapeConflict(existing, incoming ChildScope, childOwner Path, errs *[]error) {
-	*errs = append(*errs, &ErrDuplicateMember{
+	*errs = append(*errs, &ErrShapeConflict{
 		Path:   childOwner,
 		First:  existing.ChildOrigin(),
 		Second: incoming.ChildOrigin(),

--- a/internal/interop/loader.go
+++ b/internal/interop/loader.go
@@ -1,0 +1,349 @@
+package interop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// DepInfo describes one dependency that may carry overrides. `Dir` is
+// the directory containing that dep's package.json — `Dir`/overrides
+// is scanned recursively for .esc files.
+type DepInfo struct {
+	Name string
+	Dir  string
+}
+
+// ParsedOverride is a single override .esc file after parsing.
+type ParsedOverride struct {
+	Tier     OverrideTier
+	FilePath string
+	Source   *ast.Source
+	Decls    []ast.Decl
+}
+
+// TypeChecker is the dependency injection seam used by Build to invoke
+// the checker on each parsed override file. It returns the
+// post-inference namespace for the file's global block (nil when the
+// file has no `override declare global { ... }`) plus a map of
+// per-module namespaces for `override declare module "name" { ... }`
+// blocks. Errors from inference flow back through the returned []error.
+//
+// The caller is responsible for constructing a checker whose
+// surrounding scope already contains the original .d.ts symbols the
+// override references (the §5.2 sequencing constraint).
+type TypeChecker func(p *ParsedOverride) (
+	globalNs *type_system.Namespace,
+	namedNs map[string]*type_system.Namespace,
+	errs []error,
+)
+
+// Discover walks the three override locations (shipped FS, deps, user
+// project) and returns the parsed override files grouped by tier.
+//
+// Parse errors are returned alongside any successfully-parsed files —
+// the caller decides whether to proceed.
+func Discover(
+	ctx context.Context,
+	root string,
+	deps []DepInfo,
+	shipped fs.FS,
+) ([]*ParsedOverride, []error) {
+	var (
+		out  []*ParsedOverride
+		errs []error
+	)
+
+	if shipped != nil {
+		shippedFiles, sErrs := parseFromFS(ctx, shipped, ".", "shipped:/", OverrideTierShipped)
+		out = append(out, shippedFiles...)
+		errs = append(errs, sErrs...)
+	}
+
+	for _, dep := range deps {
+		depRoot := filepath.Join(dep.Dir, "overrides")
+		if !dirExists(depRoot) {
+			continue
+		}
+		depFS := os.DirFS(depRoot)
+		depFiles, dErrs := parseFromFS(ctx, depFS, ".", depRoot+"/", OverrideTierUserDep)
+		out = append(out, depFiles...)
+		errs = append(errs, dErrs...)
+	}
+
+	if root != "" {
+		userRoot := filepath.Join(root, "overrides")
+		if dirExists(userRoot) {
+			userFS := os.DirFS(userRoot)
+			userFiles, uErrs := parseFromFS(ctx, userFS, ".", userRoot+"/", OverrideTierUserProject)
+			out = append(out, userFiles...)
+			errs = append(errs, uErrs...)
+		}
+	}
+	return out, errs
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// parseFromFS recursively walks `fsys` from `root`, parsing every
+// `.esc` file as an Escalier module and tagging it with `tier`. The
+// `pathPrefix` is prepended to file paths in returned errors so a
+// reader can locate the file on disk (the embedded fs has no
+// real-disk path of its own).
+func parseFromFS(
+	ctx context.Context,
+	fsys fs.FS,
+	root, pathPrefix string,
+	tier OverrideTier,
+) ([]*ParsedOverride, []error) {
+	var (
+		out  []*ParsedOverride
+		errs []error
+	)
+	walkErr := fs.WalkDir(fsys, root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			errs = append(errs, fmt.Errorf("walking %s%s: %w", pathPrefix, p, err))
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(p, ".esc") {
+			return nil
+		}
+		contents, readErr := fs.ReadFile(fsys, p)
+		if readErr != nil {
+			errs = append(errs, fmt.Errorf("reading %s%s: %w", pathPrefix, p, readErr))
+			return nil
+		}
+		fullPath := pathPrefix + p
+		src := &ast.Source{Path: fullPath, Contents: string(contents)}
+		mod, pErrs := parser.ParseLibFiles(ctx, []*ast.Source{src})
+		if len(pErrs) > 0 {
+			for _, pe := range pErrs {
+				errs = append(errs, fmt.Errorf("parsing %s: %s", fullPath, pe.String()))
+			}
+			return nil
+		}
+		decls := collectDecls(mod)
+		out = append(out, &ParsedOverride{
+			Tier:     tier,
+			FilePath: fullPath,
+			Source:   src,
+			Decls:    decls,
+		})
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, fs.ErrNotExist) {
+		errs = append(errs, fmt.Errorf("walking %s: %w", pathPrefix, walkErr))
+	}
+	return out, errs
+}
+
+// Build is the full §5.5 pipeline: discover override files, run the
+// provided `tc` over each to obtain typed namespaces, extract scope
+// contributions, collapse three tiers, and merge against `originals`.
+//
+// `originals` is the post-inference original-side scope keyed by
+// module specifier ("" = global). Pass nil for modules with no
+// pre-loaded original — those overrides still produce store entries.
+//
+// Returns the merged store plus any errors collected from parsing,
+// type-checking, or merge.
+func Build(
+	ctx context.Context,
+	tc TypeChecker,
+	root string,
+	deps []DepInfo,
+	shipped fs.FS,
+	originals map[string]*ModuleScope,
+) (*OverrideStore, []error) {
+	files, errs := Discover(ctx, root, deps, shipped)
+
+	// Per-tier per-file extraction → one scope map per tier.
+	tierMaps := map[OverrideTier]map[string]*ModuleScope{
+		OverrideTierUserProject: {},
+		OverrideTierUserDep:     {},
+		OverrideTierShipped:     {},
+	}
+
+	if tc == nil && len(files) > 0 {
+		errs = append(errs, fmt.Errorf("interop.Build: nil TypeChecker, cannot type-check %d override file(s)", len(files)))
+		return NewOverrideStore(), errs
+	}
+
+	for _, f := range files {
+		globalNs, namedNs, tcErrs := tc(f)
+		errs = append(errs, tcErrs...)
+		contributions := Extract(f.Decls, globalNs, namedNs, f.FilePath, f.Tier)
+		mergeWithinTier(tierMaps[f.Tier], contributions, &errs)
+	}
+
+	collapsed := Collapse(
+		[]map[string]*ModuleScope{
+			tierMaps[OverrideTierUserProject],
+			tierMaps[OverrideTierUserDep],
+			tierMaps[OverrideTierShipped],
+		},
+		[]OverrideTier{
+			OverrideTierUserProject,
+			OverrideTierUserDep,
+			OverrideTierShipped,
+		},
+	)
+	store, mErrs := Merge(originals, collapsed)
+	errs = append(errs, mErrs...)
+	return store, errs
+}
+
+// mergeWithinTier folds one file's contributions into the per-tier
+// accumulator. A within-tier slot collision is ErrDuplicateMember.
+func mergeWithinTier(
+	dst, src map[string]*ModuleScope,
+	errs *[]error,
+) {
+	for modName, srcMod := range src {
+		dstMod, ok := dst[modName]
+		if !ok {
+			dst[modName] = srcMod
+			continue
+		}
+		mergeWithinContainer(&dstMod.Container, &srcMod.Container, Path{Module: modName}, errs)
+		// Module-level @all_pure: if either side claims it, the
+		// merged scope claims it. Same-tier duplicate isn't reported —
+		// the pragma is module-level metadata, not a slot.
+		if srcMod.AllPure {
+			dstMod.AllPure = true
+		}
+	}
+}
+
+func mergeWithinContainer(
+	dst, src *Container,
+	owner Path,
+	errs *[]error,
+) {
+	for name, eff := range src.Free {
+		if existing, present := dst.Free[name]; present {
+			*errs = append(*errs, &ErrDuplicateMember{
+				Path:   withFreeName(owner, name),
+				First:  firstOrigin(existing.Provenance),
+				Second: firstOrigin(eff.Provenance),
+			})
+			continue
+		}
+		dst.Free[name] = eff
+	}
+	for name, child := range src.Children {
+		existing, ok := dst.Children[name]
+		if !ok {
+			dst.Children[name] = child
+			continue
+		}
+		mergeWithinContainer(&existing.Container, &child.Container, appendChild(owner, name), errs)
+		mergeWithinMemberSet(existing.Instance, child.Instance, appendChild(owner, name), false, errs)
+		mergeWithinMemberSet(existing.Static, child.Static, appendChild(owner, name), true, errs)
+		if existing.Instance == nil && child.Instance != nil {
+			existing.Instance = child.Instance
+		}
+		if existing.Static == nil && child.Static != nil {
+			existing.Static = child.Static
+		}
+	}
+}
+
+func mergeWithinMemberSet(dst, src *MemberSet, owner Path, static bool, errs *[]error) {
+	if src == nil || dst == nil {
+		return
+	}
+	for _, pair := range []struct {
+		dst, src map[string]*Effective
+		kind     MemberKind
+	}{
+		{dst.Methods, src.Methods, KindMethod},
+		{dst.Getters, src.Getters, KindGetter},
+		{dst.Setters, src.Setters, KindSetter},
+		{dst.Properties, src.Properties, KindProperty},
+	} {
+		for name, eff := range pair.src {
+			if existing, present := pair.dst[name]; present {
+				p := owner
+				p.Kind = pair.kind
+				p.Static = static
+				*errs = append(*errs, &ErrDuplicateMember{
+					Path:   p,
+					First:  firstOrigin(existing.Provenance),
+					Second: firstOrigin(eff.Provenance),
+				})
+				continue
+			}
+			pair.dst[name] = eff
+		}
+	}
+	if dst.Ctor == nil && src.Ctor != nil {
+		dst.Ctor = src.Ctor
+	} else if src.Ctor != nil {
+		p := owner
+		p.Kind = KindCtor
+		p.Static = static
+		*errs = append(*errs, &ErrDuplicateMember{
+			Path:   p,
+			First:  firstOrigin(dst.Ctor.Provenance),
+			Second: firstOrigin(src.Ctor.Provenance),
+		})
+	}
+}
+
+func withFreeName(owner Path, name string) Path {
+	cp := owner
+	cp.Kind = KindFree
+	if name != "" {
+		cp.Name = dts_parser.NewIdent(name, ast.Span{})
+	}
+	return cp
+}
+
+func appendChild(owner Path, name string) Path {
+	cp := owner
+	cp.Owner = appendOwner(owner.Owner, name)
+	return cp
+}
+
+// collectDecls flattens all declarations across all namespaces of a
+// parsed module. Override files are single-file modules, so namespace
+// grouping (by directory) is incidental — the override format treats
+// the file's top-level decls as a flat list.
+func collectDecls(m *ast.Module) []ast.Decl {
+	if m == nil {
+		return nil
+	}
+	var out []ast.Decl
+	iter := m.Namespaces.Iter()
+	for ok := iter.First(); ok; ok = iter.Next() {
+		ns := iter.Value()
+		if ns == nil {
+			continue
+		}
+		out = append(out, ns.Decls...)
+	}
+	return out
+}
+
+func firstOrigin(ps []Origin) Origin {
+	if len(ps) == 0 {
+		return Origin{}
+	}
+	return ps[0]
+}

--- a/internal/interop/loader_test.go
+++ b/internal/interop/loader_test.go
@@ -1,0 +1,230 @@
+package interop
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+const declareFooFile = `override declare global {
+  declare fn foo() -> number
+}
+`
+
+func TestDiscoverGroupsByTier(t *testing.T) {
+	shipped := fstest.MapFS{
+		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+	}
+
+	userRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(userRoot, "overrides"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(userRoot, "overrides", "user.esc"),
+		[]byte(declareFooFile), 0o644,
+	); err != nil {
+		t.Fatalf("write user override: %v", err)
+	}
+
+	depDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(depDir, "overrides"), 0o755); err != nil {
+		t.Fatalf("mkdir dep: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(depDir, "overrides", "dep.esc"),
+		[]byte(declareFooFile), 0o644,
+	); err != nil {
+		t.Fatalf("write dep override: %v", err)
+	}
+
+	files, errs := Discover(
+		context.Background(),
+		userRoot,
+		[]DepInfo{{Name: "lib", Dir: depDir}},
+		shipped,
+	)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected discover errors: %v", errs)
+	}
+
+	tierByName := map[string]OverrideTier{}
+	for _, f := range files {
+		base := filepath.Base(f.FilePath)
+		tierByName[base] = f.Tier
+	}
+	if tierByName["core.esc"] != OverrideTierShipped {
+		t.Fatalf("expected core.esc tagged Shipped; got %v", tierByName["core.esc"])
+	}
+	if tierByName["dep.esc"] != OverrideTierUserDep {
+		t.Fatalf("expected dep.esc tagged UserDep; got %v", tierByName["dep.esc"])
+	}
+	if tierByName["user.esc"] != OverrideTierUserProject {
+		t.Fatalf("expected user.esc tagged UserProject; got %v", tierByName["user.esc"])
+	}
+}
+
+func TestDiscoverMissingOverrideDirsIsNotAnError(t *testing.T) {
+	// Empty root (no overrides/ subdir) and no deps should yield no
+	// files and no errors.
+	root := t.TempDir()
+	files, errs := Discover(context.Background(), root, nil, nil)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected zero files; got %d", len(files))
+	}
+}
+
+func TestDiscoverReportsParseErrors(t *testing.T) {
+	// Source with a clear syntax error.
+	shipped := fstest.MapFS{
+		"broken.esc": &fstest.MapFile{Data: []byte("declare global { @@@ }\n")},
+	}
+	files, errs := Discover(context.Background(), "", nil, shipped)
+	if len(errs) == 0 {
+		t.Fatalf("expected parse error to surface; got none")
+	}
+	for _, f := range files {
+		if strings.Contains(f.FilePath, "broken.esc") {
+			t.Fatalf("the broken file should not be in the parsed set; got %s", f.FilePath)
+		}
+	}
+}
+
+func TestBuildPipelineWithStubChecker(t *testing.T) {
+	// Drive Build end-to-end with a stub TypeChecker that returns a
+	// pre-built namespace. We assert that the final OverrideStore
+	// reflects the contribution.
+	shipped := fstest.MapFS{
+		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+	}
+
+	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	tc := func(p *ParsedOverride) (*type_system.Namespace, map[string]*type_system.Namespace, []error) {
+		globalNs := type_system.NewNamespace()
+		globalNs.Values["foo"] = &type_system.Binding{Type: fn}
+		return globalNs, nil, nil
+	}
+
+	store, errs := Build(context.Background(), tc, "", nil, shipped, nil)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected build errors: %v", errs)
+	}
+	mod := store.Modules[""]
+	if mod == nil {
+		t.Fatalf("expected global module scope")
+	}
+	eff := mod.Free["foo"]
+	if eff == nil || eff.Type != fn {
+		t.Fatalf("expected merged store to carry shipped foo; got %#v", eff)
+	}
+	if eff.Source != TierShippedOverride {
+		t.Fatalf("expected Source=TierShippedOverride; got %v", eff.Source)
+	}
+}
+
+func TestBuildWithoutTypeCheckerErrorsWhenFilesPresent(t *testing.T) {
+	shipped := fstest.MapFS{
+		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+	}
+	_, errs := Build(context.Background(), nil, "", nil, shipped, nil)
+	if len(errs) == 0 {
+		t.Fatalf("expected an error when TypeChecker is nil and files exist")
+	}
+}
+
+func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
+	shipped := fstest.MapFS{
+		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+	}
+	userRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(userRoot, "overrides"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(userRoot, "overrides", "user.esc"),
+		[]byte(declareFooFile), 0o644,
+	); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	fnShipped := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	fnUser := type_system.NewFuncType(nil, nil, nil, type_system.NewStrPrimType(nil), nil)
+	tc := func(p *ParsedOverride) (*type_system.Namespace, map[string]*type_system.Namespace, []error) {
+		ns := type_system.NewNamespace()
+		fn := fnShipped
+		if p.Tier == OverrideTierUserProject {
+			fn = fnUser
+		}
+		ns.Values["foo"] = &type_system.Binding{Type: fn}
+		return ns, nil, nil
+	}
+
+	store, errs := Build(context.Background(), tc, userRoot, nil, shipped, nil)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	eff := store.Modules[""].Free["foo"]
+	if eff == nil || eff.Type != fnUser {
+		t.Fatalf("expected user-project to win over shipped; got %#v", eff)
+	}
+	if eff.Source != TierUserOverride {
+		t.Fatalf("expected TierUserOverride; got %v", eff.Source)
+	}
+}
+
+func TestBuildDuplicateWithinTierIsAnError(t *testing.T) {
+	// Two files at the same tier that contribute the same name to the
+	// same module slot → ErrDuplicateMember.
+	shipped := fstest.MapFS{
+		"a.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+		"b.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+	}
+	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	tc := func(p *ParsedOverride) (*type_system.Namespace, map[string]*type_system.Namespace, []error) {
+		ns := type_system.NewNamespace()
+		ns.Values["foo"] = &type_system.Binding{Type: fn}
+		return ns, nil, nil
+	}
+	_, errs := Build(context.Background(), tc, "", nil, shipped, nil)
+	sawDup := false
+	for _, e := range errs {
+		if _, ok := e.(*ErrDuplicateMember); ok {
+			sawDup = true
+			break
+		}
+	}
+	if !sawDup {
+		t.Fatalf("expected ErrDuplicateMember in errors; got %v", errs)
+	}
+}
+
+// Ensure the parser is actually reading our content (vs silently
+// returning an empty Decls slice that the rest of the test would also
+// pass on).
+func TestDiscoverActuallyParsesDecls(t *testing.T) {
+	shipped := fstest.MapFS{
+		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+	}
+	files, errs := Discover(context.Background(), "", nil, shipped)
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file; got %d", len(files))
+	}
+	if len(files[0].Decls) == 0 {
+		t.Fatalf("expected at least one decl; got 0")
+	}
+	if _, ok := files[0].Decls[0].(*ast.DeclareGlobalDecl); !ok {
+		t.Fatalf("expected top decl to be DeclareGlobalDecl; got %T", files[0].Decls[0])
+	}
+}

--- a/internal/interop/loader_test.go
+++ b/internal/interop/loader_test.go
@@ -239,6 +239,72 @@ func TestDiscoverHonorsCanceledContext(t *testing.T) {
 	require.True(t, sawCanceled, "expected a context.Canceled error; got %v", errs)
 }
 
+// TestMergeWithinTierPropagatesAllPureTier: when one file in a tier
+// brings AllPure=true to a module another file already contributed,
+// the merged ModuleScope must carry the incoming AllPureTier — not
+// leave it at the zero value, which happens to alias the highest tier
+// and would mis-attribute provenance later.
+func TestMergeWithinTierPropagatesAllPureTier(t *testing.T) {
+	dst := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free:     map[string]*Effective{},
+				Children: map[string]ChildScope{},
+			},
+		},
+	}
+	src := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free:     map[string]*Effective{},
+				Children: map[string]ChildScope{},
+			},
+			AllPure:     true,
+			AllPureTier: OverrideTierUserDep,
+		},
+	}
+	var errs []error
+	mergeWithinTier(dst, src, &errs)
+	require.Empty(t, errs)
+	require.True(t, dst["m"].AllPure)
+	require.Equal(t, OverrideTierUserDep, dst["m"].AllPureTier)
+}
+
+// TestMergeWithinTierShapeConflictReportsShapeConflict: two files in
+// the same tier declare the same name as different child variants
+// (namespace vs. class). That's a shape conflict, not a duplicate-member
+// collision, and should surface as *ErrShapeConflict.
+func TestMergeWithinTierShapeConflictReportsShapeConflict(t *testing.T) {
+	dst := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free: map[string]*Effective{},
+				Children: map[string]ChildScope{
+					"C": &NamespaceScope{Container: Container{
+						Free:     map[string]*Effective{},
+						Children: map[string]ChildScope{},
+					}},
+				},
+			},
+		},
+	}
+	src := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free: map[string]*Effective{},
+				Children: map[string]ChildScope{
+					"C": &ClassScope{Instance: NewMemberSet(), Static: NewMemberSet()},
+				},
+			},
+		},
+	}
+	var errs []error
+	mergeWithinTier(dst, src, &errs)
+	require.Len(t, errs, 1)
+	_, ok := errs[0].(*ErrShapeConflict)
+	require.True(t, ok, "expected *ErrShapeConflict; got %T", errs[0])
+}
+
 // Ensure the parser is actually reading our content (vs silently
 // returning an empty Decls slice that the rest of the test would also
 // pass on).

--- a/internal/interop/loader_test.go
+++ b/internal/interop/loader_test.go
@@ -19,7 +19,14 @@ const declareFooFile = `override declare global {
 `
 
 func TestDiscoverGroupsByTier(t *testing.T) {
-	shipped := fstest.MapFS{
+	// Mirror the on-disk layout an Escalier package + its installed deps
+	// would actually have:
+	//
+	//   userRoot/
+	//     overrides/user.esc
+	//     node_modules/lib/
+	//       overrides/dep.esc
+	builtin := fstest.MapFS{
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
 
@@ -30,7 +37,7 @@ func TestDiscoverGroupsByTier(t *testing.T) {
 		[]byte(declareFooFile), 0o644,
 	))
 
-	depDir := t.TempDir()
+	depDir := filepath.Join(userRoot, "node_modules", "lib")
 	require.NoError(t, os.MkdirAll(filepath.Join(depDir, "overrides"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(depDir, "overrides", "dep.esc"),
@@ -40,8 +47,8 @@ func TestDiscoverGroupsByTier(t *testing.T) {
 	files, errs := Discover(
 		context.Background(),
 		userRoot,
-		[]DepInfo{{Name: "lib", Dir: depDir}},
-		shipped,
+		[]DepInfo{{Name: "lib", PkgDir: depDir}},
+		builtin,
 	)
 	require.Empty(t, errs)
 
@@ -50,7 +57,7 @@ func TestDiscoverGroupsByTier(t *testing.T) {
 		base := filepath.Base(f.FilePath)
 		tierByName[base] = f.Tier
 	}
-	require.Equal(t, OverrideTierShipped, tierByName["core.esc"])
+	require.Equal(t, OverrideTierBuiltin, tierByName["core.esc"])
 	require.Equal(t, OverrideTierUserDep, tierByName["dep.esc"])
 	require.Equal(t, OverrideTierUserProject, tierByName["user.esc"])
 }
@@ -65,53 +72,72 @@ func TestDiscoverMissingOverrideDirsIsNotAnError(t *testing.T) {
 }
 
 func TestDiscoverReportsParseErrors(t *testing.T) {
-	// Source with a clear syntax error.
-	shipped := fstest.MapFS{
+	// Source with a clear syntax error: three `@` tokens the parser
+	// can't recognise, at columns 18, 19, 20 of the only line.
+	builtin := fstest.MapFS{
 		"broken.esc": &fstest.MapFile{Data: []byte("declare global { @@@ }\n")},
 	}
-	files, errs := Discover(context.Background(), "", nil, shipped)
-	require.NotEmpty(t, errs, "expected parse error to surface")
-	for _, f := range files {
-		require.NotContains(t, f.FilePath, "broken.esc",
-			"the broken file should not be in the parsed set")
-	}
+	files, errs := Discover(context.Background(), "", nil, builtin)
+	require.Empty(t, files, "the broken file must not produce a ParsedOverride")
+	require.Len(t, errs, 3)
+	require.Equal(t, "parsing builtin:/broken.esc: 1:18-1:19: Unexpected token", errs[0].Error())
+	require.Equal(t, "parsing builtin:/broken.esc: 1:19-1:20: Unexpected token", errs[1].Error())
+	require.Equal(t, "parsing builtin:/broken.esc: 1:20-1:21: Unexpected token", errs[2].Error())
 }
 
 func TestBuildPipelineWithStubChecker(t *testing.T) {
 	// Drive Build end-to-end with a stub TypeChecker that returns a
 	// pre-built namespace. We assert that the final OverrideStore
 	// reflects the contribution.
-	shipped := fstest.MapFS{
+	builtin := fstest.MapFS{
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
 
+	// Override-side type for global `foo`: fn() -> number. The stub
+	// checker hands this pointer back for every parsed override, so it
+	// is what should land in the store and what require.Same verifies.
 	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
-	tc := func(p *ParsedOverride) (*type_system.Namespace, map[string]*type_system.Namespace, []error) {
+	checker := func(p *ParsedOverride) (*type_system.Namespace, map[string]*type_system.Namespace, []error) {
 		globalNs := type_system.NewNamespace()
 		globalNs.Values["foo"] = &type_system.Binding{Type: fn}
 		return globalNs, nil, nil
 	}
 
-	store, errs := Build(context.Background(), tc, "", nil, shipped, nil)
+	// Pre-load an original-side "foo" matching the override; without
+	// one Merge would (correctly) flag the override as unknown.
+	originals := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free: map[string]*Effective{
+					// Original-side type for global `foo`: fn() -> number.
+					// Same shape as the override so the consistency check
+					// passes; pointer identity is unimportant here.
+					"foo": {Type: type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)},
+				},
+				Children: map[string]ChildScope{},
+			},
+		},
+	}
+	store, errs := Build(context.Background(), checker, "", nil, builtin, originals)
 	require.Empty(t, errs)
 	mod := store.Modules[""]
 	require.NotNil(t, mod, "expected global module scope")
 	eff := mod.Free["foo"]
 	require.NotNil(t, eff)
 	require.Same(t, fn, eff.Type)
-	require.Equal(t, TierShippedOverride, eff.Source)
+	require.Equal(t, TierBuiltinOverride, eff.Source)
 }
 
 func TestBuildWithoutTypeCheckerErrorsWhenFilesPresent(t *testing.T) {
-	shipped := fstest.MapFS{
+	builtin := fstest.MapFS{
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
-	_, errs := Build(context.Background(), nil, "", nil, shipped, nil)
+	_, errs := Build(context.Background(), nil, "", nil, builtin, nil)
 	require.NotEmpty(t, errs, "expected an error when TypeChecker is nil and files exist")
 }
 
-func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
-	shipped := fstest.MapFS{
+func TestBuildPrecedenceUserProjectBeatsBuiltin(t *testing.T) {
+	builtin := fstest.MapFS{
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
 	userRoot := t.TempDir()
@@ -121,11 +147,21 @@ func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
 		[]byte(declareFooFile), 0o644,
 	))
 
-	fnShipped := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
-	fnUser := type_system.NewFuncType(nil, nil, nil, type_system.NewStrPrimType(nil), nil)
+	// All three FuncTypes share the same shape — `fn() -> number` —
+	// so the merge's signature-consistency check passes. Precedence is
+	// asserted via pointer identity, not signature content.
+	//
+	// Original-side type for global `foo`.
+	fnOrig := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	// Builtin-tier override type, returned by the stub checker when it
+	// sees core.esc.
+	fnBuiltin := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	// User-project-tier override type — expected winner since
+	// UserProject outranks Builtin.
+	fnUser := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
 	tc := func(p *ParsedOverride) (*type_system.Namespace, map[string]*type_system.Namespace, []error) {
 		ns := type_system.NewNamespace()
-		fn := fnShipped
+		fn := fnBuiltin
 		if p.Tier == OverrideTierUserProject {
 			fn = fnUser
 		}
@@ -133,7 +169,18 @@ func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
 		return ns, nil, nil
 	}
 
-	store, errs := Build(context.Background(), tc, userRoot, nil, shipped, nil)
+	// Pre-load an original-side "foo" so the override targets a known
+	// symbol; the test's focus is tier precedence, not the unknown-
+	// member behavior.
+	originals := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free:     map[string]*Effective{"foo": {Type: fnOrig}},
+				Children: map[string]ChildScope{},
+			},
+		},
+	}
+	store, errs := Build(context.Background(), tc, userRoot, nil, builtin, originals)
 	require.Empty(t, errs)
 	eff := store.Modules[""].Free["foo"]
 	require.NotNil(t, eff)
@@ -144,17 +191,20 @@ func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
 func TestBuildDuplicateWithinTierIsAnError(t *testing.T) {
 	// Two files at the same tier that contribute the same name to the
 	// same module slot → ErrDuplicateMember.
-	shipped := fstest.MapFS{
+	builtin := fstest.MapFS{
 		"a.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 		"b.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
+	// Shared override type returned for both a.esc and b.esc, both
+	// claiming the same global `foo : fn() -> number` slot — the
+	// collision is what the test exercises.
 	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
 	tc := func(p *ParsedOverride) (*type_system.Namespace, map[string]*type_system.Namespace, []error) {
 		ns := type_system.NewNamespace()
 		ns.Values["foo"] = &type_system.Binding{Type: fn}
 		return ns, nil, nil
 	}
-	_, errs := Build(context.Background(), tc, "", nil, shipped, nil)
+	_, errs := Build(context.Background(), tc, "", nil, builtin, nil)
 	sawDup := false
 	for _, e := range errs {
 		if _, ok := e.(*ErrDuplicateMember); ok {
@@ -170,13 +220,13 @@ func TestBuildDuplicateWithinTierIsAnError(t *testing.T) {
 // observe the cancellation error without per-file synthesis, but the
 // returned file set should be empty (cancellation short-circuits).
 func TestDiscoverHonorsCanceledContext(t *testing.T) {
-	shipped := fstest.MapFS{
+	builtin := fstest.MapFS{
 		"a.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 		"b.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	files, errs := Discover(ctx, "", nil, shipped)
+	files, errs := Discover(ctx, "", nil, builtin)
 	require.Empty(t, files, "canceled context must not yield parsed files")
 	require.NotEmpty(t, errs, "canceled context should surface ctx.Err()")
 	sawCanceled := false
@@ -193,10 +243,10 @@ func TestDiscoverHonorsCanceledContext(t *testing.T) {
 // returning an empty Decls slice that the rest of the test would also
 // pass on).
 func TestDiscoverActuallyParsesDecls(t *testing.T) {
-	shipped := fstest.MapFS{
+	builtin := fstest.MapFS{
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
-	files, errs := Discover(context.Background(), "", nil, shipped)
+	files, errs := Discover(context.Background(), "", nil, builtin)
 	require.Empty(t, errs)
 	require.Len(t, files, 1)
 	require.NotEmpty(t, files[0].Decls)

--- a/internal/interop/loader_test.go
+++ b/internal/interop/loader_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
 )
 
 const declareFooFile = `override declare global {
@@ -23,26 +24,18 @@ func TestDiscoverGroupsByTier(t *testing.T) {
 	}
 
 	userRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(userRoot, "overrides"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(
+	require.NoError(t, os.MkdirAll(filepath.Join(userRoot, "overrides"), 0o755))
+	require.NoError(t, os.WriteFile(
 		filepath.Join(userRoot, "overrides", "user.esc"),
 		[]byte(declareFooFile), 0o644,
-	); err != nil {
-		t.Fatalf("write user override: %v", err)
-	}
+	))
 
 	depDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(depDir, "overrides"), 0o755); err != nil {
-		t.Fatalf("mkdir dep: %v", err)
-	}
-	if err := os.WriteFile(
+	require.NoError(t, os.MkdirAll(filepath.Join(depDir, "overrides"), 0o755))
+	require.NoError(t, os.WriteFile(
 		filepath.Join(depDir, "overrides", "dep.esc"),
 		[]byte(declareFooFile), 0o644,
-	); err != nil {
-		t.Fatalf("write dep override: %v", err)
-	}
+	))
 
 	files, errs := Discover(
 		context.Background(),
@@ -50,24 +43,16 @@ func TestDiscoverGroupsByTier(t *testing.T) {
 		[]DepInfo{{Name: "lib", Dir: depDir}},
 		shipped,
 	)
-	if len(errs) > 0 {
-		t.Fatalf("unexpected discover errors: %v", errs)
-	}
+	require.Empty(t, errs)
 
 	tierByName := map[string]OverrideTier{}
 	for _, f := range files {
 		base := filepath.Base(f.FilePath)
 		tierByName[base] = f.Tier
 	}
-	if tierByName["core.esc"] != OverrideTierShipped {
-		t.Fatalf("expected core.esc tagged Shipped; got %v", tierByName["core.esc"])
-	}
-	if tierByName["dep.esc"] != OverrideTierUserDep {
-		t.Fatalf("expected dep.esc tagged UserDep; got %v", tierByName["dep.esc"])
-	}
-	if tierByName["user.esc"] != OverrideTierUserProject {
-		t.Fatalf("expected user.esc tagged UserProject; got %v", tierByName["user.esc"])
-	}
+	require.Equal(t, OverrideTierShipped, tierByName["core.esc"])
+	require.Equal(t, OverrideTierUserDep, tierByName["dep.esc"])
+	require.Equal(t, OverrideTierUserProject, tierByName["user.esc"])
 }
 
 func TestDiscoverMissingOverrideDirsIsNotAnError(t *testing.T) {
@@ -75,12 +60,8 @@ func TestDiscoverMissingOverrideDirsIsNotAnError(t *testing.T) {
 	// files and no errors.
 	root := t.TempDir()
 	files, errs := Discover(context.Background(), root, nil, nil)
-	if len(errs) > 0 {
-		t.Fatalf("unexpected errors: %v", errs)
-	}
-	if len(files) != 0 {
-		t.Fatalf("expected zero files; got %d", len(files))
-	}
+	require.Empty(t, errs)
+	require.Empty(t, files)
 }
 
 func TestDiscoverReportsParseErrors(t *testing.T) {
@@ -89,13 +70,10 @@ func TestDiscoverReportsParseErrors(t *testing.T) {
 		"broken.esc": &fstest.MapFile{Data: []byte("declare global { @@@ }\n")},
 	}
 	files, errs := Discover(context.Background(), "", nil, shipped)
-	if len(errs) == 0 {
-		t.Fatalf("expected parse error to surface; got none")
-	}
+	require.NotEmpty(t, errs, "expected parse error to surface")
 	for _, f := range files {
-		if strings.Contains(f.FilePath, "broken.esc") {
-			t.Fatalf("the broken file should not be in the parsed set; got %s", f.FilePath)
-		}
+		require.NotContains(t, f.FilePath, "broken.esc",
+			"the broken file should not be in the parsed set")
 	}
 }
 
@@ -115,20 +93,13 @@ func TestBuildPipelineWithStubChecker(t *testing.T) {
 	}
 
 	store, errs := Build(context.Background(), tc, "", nil, shipped, nil)
-	if len(errs) > 0 {
-		t.Fatalf("unexpected build errors: %v", errs)
-	}
+	require.Empty(t, errs)
 	mod := store.Modules[""]
-	if mod == nil {
-		t.Fatalf("expected global module scope")
-	}
+	require.NotNil(t, mod, "expected global module scope")
 	eff := mod.Free["foo"]
-	if eff == nil || eff.Type != fn {
-		t.Fatalf("expected merged store to carry shipped foo; got %#v", eff)
-	}
-	if eff.Source != TierShippedOverride {
-		t.Fatalf("expected Source=TierShippedOverride; got %v", eff.Source)
-	}
+	require.NotNil(t, eff)
+	require.Same(t, fn, eff.Type)
+	require.Equal(t, TierShippedOverride, eff.Source)
 }
 
 func TestBuildWithoutTypeCheckerErrorsWhenFilesPresent(t *testing.T) {
@@ -136,9 +107,7 @@ func TestBuildWithoutTypeCheckerErrorsWhenFilesPresent(t *testing.T) {
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
 	_, errs := Build(context.Background(), nil, "", nil, shipped, nil)
-	if len(errs) == 0 {
-		t.Fatalf("expected an error when TypeChecker is nil and files exist")
-	}
+	require.NotEmpty(t, errs, "expected an error when TypeChecker is nil and files exist")
 }
 
 func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
@@ -146,15 +115,11 @@ func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
 	userRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(userRoot, "overrides"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(
+	require.NoError(t, os.MkdirAll(filepath.Join(userRoot, "overrides"), 0o755))
+	require.NoError(t, os.WriteFile(
 		filepath.Join(userRoot, "overrides", "user.esc"),
 		[]byte(declareFooFile), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	))
 
 	fnShipped := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
 	fnUser := type_system.NewFuncType(nil, nil, nil, type_system.NewStrPrimType(nil), nil)
@@ -169,16 +134,11 @@ func TestBuildPrecedenceUserProjectBeatsShipped(t *testing.T) {
 	}
 
 	store, errs := Build(context.Background(), tc, userRoot, nil, shipped, nil)
-	if len(errs) > 0 {
-		t.Fatalf("unexpected errors: %v", errs)
-	}
+	require.Empty(t, errs)
 	eff := store.Modules[""].Free["foo"]
-	if eff == nil || eff.Type != fnUser {
-		t.Fatalf("expected user-project to win over shipped; got %#v", eff)
-	}
-	if eff.Source != TierUserOverride {
-		t.Fatalf("expected TierUserOverride; got %v", eff.Source)
-	}
+	require.NotNil(t, eff)
+	require.Same(t, fnUser, eff.Type)
+	require.Equal(t, TierUserOverride, eff.Source)
 }
 
 func TestBuildDuplicateWithinTierIsAnError(t *testing.T) {
@@ -202,9 +162,31 @@ func TestBuildDuplicateWithinTierIsAnError(t *testing.T) {
 			break
 		}
 	}
-	if !sawDup {
-		t.Fatalf("expected ErrDuplicateMember in errors; got %v", errs)
+	require.True(t, sawDup, "expected ErrDuplicateMember in errors; got %v", errs)
+}
+
+// TestDiscoverHonorsCanceledContext: a canceled context aborts the walk
+// before parsing files, so no overrides come back. We can't easily
+// observe the cancellation error without per-file synthesis, but the
+// returned file set should be empty (cancellation short-circuits).
+func TestDiscoverHonorsCanceledContext(t *testing.T) {
+	shipped := fstest.MapFS{
+		"a.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
+		"b.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	files, errs := Discover(ctx, "", nil, shipped)
+	require.Empty(t, files, "canceled context must not yield parsed files")
+	require.NotEmpty(t, errs, "canceled context should surface ctx.Err()")
+	sawCanceled := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), context.Canceled.Error()) {
+			sawCanceled = true
+			break
+		}
+	}
+	require.True(t, sawCanceled, "expected a context.Canceled error; got %v", errs)
 }
 
 // Ensure the parser is actually reading our content (vs silently
@@ -215,16 +197,9 @@ func TestDiscoverActuallyParsesDecls(t *testing.T) {
 		"core.esc": &fstest.MapFile{Data: []byte(declareFooFile)},
 	}
 	files, errs := Discover(context.Background(), "", nil, shipped)
-	if len(errs) > 0 {
-		t.Fatalf("parse errors: %v", errs)
-	}
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file; got %d", len(files))
-	}
-	if len(files[0].Decls) == 0 {
-		t.Fatalf("expected at least one decl; got 0")
-	}
-	if _, ok := files[0].Decls[0].(*ast.DeclareGlobalDecl); !ok {
-		t.Fatalf("expected top decl to be DeclareGlobalDecl; got %T", files[0].Decls[0])
-	}
+	require.Empty(t, errs)
+	require.Len(t, files, 1)
+	require.NotEmpty(t, files[0].Decls)
+	_, ok := files[0].Decls[0].(*ast.DeclareGlobalDecl)
+	require.True(t, ok, "expected top decl to be DeclareGlobalDecl; got %T", files[0].Decls[0])
 }

--- a/internal/interop/merge.go
+++ b/internal/interop/merge.go
@@ -87,6 +87,15 @@ func collapseContainer(dst, src *Container, ot OverrideTier) {
 			dst.Children[name] = dstChild
 		}
 		collapseContainer(&dstChild.Container, &child.Container, ot)
+		// If an earlier (higher-precedence) tier introduced this child
+		// as a namespace, Instance/Static may still be nil here; allocate
+		// on demand so a later tier's members aren't silently dropped.
+		if child.Instance != nil && dstChild.Instance == nil {
+			dstChild.Instance = NewMemberSet()
+		}
+		if child.Static != nil && dstChild.Static == nil {
+			dstChild.Static = NewMemberSet()
+		}
 		collapseMemberSet(dstChild.Instance, child.Instance, ot)
 		collapseMemberSet(dstChild.Static, child.Static, ot)
 	}

--- a/internal/interop/merge.go
+++ b/internal/interop/merge.go
@@ -13,56 +13,48 @@
 package interop
 
 import (
-	"github.com/escalier-lang/escalier/internal/ast"
-	"github.com/escalier-lang/escalier/internal/dts_parser"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
-func appendOwner(owner dts_parser.QualIdent, child string) dts_parser.QualIdent {
-	right := dts_parser.NewIdent(child, ast.Span{})
-	if owner == nil {
-		return right
-	}
-	return &dts_parser.Member{Left: owner, Right: right}
-}
-
 // Collapse performs the three-tier shadowing collapse described in
 // §5.5 step 7: for each (module, container path, slot) triple, take
-// the highest-precedence non-nil entry across the three input maps
-// (UserProject > UserDep > Shipped).
+// the highest-precedence non-nil entry across the three tiers
+// (UserProject > UserDep > Builtin). Any tier map may be nil, in which
+// case it contributes nothing.
 //
-// `tiers` is expected to be ordered by precedence (highest first); the
-// caller is responsible for that ordering. Passing fewer than three
-// maps is allowed (missing tiers are skipped).
-//
-// Each surviving Effective has its Tier field stamped with the tier it
-// won from; the merge pass reads that field when populating Source.
-func Collapse(tiers []map[string]*ModuleScope, tierOrder []OverrideTier) map[string]*ModuleScope {
+// Each surviving Effective is returned with its Tier set to the tier
+// it won from; the merge pass reads that field when populating Source.
+func Collapse(
+	userProject, userDep, builtin map[string]*ModuleScope,
+) map[string]*ModuleScope {
 	out := make(map[string]*ModuleScope)
-	n := min(len(tiers), len(tierOrder))
-	for i := range n {
-		t := tiers[i]
-		ot := tierOrder[i]
-		for modName, ms := range t {
-			if ms == nil {
-				continue
-			}
-			dst := out[modName]
-			if dst == nil {
-				dst = &ModuleScope{
-					Container: newContainer(ms.Container.Origin),
-				}
-				out[modName] = dst
-			}
-			if ms.AllPure && !dst.AllPure {
-				dst.AllPure = true
-				dst.AllPureTier = ot
-			}
-			collapseContainer(&dst.Container, &ms.Container, ot)
-		}
-	}
+	// Iterated highest-precedence first; collapseContainer's "skip if
+	// already present" rule then guarantees the highest tier wins.
+	collapseTier(out, userProject, OverrideTierUserProject)
+	collapseTier(out, userDep, OverrideTierUserDep)
+	collapseTier(out, builtin, OverrideTierBuiltin)
 	return out
+}
+
+func collapseTier(out, moduleMap map[string]*ModuleScope, tier OverrideTier) {
+	for name, srcScope := range moduleMap {
+		if srcScope == nil {
+			continue
+		}
+		dstScope := out[name]
+		if dstScope == nil {
+			dstScope = &ModuleScope{
+				Container: newContainer(srcScope.Container.Origin),
+			}
+			out[name] = dstScope
+		}
+		if srcScope.AllPure && !dstScope.AllPure {
+			dstScope.AllPure = true
+			dstScope.AllPureTier = tier
+		}
+		collapseContainer(&dstScope.Container, &srcScope.Container, tier)
+	}
 }
 
 func collapseContainer(dst, src *Container, ot OverrideTier) {
@@ -70,94 +62,121 @@ func collapseContainer(dst, src *Container, ot OverrideTier) {
 		if _, present := dst.Free[name]; present {
 			continue
 		}
-		dst.Free[name] = stampedCopy(eff, ot)
+		dst.Free[name] = eff.withTier(ot)
 	}
 	for name, child := range src.Children {
-		dstChild := dst.Children[name]
-		if dstChild == nil {
-			dstChild = &ChildScope{
-				Container: newContainer(child.Container.Origin),
-			}
-			if child.Instance != nil {
-				dstChild.Instance = NewMemberSet()
-			}
-			if child.Static != nil {
-				dstChild.Static = NewMemberSet()
-			}
-			dst.Children[name] = dstChild
-		}
-		collapseContainer(&dstChild.Container, &child.Container, ot)
-		// If an earlier (higher-precedence) tier introduced this child
-		// as a namespace, Instance/Static may still be nil here; allocate
-		// on demand so a later tier's members aren't silently dropped.
-		if child.Instance != nil && dstChild.Instance == nil {
-			dstChild.Instance = NewMemberSet()
-		}
-		if child.Static != nil && dstChild.Static == nil {
-			dstChild.Static = NewMemberSet()
-		}
-		collapseMemberSet(dstChild.Instance, child.Instance, ot)
-		collapseMemberSet(dstChild.Static, child.Static, ot)
+		dst.Children[name] = collapseChild(dst.Children[name], child, ot)
 	}
 }
 
-func collapseMemberSet(dst, src *MemberSet, ot OverrideTier) {
+// collapseChild folds `src` into `existing` for one Container.Children
+// slot during the three-tier collapse. When existing is nil we build a
+// fresh ChildScope of the same variant as src. When the variants match
+// we recurse. When they mismatch the higher tier (already in existing)
+// wins wholesale — src is dropped.
+func collapseChild(existing, src ChildScope, tier OverrideTier) ChildScope {
+	if existing == nil {
+		return cloneChildWithTier(src, tier)
+	}
+	switch e := existing.(type) {
+	case *NamespaceScope:
+		s, ok := src.(*NamespaceScope)
+		if !ok {
+			return existing
+		}
+		collapseContainer(&e.Container, &s.Container, tier)
+	case *ClassScope:
+		s, ok := src.(*ClassScope)
+		if !ok {
+			return existing
+		}
+		collapseMemberSet(e.Instance, s.Instance, tier)
+		collapseMemberSet(e.Static, s.Static, tier)
+	case *InterfaceScope:
+		s, ok := src.(*InterfaceScope)
+		if !ok {
+			return existing
+		}
+		collapseMemberSet(e.Instance, s.Instance, tier)
+	}
+	return existing
+}
+
+// cloneChildWithTier produces a fresh ChildScope of the same variant as
+// src, populated by collapsing src's contents with `tier` stamped on
+// every leaf.
+func cloneChildWithTier(src ChildScope, tier OverrideTier) ChildScope {
+	switch s := src.(type) {
+	case *NamespaceScope:
+		c := &NamespaceScope{Container: newContainer(s.Container.Origin)}
+		collapseContainer(&c.Container, &s.Container, tier)
+		return c
+	case *ClassScope:
+		c := &ClassScope{
+			Origin:   s.Origin,
+			Instance: NewMemberSet(),
+			Static:   NewMemberSet(),
+		}
+		collapseMemberSet(c.Instance, s.Instance, tier)
+		collapseMemberSet(c.Static, s.Static, tier)
+		return c
+	case *InterfaceScope:
+		c := &InterfaceScope{
+			Origin:   s.Origin,
+			Instance: NewMemberSet(),
+		}
+		collapseMemberSet(c.Instance, s.Instance, tier)
+		return c
+	}
+	return nil
+}
+
+func collapseMemberSet(dst, src *MemberSet, tier OverrideTier) {
 	if src == nil {
 		return
 	}
 	if dst == nil {
 		return
 	}
-	copyIfAbsent(dst.Methods, src.Methods, ot)
-	copyIfAbsent(dst.Getters, src.Getters, ot)
-	copyIfAbsent(dst.Setters, src.Setters, ot)
-	copyIfAbsent(dst.Properties, src.Properties, ot)
+	copyIfAbsent(dst.Methods, src.Methods, tier)
+	copyIfAbsent(dst.Getters, src.Getters, tier)
+	copyIfAbsent(dst.Setters, src.Setters, tier)
+	copyIfAbsent(dst.Properties, src.Properties, tier)
 	if dst.Ctor == nil && src.Ctor != nil {
-		dst.Ctor = stampedCopy(src.Ctor, ot)
+		dst.Ctor = src.Ctor.withTier(tier)
 	}
 }
 
-func copyIfAbsent(dst, src map[string]*Effective, ot OverrideTier) {
+func copyIfAbsent(dst, src map[string]*Effective, tier OverrideTier) {
 	for name, eff := range src {
 		if _, present := dst[name]; present {
 			continue
 		}
-		dst[name] = stampedCopy(eff, ot)
+		dst[name] = eff.withTier(tier)
 	}
-}
-
-// stampedCopy returns a copy of eff with Tier/Source stamped. We copy
-// rather than mutate so the per-tier Effective produced by Extract is
-// not shared across collapse runs.
-func stampedCopy(eff *Effective, ot OverrideTier) *Effective {
-	if eff == nil {
-		return nil
-	}
-	cp := *eff
-	cp.Tier = ot
-	cp.Source = ot.ResolutionTierFor()
-	return &cp
 }
 
 func newContainer(origin Origin) Container {
 	return Container{
 		Free:     make(map[string]*Effective),
-		Children: make(map[string]*ChildScope),
+		Children: make(map[string]ChildScope),
 		Origin:   origin,
 	}
 }
 
 // Merge applies the collapsed override scope on top of the original
 // per-module scopes and returns a fresh OverrideStore. The original
-// side passes through with no Source stamped (Classify's lower tiers
+// side passes through with Source left at its zero value (Classify's lower tiers
 // determine its classification); the override side replaces matching
 // slots entirely and runs consistency.CheckSet on each method/free-fn
 // slot that pairs with an original.
 //
-// `original` may be nil for any module that wasn't pre-loaded — in
-// that case only override-side entries are reported (the consistency
-// check is skipped) and ErrUnknownMember is suppressed since there's
-// nothing to compare against.
+// Every Escalier library ships .d.ts for TypeScript back-compat
+// (requirements.md §F), so an override-only leaf — with no matching
+// original — is always either a typo or caller misuse (originals not
+// pre-loaded). Such leaves still land in the store, but ErrUnknownMember
+// is reported. If `original` is nil for a module that has overrides,
+// every override leaf in that module produces an ErrUnknownMember.
 func Merge(original, override map[string]*ModuleScope) (*OverrideStore, []error) {
 	store := NewOverrideStore()
 	var errs []error
@@ -172,24 +191,34 @@ func Merge(original, override map[string]*ModuleScope) (*OverrideStore, []error)
 	}
 
 	for modName := range seen {
-		orig := original[modName]
-		over := override[modName]
+		origScope := original[modName]
+		overScope := override[modName]
 
-		ms := &ModuleScope{
-			Container: newContainer(originOf(orig, over)),
+		mergedScope := &ModuleScope{
+			Container: newContainer(originOf(origScope, overScope)),
 		}
-		if over != nil {
-			ms.AllPure = over.AllPure
-			ms.AllPureTier = over.AllPureTier
+		if overScope != nil {
+			mergedScope.AllPure = overScope.AllPure
+			mergedScope.AllPureTier = overScope.AllPureTier
 		}
-		store.Modules[modName] = ms
+		store.Modules[modName] = mergedScope
 
 		modPath := Path{Module: modName}
-		mergeContainer(&ms.Container, containerOf(orig), containerOf(over), modPath, ms.AllPure, ms.AllPureTier, &errs)
+		mergeContainer(
+			&mergedScope.Container,
+			containerOf(origScope), containerOf(overScope),
+			modPath, mergedScope.AllPure, mergedScope.AllPureTier, &errs,
+		)
 	}
 	return store, errs
 }
 
+// originOf picks the Container.Origin to attach to the merged
+// ModuleScope. The override side wins when present (it's the file a
+// module-level diagnostic most likely wants to point at after merge);
+// otherwise we fall back to the original side, then to a zero Origin.
+//
+// Mirrors childOrigin, which applies the same rule to ChildScope.
 func originOf(orig, over *ModuleScope) Origin {
 	if over != nil {
 		return over.Container.Origin
@@ -209,7 +238,7 @@ func containerOf(ms *ModuleScope) *Container {
 
 func mergeContainer(
 	dst, orig, over *Container,
-	owner Path,
+	ownerPath Path,
 	allPure bool,
 	allPureTier OverrideTier,
 	errs *[]error,
@@ -227,14 +256,17 @@ func mergeContainer(
 		}
 	}
 	for n := range names {
-		var oEff, vEff *Effective
+		var origEff, overEff *Effective
 		if orig != nil {
-			oEff = orig.Free[n]
+			origEff = orig.Free[n]
 		}
 		if over != nil {
-			vEff = over.Free[n]
+			overEff = over.Free[n]
 		}
-		leaf, err := mergeLeaf(oEff, vEff, withName(owner, n, KindFree, false), false /*allPure n/a for free*/, allPureTier, orig != nil)
+		leaf, err := mergeLeaf(
+			origEff, overEff, ownerPath.withMember(n, KindFree, false),
+			false /*allPure n/a for free*/, allPureTier,
+		)
 		if err != nil {
 			*errs = append(*errs, err)
 		}
@@ -256,78 +288,165 @@ func mergeContainer(
 		}
 	}
 	for n := range childNames {
-		var oCh, vCh *ChildScope
+		var origCh, overCh ChildScope
 		if orig != nil {
-			oCh = orig.Children[n]
+			origCh = orig.Children[n]
 		}
 		if over != nil {
-			vCh = over.Children[n]
+			overCh = over.Children[n]
 		}
-		mergedChild := mergeChild(oCh, vCh, withChildOwner(owner, n), allPure, allPureTier, errs)
+		mergedChild := mergeChild(
+			origCh, overCh, ownerPath.withChild(n),
+			allPure, allPureTier, errs,
+		)
 		if mergedChild != nil {
 			dst.Children[n] = mergedChild
 		}
 	}
 }
 
+// mergeChild merges one Container.Children entry across original and
+// override sides. The variant of the result follows whichever side is
+// present; if both sides have a value with the same variant we recurse
+// per slot. A shape mismatch between the two sides (e.g. namespace vs
+// class at the same name) is upstream ErrDuplicateMember — we emit the
+// error and proceed with the override side's variant.
 func mergeChild(
-	orig, over *ChildScope,
-	owner Path,
+	orig, over ChildScope,
+	ownerPath Path,
 	allPure bool,
 	allPureTier OverrideTier,
 	errs *[]error,
-) *ChildScope {
-	dst := &ChildScope{
-		Container: newContainer(childOrigin(orig, over)),
-	}
-	// Decide shape: namespace (no Instance/Static on either side) or
-	// class/interface (Instance/Static populated).
-	hasMembers := (orig != nil && (orig.Instance != nil || orig.Static != nil)) ||
-		(over != nil && (over.Instance != nil || over.Static != nil))
-	if hasMembers {
-		dst.Instance = NewMemberSet()
-		dst.Static = NewMemberSet()
+) ChildScope {
+	if orig == nil && over == nil {
+		return nil
 	}
 
-	mergeContainer(&dst.Container, containerFromChild(orig), containerFromChild(over), owner, allPure, allPureTier, errs)
-
-	if hasMembers {
-		mergeMemberSet(dst.Instance, msFromChild(orig, false), msFromChild(over, false), owner, false, allPure, allPureTier, errs)
-		mergeMemberSet(dst.Static, msFromChild(orig, true), msFromChild(over, true), owner, true, allPure, allPureTier, errs)
+	// Resolve the variant of the result and obtain its (possibly nil)
+	// orig/over MemberSet pairs.
+	if orig != nil && over != nil && !sameChildKind(orig, over) {
+		*errs = append(*errs, &ErrDuplicateMember{
+			Path:   ownerPath,
+			First:  orig.ChildOrigin(),
+			Second: over.ChildOrigin(),
+		})
+		orig = nil // proceed with override side only
 	}
-	return dst
+
+	return mergeSameKindChild(orig, over, ownerPath, allPure, allPureTier, errs)
 }
 
-func childOrigin(orig, over *ChildScope) Origin {
+func sameChildKind(a, b ChildScope) bool {
+	switch a.(type) {
+	case *NamespaceScope:
+		_, ok := b.(*NamespaceScope)
+		return ok
+	case *ClassScope:
+		_, ok := b.(*ClassScope)
+		return ok
+	case *InterfaceScope:
+		_, ok := b.(*InterfaceScope)
+		return ok
+	}
+	return false
+}
+
+// mergeSameKindChild assumes orig and over are either nil or the same
+// variant. It picks a shape, recurses on Container, and merges any
+// MemberSets the variant carries.
+func mergeSameKindChild(
+	orig, over ChildScope,
+	ownerPath Path,
+	allPure bool,
+	allPureTier OverrideTier,
+	errs *[]error,
+) ChildScope {
+	origin := childOrigin(orig, over)
+
+	// Pick the shape based on whichever side is present (over wins).
+	probe := over
+	if probe == nil {
+		probe = orig
+	}
+
+	switch probe.(type) {
+	case *NamespaceScope:
+		dst := &NamespaceScope{Container: newContainer(origin)}
+		var origCont, overCont *Container
+		if ns, ok := orig.(*NamespaceScope); ok {
+			origCont = &ns.Container
+		}
+		if ns, ok := over.(*NamespaceScope); ok {
+			overCont = &ns.Container
+		}
+		mergeContainer(&dst.Container, origCont, overCont,
+			ownerPath, allPure, allPureTier, errs)
+		return dst
+	case *ClassScope:
+		dst := &ClassScope{
+			Origin:   origin,
+			Instance: NewMemberSet(),
+			Static:   NewMemberSet(),
+		}
+		origInstMembs := memberSetFromChild(orig, false)
+		overInstMembs := memberSetFromChild(over, false)
+		mergeMemberSet(
+			dst.Instance, origInstMembs, overInstMembs,
+			ownerPath, false, allPure, allPureTier, errs,
+		)
+		origStatMembs := memberSetFromChild(orig, true)
+		overStatMembs := memberSetFromChild(over, true)
+		mergeMemberSet(
+			dst.Static, origStatMembs, overStatMembs,
+			ownerPath, true, allPure, allPureTier, errs,
+		)
+		return dst
+	case *InterfaceScope:
+		dst := &InterfaceScope{
+			Origin:   origin,
+			Instance: NewMemberSet(),
+		}
+		origInstMembs := memberSetFromChild(orig, false)
+		overInstMembs := memberSetFromChild(over, false)
+		mergeMemberSet(
+			dst.Instance, origInstMembs, overInstMembs,
+			ownerPath, false, allPure, allPureTier, errs,
+		)
+		return dst
+	}
+	return nil
+}
+
+// childOrigin picks the Origin to attach to the merged ChildScope. The
+// override side wins when present (it's the file a child-level
+// diagnostic most likely wants to point at after merge); otherwise we
+// fall back to the original side, then to a zero Origin.
+//
+// Mirrors originOf, which applies the same rule to ModuleScope.
+func childOrigin(orig, over ChildScope) Origin {
 	if over != nil {
-		return over.Container.Origin
+		return over.ChildOrigin()
 	}
 	if orig != nil {
-		return orig.Container.Origin
+		return orig.ChildOrigin()
 	}
 	return Origin{}
 }
 
-func containerFromChild(c *ChildScope) *Container {
+// memberSetFromChild is a nil-safe wrapper around ChildScope.MembersFor. The
+// method itself can't be called on a nil interface value (Go panics on
+// nil-interface dispatch), so callers that may pass a nil ChildScope
+// go through this helper.
+func memberSetFromChild(c ChildScope, static bool) *MemberSet {
 	if c == nil {
 		return nil
 	}
-	return &c.Container
-}
-
-func msFromChild(c *ChildScope, static bool) *MemberSet {
-	if c == nil {
-		return nil
-	}
-	if static {
-		return c.Static
-	}
-	return c.Instance
+	return c.MembersFor(static)
 }
 
 func mergeMemberSet(
 	dst, orig, over *MemberSet,
-	owner Path,
+	ownerPath Path,
 	static bool,
 	allPure bool,
 	allPureTier OverrideTier,
@@ -335,20 +454,20 @@ func mergeMemberSet(
 ) {
 	// @all_pure only strips mut from instance-method receivers; static
 	// methods have no receiver, so the flag is silenced on the static side.
-	mergeKind(orig, over, dst, owner, KindMethod, static, allPure && !static, allPureTier, errs)
-	mergeKind(orig, over, dst, owner, KindGetter, static, false, allPureTier, errs)
-	mergeKind(orig, over, dst, owner, KindSetter, static, false, allPureTier, errs)
-	mergeKind(orig, over, dst, owner, KindProperty, static, false, allPureTier, errs)
+	mergeKind(orig, over, dst, ownerPath, KindMethod, static, allPure && !static, allPureTier, errs)
+	mergeKind(orig, over, dst, ownerPath, KindGetter, static, false, allPureTier, errs)
+	mergeKind(orig, over, dst, ownerPath, KindSetter, static, false, allPureTier, errs)
+	mergeKind(orig, over, dst, ownerPath, KindProperty, static, false, allPureTier, errs)
 
 	// Ctor is a single slot.
-	var oCtor, vCtor *Effective
+	var origCtor, overCtor *Effective
 	if orig != nil {
-		oCtor = orig.Ctor
+		origCtor = orig.Ctor
 	}
 	if over != nil {
-		vCtor = over.Ctor
+		overCtor = over.Ctor
 	}
-	leaf, err := mergeLeaf(oCtor, vCtor, withName(owner, "", KindCtor, static), false, allPureTier, orig != nil)
+	leaf, err := mergeLeaf(origCtor, overCtor, ownerPath.withMember("", KindCtor, static), false, allPureTier)
 	if err != nil {
 		*errs = append(*errs, err)
 	}
@@ -359,26 +478,29 @@ func mergeMemberSet(
 
 func mergeKind(
 	orig, over, dst *MemberSet,
-	owner Path,
+	ownerPath Path,
 	kind MemberKind,
 	static bool,
 	allPureForThisKind bool,
 	allPureTier OverrideTier,
 	errs *[]error,
 ) {
-	oMap := kindMap(orig, kind)
-	vMap := kindMap(over, kind)
+	origMap := kindMap(orig, kind)
+	overMap := kindMap(over, kind)
 	dMap := kindMap(dst, kind)
 	names := set.NewSet[string]()
-	for n := range oMap {
+	for n := range origMap {
 		names.Add(n)
 	}
-	for n := range vMap {
+	for n := range overMap {
 		names.Add(n)
 	}
-	origParentExists := orig != nil
 	for n := range names {
-		leaf, err := mergeLeaf(oMap[n], vMap[n], withName(owner, n, kind, static), allPureForThisKind, allPureTier, origParentExists)
+		leaf, err := mergeLeaf(
+			origMap[n], overMap[n],
+			ownerPath.withMember(n, kind, static),
+			allPureForThisKind, allPureTier,
+		)
 		if err != nil {
 			*errs = append(*errs, err)
 		}
@@ -388,30 +510,33 @@ func mergeKind(
 	}
 }
 
-func kindMap(ms *MemberSet, kind MemberKind) map[string]*Effective {
-	if ms == nil {
+func kindMap(memberSet *MemberSet, kind MemberKind) map[string]*Effective {
+	if memberSet == nil {
 		return nil
 	}
 	switch kind {
 	case KindMethod:
-		return ms.Methods
+		return memberSet.Methods
 	case KindGetter:
-		return ms.Getters
+		return memberSet.Getters
 	case KindSetter:
-		return ms.Setters
+		return memberSet.Setters
 	case KindProperty:
-		return ms.Properties
+		return memberSet.Properties
 	}
 	return nil
 }
 
 // mergeLeaf produces the merged Effective for a single slot:
 //   - both nil: returns nil (caller does not set).
-//   - only orig: return a fresh Effective with Source unstamped.
-//   - only over: ErrUnknownMember when the parent original scope was
-//     present (origParentExists==true) — the override targets a
-//     non-existent sibling. When the parent was absent
-//     (origParentExists==false) the override is emitted as-is per §5.7.
+//   - only orig: return a fresh Effective with Source left unset.
+//   - only over: ErrUnknownMember — the override targets a name that
+//     doesn't exist on the original side. Every Escalier library ships
+//     .d.ts for TS back-compat (requirements.md §F), so there is no
+//     "no original types" case; an override-only leaf is always either
+//     a typo or caller misuse (originals not pre-loaded). The leaf is
+//     still returned so the caller can populate the store, but the
+//     error is reported.
 //   - both: replace with override; run consistency check when both
 //     are *FuncType.
 //
@@ -423,7 +548,6 @@ func mergeLeaf(
 	p Path,
 	allPureForKind bool,
 	allPureTier OverrideTier,
-	origParentExists bool,
 ) (*Effective, error) {
 	switch {
 	case orig == nil && over == nil:
@@ -432,21 +556,16 @@ func mergeLeaf(
 		if allPureForKind {
 			return synthesiseAllPure(orig, allPureTier), nil
 		}
-		// Leave Source unstamped — Classify's lower tiers decide.
+		// Leave Source unset — Classify's lower tiers decide.
 		return &Effective{
-			Type:       orig.Type,
-			Provenance: orig.Provenance,
+			Type:    orig.Type,
+			Origins: orig.Origins,
 		}, nil
 	case orig == nil && over != nil:
-		if origParentExists {
-			return over, &ErrUnknownMember{
-				Path:     p,
-				Override: lastOrigin(over.Provenance),
-			}
+		return over, &ErrUnknownMember{
+			Path:     p,
+			Override: lastOrigin(over.Origins),
 		}
-		// Parent original wasn't pre-loaded — accept the override
-		// silently (no original to compare against).
-		return over, nil
 	default:
 		// Both: override replaces original. Consistency check on
 		// FuncType pairs (single-signature for now; CheckSet handles
@@ -454,7 +573,7 @@ func mergeLeaf(
 		// for follow-up).
 		if oFn, ok := orig.Type.(*type_system.FuncType); ok {
 			if vFn, ok2 := over.Type.(*type_system.FuncType); ok2 {
-				origin := lastOrigin(over.Provenance)
+				origin := lastOrigin(over.Origins)
 				if err := Check(vFn, oFn, p, origin); err != nil {
 					return over, err
 				}
@@ -469,15 +588,15 @@ func synthesiseAllPure(orig *Effective, tier OverrideTier) *Effective {
 	if !ok || fn.SelfParam == nil {
 		// Not a receiver-bearing method; @all_pure doesn't apply.
 		return &Effective{
-			Type:       orig.Type,
-			Provenance: orig.Provenance,
+			Type:    orig.Type,
+			Origins: orig.Origins,
 		}
 	}
 	stripped := stripMutSelf(fn)
 	return &Effective{
-		Type:       stripped,
-		Source:     tier.ResolutionTierFor(),
-		Provenance: orig.Provenance,
+		Type:    stripped,
+		Source:  tier.ResolutionTierFor(),
+		Origins: orig.Origins,
 	}
 }
 
@@ -500,30 +619,9 @@ func stripMutSelf(fn *type_system.FuncType) *type_system.FuncType {
 	return &cp
 }
 
-func lastOrigin(ps []Origin) Origin {
-	if len(ps) == 0 {
+func lastOrigin(origins []Origin) Origin {
+	if len(origins) == 0 {
 		return Origin{}
 	}
-	return ps[len(ps)-1]
-}
-
-// withName returns owner with Name/Kind/Static set.
-func withName(owner Path, name string, kind MemberKind, static bool) Path {
-	if name != "" {
-		owner.Name = dts_parser.NewIdent(name, ast.Span{})
-	} else {
-		owner.Name = nil
-	}
-	owner.Kind = kind
-	owner.Static = static
-	return owner
-}
-
-func withChildOwner(owner Path, child string) Path {
-	// Append the child segment onto Owner via dts_parser.Member chain.
-	// For now we use a synthetic identifier wrapper since the merge
-	// only consumes Owner for diagnostics.
-	cp := owner
-	cp.Owner = appendOwner(owner.Owner, child)
-	return cp
+	return origins[len(origins)-1]
 }

--- a/internal/interop/merge.go
+++ b/internal/interop/merge.go
@@ -309,7 +309,7 @@ func mergeContainer(
 // override sides. The variant of the result follows whichever side is
 // present; if both sides have a value with the same variant we recurse
 // per slot. A shape mismatch between the two sides (e.g. namespace vs
-// class at the same name) is upstream ErrDuplicateMember — we emit the
+// class at the same name) is upstream ErrShapeConflict — we emit the
 // error and proceed with the override side's variant.
 func mergeChild(
 	orig, over ChildScope,
@@ -325,7 +325,7 @@ func mergeChild(
 	// Resolve the variant of the result and obtain its (possibly nil)
 	// orig/over MemberSet pairs.
 	if orig != nil && over != nil && !sameChildKind(orig, over) {
-		*errs = append(*errs, &ErrDuplicateMember{
+		*errs = append(*errs, &ErrShapeConflict{
 			Path:   ownerPath,
 			First:  orig.ChildOrigin(),
 			Second: over.ChildOrigin(),

--- a/internal/interop/merge.go
+++ b/internal/interop/merge.go
@@ -1,0 +1,520 @@
+// merge.go: the override-merge pipeline described in
+// planning/interop_mutability/implementation_plan.md §5.
+//
+// Exports:
+//
+//   - Collapse: three-tier shadowing collapse of per-tier scopes (§5.5
+//     step 7).
+//   - Merge: eager merge of a collapsed override scope onto the
+//     original (§5.6).
+//
+// The loader's full pipeline (Discover + Build) lives in loader.go.
+
+package interop
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+func appendOwner(owner dts_parser.QualIdent, child string) dts_parser.QualIdent {
+	right := dts_parser.NewIdent(child, ast.Span{})
+	if owner == nil {
+		return right
+	}
+	return &dts_parser.Member{Left: owner, Right: right}
+}
+
+// Collapse performs the three-tier shadowing collapse described in
+// §5.5 step 7: for each (module, container path, slot) triple, take
+// the highest-precedence non-nil entry across the three input maps
+// (UserProject > UserDep > Shipped).
+//
+// `tiers` is expected to be ordered by precedence (highest first); the
+// caller is responsible for that ordering. Passing fewer than three
+// maps is allowed (missing tiers are skipped).
+//
+// Each surviving Effective has its Tier field stamped with the tier it
+// won from; the merge pass reads that field when populating Source.
+func Collapse(tiers []map[string]*ModuleScope, tierOrder []OverrideTier) map[string]*ModuleScope {
+	out := make(map[string]*ModuleScope)
+	n := min(len(tiers), len(tierOrder))
+	for i := range n {
+		t := tiers[i]
+		ot := tierOrder[i]
+		for modName, ms := range t {
+			if ms == nil {
+				continue
+			}
+			dst := out[modName]
+			if dst == nil {
+				dst = &ModuleScope{
+					Container: newContainer(ms.Container.Origin),
+				}
+				out[modName] = dst
+			}
+			if ms.AllPure && !dst.AllPure {
+				dst.AllPure = true
+				dst.AllPureTier = ot
+			}
+			collapseContainer(&dst.Container, &ms.Container, ot)
+		}
+	}
+	return out
+}
+
+func collapseContainer(dst, src *Container, ot OverrideTier) {
+	for name, eff := range src.Free {
+		if _, present := dst.Free[name]; present {
+			continue
+		}
+		dst.Free[name] = stampedCopy(eff, ot)
+	}
+	for name, child := range src.Children {
+		dstChild := dst.Children[name]
+		if dstChild == nil {
+			dstChild = &ChildScope{
+				Container: newContainer(child.Container.Origin),
+			}
+			if child.Instance != nil {
+				dstChild.Instance = NewMemberSet()
+			}
+			if child.Static != nil {
+				dstChild.Static = NewMemberSet()
+			}
+			dst.Children[name] = dstChild
+		}
+		collapseContainer(&dstChild.Container, &child.Container, ot)
+		collapseMemberSet(dstChild.Instance, child.Instance, ot)
+		collapseMemberSet(dstChild.Static, child.Static, ot)
+	}
+}
+
+func collapseMemberSet(dst, src *MemberSet, ot OverrideTier) {
+	if src == nil {
+		return
+	}
+	if dst == nil {
+		return
+	}
+	copyIfAbsent(dst.Methods, src.Methods, ot)
+	copyIfAbsent(dst.Getters, src.Getters, ot)
+	copyIfAbsent(dst.Setters, src.Setters, ot)
+	copyIfAbsent(dst.Properties, src.Properties, ot)
+	if dst.Ctor == nil && src.Ctor != nil {
+		dst.Ctor = stampedCopy(src.Ctor, ot)
+	}
+}
+
+func copyIfAbsent(dst, src map[string]*Effective, ot OverrideTier) {
+	for name, eff := range src {
+		if _, present := dst[name]; present {
+			continue
+		}
+		dst[name] = stampedCopy(eff, ot)
+	}
+}
+
+// stampedCopy returns a copy of eff with Tier/Source stamped. We copy
+// rather than mutate so the per-tier Effective produced by Extract is
+// not shared across collapse runs.
+func stampedCopy(eff *Effective, ot OverrideTier) *Effective {
+	if eff == nil {
+		return nil
+	}
+	cp := *eff
+	cp.Tier = ot
+	cp.Source = ot.ResolutionTierFor()
+	return &cp
+}
+
+func newContainer(origin Origin) Container {
+	return Container{
+		Free:     make(map[string]*Effective),
+		Children: make(map[string]*ChildScope),
+		Origin:   origin,
+	}
+}
+
+// Merge applies the collapsed override scope on top of the original
+// per-module scopes and returns a fresh OverrideStore. The original
+// side passes through with no Source stamped (Classify's lower tiers
+// determine its classification); the override side replaces matching
+// slots entirely and runs consistency.CheckSet on each method/free-fn
+// slot that pairs with an original.
+//
+// `original` may be nil for any module that wasn't pre-loaded — in
+// that case only override-side entries are reported (the consistency
+// check is skipped) and ErrUnknownMember is suppressed since there's
+// nothing to compare against.
+func Merge(original, override map[string]*ModuleScope) (*OverrideStore, []error) {
+	store := NewOverrideStore()
+	var errs []error
+
+	// Visit every module that appears on either side.
+	seen := set.NewSet[string]()
+	for modName := range original {
+		seen.Add(modName)
+	}
+	for modName := range override {
+		seen.Add(modName)
+	}
+
+	for modName := range seen {
+		orig := original[modName]
+		over := override[modName]
+
+		ms := &ModuleScope{
+			Container: newContainer(originOf(orig, over)),
+		}
+		if over != nil {
+			ms.AllPure = over.AllPure
+			ms.AllPureTier = over.AllPureTier
+		}
+		store.Modules[modName] = ms
+
+		modPath := Path{Module: modName}
+		mergeContainer(&ms.Container, containerOf(orig), containerOf(over), modPath, ms.AllPure, ms.AllPureTier, &errs)
+	}
+	return store, errs
+}
+
+func originOf(orig, over *ModuleScope) Origin {
+	if over != nil {
+		return over.Container.Origin
+	}
+	if orig != nil {
+		return orig.Container.Origin
+	}
+	return Origin{}
+}
+
+func containerOf(ms *ModuleScope) *Container {
+	if ms == nil {
+		return nil
+	}
+	return &ms.Container
+}
+
+func mergeContainer(
+	dst, orig, over *Container,
+	owner Path,
+	allPure bool,
+	allPureTier OverrideTier,
+	errs *[]error,
+) {
+	// Free entries: union of names from both sides.
+	names := set.NewSet[string]()
+	if orig != nil {
+		for n := range orig.Free {
+			names.Add(n)
+		}
+	}
+	if over != nil {
+		for n := range over.Free {
+			names.Add(n)
+		}
+	}
+	for n := range names {
+		var oEff, vEff *Effective
+		if orig != nil {
+			oEff = orig.Free[n]
+		}
+		if over != nil {
+			vEff = over.Free[n]
+		}
+		leaf, err := mergeLeaf(oEff, vEff, withName(owner, n, KindFree, false), false /*allPure n/a for free*/, allPureTier, orig != nil)
+		if err != nil {
+			*errs = append(*errs, err)
+		}
+		if leaf != nil {
+			dst.Free[n] = leaf
+		}
+	}
+
+	// Children: union of names.
+	childNames := set.NewSet[string]()
+	if orig != nil {
+		for n := range orig.Children {
+			childNames.Add(n)
+		}
+	}
+	if over != nil {
+		for n := range over.Children {
+			childNames.Add(n)
+		}
+	}
+	for n := range childNames {
+		var oCh, vCh *ChildScope
+		if orig != nil {
+			oCh = orig.Children[n]
+		}
+		if over != nil {
+			vCh = over.Children[n]
+		}
+		mergedChild := mergeChild(oCh, vCh, withChildOwner(owner, n), allPure, allPureTier, errs)
+		if mergedChild != nil {
+			dst.Children[n] = mergedChild
+		}
+	}
+}
+
+func mergeChild(
+	orig, over *ChildScope,
+	owner Path,
+	allPure bool,
+	allPureTier OverrideTier,
+	errs *[]error,
+) *ChildScope {
+	dst := &ChildScope{
+		Container: newContainer(childOrigin(orig, over)),
+	}
+	// Decide shape: namespace (no Instance/Static on either side) or
+	// class/interface (Instance/Static populated).
+	hasMembers := (orig != nil && (orig.Instance != nil || orig.Static != nil)) ||
+		(over != nil && (over.Instance != nil || over.Static != nil))
+	if hasMembers {
+		dst.Instance = NewMemberSet()
+		dst.Static = NewMemberSet()
+	}
+
+	mergeContainer(&dst.Container, containerFromChild(orig), containerFromChild(over), owner, allPure, allPureTier, errs)
+
+	if hasMembers {
+		mergeMemberSet(dst.Instance, msFromChild(orig, false), msFromChild(over, false), owner, false, allPure, allPureTier, errs)
+		mergeMemberSet(dst.Static, msFromChild(orig, true), msFromChild(over, true), owner, true, allPure, allPureTier, errs)
+	}
+	return dst
+}
+
+func childOrigin(orig, over *ChildScope) Origin {
+	if over != nil {
+		return over.Container.Origin
+	}
+	if orig != nil {
+		return orig.Container.Origin
+	}
+	return Origin{}
+}
+
+func containerFromChild(c *ChildScope) *Container {
+	if c == nil {
+		return nil
+	}
+	return &c.Container
+}
+
+func msFromChild(c *ChildScope, static bool) *MemberSet {
+	if c == nil {
+		return nil
+	}
+	if static {
+		return c.Static
+	}
+	return c.Instance
+}
+
+func mergeMemberSet(
+	dst, orig, over *MemberSet,
+	owner Path,
+	static bool,
+	allPure bool,
+	allPureTier OverrideTier,
+	errs *[]error,
+) {
+	// @all_pure only strips mut from instance-method receivers; static
+	// methods have no receiver, so the flag is silenced on the static side.
+	mergeKind(orig, over, dst, owner, KindMethod, static, allPure && !static, allPureTier, errs)
+	mergeKind(orig, over, dst, owner, KindGetter, static, false, allPureTier, errs)
+	mergeKind(orig, over, dst, owner, KindSetter, static, false, allPureTier, errs)
+	mergeKind(orig, over, dst, owner, KindProperty, static, false, allPureTier, errs)
+
+	// Ctor is a single slot.
+	var oCtor, vCtor *Effective
+	if orig != nil {
+		oCtor = orig.Ctor
+	}
+	if over != nil {
+		vCtor = over.Ctor
+	}
+	leaf, err := mergeLeaf(oCtor, vCtor, withName(owner, "", KindCtor, static), false, allPureTier, orig != nil)
+	if err != nil {
+		*errs = append(*errs, err)
+	}
+	if leaf != nil {
+		dst.Ctor = leaf
+	}
+}
+
+func mergeKind(
+	orig, over, dst *MemberSet,
+	owner Path,
+	kind MemberKind,
+	static bool,
+	allPureForThisKind bool,
+	allPureTier OverrideTier,
+	errs *[]error,
+) {
+	oMap := kindMap(orig, kind)
+	vMap := kindMap(over, kind)
+	dMap := kindMap(dst, kind)
+	names := set.NewSet[string]()
+	for n := range oMap {
+		names.Add(n)
+	}
+	for n := range vMap {
+		names.Add(n)
+	}
+	origParentExists := orig != nil
+	for n := range names {
+		leaf, err := mergeLeaf(oMap[n], vMap[n], withName(owner, n, kind, static), allPureForThisKind, allPureTier, origParentExists)
+		if err != nil {
+			*errs = append(*errs, err)
+		}
+		if leaf != nil {
+			dMap[n] = leaf
+		}
+	}
+}
+
+func kindMap(ms *MemberSet, kind MemberKind) map[string]*Effective {
+	if ms == nil {
+		return nil
+	}
+	switch kind {
+	case KindMethod:
+		return ms.Methods
+	case KindGetter:
+		return ms.Getters
+	case KindSetter:
+		return ms.Setters
+	case KindProperty:
+		return ms.Properties
+	}
+	return nil
+}
+
+// mergeLeaf produces the merged Effective for a single slot:
+//   - both nil: returns nil (caller does not set).
+//   - only orig: return a fresh Effective with Source unstamped.
+//   - only over: ErrUnknownMember when the parent original scope was
+//     present (origParentExists==true) — the override targets a
+//     non-existent sibling. When the parent was absent
+//     (origParentExists==false) the override is emitted as-is per §5.7.
+//   - both: replace with override; run consistency check when both
+//     are *FuncType.
+//
+// `allPureForKind` true means the slot is in the @all_pure-affected
+// set (i.e. an instance method). When true and only orig is present,
+// synthesise a stripped Effective.
+func mergeLeaf(
+	orig, over *Effective,
+	p Path,
+	allPureForKind bool,
+	allPureTier OverrideTier,
+	origParentExists bool,
+) (*Effective, error) {
+	switch {
+	case orig == nil && over == nil:
+		return nil, nil
+	case orig != nil && over == nil:
+		if allPureForKind {
+			return synthesiseAllPure(orig, allPureTier), nil
+		}
+		// Leave Source unstamped — Classify's lower tiers decide.
+		return &Effective{
+			Type:       orig.Type,
+			Provenance: orig.Provenance,
+		}, nil
+	case orig == nil && over != nil:
+		if origParentExists {
+			return over, &ErrUnknownMember{
+				Path:     p,
+				Override: lastOrigin(over.Provenance),
+			}
+		}
+		// Parent original wasn't pre-loaded — accept the override
+		// silently (no original to compare against).
+		return over, nil
+	default:
+		// Both: override replaces original. Consistency check on
+		// FuncType pairs (single-signature for now; CheckSet handles
+		// overload sets when packed under a union/intersection — left
+		// for follow-up).
+		if oFn, ok := orig.Type.(*type_system.FuncType); ok {
+			if vFn, ok2 := over.Type.(*type_system.FuncType); ok2 {
+				origin := lastOrigin(over.Provenance)
+				if err := Check(vFn, oFn, p, origin); err != nil {
+					return over, err
+				}
+			}
+		}
+		return over, nil
+	}
+}
+
+func synthesiseAllPure(orig *Effective, tier OverrideTier) *Effective {
+	fn, ok := orig.Type.(*type_system.FuncType)
+	if !ok || fn.SelfParam == nil {
+		// Not a receiver-bearing method; @all_pure doesn't apply.
+		return &Effective{
+			Type:       orig.Type,
+			Provenance: orig.Provenance,
+		}
+	}
+	stripped := stripMutSelf(fn)
+	return &Effective{
+		Type:       stripped,
+		Source:     tier.ResolutionTierFor(),
+		Provenance: orig.Provenance,
+	}
+}
+
+// stripMutSelf returns a shallow copy of fn with SelfParam.Type
+// unwrapped from MutType, if it was wrapped.
+func stripMutSelf(fn *type_system.FuncType) *type_system.FuncType {
+	if fn.SelfParam == nil {
+		return fn
+	}
+	mt, ok := fn.SelfParam.Type.(*type_system.MutType)
+	if !ok {
+		return fn
+	}
+	cp := *fn
+	cp.SelfParam = &type_system.FuncParam{
+		Pattern:  fn.SelfParam.Pattern,
+		Type:     mt.Type,
+		Optional: fn.SelfParam.Optional,
+	}
+	return &cp
+}
+
+func lastOrigin(ps []Origin) Origin {
+	if len(ps) == 0 {
+		return Origin{}
+	}
+	return ps[len(ps)-1]
+}
+
+// withName returns owner with Name/Kind/Static set.
+func withName(owner Path, name string, kind MemberKind, static bool) Path {
+	if name != "" {
+		owner.Name = dts_parser.NewIdent(name, ast.Span{})
+	} else {
+		owner.Name = nil
+	}
+	owner.Kind = kind
+	owner.Static = static
+	return owner
+}
+
+func withChildOwner(owner Path, child string) Path {
+	// Append the child segment onto Owner via dts_parser.Member chain.
+	// For now we use a synthetic identifier wrapper since the merge
+	// only consumes Owner for diagnostics.
+	cp := owner
+	cp.Owner = appendOwner(owner.Owner, child)
+	return cp
+}

--- a/internal/interop/merge_test.go
+++ b/internal/interop/merge_test.go
@@ -1,0 +1,118 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+func mkFn() *type_system.FuncType {
+	return type_system.NewFuncType(nil, nil, nil, nil, nil)
+}
+
+func TestCollapseShadowing(t *testing.T) {
+	fnUser := mkFn()
+	fnShipped := mkFn()
+	userProject := map[string]*ModuleScope{
+		"lodash": {
+			Container: Container{
+				Free: map[string]*Effective{
+					"map": {Type: fnUser},
+				},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	shipped := map[string]*ModuleScope{
+		"lodash": {
+			Container: Container{
+				Free: map[string]*Effective{
+					"map":    {Type: fnShipped},
+					"filter": {Type: fnShipped},
+				},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	out := Collapse(
+		[]map[string]*ModuleScope{userProject, shipped},
+		[]OverrideTier{OverrideTierUserProject, OverrideTierShipped},
+	)
+	mod := out["lodash"]
+	if mod == nil {
+		t.Fatal("expected lodash in collapsed output")
+	}
+	if got := mod.Free["map"]; got == nil || got.Type != fnUser {
+		t.Fatalf("user-project entry should win; got %#v", got)
+	}
+	if got := mod.Free["map"]; got.Source != TierUserOverride {
+		t.Fatalf("expected Source=TierUserOverride; got %v", got.Source)
+	}
+	if got := mod.Free["filter"]; got == nil || got.Type != fnShipped {
+		t.Fatalf("shipped-only entry should survive; got %#v", got)
+	}
+	if got := mod.Free["filter"]; got.Source != TierShippedOverride {
+		t.Fatalf("expected Source=TierShippedOverride; got %v", got.Source)
+	}
+}
+
+func TestMergeOverrideReplacesOriginal(t *testing.T) {
+	origFn := mkFn()
+	overFn := mkFn()
+	original := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free: map[string]*Effective{
+					"identity": {Type: origFn},
+				},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	override := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free: map[string]*Effective{
+					"identity": {Type: overFn, Source: TierUserOverride},
+				},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	store, errs := Merge(original, override)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected merge errors: %v", errs)
+	}
+	got := store.Modules[""].Free["identity"]
+	if got == nil || got.Type != overFn {
+		t.Fatalf("override should replace original; got %#v", got)
+	}
+}
+
+func TestMergePassesThroughOriginalWithoutOverride(t *testing.T) {
+	origFn := mkFn()
+	original := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free: map[string]*Effective{
+					"identity": {Type: origFn},
+				},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	store, errs := Merge(original, nil)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	got := store.Modules[""].Free["identity"]
+	if got == nil || got.Type != origFn {
+		t.Fatalf("original should pass through; got %#v", got)
+	}
+	// TierUserSource is the zero value of ResolutionTier, used here as
+	// the "unstamped" sentinel for original-only leaves — Classify's
+	// lower tiers then decide the final tier.
+	if got.Source != TierUserSource {
+		t.Fatalf("expected unstamped Source (TierUserSource sentinel); got %v", got.Source)
+	}
+}

--- a/internal/interop/merge_test.go
+++ b/internal/interop/merge_test.go
@@ -452,6 +452,37 @@ func TestMergeExplicitMutSelfOverrideWins(t *testing.T) {
 	require.Same(t, receiver, fn.SelfParam.Type)
 }
 
+// TestMergeShapeConflictBetweenOriginalAndOverride: when the original
+// has a child as one variant (namespace) and the override has the same
+// child as a different variant (class), the merge proceeds with the
+// override's variant but reports *ErrShapeConflict so the caller can
+// distinguish a shape clash from a duplicate-member collision.
+func TestMergeShapeConflictBetweenOriginalAndOverride(t *testing.T) {
+	original := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free: map[string]*Effective{},
+			Children: map[string]ChildScope{
+				"C": &NamespaceScope{Container: Container{
+					Free:     map[string]*Effective{},
+					Children: map[string]ChildScope{},
+				}},
+			},
+		}},
+	}
+	override := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free: map[string]*Effective{},
+			Children: map[string]ChildScope{
+				"C": &ClassScope{Instance: NewMemberSet(), Static: NewMemberSet()},
+			},
+		}},
+	}
+	_, errs := Merge(original, override)
+	require.Len(t, errs, 1)
+	_, ok := errs[0].(*ErrShapeConflict)
+	require.True(t, ok, "expected *ErrShapeConflict; got %T", errs[0])
+}
+
 // TestMergeNamespaceNestedOverrideMatchesOriginal: an override targets
 // a function inside a nested namespace (e.g. `lodash.fp.map`). The
 // merger must descend through Container.Children to the matching

--- a/internal/interop/merge_test.go
+++ b/internal/interop/merge_test.go
@@ -157,3 +157,186 @@ func TestMergePassesThroughOriginalWithoutOverride(t *testing.T) {
 	// lower tiers then decide the final tier.
 	require.Equal(t, TierUserSource, got.Source)
 }
+
+// TestMergeAllPureStripsMutSelf: @all_pure on the override module side
+// rewrites instance methods that have only an original to drop their
+// `mut self` receiver wrapping.
+func TestMergeAllPureStripsMutSelf(t *testing.T) {
+	receiver := type_system.NewNumPrimType(nil)
+	mutReceiver := type_system.NewMutType(nil, receiver)
+	origMethod := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	origMethod.SelfParam = &type_system.FuncParam{Type: mutReceiver}
+
+	original := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free: map[string]*Effective{},
+				Children: map[string]*ChildScope{
+					"C": {
+						Container: Container{
+							Free:     map[string]*Effective{},
+							Children: map[string]*ChildScope{},
+						},
+						Instance: &MemberSet{
+							Methods:    map[string]*Effective{"m": {Type: origMethod}},
+							Getters:    map[string]*Effective{},
+							Setters:    map[string]*Effective{},
+							Properties: map[string]*Effective{},
+						},
+						Static: NewMemberSet(),
+					},
+				},
+			},
+		},
+	}
+	// Override module declares @all_pure but does not redeclare C.m.
+	override := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free:     map[string]*Effective{},
+				Children: map[string]*ChildScope{},
+			},
+			AllPure:     true,
+			AllPureTier: OverrideTierUserProject,
+		},
+	}
+
+	store, errs := Merge(original, override)
+	require.Empty(t, errs)
+	got := store.Modules[""].Children["C"].Instance.Methods["m"]
+	require.NotNil(t, got)
+	fn, ok := got.Type.(*type_system.FuncType)
+	require.True(t, ok, "expected merged method to remain a FuncType")
+	require.NotNil(t, fn.SelfParam)
+	_, stillMut := fn.SelfParam.Type.(*type_system.MutType)
+	require.False(t, stillMut, "@all_pure must unwrap MutType from instance method receiver")
+	require.Same(t, receiver, fn.SelfParam.Type)
+	require.Equal(t, TierUserOverride, got.Source)
+}
+
+// TestMergeUnknownMemberWhenOverrideOnlyAndParentExists: an override
+// adds a free name the original side does not declare, while the
+// original parent (module) was pre-loaded — that is `ErrUnknownMember`.
+func TestMergeUnknownMemberWhenOverrideOnlyAndParentExists(t *testing.T) {
+	origFn := mkFn()
+	overFn := mkFn()
+	original := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free:     map[string]*Effective{"foo": {Type: origFn}},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	override := map[string]*ModuleScope{
+		"": {
+			Container: Container{
+				Free:     map[string]*Effective{"bar": {Type: overFn, Source: TierUserOverride}},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	store, errs := Merge(original, override)
+	require.Len(t, errs, 1)
+	_, ok := errs[0].(*ErrUnknownMember)
+	require.True(t, ok, "expected *ErrUnknownMember; got %T", errs[0])
+
+	// The override-only leaf is still emitted into the store so downstream
+	// queries can find it; the error tells the user it has nothing to
+	// compare against.
+	require.NotNil(t, store.Modules[""].Free["bar"])
+}
+
+// TestMergeUnknownMemberSuppressedWhenParentOriginalAbsent: when the
+// parent module wasn't pre-loaded on the original side, an override-only
+// leaf is accepted silently (per §5.7).
+func TestMergeUnknownMemberSuppressedWhenParentOriginalAbsent(t *testing.T) {
+	overFn := mkFn()
+	override := map[string]*ModuleScope{
+		"lodash": {
+			Container: Container{
+				Free:     map[string]*Effective{"map": {Type: overFn, Source: TierUserOverride}},
+				Children: map[string]*ChildScope{},
+			},
+		},
+	}
+	store, errs := Merge(nil, override)
+	require.Empty(t, errs)
+	require.NotNil(t, store.Modules["lodash"].Free["map"])
+}
+
+// TestMergeCtorOverrideReplacesOriginal: the constructor slot is single
+// per class; an override Ctor replaces the original Ctor.
+func TestMergeCtorOverrideReplacesOriginal(t *testing.T) {
+	origCtor := mkFn()
+	overCtor := mkFn()
+	mkClass := func(ctor *type_system.FuncType) *ChildScope {
+		return &ChildScope{
+			Container: Container{
+				Free:     map[string]*Effective{},
+				Children: map[string]*ChildScope{},
+			},
+			Instance: &MemberSet{
+				Methods:    map[string]*Effective{},
+				Getters:    map[string]*Effective{},
+				Setters:    map[string]*Effective{},
+				Properties: map[string]*Effective{},
+				Ctor:       &Effective{Type: ctor},
+			},
+			Static: NewMemberSet(),
+		}
+	}
+	original := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free:     map[string]*Effective{},
+			Children: map[string]*ChildScope{"C": mkClass(origCtor)},
+		}},
+	}
+	override := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free:     map[string]*Effective{},
+			Children: map[string]*ChildScope{"C": mkClass(overCtor)},
+		}},
+	}
+	store, errs := Merge(original, override)
+	require.Empty(t, errs)
+	got := store.Modules[""].Children["C"].Instance.Ctor
+	require.NotNil(t, got)
+	require.Same(t, overCtor, got.Type)
+}
+
+// TestMergeFuncTypeMismatchSurfacesError: when both sides have a
+// *FuncType at the same slot and signatures disagree, `Check` runs and
+// returns *ErrSignatureMismatch, but the override still wins in the
+// merged store.
+func TestMergeFuncTypeMismatchSurfacesError(t *testing.T) {
+	num := type_system.NewNumPrimType(nil)
+	str := type_system.NewStrPrimType(nil)
+	origFn := type_system.NewFuncType(
+		nil, nil,
+		[]*type_system.FuncParam{{Type: num}},
+		num, nil,
+	)
+	overFn := type_system.NewFuncType(
+		nil, nil,
+		[]*type_system.FuncParam{{Type: num}, {Type: str}},
+		num, nil,
+	)
+	original := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free:     map[string]*Effective{"f": {Type: origFn}},
+			Children: map[string]*ChildScope{},
+		}},
+	}
+	override := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free:     map[string]*Effective{"f": {Type: overFn, Source: TierUserOverride}},
+			Children: map[string]*ChildScope{},
+		}},
+	}
+	store, errs := Merge(original, override)
+	require.Len(t, errs, 1)
+	_, ok := errs[0].(*ErrSignatureMismatch)
+	require.True(t, ok, "expected *ErrSignatureMismatch; got %T", errs[0])
+	require.Same(t, overFn, store.Modules[""].Free["f"].Type)
+}

--- a/internal/interop/merge_test.go
+++ b/internal/interop/merge_test.go
@@ -13,59 +13,57 @@ func mkFn() *type_system.FuncType {
 
 func TestCollapseShadowing(t *testing.T) {
 	fnUser := mkFn()
-	fnShipped := mkFn()
+	fnBuiltin := mkFn()
 	userProject := map[string]*ModuleScope{
 		"lodash": {
 			Container: Container{
 				Free: map[string]*Effective{
 					"map": {Type: fnUser},
 				},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
-	shipped := map[string]*ModuleScope{
+	builtin := map[string]*ModuleScope{
 		"lodash": {
 			Container: Container{
 				Free: map[string]*Effective{
-					"map":    {Type: fnShipped},
-					"filter": {Type: fnShipped},
+					"map":    {Type: fnBuiltin},
+					"filter": {Type: fnBuiltin},
 				},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
-	out := Collapse(
-		[]map[string]*ModuleScope{userProject, shipped},
-		[]OverrideTier{OverrideTierUserProject, OverrideTierShipped},
-	)
+	out := Collapse(userProject, nil, builtin)
 	mod := out["lodash"]
 	require.NotNil(t, mod, "expected lodash in collapsed output")
 	require.NotNil(t, mod.Free["map"])
 	require.Same(t, fnUser, mod.Free["map"].Type)
 	require.Equal(t, TierUserOverride, mod.Free["map"].Source)
 	require.NotNil(t, mod.Free["filter"])
-	require.Same(t, fnShipped, mod.Free["filter"].Type)
-	require.Equal(t, TierShippedOverride, mod.Free["filter"].Source)
+	require.Same(t, fnBuiltin, mod.Free["filter"].Type)
+	require.Equal(t, TierBuiltinOverride, mod.Free["filter"].Source)
 }
 
-// TestCollapseChildMemberSetAcrossTiers exercises the case where an
-// earlier (higher-precedence) tier introduces a child as a namespace
-// (Instance/Static nil) and a later tier introduces the same child as a
-// class with members. The later tier's members should still merge into
-// the collapsed child rather than being silently dropped.
-func TestCollapseChildMemberSetAcrossTiers(t *testing.T) {
+// TestCollapseChildShapeMismatchHigherTierWins exercises cross-tier
+// shape conflict: the higher-precedence tier declares a child as one
+// variant (e.g. namespace) and a lower tier declares the same name as
+// a different variant (e.g. class). With the sum-type ChildScope, the
+// shapes can't merge — higher tier wins wholesale, the lower tier's
+// variant is silently dropped.
+func TestCollapseChildShapeMismatchHigherTierWins(t *testing.T) {
 	fnMethod := mkFn()
 	// Higher tier: child "C" as a namespace.
 	userProject := map[string]*ModuleScope{
 		"m": {
 			Container: Container{
 				Free: map[string]*Effective{},
-				Children: map[string]*ChildScope{
-					"C": {
+				Children: map[string]ChildScope{
+					"C": &NamespaceScope{
 						Container: Container{
 							Free:     map[string]*Effective{},
-							Children: map[string]*ChildScope{},
+							Children: map[string]ChildScope{},
 						},
 					},
 				},
@@ -73,36 +71,82 @@ func TestCollapseChildMemberSetAcrossTiers(t *testing.T) {
 		},
 	}
 	// Lower tier: child "C" as a class with an instance method.
-	shippedInstance := NewMemberSet()
-	shippedInstance.Methods["m"] = &Effective{Type: fnMethod}
-	shipped := map[string]*ModuleScope{
+	builtinInstance := NewMemberSet()
+	builtinInstance.Methods["m"] = &Effective{Type: fnMethod}
+	builtin := map[string]*ModuleScope{
 		"m": {
 			Container: Container{
 				Free: map[string]*Effective{},
-				Children: map[string]*ChildScope{
-					"C": {
-						Container: Container{
-							Free:     map[string]*Effective{},
-							Children: map[string]*ChildScope{},
-						},
-						Instance: shippedInstance,
+				Children: map[string]ChildScope{
+					"C": &ClassScope{
+						Instance: builtinInstance,
+						Static:   NewMemberSet(),
 					},
 				},
 			},
 		},
 	}
-	out := Collapse(
-		[]map[string]*ModuleScope{userProject, shipped},
-		[]OverrideTier{OverrideTierUserProject, OverrideTierShipped},
-	)
+	out := Collapse(userProject, nil, builtin)
 	mod := out["m"]
 	require.NotNil(t, mod)
-	child := mod.Children["C"]
-	require.NotNil(t, child)
-	require.NotNil(t, child.Instance, "Instance should be allocated when a later tier introduces members")
-	require.NotNil(t, child.Instance.Methods["m"])
-	require.Same(t, fnMethod, child.Instance.Methods["m"].Type)
-	require.Equal(t, TierShippedOverride, child.Instance.Methods["m"].Source)
+	// Higher tier wins: the merged child is a NamespaceScope. The
+	// builtin's class methods are dropped — shapes do not merge.
+	_, ok := mod.Children["C"].(*NamespaceScope)
+	require.True(t, ok, "expected merged child to remain a *NamespaceScope (higher tier wins)")
+}
+
+// TestCollapseChildSameShapeAcrossTiers exercises the normal case:
+// both tiers declare the child with the same variant. Per-slot
+// precedence applies — higher tier wins per name, lower tier fills in
+// any names the higher tier didn't supply.
+func TestCollapseChildSameShapeAcrossTiers(t *testing.T) {
+	fnHigh := mkFn()
+	fnLow := mkFn()
+	// Higher tier: class "C" with method "a".
+	userProject := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free: map[string]*Effective{},
+				Children: map[string]ChildScope{
+					"C": &ClassScope{
+						Instance: &MemberSet{
+							Methods:    map[string]*Effective{"a": {Type: fnHigh}},
+							Getters:    map[string]*Effective{},
+							Setters:    map[string]*Effective{},
+							Properties: map[string]*Effective{},
+						},
+						Static: NewMemberSet(),
+					},
+				},
+			},
+		},
+	}
+	// Lower tier: class "C" with method "b" (different name, fills in).
+	builtin := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free: map[string]*Effective{},
+				Children: map[string]ChildScope{
+					"C": &ClassScope{
+						Instance: &MemberSet{
+							Methods:    map[string]*Effective{"b": {Type: fnLow}},
+							Getters:    map[string]*Effective{},
+							Setters:    map[string]*Effective{},
+							Properties: map[string]*Effective{},
+						},
+						Static: NewMemberSet(),
+					},
+				},
+			},
+		},
+	}
+	out := Collapse(userProject, nil, builtin)
+	cls, ok := out["m"].Children["C"].(*ClassScope)
+	require.True(t, ok)
+	require.Same(t, fnHigh, cls.Instance.Methods["a"].Type)
+	require.Equal(t, TierUserOverride, cls.Instance.Methods["a"].Source)
+	require.Same(t, fnLow, cls.Instance.Methods["b"].Type)
+	require.Equal(t, TierBuiltinOverride, cls.Instance.Methods["b"].Source)
 }
 
 func TestMergeOverrideReplacesOriginal(t *testing.T) {
@@ -114,7 +158,7 @@ func TestMergeOverrideReplacesOriginal(t *testing.T) {
 				Free: map[string]*Effective{
 					"identity": {Type: origFn},
 				},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
@@ -124,7 +168,7 @@ func TestMergeOverrideReplacesOriginal(t *testing.T) {
 				Free: map[string]*Effective{
 					"identity": {Type: overFn, Source: TierUserOverride},
 				},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
@@ -143,7 +187,7 @@ func TestMergePassesThroughOriginalWithoutOverride(t *testing.T) {
 				Free: map[string]*Effective{
 					"identity": {Type: origFn},
 				},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
@@ -153,8 +197,8 @@ func TestMergePassesThroughOriginalWithoutOverride(t *testing.T) {
 	require.NotNil(t, got)
 	require.Same(t, origFn, got.Type)
 	// TierUserSource is the zero value of ResolutionTier, used here as
-	// the "unstamped" sentinel for original-only leaves — Classify's
-	// lower tiers then decide the final tier.
+	// the "Source left unset" sentinel for original-only leaves —
+	// Classify's lower tiers then decide the final tier.
 	require.Equal(t, TierUserSource, got.Source)
 }
 
@@ -171,12 +215,8 @@ func TestMergeAllPureStripsMutSelf(t *testing.T) {
 		"": {
 			Container: Container{
 				Free: map[string]*Effective{},
-				Children: map[string]*ChildScope{
-					"C": {
-						Container: Container{
-							Free:     map[string]*Effective{},
-							Children: map[string]*ChildScope{},
-						},
+				Children: map[string]ChildScope{
+					"C": &ClassScope{
 						Instance: &MemberSet{
 							Methods:    map[string]*Effective{"m": {Type: origMethod}},
 							Getters:    map[string]*Effective{},
@@ -194,7 +234,7 @@ func TestMergeAllPureStripsMutSelf(t *testing.T) {
 		"": {
 			Container: Container{
 				Free:     map[string]*Effective{},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 			AllPure:     true,
 			AllPureTier: OverrideTierUserProject,
@@ -203,7 +243,9 @@ func TestMergeAllPureStripsMutSelf(t *testing.T) {
 
 	store, errs := Merge(original, override)
 	require.Empty(t, errs)
-	got := store.Modules[""].Children["C"].Instance.Methods["m"]
+	mergedC, ok := store.Modules[""].Children["C"].(*ClassScope)
+	require.True(t, ok)
+	got := mergedC.Instance.Methods["m"]
 	require.NotNil(t, got)
 	fn, ok := got.Type.(*type_system.FuncType)
 	require.True(t, ok, "expected merged method to remain a FuncType")
@@ -224,7 +266,7 @@ func TestMergeUnknownMemberWhenOverrideOnlyAndParentExists(t *testing.T) {
 		"": {
 			Container: Container{
 				Free:     map[string]*Effective{"foo": {Type: origFn}},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
@@ -232,7 +274,7 @@ func TestMergeUnknownMemberWhenOverrideOnlyAndParentExists(t *testing.T) {
 		"": {
 			Container: Container{
 				Free:     map[string]*Effective{"bar": {Type: overFn, Source: TierUserOverride}},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
@@ -247,21 +289,26 @@ func TestMergeUnknownMemberWhenOverrideOnlyAndParentExists(t *testing.T) {
 	require.NotNil(t, store.Modules[""].Free["bar"])
 }
 
-// TestMergeUnknownMemberSuppressedWhenParentOriginalAbsent: when the
-// parent module wasn't pre-loaded on the original side, an override-only
-// leaf is accepted silently (per §5.7).
-func TestMergeUnknownMemberSuppressedWhenParentOriginalAbsent(t *testing.T) {
+// TestMergeUnknownMemberWhenParentOriginalAbsent: every Escalier
+// library ships .d.ts for TS back-compat (requirements.md §F), so an
+// override that targets a module with no original side is a caller
+// bug (originals weren't pre-loaded) or a typo. Either way the
+// override leaf is still emitted into the store, but ErrUnknownMember
+// is reported so the caller notices.
+func TestMergeUnknownMemberWhenParentOriginalAbsent(t *testing.T) {
 	overFn := mkFn()
 	override := map[string]*ModuleScope{
 		"lodash": {
 			Container: Container{
 				Free:     map[string]*Effective{"map": {Type: overFn, Source: TierUserOverride}},
-				Children: map[string]*ChildScope{},
+				Children: map[string]ChildScope{},
 			},
 		},
 	}
 	store, errs := Merge(nil, override)
-	require.Empty(t, errs)
+	require.Len(t, errs, 1)
+	_, ok := errs[0].(*ErrUnknownMember)
+	require.True(t, ok, "expected *ErrUnknownMember; got %T", errs[0])
 	require.NotNil(t, store.Modules["lodash"].Free["map"])
 }
 
@@ -270,12 +317,8 @@ func TestMergeUnknownMemberSuppressedWhenParentOriginalAbsent(t *testing.T) {
 func TestMergeCtorOverrideReplacesOriginal(t *testing.T) {
 	origCtor := mkFn()
 	overCtor := mkFn()
-	mkClass := func(ctor *type_system.FuncType) *ChildScope {
-		return &ChildScope{
-			Container: Container{
-				Free:     map[string]*Effective{},
-				Children: map[string]*ChildScope{},
-			},
+	mkClass := func(ctor *type_system.FuncType) *ClassScope {
+		return &ClassScope{
 			Instance: &MemberSet{
 				Methods:    map[string]*Effective{},
 				Getters:    map[string]*Effective{},
@@ -289,18 +332,20 @@ func TestMergeCtorOverrideReplacesOriginal(t *testing.T) {
 	original := map[string]*ModuleScope{
 		"": {Container: Container{
 			Free:     map[string]*Effective{},
-			Children: map[string]*ChildScope{"C": mkClass(origCtor)},
+			Children: map[string]ChildScope{"C": mkClass(origCtor)},
 		}},
 	}
 	override := map[string]*ModuleScope{
 		"": {Container: Container{
 			Free:     map[string]*Effective{},
-			Children: map[string]*ChildScope{"C": mkClass(overCtor)},
+			Children: map[string]ChildScope{"C": mkClass(overCtor)},
 		}},
 	}
 	store, errs := Merge(original, override)
 	require.Empty(t, errs)
-	got := store.Modules[""].Children["C"].Instance.Ctor
+	mergedC, ok := store.Modules[""].Children["C"].(*ClassScope)
+	require.True(t, ok)
+	got := mergedC.Instance.Ctor
 	require.NotNil(t, got)
 	require.Same(t, overCtor, got.Type)
 }
@@ -325,13 +370,13 @@ func TestMergeFuncTypeMismatchSurfacesError(t *testing.T) {
 	original := map[string]*ModuleScope{
 		"": {Container: Container{
 			Free:     map[string]*Effective{"f": {Type: origFn}},
-			Children: map[string]*ChildScope{},
+			Children: map[string]ChildScope{},
 		}},
 	}
 	override := map[string]*ModuleScope{
 		"": {Container: Container{
 			Free:     map[string]*Effective{"f": {Type: overFn, Source: TierUserOverride}},
-			Children: map[string]*ChildScope{},
+			Children: map[string]ChildScope{},
 		}},
 	}
 	store, errs := Merge(original, override)
@@ -339,4 +384,112 @@ func TestMergeFuncTypeMismatchSurfacesError(t *testing.T) {
 	_, ok := errs[0].(*ErrSignatureMismatch)
 	require.True(t, ok, "expected *ErrSignatureMismatch; got %T", errs[0])
 	require.Same(t, overFn, store.Modules[""].Free["f"].Type)
+}
+
+// TestMergeExplicitMutSelfOverrideWins: an override declares a method
+// with `self` (bare receiver) against an original that declared the
+// same method with `mut self` (MutType-wrapped receiver). Merge picks
+// the override; the consistency check intentionally excludes SelfParam
+// mode from equivalence (see consistency.go funcSignatureEquivalent —
+// "that's the field the override is allowed to change"), so no error
+// is raised. The bare receiver lands in the merged store.
+//
+// This is the canonical receiver-mutability refinement that the whole
+// interop-mutability subsystem exists to support. If consistency
+// equivalence ever starts checking SelfParam, this test fails — which
+// is the invariant we want to lock in.
+func TestMergeExplicitMutSelfOverrideWins(t *testing.T) {
+	receiver := type_system.NewNumPrimType(nil)
+	mutReceiver := type_system.NewMutType(nil, receiver)
+
+	// Original-side method on class C: takes `mut self`.
+	origMethod := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	origMethod.SelfParam = &type_system.FuncParam{Type: mutReceiver}
+
+	// Override-side method on class C: takes plain `self` (bare
+	// receiver, not wrapped in MutType). Same return type and arity.
+	overMethod := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	overMethod.SelfParam = &type_system.FuncParam{Type: receiver}
+
+	mkClassWithMethod := func(fn *type_system.FuncType, source ResolutionTier) *ClassScope {
+		return &ClassScope{
+			Instance: &MemberSet{
+				Methods:    map[string]*Effective{"m": {Type: fn, Source: source}},
+				Getters:    map[string]*Effective{},
+				Setters:    map[string]*Effective{},
+				Properties: map[string]*Effective{},
+			},
+			Static: NewMemberSet(),
+		}
+	}
+
+	original := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free:     map[string]*Effective{},
+			Children: map[string]ChildScope{"C": mkClassWithMethod(origMethod, 0)},
+		}},
+	}
+	override := map[string]*ModuleScope{
+		"": {Container: Container{
+			Free:     map[string]*Effective{},
+			Children: map[string]ChildScope{"C": mkClassWithMethod(overMethod, TierUserOverride)},
+		}},
+	}
+
+	store, errs := Merge(original, override)
+	require.Empty(t, errs,
+		"receiver-mutability override must not trip the consistency check")
+
+	mergedC, ok := store.Modules[""].Children["C"].(*ClassScope)
+	require.True(t, ok)
+	got := mergedC.Instance.Methods["m"]
+	require.NotNil(t, got)
+	fn, ok := got.Type.(*type_system.FuncType)
+	require.True(t, ok)
+	require.NotNil(t, fn.SelfParam)
+	_, stillMut := fn.SelfParam.Type.(*type_system.MutType)
+	require.False(t, stillMut, "merged method must keep the override's bare receiver")
+	require.Same(t, receiver, fn.SelfParam.Type)
+}
+
+// TestMergeNamespaceNestedOverrideMatchesOriginal: an override targets
+// a function inside a nested namespace (e.g. `lodash.fp.map`). The
+// merger must descend through Container.Children to the matching
+// namespace child on the original side, replace the leaf, and not emit
+// ErrUnknownMember.
+func TestMergeNamespaceNestedOverrideMatchesOriginal(t *testing.T) {
+	origFn := mkFn()
+	overFn := mkFn()
+
+	// Build a NamespaceScope with `map` as a free function in its Container.
+	mkNamespaceWithMap := func(fn *type_system.FuncType, source ResolutionTier) *NamespaceScope {
+		return &NamespaceScope{
+			Container: Container{
+				Free:     map[string]*Effective{"map": {Type: fn, Source: source}},
+				Children: map[string]ChildScope{},
+			},
+		}
+	}
+
+	original := map[string]*ModuleScope{
+		"lodash": {Container: Container{
+			Free:     map[string]*Effective{},
+			Children: map[string]ChildScope{"fp": mkNamespaceWithMap(origFn, 0)},
+		}},
+	}
+	override := map[string]*ModuleScope{
+		"lodash": {Container: Container{
+			Free:     map[string]*Effective{},
+			Children: map[string]ChildScope{"fp": mkNamespaceWithMap(overFn, TierUserOverride)},
+		}},
+	}
+
+	store, errs := Merge(original, override)
+	require.Empty(t, errs, "nested-namespace override should match the original at the same path")
+
+	mergedFp, ok := store.Modules["lodash"].Children["fp"].(*NamespaceScope)
+	require.True(t, ok, "merged namespace must remain shape-namespace, not class")
+	got := mergedFp.Container.Free["map"]
+	require.NotNil(t, got)
+	require.Same(t, overFn, got.Type, "override should replace original at the nested path")
 }

--- a/internal/interop/merge_test.go
+++ b/internal/interop/merge_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
 )
 
 func mkFn() *type_system.FuncType {
@@ -39,21 +40,69 @@ func TestCollapseShadowing(t *testing.T) {
 		[]OverrideTier{OverrideTierUserProject, OverrideTierShipped},
 	)
 	mod := out["lodash"]
-	if mod == nil {
-		t.Fatal("expected lodash in collapsed output")
+	require.NotNil(t, mod, "expected lodash in collapsed output")
+	require.NotNil(t, mod.Free["map"])
+	require.Same(t, fnUser, mod.Free["map"].Type)
+	require.Equal(t, TierUserOverride, mod.Free["map"].Source)
+	require.NotNil(t, mod.Free["filter"])
+	require.Same(t, fnShipped, mod.Free["filter"].Type)
+	require.Equal(t, TierShippedOverride, mod.Free["filter"].Source)
+}
+
+// TestCollapseChildMemberSetAcrossTiers exercises the case where an
+// earlier (higher-precedence) tier introduces a child as a namespace
+// (Instance/Static nil) and a later tier introduces the same child as a
+// class with members. The later tier's members should still merge into
+// the collapsed child rather than being silently dropped.
+func TestCollapseChildMemberSetAcrossTiers(t *testing.T) {
+	fnMethod := mkFn()
+	// Higher tier: child "C" as a namespace.
+	userProject := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free: map[string]*Effective{},
+				Children: map[string]*ChildScope{
+					"C": {
+						Container: Container{
+							Free:     map[string]*Effective{},
+							Children: map[string]*ChildScope{},
+						},
+					},
+				},
+			},
+		},
 	}
-	if got := mod.Free["map"]; got == nil || got.Type != fnUser {
-		t.Fatalf("user-project entry should win; got %#v", got)
+	// Lower tier: child "C" as a class with an instance method.
+	shippedInstance := NewMemberSet()
+	shippedInstance.Methods["m"] = &Effective{Type: fnMethod}
+	shipped := map[string]*ModuleScope{
+		"m": {
+			Container: Container{
+				Free: map[string]*Effective{},
+				Children: map[string]*ChildScope{
+					"C": {
+						Container: Container{
+							Free:     map[string]*Effective{},
+							Children: map[string]*ChildScope{},
+						},
+						Instance: shippedInstance,
+					},
+				},
+			},
+		},
 	}
-	if got := mod.Free["map"]; got.Source != TierUserOverride {
-		t.Fatalf("expected Source=TierUserOverride; got %v", got.Source)
-	}
-	if got := mod.Free["filter"]; got == nil || got.Type != fnShipped {
-		t.Fatalf("shipped-only entry should survive; got %#v", got)
-	}
-	if got := mod.Free["filter"]; got.Source != TierShippedOverride {
-		t.Fatalf("expected Source=TierShippedOverride; got %v", got.Source)
-	}
+	out := Collapse(
+		[]map[string]*ModuleScope{userProject, shipped},
+		[]OverrideTier{OverrideTierUserProject, OverrideTierShipped},
+	)
+	mod := out["m"]
+	require.NotNil(t, mod)
+	child := mod.Children["C"]
+	require.NotNil(t, child)
+	require.NotNil(t, child.Instance, "Instance should be allocated when a later tier introduces members")
+	require.NotNil(t, child.Instance.Methods["m"])
+	require.Same(t, fnMethod, child.Instance.Methods["m"].Type)
+	require.Equal(t, TierShippedOverride, child.Instance.Methods["m"].Source)
 }
 
 func TestMergeOverrideReplacesOriginal(t *testing.T) {
@@ -80,13 +129,10 @@ func TestMergeOverrideReplacesOriginal(t *testing.T) {
 		},
 	}
 	store, errs := Merge(original, override)
-	if len(errs) > 0 {
-		t.Fatalf("unexpected merge errors: %v", errs)
-	}
+	require.Empty(t, errs)
 	got := store.Modules[""].Free["identity"]
-	if got == nil || got.Type != overFn {
-		t.Fatalf("override should replace original; got %#v", got)
-	}
+	require.NotNil(t, got)
+	require.Same(t, overFn, got.Type)
 }
 
 func TestMergePassesThroughOriginalWithoutOverride(t *testing.T) {
@@ -102,17 +148,12 @@ func TestMergePassesThroughOriginalWithoutOverride(t *testing.T) {
 		},
 	}
 	store, errs := Merge(original, nil)
-	if len(errs) > 0 {
-		t.Fatalf("unexpected errors: %v", errs)
-	}
+	require.Empty(t, errs)
 	got := store.Modules[""].Free["identity"]
-	if got == nil || got.Type != origFn {
-		t.Fatalf("original should pass through; got %#v", got)
-	}
+	require.NotNil(t, got)
+	require.Same(t, origFn, got.Type)
 	// TierUserSource is the zero value of ResolutionTier, used here as
 	// the "unstamped" sentinel for original-only leaves — Classify's
 	// lower tiers then decide the final tier.
-	if got.Source != TierUserSource {
-		t.Fatalf("expected unstamped Source (TierUserSource sentinel); got %v", got.Source)
-	}
+	require.Equal(t, TierUserSource, got.Source)
 }

--- a/internal/interop/mutability.go
+++ b/internal/interop/mutability.go
@@ -17,7 +17,7 @@ import (
 //  1. User override files
 //  2. @esctype tag (round-trip from Escalier source)
 //  3. Explicit author signals (this: Readonly<T>, getters/setters, Readonly<T>, readonly props)
-//  4. Shipped overrides (stdlib, FP libraries)
+//  4. Builtin overrides (stdlib, FP libraries)
 //  5. get* prefix rule (with documented exceptions)
 //  6. Name-based heuristics
 //  7. Default: mutating
@@ -28,7 +28,7 @@ const (
 	TierUserOverride                          // 1
 	TierEsctype                               // 2
 	TierExplicitSignal                        // 3
-	TierShippedOverride                       // 4
+	TierBuiltinOverride                       // 4
 	TierGetPrefix                             // 5
 	TierNameHeuristic                         // 6
 	TierDefault                               // 7
@@ -68,7 +68,7 @@ func Classify(ctx ClassifyContext) ClassifyResult {
 		return result
 	}
 
-	// Tier 4: shipped overrides (stdlib, FP libraries) — §6.
+	// Tier 4: builtin overrides (stdlib, FP libraries) — §6.
 
 	// Tier 5: get* prefix rule.
 	if result, ok := classifyGetPrefix(ctx); ok {

--- a/internal/interop/mutability_test.go
+++ b/internal/interop/mutability_test.go
@@ -346,7 +346,7 @@ func TestClassifyTier6_NameHeuristics(t *testing.T) {
 		{"cloneDeep", "cloneDeep", false, TierNameHeuristic},
 		// copyWithin matches the `copy` non-mutating prefix at tier 6.
 		// Array.prototype.copyWithin is actually mutating in JS, but
-		// that's the job of tier 4 (shipped overrides) — tier 6 only
+		// that's the job of tier 4 (builtin overrides) — tier 6 only
 		// reflects the name-based heuristic.
 		{"copyWithin", "copyWithin", false, TierNameHeuristic},
 		// Non-mutating exact.

--- a/internal/interop/store.go
+++ b/internal/interop/store.go
@@ -10,7 +10,7 @@ import (
 
 // OverrideStore holds the post-merge module map. Per-tier pre-merge
 // module maps exist only inside Build and are not retained — every
-// diagnostic that needs provenance reads Effective.Provenance, which
+// diagnostic that needs provenance reads Effective.Origins, which
 // already carries the contributing Origins.
 //
 // See planning/interop_mutability/implementation_plan.md §5.
@@ -29,9 +29,9 @@ func NewOverrideStore() *OverrideStore {
 // both ModuleScope and ChildScope so namespace-nested functions land in
 // the same slot as module-top-level functions.
 type Container struct {
-	Free     map[string]*Effective  // free functions, vals, type aliases
-	Children map[string]*ChildScope // nested namespaces / classes / interfaces
-	Origin   Origin                 // declaring file for diagnostics
+	Free     map[string]*Effective // free functions, vals, type aliases
+	Children map[string]ChildScope // nested namespaces / classes / interfaces
+	Origin   Origin                // declaring file for diagnostics
 }
 
 // ModuleScope is the per-module root.
@@ -43,14 +43,75 @@ type ModuleScope struct {
 	AllPureTier OverrideTier
 }
 
-// ChildScope is a namespace, class, or interface. Namespaces use only
-// Container.Free and Container.Children; classes/interfaces use Instance
-// and Static. A ChildScope with both shapes populated is an upstream
-// ErrDuplicateMember — namespace+class declaration merging is not supported.
-type ChildScope struct {
-	Container
-	Instance *MemberSet // nil for namespaces
-	Static   *MemberSet // nil for namespaces
+//sumtype:decl
+
+// ChildScope is one of {NamespaceScope, ClassScope, InterfaceScope} —
+// the three shapes a Container.Children entry can take. Class/namespace
+// declaration merging is not supported, so only NamespaceScope carries
+// nested Free/Children; class and interface scopes carry only their
+// MemberSet(s) and an Origin.
+type ChildScope interface {
+	isChildScope()
+	// ChildOrigin is the declaration site used for diagnostics.
+	ChildOrigin() Origin
+	// MembersFor returns Instance (static=false) or Static (static=true)
+	// for the variants that carry them: ClassScope has both; InterfaceScope
+	// has only Instance; NamespaceScope has neither. Returns nil when the
+	// requested side doesn't apply to the variant.
+	MembersFor(static bool) *MemberSet
+}
+
+// NamespaceScope is a `namespace Foo { ... }` block. Its Container
+// holds nested namespaces and free declarations; it has no instance
+// or static members.
+type NamespaceScope struct {
+	Container Container
+}
+
+// ClassScope is a `class Foo { ... }` declaration. Instance carries
+// non-static methods/getters/setters/properties + Ctor; Static carries
+// the static side. Class+namespace declaration merging is not
+// supported, so a ClassScope has no Free/Children — only an Origin.
+type ClassScope struct {
+	Origin   Origin
+	Instance *MemberSet
+	Static   *MemberSet
+}
+
+// InterfaceScope is an `interface Foo { ... }` declaration. Interfaces
+// have no static side, so only Instance is populated. Like ClassScope,
+// no namespace-merge side — just an Origin.
+type InterfaceScope struct {
+	Origin   Origin
+	Instance *MemberSet
+}
+
+func (*NamespaceScope) isChildScope() {}
+func (*ClassScope) isChildScope()     {}
+func (*InterfaceScope) isChildScope() {}
+
+func (s *NamespaceScope) ChildOrigin() Origin { return s.Container.Origin }
+func (s *ClassScope) ChildOrigin() Origin     { return s.Origin }
+func (s *InterfaceScope) ChildOrigin() Origin { return s.Origin }
+
+// MembersFor: NamespaceScope has no instance or static side.
+func (*NamespaceScope) MembersFor(bool) *MemberSet { return nil }
+
+// MembersFor: ClassScope returns Instance (static=false) or Static (static=true).
+func (s *ClassScope) MembersFor(static bool) *MemberSet {
+	if static {
+		return s.Static
+	}
+	return s.Instance
+}
+
+// MembersFor: InterfaceScope returns Instance for the instance side
+// and nil for static (interfaces have no static).
+func (s *InterfaceScope) MembersFor(static bool) *MemberSet {
+	if static {
+		return nil
+	}
+	return s.Instance
 }
 
 // MemberSet groups the four independent slots that share a name space
@@ -86,17 +147,17 @@ type OverrideTier int
 const (
 	OverrideTierUserProject OverrideTier = iota // requirements tier 1b
 	OverrideTierUserDep                         // requirements tier 1a
-	OverrideTierShipped                         // requirements tier 4
+	OverrideTierBuiltin                         // requirements tier 4
 )
 
 // ResolutionTierFor maps an OverrideTier to the broader ResolutionTier
-// the merge stamps on Effective.Source.
+// the merge sets on Effective.Source.
 func (t OverrideTier) ResolutionTierFor() ResolutionTier {
 	switch t {
 	case OverrideTierUserProject, OverrideTierUserDep:
 		return TierUserOverride
-	case OverrideTierShipped:
-		return TierShippedOverride
+	case OverrideTierBuiltin:
+		return TierBuiltinOverride
 	}
 	return TierDefault
 }
@@ -105,15 +166,28 @@ func (t OverrideTier) ResolutionTierFor() ResolutionTier {
 // (no receiver / self / mut self) is encoded structurally on Type's
 // *FuncType.SelfParam — callers use type_system.ReceiverIsMut.
 type Effective struct {
-	Type       type_system.Type
-	Source     ResolutionTier
-	Provenance []Origin
+	Type    type_system.Type
+	Source  ResolutionTier
+	Origins []Origin
 
 	// Tier records the OverrideTier that produced this leaf in the
-	// collapsed per-tier scope. Set by extract; consumed by merge when
-	// stamping Source. Not meaningful on Effectives after merge — merge
-	// derives Source from this field once and may then clear it.
+	// collapsed per-tier scope. Set by extract; consumed by merge to
+	// derive Source. Not meaningful on Effectives after merge.
 	Tier OverrideTier
+}
+
+// withTier returns a copy of e with Tier set to `ot` and Source derived
+// from it. Returns nil when called on a nil receiver. Copies rather
+// than mutating so the per-tier Effective produced by Extract is not
+// shared across collapse runs.
+func (e *Effective) withTier(tier OverrideTier) *Effective {
+	if e == nil {
+		return nil
+	}
+	cp := *e
+	cp.Tier = tier
+	cp.Source = tier.ResolutionTierFor()
+	return &cp
 }
 
 // OriginKind discriminates the kind of source location.
@@ -137,7 +211,7 @@ type Origin struct {
 	//     depend on the compiler's CWD). Use the path the user typed
 	//     where possible; don't normalize or symlink-resolve.
 	//   - Sources with no real path (embedded FS, synthetic input):
-	//     a "scheme:/path" form, e.g. "shipped:/data/libs/lodash.esc".
+	//     a "scheme:/path" form, e.g. "builtin:/data/libs/lodash.esc".
 	//     The colon-prefix disambiguates from a real path.
 	//   - Empty string is legal but renders as ":<line>" in diagnostics
 	//     and should be avoided outside tests.
@@ -167,6 +241,36 @@ type Path struct {
 	Static bool
 }
 
+// withMember returns a copy of p with the member-addressing trio
+// (Name, Kind, Static) set. Module and Owner — the navigation half of
+// the Path — are unchanged. An empty `name` clears Name (used for
+// Ctor, which has no name of its own).
+func (p Path) withMember(name string, kind MemberKind, static bool) Path {
+	if name != "" {
+		p.Name = dts_parser.NewIdent(name, ast.Span{})
+	} else {
+		p.Name = nil
+	}
+	p.Kind = kind
+	p.Static = static
+	return p
+}
+
+// withChild returns a copy of p with `name` appended to the Owner
+// chain — the breadcrumb of nested class/interface/namespace segments
+// the merge recursion has descended through. Used when the merge enters
+// a Container.Children[name] so leaves emitted beneath get a fully-
+// qualified Path for diagnostics.
+func (p Path) withChild(name string) Path {
+	right := dts_parser.NewIdent(name, ast.Span{})
+	if p.Owner == nil {
+		p.Owner = right
+	} else {
+		p.Owner = &dts_parser.Member{Left: p.Owner, Right: right}
+	}
+	return p
+}
+
 // Resolve walks Modules by Path. Returns nil if no override applies.
 func (s *OverrideStore) Resolve(p Path) *Effective {
 	if s == nil {
@@ -177,31 +281,36 @@ func (s *OverrideStore) Resolve(p Path) *Effective {
 		return nil
 	}
 
-	container := &mod.Container
-	var child *ChildScope
-	if p.Owner != nil {
-		child = walkChild(mod.Children, p.Owner)
-		if child == nil {
-			return nil
-		}
-		container = &child.Container
-	}
-
 	name := canonicalNameFromPK(p.Name)
-	if p.Kind == KindFree {
-		if container.Free == nil {
-			return nil
+
+	// Top-level of module: only KindFree is meaningful (member kinds
+	// require a class/interface owner).
+	if p.Owner == nil {
+		if p.Kind == KindFree {
+			return mod.Container.Free[name]
 		}
-		return container.Free[name]
+		return nil
 	}
 
+	child := walkChild(mod.Children, p.Owner)
 	if child == nil {
 		return nil
 	}
-	set := child.Instance
-	if p.Static {
-		set = child.Static
+
+	if p.Kind == KindFree {
+		// Free lookups can only land in a NamespaceScope — class and
+		// interface scopes don't carry a Free side.
+		ns, ok := child.(*NamespaceScope)
+		if !ok {
+			return nil
+		}
+		return ns.Container.Free[name]
 	}
+
+	// Member access (method/getter/setter/property/ctor): only class
+	// and interface variants carry MemberSets; NamespaceScope returns
+	// nil from MembersFor and falls through.
+	set := child.MembersFor(p.Static)
 	if set == nil {
 		return nil
 	}
@@ -221,21 +330,23 @@ func (s *OverrideStore) Resolve(p Path) *Effective {
 }
 
 // walkChild descends a Member chain through Container.Children. Returns
-// nil if any segment doesn't resolve.
-func walkChild(children map[string]*ChildScope, qi dts_parser.QualIdent) *ChildScope {
+// nil if any segment doesn't resolve. Only NamespaceScope can host
+// nested children — descent through a class/interface mid-chain fails.
+func walkChild(children map[string]ChildScope, qi dts_parser.QualIdent) ChildScope {
 	segs := qualIdentSegments(qi)
 	if len(segs) == 0 {
 		return nil
 	}
-	var cur *ChildScope
+	var cur ChildScope
 	for i, seg := range segs {
 		if i == 0 {
 			cur = children[seg]
 		} else {
-			if cur == nil || cur.Children == nil {
+			ns, ok := cur.(*NamespaceScope)
+			if !ok {
 				return nil
 			}
-			cur = cur.Children[seg]
+			cur = ns.Container.Children[seg]
 		}
 		if cur == nil {
 			return nil

--- a/internal/interop/store_test.go
+++ b/internal/interop/store_test.go
@@ -18,9 +18,9 @@ func TestResolveFreeFunctionAtModuleTop(t *testing.T) {
 	store.Modules["lodash"] = &ModuleScope{
 		Container: Container{
 			Free: map[string]*Effective{
-				"map": {Type: fn, Source: TierShippedOverride},
+				"map": {Type: fn, Source: TierBuiltinOverride},
 			},
-			Children: map[string]*ChildScope{},
+			Children: map[string]ChildScope{},
 		},
 	}
 	got := store.Resolve(Path{
@@ -39,15 +39,11 @@ func TestResolveInstanceMethod(t *testing.T) {
 	store.Modules[""] = &ModuleScope{
 		Container: Container{
 			Free: map[string]*Effective{},
-			Children: map[string]*ChildScope{
-				"Array": {
-					Container: Container{
-						Free:     map[string]*Effective{},
-						Children: map[string]*ChildScope{},
-					},
+			Children: map[string]ChildScope{
+				"Array": &ClassScope{
 					Instance: &MemberSet{
 						Methods: map[string]*Effective{
-							"map": {Type: fn, Source: TierShippedOverride},
+							"map": {Type: fn, Source: TierBuiltinOverride},
 						},
 						Getters:    map[string]*Effective{},
 						Setters:    map[string]*Effective{},

--- a/internal/interop/store_test.go
+++ b/internal/interop/store_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
 	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
 )
 
 func ident(name string) *dts_parser.Ident {
@@ -28,9 +29,8 @@ func TestResolveFreeFunctionAtModuleTop(t *testing.T) {
 		Name:   ident("map"),
 		Kind:   KindFree,
 	})
-	if got == nil || got.Type != fn {
-		t.Fatalf("expected free fn lookup to return fn; got %#v", got)
-	}
+	require.NotNil(t, got)
+	require.Same(t, fn, got.Type)
 }
 
 func TestResolveInstanceMethod(t *testing.T) {
@@ -60,25 +60,20 @@ func TestResolveInstanceMethod(t *testing.T) {
 		Kind:   KindMethod,
 		Static: false,
 	})
-	if eff == nil || eff.Type != fn {
-		t.Fatalf("expected instance method lookup to return fn; got %#v", eff)
-	}
+	require.NotNil(t, eff)
+	require.Same(t, fn, eff.Type)
 	// Static lookup misses.
-	if got := store.Resolve(Path{
+	require.Nil(t, store.Resolve(Path{
 		Owner:  ident("Array"),
 		Name:   ident("map"),
 		Kind:   KindMethod,
 		Static: true,
-	}); got != nil {
-		t.Fatalf("expected static lookup to miss; got %#v", got)
-	}
+	}))
 }
 
 func TestResolveNilStoreReturnsNil(t *testing.T) {
 	var store *OverrideStore
-	if got := store.Resolve(Path{Module: "anything"}); got != nil {
-		t.Fatalf("nil store should resolve to nil; got %#v", got)
-	}
+	require.Nil(t, store.Resolve(Path{Module: "anything"}))
 }
 
 func TestCanonicalNameFromPK(t *testing.T) {
@@ -92,9 +87,7 @@ func TestCanonicalNameFromPK(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := canonicalNameFromPK(c.in); got != c.want {
-				t.Fatalf("canonicalNameFromPK = %q; want %q", got, c.want)
-			}
+			require.Equal(t, c.want, canonicalNameFromPK(c.in))
 		})
 	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -110,6 +110,18 @@ func (p *Parser) ParseScript() (*ast.Script, []*Error) {
 	return ast.NewScript(*stmts, span), p.errors
 }
 
+// ParseDecls parses `source` as a stream of top-level declarations and
+// returns them. Unlike ParseLibFiles it does no namespace grouping by
+// path, and unlike ParseScript it admits decl productions directly
+// rather than wrapping them in DeclStmt. Intended for callers (e.g.
+// the interop override loader) that consume a single file's decl list
+// without the module/script scaffolding.
+func ParseDecls(ctx context.Context, source *ast.Source) ([]ast.Decl, []*Error) {
+	p := NewParser(ctx, source)
+	decls := p.decls()
+	return decls, p.errors
+}
+
 func (p *Parser) decls() []ast.Decl {
 	decls := []ast.Decl{}
 

--- a/planning/interop_mutability/implementation_plan.md
+++ b/planning/interop_mutability/implementation_plan.md
@@ -1123,8 +1123,10 @@ Three sub-tasks, the first two parallelizable:
   than per-method.
 
 - **Consistency test against original `.d.ts`.** Test in the
-  compiler suite that runs over every shipped override entry where
-  a corresponding original `.d.ts` exists:
+  compiler suite that runs over every shipped override entry. Every
+  override has a corresponding original `.d.ts` — Escalier-authored
+  libraries also ship `.d.ts` for TypeScript back-compat, so there
+  is no "no original types" case:
   - Built-in symbols → TS lib `.d.ts` set bundled with the
     `typescript` version pinned in the repo's root
     [package.json](../../package.json) (currently `^5.7.2`).
@@ -1136,7 +1138,6 @@ Three sub-tasks, the first two parallelizable:
   For each entry, look up the original declaration, compare
   non-receiver arity / parameter types / return type under the
   same mapping the merge uses, and fail the build on divergence.
-  Libraries that ship no original types are exempt by definition.
   Bumping any pinned version surfaces drift as a deliberate
   fix-up step.
 

--- a/planning/interop_mutability/requirements.md
+++ b/planning/interop_mutability/requirements.md
@@ -323,8 +323,7 @@ fork the shape of a built-in API.
 
 To keep shipped overrides in sync as upstream `.d.ts` files evolve,
 the compiler test suite includes a **consistency test** that runs
-over every shipped override entry where a corresponding upstream
-`.d.ts` exists:
+over every shipped override entry:
 
 - For TS built-in symbols, the upstream is the bundled TS lib
   `.d.ts` set pinned to the compiler's TS lib version.
@@ -333,7 +332,11 @@ over every shipped override entry where a corresponding upstream
   `@types/*` package (or the library's own bundled types) at a
   pinned version recorded alongside the shipped override.
 
-For each such entry, the test:
+Every overridden symbol has an upstream `.d.ts` counterpart: even
+Escalier-authored libraries ship `.d.ts` for TypeScript
+back-compat, so "no upstream types" is not a case that arises.
+
+For each entry, the test:
 
 1. Looks up the corresponding declaration in the pinned upstream
    `.d.ts`.
@@ -342,10 +345,8 @@ For each such entry, the test:
 3. Fails the build on any divergence, reporting the specific member
    and which field disagrees.
 
-Shipped overrides for libraries that ship no upstream types (purely
-Escalier-authored) are exempt from the test by definition. Bumping
-any pinned upstream version is expected to surface override drift
-as a deliberate fix-up step rather than letting it accumulate.
+Bumping any pinned upstream version is expected to surface override
+drift as a deliberate fix-up step rather than letting it accumulate.
 
 ### Override file format
 


### PR DESCRIPTION
## Summary
Third slice of the #603 stack.

- `merge.go` — three-tier `Collapse` + `Merge` of override scopes onto originals; uses the store types from 5.1, the signature check from 5.2, and the error types from 5.1.
- `loader.go` — orchestrates the discover → parse → extract → merge pipeline.

## Stack
- 5.1 — store + errors + plan doc (#606)
- 5.2 — extract + consistency (#607)
- **5.3 (this PR)** — merge + loader
- 5.4 — wire into checker (#)

## Test plan
- [x] go build ./...
- [x] go test ./internal/interop/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented an override discovery & merge pipeline that scans multiple override sources, applies tiered precedence, and reports duplicate-member conflicts.

* **Refactor**
  * Refactored override store and scope model to improve nested-namespace and member resolution and unify override tier semantics.

* **Tests**
  * Added broad end-to-end and unit tests covering discovery, parsing, tier precedence, merging, duplicate detection, and cancellation handling.

* **Documentation**
  * Clarified consistency-test requirements: all builtin/shipped overrides are validated against upstream types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->