### PR TITLE
Interop mutability 5.4: wire overrides into checker

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/interop"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/type_system"
@@ -32,6 +33,12 @@ type Checker struct {
 	// AmbiguousLifetimeElisionError on those signatures — Phase 12 (TS
 	// interop) will replace this with per-source-file policy.
 	loadingExternalTypes bool
+
+	// OverrideStore holds the merged tier-1 (user) and tier-4 (builtin)
+	// mutability overrides consulted while converting TypeScript
+	// declarations. nil means "no overrides registered"; Classify falls
+	// through to its built-in heuristics.
+	OverrideStore *interop.OverrideStore
 }
 
 func NewChecker(ctx context.Context) *Checker {

--- a/internal/checker/infer_import.go
+++ b/internal/checker/infer_import.go
@@ -194,7 +194,17 @@ type ParsedTypeDef struct {
 
 // parseTypeDef parses a .d.ts file and classifies its contents
 // using the FileClassification system from dts_parser/classifier.go.
-func parseTypeDef(filename string) (*ParsedTypeDef, error) {
+//
+// packageModulePath is the module key under which any package-level
+// declarations from this file should look up overrides — typically the
+// package import specifier (e.g. "lodash/fp"). Globals and prelude lib
+// files pass "" since their declarations are stored at module="" in the
+// override store. Named `declare module "X" { ... }` blocks always use
+// their own quoted name, regardless of packageModulePath.
+//
+// store is the merged override store consulted while converting class
+// members; nil disables tier-1 and tier-4 lookups.
+func parseTypeDef(filename string, store *interop.OverrideStore, packageModulePath string) (*ParsedTypeDef, error) {
 	// Read the file
 	contents, err := os.ReadFile(filename)
 	if err != nil {
@@ -240,7 +250,7 @@ func parseTypeDef(filename string) (*ParsedTypeDef, error) {
 		pkgDtsModule := &dts_parser.Module{
 			Statements: classification.PackageDecls,
 		}
-		pkgAstModule, err := interop.ConvertModule(pkgDtsModule)
+		pkgAstModule, err := interop.ConvertModuleWithOverrides(pkgDtsModule, store, packageModulePath)
 		if err != nil {
 			return nil, fmt.Errorf("converting package declarations: %w", err)
 		}
@@ -253,7 +263,7 @@ func parseTypeDef(filename string) (*ParsedTypeDef, error) {
 		globalDtsModule := &dts_parser.Module{
 			Statements: classification.GlobalDecls,
 		}
-		globalAstModule, err := interop.ConvertModule(globalDtsModule)
+		globalAstModule, err := interop.ConvertModuleWithOverrides(globalDtsModule, store, "")
 		if err != nil {
 			return nil, fmt.Errorf("converting global declarations: %w", err)
 		}
@@ -266,7 +276,7 @@ func parseTypeDef(filename string) (*ParsedTypeDef, error) {
 		namedDtsModule := &dts_parser.Module{
 			Statements: namedMod.Decls,
 		}
-		namedAstModule, err := interop.ConvertModule(namedDtsModule)
+		namedAstModule, err := interop.ConvertModuleWithOverrides(namedDtsModule, store, namedMod.ModuleName)
 		if err != nil {
 			return nil, fmt.Errorf("converting named module %s: %w", namedMod.ModuleName, err)
 		}
@@ -734,7 +744,8 @@ func resolveRelativeDtsPath(sourceFilePath string, relativePath string) string {
 func (c *Checker) loadPathReferencedFile(filePath string) []Error {
 	var errors []Error
 
-	parsedTypeDef, loadErr := parseTypeDef(filePath)
+	// Path-referenced files define globals — store-keyed by module="".
+	parsedTypeDef, loadErr := parseTypeDef(filePath, c.OverrideStore, "")
 	if loadErr != nil {
 		// Remove the in-progress entry so later loads can retry and report the real failure.
 		delete(c.PackageRegistry.packages, filePath)
@@ -824,8 +835,9 @@ func (c *Checker) loadPackageFromPath(ctx Context, dtsFilePath string, packageNa
 	// The sentinel will be replaced with the real namespace after loading via Update()
 	c.PackageRegistry.MarkInProgress(dtsFilePath)
 
-	// Step 3: Load and classify the .d.ts file
-	parsedTypeDef, loadErr := parseTypeDef(dtsFilePath)
+	// Step 3: Load and classify the .d.ts file. Use the package import
+	// specifier as the override-store key for the file's package decls.
+	parsedTypeDef, loadErr := parseTypeDef(dtsFilePath, c.OverrideStore, packageName)
 	if loadErr != nil {
 		// Clean up sentinel so the package can be retried
 		delete(c.PackageRegistry.packages, dtsFilePath) // Need to expose a Remove method

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -44,12 +44,12 @@ func (c *Checker) inferStmt(ctx Context, stmt ast.Stmt) []Error {
 // `declare module "..."`, `declare global`, or `declare namespace`
 // block, inferring each into the surrounding namespace. The block
 // itself is a parser-recognized grouping; for override files the inner
-// decls are what carry the actual types consumed by §5's shape
-// extractor.
+// decls are what carry the actual types consumed by the override
+// system's shape extractor.
 //
-// Non-override ambient blocks are still no-ops — when the legacy .d.ts
-// ingestion path needs them, this helper can be reused from those
-// branches as well.
+// Non-override ambient blocks are no-ops: `.d.ts` ingestion has its
+// own pipeline (dts_parser → interop.ConvertModule) that never routes
+// through inferDecl, and there is no plan to unify the two.
 func (c *Checker) inferDeclareBlock(ctx Context, decls []ast.Decl, enclosingStmt ast.Stmt) []Error {
 	var errors []Error
 	for _, d := range decls {
@@ -85,9 +85,9 @@ func (c *Checker) inferDecl(ctx Context, decl ast.Decl, enclosingStmt ast.Stmt) 
 	case *ast.EnumDecl:
 		return c.inferEnumDecl(ctx, decl)
 	case *ast.DeclareModuleDecl:
-		// Override blocks descend into their contained declarations;
-		// non-override `declare module` blocks remain a no-op until the
-		// .d.ts ingestion path needs them.
+		// Override blocks descend into their contained declarations.
+		// Non-override `declare module` blocks are a no-op here —
+		// `.d.ts` ingestion uses a separate pipeline.
 		if decl.Override() {
 			return c.inferDeclareBlock(ctx, decl.Decls, enclosingStmt)
 		}

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -40,6 +40,24 @@ func (c *Checker) inferStmt(ctx Context, stmt ast.Stmt) []Error {
 	}
 }
 
+// inferDeclareBlock walks the inner declarations of an Override()-prefixed
+// `declare module "..."`, `declare global`, or `declare namespace`
+// block, inferring each into the surrounding namespace. The block
+// itself is a parser-recognized grouping; for override files the inner
+// decls are what carry the actual types consumed by §5's shape
+// extractor.
+//
+// Non-override ambient blocks are still no-ops — when the legacy .d.ts
+// ingestion path needs them, this helper can be reused from those
+// branches as well.
+func (c *Checker) inferDeclareBlock(ctx Context, decls []ast.Decl, enclosingStmt ast.Stmt) []Error {
+	var errors []Error
+	for _, d := range decls {
+		errors = append(errors, c.inferDecl(ctx, d, enclosingStmt)...)
+	}
+	return errors
+}
+
 func (c *Checker) inferDecl(ctx Context, decl ast.Decl, enclosingStmt ast.Stmt) []Error {
 	switch decl := decl.(type) {
 	case *ast.FuncDecl:
@@ -66,11 +84,23 @@ func (c *Checker) inferDecl(ctx Context, decl ast.Decl, enclosingStmt ast.Stmt) 
 		return c.inferClassDecl(ctx, decl)
 	case *ast.EnumDecl:
 		return c.inferEnumDecl(ctx, decl)
-	case *ast.DeclareModuleDecl, *ast.DeclareGlobalDecl, *ast.NamespaceDecl:
-		// Ambient block declarations (`declare module "x" { ... }` /
-		// `declare global { ... }`, optionally `override`-prefixed) are
-		// recognized by the parser but not yet processed by the checker.
-		// Treat as a no-op so they don't crash the type-inference pass.
+	case *ast.DeclareModuleDecl:
+		// Override blocks descend into their contained declarations;
+		// non-override `declare module` blocks remain a no-op until the
+		// .d.ts ingestion path needs them.
+		if decl.Override() {
+			return c.inferDeclareBlock(ctx, decl.Decls, enclosingStmt)
+		}
+		return []Error{}
+	case *ast.DeclareGlobalDecl:
+		if decl.Override() {
+			return c.inferDeclareBlock(ctx, decl.Decls, enclosingStmt)
+		}
+		return []Error{}
+	case *ast.NamespaceDecl:
+		if decl.Override() {
+			return c.inferDeclareBlock(ctx, decl.Decls, enclosingStmt)
+		}
 		return []Error{}
 	default:
 		panic(fmt.Sprintf("Unknown declaration type: %T", decl))

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -526,7 +526,7 @@ func (c *Checker) loadGlobalDefinitions(globalScope *Scope) {
 
 	for _, filename := range allLibFiles {
 		libPath := filepath.Join(libDir, filename)
-		parsedTypeDef, loadErr := parseTypeDef(libPath)
+		parsedTypeDef, loadErr := parseTypeDef(libPath, c.OverrideStore, "")
 		if loadErr != nil {
 			panic(fmt.Sprintf("Failed to load TypeScript lib file: %s: %v", libPath, loadErr))
 		}

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/interop"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 	"github.com/tidwall/btree"
@@ -402,6 +403,7 @@ var cachedGlobalScope *Scope
 var cachedSymbolIDCounter int
 var cachedCustomMatcherSymbolID int
 var cachedPackageRegistry *PackageRegistry
+var cachedOverrideStore *interop.OverrideStore
 
 // initializeGlobalScope creates the global scope containing TypeScript built-in types
 // (Array, Promise, etc. from lib.es5.d.ts and lib.dom.d.ts), operator bindings, and
@@ -733,6 +735,14 @@ func (c *Checker) addGlobalThisBinding(ns *type_system.Namespace) {
 // We assume that a new Checker instance is being passed in every time Prelude is called.
 // TODO(#256): Report all errors to the caller.
 func Prelude(c *Checker) *Scope {
+	// The cached global scope encodes mutability decisions that depend on
+	// c.OverrideStore (see parseTypeDef → ConvertModuleWithOverrides). If a
+	// different store is in play, the cache is stale — invalidate it.
+	if cachedGlobalScope != nil && cachedOverrideStore != c.OverrideStore {
+		cachedGlobalScope = nil
+		cachedPackageRegistry = nil
+		cachedOverrideStore = nil
+	}
 	if cachedGlobalScope != nil {
 		c.SymbolID = cachedSymbolIDCounter
 		c.CustomMatcherSymbolID = cachedCustomMatcherSymbolID
@@ -759,6 +769,7 @@ func Prelude(c *Checker) *Scope {
 	cachedSymbolIDCounter = c.SymbolID
 	cachedCustomMatcherSymbolID = c.CustomMatcherSymbolID
 	cachedPackageRegistry = c.PackageRegistry.Copy() // copy to prevent test pollution
+	cachedOverrideStore = c.OverrideStore
 
 	return c.GlobalScope.WithNewScope()
 }

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -738,6 +738,11 @@ func Prelude(c *Checker) *Scope {
 	// The cached global scope encodes mutability decisions that depend on
 	// c.OverrideStore (see parseTypeDef → ConvertModuleWithOverrides). If a
 	// different store is in play, the cache is stale — invalidate it.
+	//
+	// Identity comparison is intentional: OverrideStore is constructed by
+	// Merge and is read-only thereafter (Resolve never writes), so equal
+	// pointers imply equal contents. In-place mutation of a store after
+	// caching would defeat this — callers must not mutate.
 	if cachedGlobalScope != nil && cachedOverrideStore != c.OverrideStore {
 		cachedGlobalScope = nil
 		cachedPackageRegistry = nil

--- a/internal/checker/prelude_test.go
+++ b/internal/checker/prelude_test.go
@@ -1,11 +1,47 @@
 package checker
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/escalier-lang/escalier/internal/interop"
+	"github.com/stretchr/testify/require"
 )
+
+// TestPrelude_InvalidatesCacheOnOverrideStoreChange ensures the
+// process-wide Prelude cache is keyed by c.OverrideStore: a second
+// Checker with a different (non-nil) store must not reuse a global
+// scope built against a different store, because that scope encodes
+// override-dependent mutability decisions from parseTypeDef.
+func TestPrelude_InvalidatesCacheOnOverrideStoreChange(t *testing.T) {
+	// Prime the cache with no overrides.
+	c1 := NewChecker(context.Background())
+	Prelude(c1)
+	require.NotNil(t, cachedGlobalScope, "cache should populate after first Prelude")
+	primed := cachedGlobalScope
+
+	// Same nil store: cache reused.
+	c2 := NewChecker(context.Background())
+	Prelude(c2)
+	require.Same(t, primed, cachedGlobalScope, "cache should be reused when OverrideStore is unchanged")
+
+	// Different store: cache must be invalidated and rebuilt.
+	c3 := NewChecker(context.Background())
+	c3.OverrideStore = interop.NewOverrideStore()
+	Prelude(c3)
+	require.NotSame(t, primed, cachedGlobalScope, "cache should be rebuilt when OverrideStore differs")
+	require.Same(t, c3.OverrideStore, cachedOverrideStore, "cached store pointer should track current Checker")
+
+	// Reset so subsequent tests see a clean cache.
+	t.Cleanup(func() {
+		cachedGlobalScope = nil
+		cachedPackageRegistry = nil
+		cachedOverrideStore = nil
+	})
+}
 
 func TestIsESNextFile(t *testing.T) {
 	tests := []struct {

--- a/internal/checker/prelude_test.go
+++ b/internal/checker/prelude_test.go
@@ -34,6 +34,16 @@ func TestPrelude_InvalidatesCacheOnOverrideStoreChange(t *testing.T) {
 	Prelude(c3)
 	require.NotSame(t, primed, cachedGlobalScope, "cache should be rebuilt when OverrideStore differs")
 	require.Same(t, c3.OverrideStore, cachedOverrideStore, "cached store pointer should track current Checker")
+	primedC3 := cachedGlobalScope
+
+	// Non-nil A → non-nil B: a second distinct store must also invalidate.
+	// Guards against regressions that only catch the nil→non-nil transition.
+	c4 := NewChecker(context.Background())
+	c4.OverrideStore = interop.NewOverrideStore()
+	require.NotSame(t, c3.OverrideStore, c4.OverrideStore, "test precondition: distinct store pointers")
+	Prelude(c4)
+	require.NotSame(t, primedC3, cachedGlobalScope, "cache should be rebuilt when transitioning between distinct non-nil stores")
+	require.Same(t, c4.OverrideStore, cachedOverrideStore)
 
 	// Reset so subsequent tests see a clean cache.
 	t.Cleanup(func() {

--- a/internal/checker/react_types.go
+++ b/internal/checker/react_types.go
@@ -55,7 +55,7 @@ func (c *Checker) LoadReactTypes(ctx Context, sourceDir string) []Error {
 	}
 
 	// 4. Load and classify the main entry point using existing infrastructure
-	parsedTypeDef, loadErr := parseTypeDef(entryPoint)
+	parsedTypeDef, loadErr := parseTypeDef(entryPoint, c.OverrideStore, "react")
 	if loadErr != nil {
 		return []Error{&GenericError{
 			message: "Could not load @types/react: " + loadErr.Error(),

--- a/internal/interop/decl.go
+++ b/internal/interop/decl.go
@@ -9,7 +9,7 @@ import (
 
 // convertStatement attempts to convert a dts_parser.Statement to an ast.Decl.
 // Returns nil for statements that can't be represented as Decl (like imports).
-func convertStatement(stmt dts_parser.Statement) (ast.Decl, error) {
+func convertStatement(cctx *convertCtx, stmt dts_parser.Statement) (ast.Decl, error) {
 	switch s := stmt.(type) {
 	case *dts_parser.VarDecl:
 		return convertVarDecl(s)
@@ -20,7 +20,7 @@ func convertStatement(stmt dts_parser.Statement) (ast.Decl, error) {
 	case *dts_parser.EnumDecl:
 		return convertEnumDecl(s)
 	case *dts_parser.ClassDecl:
-		return convertClassDecl(s)
+		return convertClassDecl(cctx, s)
 	case *dts_parser.InterfaceDecl:
 		return convertInterfaceDecl(s)
 	case *dts_parser.ImportDecl,
@@ -147,7 +147,7 @@ func convertEnumDecl(de *dts_parser.EnumDecl) (ast.Decl, error) {
 }
 
 // convertClassDecl converts a dts_parser.ClassDecl to an ast.ClassDecl.
-func convertClassDecl(dc *dts_parser.ClassDecl) (*ast.ClassDecl, error) {
+func convertClassDecl(cctx *convertCtx, dc *dts_parser.ClassDecl) (*ast.ClassDecl, error) {
 	// Convert type parameters
 	typeParams, err := convertTypeParams(dc.TypeParams)
 	if err != nil {
@@ -171,7 +171,12 @@ func convertClassDecl(dc *dts_parser.ClassDecl) (*ast.ClassDecl, error) {
 			selfParam := &ast.Param{Pattern: selfPat, TypeAnn: nil, Optional: false}
 			allParams := append([]*ast.Param{selfParam}, params...)
 			fn := ast.NewFuncExpr(nil, nil, allParams, nil, nil, false, nil, convertSpan(m.Span()))
-			ctorResult := Classify(ClassifyContext{Member: m, ClassName: dc.Name.Name})
+			ctorResult := Classify(ClassifyContext{
+				Member:     m,
+				ClassName:  dc.Name.Name,
+				ModulePath: cctx.modulePath,
+				Store:      cctx.store,
+			})
 			bodyElems = append(bodyElems, &ast.ConstructorElem{
 				Fn:       fn,
 				Receiver: &ast.MethodReceiver{Mut: ctorResult.Mut, Span_: selfSpan},
@@ -180,7 +185,7 @@ func convertClassDecl(dc *dts_parser.ClassDecl) (*ast.ClassDecl, error) {
 			})
 
 		case *dts_parser.MethodDecl:
-			elem, err := convertMethodDecl(m, dc.Name.Name)
+			elem, err := convertMethodDecl(cctx, m, dc.Name.Name)
 			if err != nil {
 				return nil, fmt.Errorf("converting method for class %s: %w", dc.Name.Name, err)
 			}
@@ -194,14 +199,14 @@ func convertClassDecl(dc *dts_parser.ClassDecl) (*ast.ClassDecl, error) {
 			bodyElems = append(bodyElems, elem)
 
 		case *dts_parser.GetterDecl:
-			elem, err := convertGetterDecl(m, dc.Name.Name)
+			elem, err := convertGetterDecl(cctx, m, dc.Name.Name)
 			if err != nil {
 				return nil, fmt.Errorf("converting getter for class %s: %w", dc.Name.Name, err)
 			}
 			bodyElems = append(bodyElems, elem)
 
 		case *dts_parser.SetterDecl:
-			elem, err := convertSetterDecl(m, dc.Name.Name)
+			elem, err := convertSetterDecl(cctx, m, dc.Name.Name)
 			if err != nil {
 				return nil, fmt.Errorf("converting setter for class %s: %w", dc.Name.Name, err)
 			}

--- a/internal/interop/decl.go
+++ b/internal/interop/decl.go
@@ -172,10 +172,11 @@ func convertClassDecl(cctx *convertCtx, dc *dts_parser.ClassDecl) (*ast.ClassDec
 			allParams := append([]*ast.Param{selfParam}, params...)
 			fn := ast.NewFuncExpr(nil, nil, allParams, nil, nil, false, nil, convertSpan(m.Span()))
 			ctorResult := Classify(ClassifyContext{
-				Member:     m,
-				ClassName:  dc.Name.Name,
-				ModulePath: cctx.modulePath,
-				Store:      cctx.store,
+				Member:        m,
+				ClassName:     dc.Name.Name,
+				ModulePath:    cctx.modulePath,
+				NamespacePath: cctx.namespacePath,
+				Store:         cctx.store,
 			})
 			bodyElems = append(bodyElems, &ast.ConstructorElem{
 				Fn:       fn,

--- a/internal/interop/decl.go
+++ b/internal/interop/decl.go
@@ -171,13 +171,7 @@ func convertClassDecl(cctx *convertCtx, dc *dts_parser.ClassDecl) (*ast.ClassDec
 			selfParam := &ast.Param{Pattern: selfPat, TypeAnn: nil, Optional: false}
 			allParams := append([]*ast.Param{selfParam}, params...)
 			fn := ast.NewFuncExpr(nil, nil, allParams, nil, nil, false, nil, convertSpan(m.Span()))
-			ctorResult := Classify(ClassifyContext{
-				Member:        m,
-				ClassName:     dc.Name.Name,
-				ModulePath:    cctx.modulePath,
-				NamespacePath: cctx.namespacePath,
-				Store:         cctx.store,
-			})
+			ctorResult := cctx.classifyMember(m, dc.Name.Name)
 			bodyElems = append(bodyElems, &ast.ConstructorElem{
 				Fn:       fn,
 				Receiver: &ast.MethodReceiver{Mut: ctorResult.Mut, Span_: selfSpan},

--- a/internal/interop/decl_test.go
+++ b/internal/interop/decl_test.go
@@ -93,7 +93,7 @@ func TestConvertStatement(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stmt := parseStatement(t, tt.input)
-			result, err := convertStatement(stmt)
+			result, err := convertStatement(&convertCtx{}, stmt)
 
 			if tt.wantError {
 				if err == nil {
@@ -525,7 +525,7 @@ func TestConvertClassDecl(t *testing.T) {
 				t.Fatalf("expected ClassDecl, got %T", stmt)
 			}
 
-			result, err := convertClassDecl(dc)
+			result, err := convertClassDecl(&convertCtx{}, dc)
 
 			if tt.wantError {
 				if err == nil {

--- a/internal/interop/helper.go
+++ b/internal/interop/helper.go
@@ -655,10 +655,11 @@ func convertMethodDecl(cctx *convertCtx, md *dts_parser.MethodDecl, className st
 	var receiver *ast.MethodReceiver
 	if !md.Modifiers.Static {
 		result := Classify(ClassifyContext{
-			Member:     md,
-			ClassName:  className,
-			ModulePath: cctx.modulePath,
-			Store:      cctx.store,
+			Member:        md,
+			ClassName:     className,
+			ModulePath:    cctx.modulePath,
+			NamespacePath: cctx.namespacePath,
+			Store:         cctx.store,
 		})
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: md.Span()}
 	}
@@ -726,10 +727,11 @@ func convertGetterDecl(cctx *convertCtx, gd *dts_parser.GetterDecl, className st
 	var receiver *ast.MethodReceiver
 	if !gd.Modifiers.Static {
 		result := Classify(ClassifyContext{
-			Member:     gd,
-			ClassName:  className,
-			ModulePath: cctx.modulePath,
-			Store:      cctx.store,
+			Member:        gd,
+			ClassName:     className,
+			ModulePath:    cctx.modulePath,
+			NamespacePath: cctx.namespacePath,
+			Store:         cctx.store,
 		})
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: gd.Span()}
 	}
@@ -767,10 +769,11 @@ func convertSetterDecl(cctx *convertCtx, sd *dts_parser.SetterDecl, className st
 	var receiver *ast.MethodReceiver
 	if !sd.Modifiers.Static {
 		result := Classify(ClassifyContext{
-			Member:     sd,
-			ClassName:  className,
-			ModulePath: cctx.modulePath,
-			Store:      cctx.store,
+			Member:        sd,
+			ClassName:     className,
+			ModulePath:    cctx.modulePath,
+			NamespacePath: cctx.namespacePath,
+			Store:         cctx.store,
 		})
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: sd.Span()}
 	}

--- a/internal/interop/helper.go
+++ b/internal/interop/helper.go
@@ -620,7 +620,7 @@ func convertParams(params []*dts_parser.Param) ([]*ast.Param, error) {
 
 // convertMethodDecl converts a dts_parser.MethodDecl to an ast.MethodElem.
 // className is the enclosing class name, passed to Classify for tier-3 signals (explicit author signals).
-func convertMethodDecl(md *dts_parser.MethodDecl, className string) (*ast.MethodElem, error) {
+func convertMethodDecl(cctx *convertCtx, md *dts_parser.MethodDecl, className string) (*ast.MethodElem, error) {
 	// Convert type parameters
 	typeParams, err := convertTypeParams(md.TypeParams)
 	if err != nil {
@@ -654,7 +654,12 @@ func convertMethodDecl(md *dts_parser.MethodDecl, className string) (*ast.Method
 	// Classify receiver mutability. Static methods have no receiver.
 	var receiver *ast.MethodReceiver
 	if !md.Modifiers.Static {
-		result := Classify(ClassifyContext{Member: md, ClassName: className})
+		result := Classify(ClassifyContext{
+			Member:     md,
+			ClassName:  className,
+			ModulePath: cctx.modulePath,
+			Store:      cctx.store,
+		})
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: md.Span()}
 	}
 
@@ -698,7 +703,7 @@ func convertPropertyDecl(pd *dts_parser.PropertyDecl) (*ast.FieldElem, error) {
 
 // convertGetterDecl converts a dts_parser.GetterDecl to an ast.GetterElem.
 // className is the enclosing class name, passed to Classify for tier-3 signals (explicit author signals).
-func convertGetterDecl(gd *dts_parser.GetterDecl, className string) (*ast.GetterElem, error) {
+func convertGetterDecl(cctx *convertCtx, gd *dts_parser.GetterDecl, className string) (*ast.GetterElem, error) {
 	// Convert property key to object key
 	name, err := convertPropertyKey(gd.Name)
 	if err != nil {
@@ -720,7 +725,12 @@ func convertGetterDecl(gd *dts_parser.GetterDecl, className string) (*ast.Getter
 	// Classify receiver mutability. Static getters have no receiver.
 	var receiver *ast.MethodReceiver
 	if !gd.Modifiers.Static {
-		result := Classify(ClassifyContext{Member: gd, ClassName: className})
+		result := Classify(ClassifyContext{
+			Member:     gd,
+			ClassName:  className,
+			ModulePath: cctx.modulePath,
+			Store:      cctx.store,
+		})
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: gd.Span()}
 	}
 
@@ -736,7 +746,7 @@ func convertGetterDecl(gd *dts_parser.GetterDecl, className string) (*ast.Getter
 
 // convertSetterDecl converts a dts_parser.SetterDecl to an ast.SetterElem.
 // className is the enclosing class name, passed to Classify for tier-3 signals (explicit author signals).
-func convertSetterDecl(sd *dts_parser.SetterDecl, className string) (*ast.SetterElem, error) {
+func convertSetterDecl(cctx *convertCtx, sd *dts_parser.SetterDecl, className string) (*ast.SetterElem, error) {
 	// Convert property key to object key
 	name, err := convertPropertyKey(sd.Name)
 	if err != nil {
@@ -756,7 +766,12 @@ func convertSetterDecl(sd *dts_parser.SetterDecl, className string) (*ast.Setter
 	// Classify receiver mutability. Static setters have no receiver.
 	var receiver *ast.MethodReceiver
 	if !sd.Modifiers.Static {
-		result := Classify(ClassifyContext{Member: sd, ClassName: className})
+		result := Classify(ClassifyContext{
+			Member:     sd,
+			ClassName:  className,
+			ModulePath: cctx.modulePath,
+			Store:      cctx.store,
+		})
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: sd.Span()}
 	}
 

--- a/internal/interop/helper.go
+++ b/internal/interop/helper.go
@@ -654,13 +654,7 @@ func convertMethodDecl(cctx *convertCtx, md *dts_parser.MethodDecl, className st
 	// Classify receiver mutability. Static methods have no receiver.
 	var receiver *ast.MethodReceiver
 	if !md.Modifiers.Static {
-		result := Classify(ClassifyContext{
-			Member:        md,
-			ClassName:     className,
-			ModulePath:    cctx.modulePath,
-			NamespacePath: cctx.namespacePath,
-			Store:         cctx.store,
-		})
+		result := cctx.classifyMember(md, className)
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: md.Span()}
 	}
 
@@ -726,13 +720,7 @@ func convertGetterDecl(cctx *convertCtx, gd *dts_parser.GetterDecl, className st
 	// Classify receiver mutability. Static getters have no receiver.
 	var receiver *ast.MethodReceiver
 	if !gd.Modifiers.Static {
-		result := Classify(ClassifyContext{
-			Member:        gd,
-			ClassName:     className,
-			ModulePath:    cctx.modulePath,
-			NamespacePath: cctx.namespacePath,
-			Store:         cctx.store,
-		})
+		result := cctx.classifyMember(gd, className)
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: gd.Span()}
 	}
 
@@ -768,13 +756,7 @@ func convertSetterDecl(cctx *convertCtx, sd *dts_parser.SetterDecl, className st
 	// Classify receiver mutability. Static setters have no receiver.
 	var receiver *ast.MethodReceiver
 	if !sd.Modifiers.Static {
-		result := Classify(ClassifyContext{
-			Member:        sd,
-			ClassName:     className,
-			ModulePath:    cctx.modulePath,
-			NamespacePath: cctx.namespacePath,
-			Store:         cctx.store,
-		})
+		result := cctx.classifyMember(sd, className)
 		receiver = &ast.MethodReceiver{Mut: result.Mut, Span_: sd.Span()}
 	}
 

--- a/internal/interop/helper_test.go
+++ b/internal/interop/helper_test.go
@@ -523,7 +523,7 @@ func TestConvertMethodDecl(t *testing.T) {
 				t.Fatalf("Expected MethodDecl at index %d, got %T", tt.methodIdx, classDecl.Members[tt.methodIdx])
 			}
 
-			result, err := convertMethodDecl(methodDecl, classDecl.Name.Name)
+			result, err := convertMethodDecl(&convertCtx{}, methodDecl, classDecl.Name.Name)
 			if err != nil {
 				t.Fatalf("convertMethodDecl failed: %v", err)
 			}
@@ -670,7 +670,7 @@ func TestConvertGetterDecl(t *testing.T) {
 				t.Fatalf("Expected GetterDecl at index %d, got %T", tt.getterIdx, classDecl.Members[tt.getterIdx])
 			}
 
-			result, err := convertGetterDecl(getterDecl, classDecl.Name.Name)
+			result, err := convertGetterDecl(&convertCtx{}, getterDecl, classDecl.Name.Name)
 			if err != nil {
 				t.Fatalf("convertGetterDecl failed: %v", err)
 			}
@@ -736,7 +736,7 @@ func TestConvertSetterDecl(t *testing.T) {
 				t.Fatalf("Expected SetterDecl at index %d, got %T", tt.setterIdx, classDecl.Members[tt.setterIdx])
 			}
 
-			result, err := convertSetterDecl(setterDecl, classDecl.Name.Name)
+			result, err := convertSetterDecl(&convertCtx{}, setterDecl, classDecl.Name.Name)
 			if err != nil {
 				t.Fatalf("convertSetterDecl failed: %v", err)
 			}

--- a/internal/interop/module.go
+++ b/internal/interop/module.go
@@ -12,9 +12,15 @@ import (
 // convertCtx carries override-related state through the conversion
 // pipeline. nil store / empty modulePath mean "no overrides registered"
 // — Classify falls through to its built-in heuristics.
+//
+// namespacePath is the dotted name of the enclosing `namespace` chain
+// (e.g. "Outer.Inner") and is empty at the module root. It is threaded
+// into ClassifyContext so pathForMember can build a Member-chain Owner
+// that walkChild can descend through nested NamespaceScopes.
 type convertCtx struct {
-	store      *OverrideStore
-	modulePath string
+	store         *OverrideStore
+	modulePath    string
+	namespacePath string
 }
 
 // qualifiedName constructs a qualified namespace name by appending a child name to a parent name.
@@ -52,7 +58,12 @@ func processNamespace(
 			nestedName := qualifiedName(name, s.Name.Name)
 			nestedAmbient := inAmbientNamespace || s.Declare()
 			nestedExported := s.Export()
-			if err := processNamespace(cctx, nestedName, s.Statements, namespaces, nestedAmbient, nestedExported); err != nil {
+			nestedCctx := &convertCtx{
+				store:         cctx.store,
+				modulePath:    cctx.modulePath,
+				namespacePath: nestedName,
+			}
+			if err := processNamespace(nestedCctx, nestedName, s.Statements, namespaces, nestedAmbient, nestedExported); err != nil {
 				return fmt.Errorf("processing namespace %s: %w", s.Name.Name, err)
 			}
 

--- a/internal/interop/module.go
+++ b/internal/interop/module.go
@@ -12,15 +12,35 @@ import (
 // convertCtx carries override-related state through the conversion
 // pipeline. nil store / empty modulePath mean "no overrides registered"
 // — Classify falls through to its built-in heuristics.
-//
-// namespacePath is the dotted name of the enclosing `namespace` chain
-// (e.g. "Outer.Inner") and is empty at the module root. It is threaded
-// into ClassifyContext so pathForMember can build a Member-chain Owner
-// that walkChild can descend through nested NamespaceScopes.
 type convertCtx struct {
-	store         *OverrideStore
-	modulePath    string
+	// store is the merged override store consulted by Classify; nil
+	// means no overrides are registered.
+	store *OverrideStore
+
+	// modulePath is the store key for the module being converted: ""
+	// for globals/prelude lib files, the import specifier for an
+	// imported package (e.g. "lodash/fp"), or the module name from a
+	// `declare module "X"` wrapper.
+	modulePath string
+
+	// namespacePath is the dotted name of the enclosing `namespace`
+	// chain (e.g. "Outer.Inner"); empty at the module root. It is
+	// threaded into ClassifyContext so pathForMember can build a
+	// Member-chain Owner that walkChild can descend through nested
+	// NamespaceScopes.
 	namespacePath string
+}
+
+// classifyMember runs Classify for a member of the given enclosing class,
+// threading the convertCtx's module/namespace/store fields through.
+func (c *convertCtx) classifyMember(member dts_parser.ClassMember, className string) ClassifyResult {
+	return Classify(ClassifyContext{
+		Member:        member,
+		ClassName:     className,
+		ModulePath:    c.modulePath,
+		NamespacePath: c.namespacePath,
+		Store:         c.store,
+	})
 }
 
 // qualifiedName constructs a qualified namespace name by appending a child name to a parent name.

--- a/internal/interop/module.go
+++ b/internal/interop/module.go
@@ -9,6 +9,14 @@ import (
 	"github.com/tidwall/btree"
 )
 
+// convertCtx carries override-related state through the conversion
+// pipeline. nil store / empty modulePath mean "no overrides registered"
+// — Classify falls through to its built-in heuristics.
+type convertCtx struct {
+	store      *OverrideStore
+	modulePath string
+}
+
 // qualifiedName constructs a qualified namespace name by appending a child name to a parent name.
 // If parent is empty (root namespace), returns just the child name.
 // Otherwise, returns "parent.child".
@@ -26,6 +34,7 @@ func qualifiedName(parent, child string) string {
 // all declarations inside an ambient namespace are implicitly exported.
 // The isExported parameter indicates whether this namespace was declared with 'export' keyword.
 func processNamespace(
+	cctx *convertCtx,
 	name string,
 	stmts []dts_parser.Statement,
 	namespaces *btree.Map[string, *ast.Namespace],
@@ -43,7 +52,7 @@ func processNamespace(
 			nestedName := qualifiedName(name, s.Name.Name)
 			nestedAmbient := inAmbientNamespace || s.Declare()
 			nestedExported := s.Export()
-			if err := processNamespace(nestedName, s.Statements, namespaces, nestedAmbient, nestedExported); err != nil {
+			if err := processNamespace(cctx, nestedName, s.Statements, namespaces, nestedAmbient, nestedExported); err != nil {
 				return fmt.Errorf("processing namespace %s: %w", s.Name.Name, err)
 			}
 
@@ -75,7 +84,7 @@ func processNamespace(
 		default:
 			// Convert regular declarations
 			// Skip declarations that fail to convert (e.g., due to unsupported features)
-			decl, err := convertStatement(s)
+			decl, err := convertStatement(cctx, s)
 			if err != nil {
 				// Log the error but continue processing other declarations
 				fmt.Fprintf(os.Stderr, "Warning: skipping statement due to conversion error: %v\n", err)
@@ -131,15 +140,29 @@ func mergeNamespace(
 	}
 }
 
-// ConvertModule converts dts_parser.Module to ast.Module.
+// ConvertModule converts dts_parser.Module to ast.Module with no
+// override store; tier-1 and tier-4 will miss for every member.
 func ConvertModule(dtsModule *dts_parser.Module) (*ast.Module, error) {
+	return ConvertModuleWithOverrides(dtsModule, nil, "")
+}
+
+// ConvertModuleWithOverrides converts dts_parser.Module to ast.Module,
+// consulting `store` for tier-1 (user) and tier-4 (builtin) overrides
+// during member mutability classification. `modulePath` is the path the
+// store was keyed under for these declarations — "" for globals and
+// prelude lib files; the package import specifier for an imported
+// package's package decls (e.g. "lodash/fp"); the module name for
+// `declare module "X" { ... }` blocks (passed by the caller, since the
+// classifier strips that wrapper before getting here).
+func ConvertModuleWithOverrides(dtsModule *dts_parser.Module, store *OverrideStore, modulePath string) (*ast.Module, error) {
+	cctx := &convertCtx{store: store, modulePath: modulePath}
 	var namespaces btree.Map[string, *ast.Namespace]
 
 	// Process all statements, organizing them into namespaces
 	// Use empty string "" as the root/global namespace name
 	// Pass false for inAmbientNamespace since we're at the top level
 	// Pass false for isExported since the root namespace is not exported
-	if err := processNamespace("", dtsModule.Statements, &namespaces, false, false); err != nil {
+	if err := processNamespace(cctx, "", dtsModule.Statements, &namespaces, false, false); err != nil {
 		return nil, fmt.Errorf("converting module: %w", err)
 	}
 

--- a/internal/interop/mutability.go
+++ b/internal/interop/mutability.go
@@ -48,6 +48,13 @@ type ClassifyContext struct {
 	ClassName  string                 // enclosing class name (empty if none)
 	ModulePath string                 // module path (empty if none)
 
+	// NamespacePath is the dotted name of the enclosing `namespace`
+	// chain (e.g. "Outer.Inner"); empty when the class lives at the
+	// module root. pathForMember combines it with ClassName to build a
+	// Member-chain Owner that OverrideStore.walkChild can descend
+	// through nested NamespaceScopes.
+	NamespacePath string
+
 	// Store, if non-nil, is the merged override store consulted by tiers
 	// 1 and 4 (user overrides and shipped overrides). nil is permitted
 	// and means "no overrides registered".

--- a/internal/interop/mutability.go
+++ b/internal/interop/mutability.go
@@ -48,6 +48,11 @@ type ClassifyContext struct {
 	ClassName  string                 // enclosing class name (empty if none)
 	ModulePath string                 // module path (empty if none)
 
+	// Store, if non-nil, is the merged override store consulted by tiers
+	// 1 and 4 (user overrides and shipped overrides). nil is permitted
+	// and means "no overrides registered".
+	Store *OverrideStore
+
 	// Base, if non-nil, is the inheritance fallthrough context: if all
 	// per-class tiers (1–6) miss on `Member`, `Classify` recurses on
 	// *Base. The caller is responsible for resolving the same-named
@@ -59,7 +64,18 @@ type ClassifyContext struct {
 // seven-tier resolution order defined in
 // planning/interop_mutability/requirements.md.
 func Classify(ctx ClassifyContext) ClassifyResult {
+	// Consult the override store once. Its Source field tells us whether
+	// this is a tier-1 (user) hit or a tier-4 (shipped) hit — applied at
+	// the correct rung below.
+	var override *Effective
+	if ctx.Store != nil {
+		override = ctx.Store.Resolve(pathForMember(ctx))
+	}
+
 	// Tier 1: user override files — §5.
+	if override != nil && override.Source == TierUserOverride {
+		return overrideToResult(override)
+	}
 
 	// Tier 2: @esctype tag — §9.
 
@@ -69,6 +85,9 @@ func Classify(ctx ClassifyContext) ClassifyResult {
 	}
 
 	// Tier 4: builtin overrides (stdlib, FP libraries) — §6.
+	if override != nil && override.Source == TierBuiltinOverride {
+		return overrideToResult(override)
+	}
 
 	// Tier 5: get* prefix rule.
 	if result, ok := classifyGetPrefix(ctx); ok {

--- a/internal/interop/mutability.go
+++ b/internal/interop/mutability.go
@@ -56,7 +56,7 @@ type ClassifyContext struct {
 	NamespacePath string
 
 	// Store, if non-nil, is the merged override store consulted by tiers
-	// 1 and 4 (user overrides and shipped overrides). nil is permitted
+	// 1 and 4 (user overrides and built-in overrides). nil is permitted
 	// and means "no overrides registered".
 	Store *OverrideStore
 
@@ -72,7 +72,7 @@ type ClassifyContext struct {
 // planning/interop_mutability/requirements.md.
 func Classify(ctx ClassifyContext) ClassifyResult {
 	// Consult the override store once. Its Source field tells us whether
-	// this is a tier-1 (user) hit or a tier-4 (shipped) hit — applied at
+	// this is a tier-1 (user) hit or a tier-4 (built-in) hit — applied at
 	// the correct rung below.
 	var override *Effective
 	if ctx.Store != nil {

--- a/internal/interop/store.go
+++ b/internal/interop/store.go
@@ -2,6 +2,7 @@ package interop
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
@@ -443,6 +444,32 @@ func identNameFromAst(n *ast.Ident) string {
 	return n.Name
 }
 
+// buildOwnerQualIdent constructs the QualIdent that names the
+// enclosing class in the override store, walking outward from the
+// nearest namespace segment. For "Outer.Inner" + "Cls" it returns
+// Member{Member{Ident("Outer"), "Inner"}, "Cls"} so walkChild can
+// descend through nested NamespaceScope children. Returns nil when
+// className is empty (free-function lookups).
+func buildOwnerQualIdent(namespacePath, className string) dts_parser.QualIdent {
+	if className == "" {
+		return nil
+	}
+	var cur dts_parser.QualIdent
+	if namespacePath != "" {
+		for seg := range strings.SplitSeq(namespacePath, ".") {
+			if cur == nil {
+				cur = dts_parser.NewIdent(seg, ast.Span{})
+			} else {
+				cur = &dts_parser.Member{Left: cur, Right: dts_parser.NewIdent(seg, ast.Span{})}
+			}
+		}
+	}
+	if cur == nil {
+		return dts_parser.NewIdent(className, ast.Span{})
+	}
+	return &dts_parser.Member{Left: cur, Right: dts_parser.NewIdent(className, ast.Span{})}
+}
+
 // pathForMember constructs a Path for the member in a ClassifyContext.
 // Returns a zero Path if the member shape is one Classify doesn't query
 // the store for (e.g. unsupported member type).
@@ -450,10 +477,7 @@ func pathForMember(ctx ClassifyContext) Path {
 	if ctx.Member == nil {
 		return Path{}
 	}
-	var owner dts_parser.QualIdent
-	if ctx.ClassName != "" {
-		owner = dts_parser.NewIdent(ctx.ClassName, ast.Span{})
-	}
+	owner := buildOwnerQualIdent(ctx.NamespacePath, ctx.ClassName)
 	p := Path{
 		Module: ctx.ModulePath,
 		Owner:  owner,

--- a/internal/interop/wiring_test.go
+++ b/internal/interop/wiring_test.go
@@ -27,7 +27,7 @@ declare class Foo {
 	// Sanity check: without an override, findItem is immutable.
 	noOverride, err := ConvertModule(dtsModule)
 	require.NoError(t, err)
-	require.False(t, methodReceiverMut(t, noOverride, "Foo", "findItem"),
+	require.False(t, methodReceiverMut(t, noOverride, "", "Foo", "findItem"),
 		"baseline: findItem should default to immutable receiver")
 
 	// Build a store with a tier-4 override that gives Foo.findItem a
@@ -63,7 +63,7 @@ declare class Foo {
 
 	withOverride, err := ConvertModuleWithOverrides(dtsModule, store, "")
 	require.NoError(t, err)
-	require.True(t, methodReceiverMut(t, withOverride, "Foo", "findItem"),
+	require.True(t, methodReceiverMut(t, withOverride, "", "Foo", "findItem"),
 		"tier-4 override should flip findItem's receiver to mut self")
 }
 
@@ -86,7 +86,7 @@ declare namespace Outer {
 	// Baseline: no override → name heuristic → non-mut.
 	noOverride, err := ConvertModule(dtsModule)
 	require.NoError(t, err)
-	require.False(t, namespacedMethodReceiverMut(t, noOverride, "Outer", "Inner", "findItem"),
+	require.False(t, methodReceiverMut(t, noOverride, "Outer", "Inner", "findItem"),
 		"baseline: findItem should default to immutable receiver")
 
 	receiver := type_system.NewNumPrimType(nil)
@@ -126,17 +126,18 @@ declare namespace Outer {
 
 	withOverride, err := ConvertModuleWithOverrides(dtsModule, store, "")
 	require.NoError(t, err)
-	require.True(t, namespacedMethodReceiverMut(t, withOverride, "Outer", "Inner", "findItem"),
+	require.True(t, methodReceiverMut(t, withOverride, "Outer", "Inner", "findItem"),
 		"tier-4 override on Outer.Inner.findItem should flip the receiver to mut self")
 }
 
-// namespacedMethodReceiverMut walks the qualified-name namespace
-// (processNamespace flattens nested namespaces into "Outer.Inner"-keyed
-// AST namespaces) and returns the Mut flag of the named method.
-func namespacedMethodReceiverMut(t *testing.T, m *ast.Module, nsName, className, methodName string) bool {
+// methodReceiverMut walks the namespace keyed by nsName ("" for the
+// root namespace; "Outer.Inner" for nested namespaces, which
+// processNamespace flattens into qualified keys), finds the named
+// method on the named class, and returns its receiver's Mut flag.
+func methodReceiverMut(t *testing.T, m *ast.Module, nsName, className, methodName string) bool {
 	t.Helper()
 	ns, ok := m.Namespaces.Get(nsName)
-	require.True(t, ok, "namespace %s missing", nsName)
+	require.True(t, ok, "namespace %q missing", nsName)
 	for _, decl := range ns.Decls {
 		cd, ok := decl.(*ast.ClassDecl)
 		if !ok || cd.Name.Name != className {
@@ -156,35 +157,6 @@ func namespacedMethodReceiverMut(t *testing.T, m *ast.Module, nsName, className,
 		}
 		t.Fatalf("class %s has no method %s", className, methodName)
 	}
-	t.Fatalf("class %s.%s not found", nsName, className)
-	return false
-}
-
-// methodReceiverMut pulls the named class out of the root namespace,
-// finds the named method, and returns its receiver's Mut flag.
-func methodReceiverMut(t *testing.T, m *ast.Module, className, methodName string) bool {
-	t.Helper()
-	rootNS, ok := m.Namespaces.Get("")
-	require.True(t, ok, "root namespace missing")
-	for _, decl := range rootNS.Decls {
-		cd, ok := decl.(*ast.ClassDecl)
-		if !ok || cd.Name.Name != className {
-			continue
-		}
-		for _, elem := range cd.Body {
-			me, ok := elem.(*ast.MethodElem)
-			if !ok {
-				continue
-			}
-			keyIdent, ok := me.Name.(*ast.IdentExpr)
-			if !ok || keyIdent.Name != methodName {
-				continue
-			}
-			require.NotNil(t, me.Receiver, "method %s has no receiver", methodName)
-			return me.Receiver.Mut
-		}
-		t.Fatalf("class %s has no method %s", className, methodName)
-	}
-	t.Fatalf("class %s not found in root namespace", className)
+	t.Fatalf("class %s not found in namespace %q", className, nsName)
 	return false
 }

--- a/internal/interop/wiring_test.go
+++ b/internal/interop/wiring_test.go
@@ -67,6 +67,99 @@ declare class Foo {
 		"tier-4 override should flip findItem's receiver to mut self")
 }
 
+// TestConvertModuleWithOverrides_FlipsReceiverMut_NestedNamespace mirrors
+// the root-namespace wiring test but for a class nested inside a
+// `namespace` block. The override store keys the class by the qualified
+// path "Outer.Inner.findItem"; pathForMember must build a Member-chain
+// Owner (not a bare Ident) so OverrideStore.Resolve can walkChild
+// through the NamespaceScope down to the ClassScope.
+func TestConvertModuleWithOverrides_FlipsReceiverMut_NestedNamespace(t *testing.T) {
+	input := `
+declare namespace Outer {
+	class Inner {
+		findItem(): number;
+	}
+}
+`
+	dtsModule := parseModule(t, input)
+
+	// Baseline: no override → name heuristic → non-mut.
+	noOverride, err := ConvertModule(dtsModule)
+	require.NoError(t, err)
+	require.False(t, namespacedMethodReceiverMut(t, noOverride, "Outer", "Inner", "findItem"),
+		"baseline: findItem should default to immutable receiver")
+
+	receiver := type_system.NewNumPrimType(nil)
+	mutReceiver := type_system.NewMutType(nil, receiver)
+	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	fn.SelfParam = &type_system.FuncParam{Type: mutReceiver}
+
+	store := &OverrideStore{
+		Modules: map[string]*ModuleScope{
+			"": {
+				Container: Container{
+					Free: map[string]*Effective{},
+					Children: map[string]ChildScope{
+						"Outer": &NamespaceScope{
+							Container: Container{
+								Free: map[string]*Effective{},
+								Children: map[string]ChildScope{
+									"Inner": &ClassScope{
+										Instance: &MemberSet{
+											Methods: map[string]*Effective{
+												"findItem": {Type: fn, Source: TierBuiltinOverride},
+											},
+											Getters:    map[string]*Effective{},
+											Setters:    map[string]*Effective{},
+											Properties: map[string]*Effective{},
+										},
+										Static: NewMemberSet(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	withOverride, err := ConvertModuleWithOverrides(dtsModule, store, "")
+	require.NoError(t, err)
+	require.True(t, namespacedMethodReceiverMut(t, withOverride, "Outer", "Inner", "findItem"),
+		"tier-4 override on Outer.Inner.findItem should flip the receiver to mut self")
+}
+
+// namespacedMethodReceiverMut walks the qualified-name namespace
+// (processNamespace flattens nested namespaces into "Outer.Inner"-keyed
+// AST namespaces) and returns the Mut flag of the named method.
+func namespacedMethodReceiverMut(t *testing.T, m *ast.Module, nsName, className, methodName string) bool {
+	t.Helper()
+	ns, ok := m.Namespaces.Get(nsName)
+	require.True(t, ok, "namespace %s missing", nsName)
+	for _, decl := range ns.Decls {
+		cd, ok := decl.(*ast.ClassDecl)
+		if !ok || cd.Name.Name != className {
+			continue
+		}
+		for _, elem := range cd.Body {
+			me, ok := elem.(*ast.MethodElem)
+			if !ok {
+				continue
+			}
+			keyIdent, ok := me.Name.(*ast.IdentExpr)
+			if !ok || keyIdent.Name != methodName {
+				continue
+			}
+			require.NotNil(t, me.Receiver, "method %s has no receiver", methodName)
+			return me.Receiver.Mut
+		}
+		t.Fatalf("class %s has no method %s", className, methodName)
+	}
+	t.Fatalf("class %s.%s not found", nsName, className)
+	return false
+}
+
 // methodReceiverMut pulls the named class out of the root namespace,
 // finds the named method, and returns its receiver's Mut flag.
 func methodReceiverMut(t *testing.T, m *ast.Module, className, methodName string) bool {

--- a/internal/interop/wiring_test.go
+++ b/internal/interop/wiring_test.go
@@ -1,0 +1,97 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertModuleWithOverrides_FlipsReceiverMut proves that
+// ConvertModuleWithOverrides threads the override store all the way
+// down to Classify for class methods, getters, and setters: a method
+// that defaults to immutable by the name heuristic (`findItem`) gets
+// flipped to `mut self` when the store carries a tier-4 entry with a
+// MutType-wrapped receiver. This is the end-to-end wiring check for
+// PR #609 — without it, the only proof that overrides are consulted
+// lives in mutability_test.go, which calls Classify directly.
+func TestConvertModuleWithOverrides_FlipsReceiverMut(t *testing.T) {
+	input := `
+declare class Foo {
+	findItem(): number;
+}
+`
+	dtsModule := parseModule(t, input)
+
+	// Sanity check: without an override, findItem is immutable.
+	noOverride, err := ConvertModule(dtsModule)
+	require.NoError(t, err)
+	require.False(t, methodReceiverMut(t, noOverride, "Foo", "findItem"),
+		"baseline: findItem should default to immutable receiver")
+
+	// Build a store with a tier-4 override that gives Foo.findItem a
+	// `mut self` receiver. Module key "" matches the modulePath we pass
+	// to ConvertModuleWithOverrides.
+	receiver := type_system.NewNumPrimType(nil)
+	mutReceiver := type_system.NewMutType(nil, receiver)
+	fn := type_system.NewFuncType(nil, nil, nil, type_system.NewNumPrimType(nil), nil)
+	fn.SelfParam = &type_system.FuncParam{Type: mutReceiver}
+
+	store := &OverrideStore{
+		Modules: map[string]*ModuleScope{
+			"": {
+				Container: Container{
+					Free: map[string]*Effective{},
+					Children: map[string]ChildScope{
+						"Foo": &ClassScope{
+							Instance: &MemberSet{
+								Methods: map[string]*Effective{
+									"findItem": {Type: fn, Source: TierBuiltinOverride},
+								},
+								Getters:    map[string]*Effective{},
+								Setters:    map[string]*Effective{},
+								Properties: map[string]*Effective{},
+							},
+							Static: NewMemberSet(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	withOverride, err := ConvertModuleWithOverrides(dtsModule, store, "")
+	require.NoError(t, err)
+	require.True(t, methodReceiverMut(t, withOverride, "Foo", "findItem"),
+		"tier-4 override should flip findItem's receiver to mut self")
+}
+
+// methodReceiverMut pulls the named class out of the root namespace,
+// finds the named method, and returns its receiver's Mut flag.
+func methodReceiverMut(t *testing.T, m *ast.Module, className, methodName string) bool {
+	t.Helper()
+	rootNS, ok := m.Namespaces.Get("")
+	require.True(t, ok, "root namespace missing")
+	for _, decl := range rootNS.Decls {
+		cd, ok := decl.(*ast.ClassDecl)
+		if !ok || cd.Name.Name != className {
+			continue
+		}
+		for _, elem := range cd.Body {
+			me, ok := elem.(*ast.MethodElem)
+			if !ok {
+				continue
+			}
+			keyIdent, ok := me.Name.(*ast.IdentExpr)
+			if !ok || keyIdent.Name != methodName {
+				continue
+			}
+			require.NotNil(t, me.Receiver, "method %s has no receiver", methodName)
+			return me.Receiver.Mut
+		}
+		t.Fatalf("class %s has no method %s", className, methodName)
+	}
+	t.Fatalf("class %s not found in root namespace", className)
+	return false
+}

--- a/planning/interop_mutability/implementation_plan.md
+++ b/planning/interop_mutability/implementation_plan.md
@@ -17,10 +17,10 @@ table below makes both explicit. Status legend: ✅ done,
 | 1   | Existing surface area                  | ✅      | —           | Descriptive only.                                                                                                                                                                                                                                                                              |
 | 2.1 | Spec scaffolding                       | ✅      | —           | `override` keyword, fixtures, merge-semantics doc, `@esctype` grammar.                                                                                                                                                                                                                         |
 | 2.2 | Parser sub-task                        | ✅      | 2.1         | `declare module/global/namespace` and `override` prefix accepted by [internal/parser/decl.go](../../internal/parser/decl.go); `fixtures/interop_mutability/overrides/example.esc` is no longer `.future`.                                                                                       |
-| 3   | Resolution-order plumbing              | ✅     | 2.2         | `ResolutionTier` enum and `Classify` entry point in [internal/interop/mutability.go](../../internal/interop/mutability.go) use the 7-tier ladder (`TierUserSource=0` sentinel, `TierUserOverride=1`, `TierEsctype=2`, `TierExplicitSignal=3`, `TierShippedOverride=4`, `TierGetPrefix=5`, `TierNameHeuristic=6`, `TierDefault=7`). All decision sites in `decl.go`/`helper.go` route through `Classify`. |
+| 3   | Resolution-order plumbing              | ✅     | 2.2         | `ResolutionTier` enum and `Classify` entry point in [internal/interop/mutability.go](../../internal/interop/mutability.go) use the 7-tier ladder (`TierUserSource=0` sentinel, `TierUserOverride=1`, `TierEsctype=2`, `TierExplicitSignal=3`, `TierBuiltinOverride=4`, `TierGetPrefix=5`, `TierNameHeuristic=6`, `TierDefault=7`). All decision sites in `decl.go`/`helper.go` route through `Classify`. |
 | 4   | Strong signals (tier 3)                | ✅     | 3           | `classifyExplicitSignal` in [internal/interop/mutability.go](../../internal/interop/mutability.go) handles getters/setters, `readonly` props, `Readonly<T>`/`ReadonlyArray<T>`/`ReadonlySet<T>`/`ReadonlyMap<T>` wrappers, `this: Readonly<T>` (incl. `readonly T[]`), Readonly-prefixed collection classes, and the well-known-symbol allow-list. End-to-end coverage in `TestClassifyTier3_EndToEnd`. Known parser gap (separate from §4): `dts_parser` does not yet parse `[Symbol.iterator]()` as a computed method name — it treats `[` at member position as an index signature. The classifier already handles `ComputedKey` correctly. |
 | 5   | Override file format, loader, merge    | ⬜      | 2.2, 3      | Largest single chunk. No code yet.                                                                                                                                                                                                                                                             |
-| 6   | Shipped overrides                      | ⬜      | 5           | Per-class authoring of stdlib + FP-library overrides. Includes the always-immutable built-ins (`Number`/`BigInt`/`String`/`Boolean`/`Symbol`/`Promise`).                                                                                                                                       |
+| 6   | Built-in overrides                      | ⬜      | 5           | Per-class authoring of stdlib + FP-library overrides. Includes the always-immutable built-ins (`Number`/`BigInt`/`String`/`Boolean`/`Symbol`/`Promise`).                                                                                                                                       |
 | 7   | Heuristics (tiers 5–6)                 | 🚧     | 3           | `classifyGetPrefix` (tier 5) and `classifyNameHeuristic` (tier 6) in [internal/interop/mutability.go](../../internal/interop/mutability.go) implement the full requirements prefix/exact-match lists with mutating-wins-on-conflict and `getOr{Insert,Update,Create}` fall-through. Inheritance fallthrough wired via optional `ClassifyContext.Base`: when all per-class tiers miss, `Classify` recurses on the base context; tests cover explicit-on-base, heuristic-on-base, default fall-through, and subclass-wins. Pending: plumb `Base` from `decl.go`/`helper.go` call sites (needs class-name → declaration lookup, blocked on §5 override-store path conventions). |
 | 8   | Type-printer round-trip audit          | ⬜      | —           | Independent; prerequisite for §9 emit. Can be done at any time.                                                                                                                                                                                                                                |
 | 9   | `@esctype` round-trip                  | ⬜      | 3, 5, 8     | Emit side needs §8; consume side needs parser TSDoc retention (§9.2); integration needs §5.                                                                                                                                                                                                    |
@@ -41,7 +41,7 @@ is finished first):
 2. **§4 cleanup.** Rename `classifyTier2` → `classifyTier3`,
    finish remaining tier-3 cases.
 3. **§5 (override system).** Largest chunk; unblocks §6, §9, §11.
-4. **§6 (shipped overrides).** Author the stdlib + FP data,
+4. **§6 (built-in overrides).** Author the stdlib + FP data,
    including the always-immutable built-ins.
 5. **§7 (heuristics).** Add `classifyTier5` (get-prefix) and
    `classifyTier6` (name-based) plus inheritance fallthrough.
@@ -86,7 +86,7 @@ writing code that depends on either.
   [expect.go](../../internal/parser/expect.go)). Tests pass; no
   conflicts with existing identifiers.
 - **`overrides/` discovery rule** specified in
-  [requirements.md](requirements.md) — three-location walk (shipped
+  [requirements.md](requirements.md) — three-location walk (built-in
   tier 4 → dep `node_modules/*/overrides/` tier 1a → consuming
   project tier 1b), recursive within each, subdirectory layout has
   no semantic effect. "Root of a package" means the directory
@@ -189,7 +189,7 @@ behavior (so output is unchanged).
       TierUserOverride                            // 1: requirements tier 1
       TierEsctype                                 // 2
       TierExplicitSignal                          // 3
-      TierShippedOverride                         // 4
+      TierBuiltinOverride                         // 4
       TierGetPrefix                               // 5
       TierNameHeuristic                           // 6
       TierDefault                                 // 7
@@ -247,7 +247,7 @@ fixture classifies correctly, with `Source = TierExplicitSignal`.
 ## 5. Override file format, loader & merge
 
 Goal: build the eager-merge pipeline (Approach A, per requirements
-§"Implementation decision") that §6 (shipped overrides) and the
+§"Implementation decision") that §6 (built-in overrides) and the
 user override file feature both depend on.
 
 ### 5.1 Merge model
@@ -280,7 +280,7 @@ There are two layers of competition:
 
 1. **Within the override system** — three internal tiers
    (`OverrideTierUserProject` > `OverrideTierUserDep` >
-   `OverrideTierShipped`). The loader builds one module map per
+   `OverrideTierBuiltin`). The loader builds one module map per
    tier (a `map[string]*ModuleScope`).
    The merge collapses them into a single override scope by walking
    slot-by-slot and keeping the highest-precedence non-empty entry.
@@ -302,7 +302,7 @@ leaf.
 After merge, `Effective.Source` records which tier of the broader
 7-tier resolution ladder produced the value: `TierUserOverride`
 (ladder tier 1) when a user-project or user-dep entry won, or
-`TierShippedOverride` (ladder tier 4) when only a shipped entry was
+`TierBuiltinOverride` (ladder tier 4) when only a built-in entry was
 present. `Classify` reads this value to decide where in the ladder
 the override fits, and §11's warning predicate reads it to
 suppress warnings on override-backed classifications.
@@ -319,7 +319,7 @@ suppress warnings on override-backed classifications.
   merging (legacy TS) is not supported.
 - *Across `OverrideTier`s:* the lower-precedence entry is silently
   dropped. This is the whole point of the tier system — user
-  overrides shadow shipped ones without complaint.
+  overrides shadow built-in ones without complaint.
 
 The same shadowing applies to `@all_pure`: a module pragma at a
 higher tier wins over the same pragma at a lower tier, but does
@@ -472,14 +472,14 @@ type MemberSet struct {
 // Effective.Source.
 //
 // Lower integer = higher precedence (UserProject beats UserDep
-// beats Shipped). This matches the convention used by
+// beats Built-in). This matches the convention used by
 // ResolutionTier where TierUserOverride = 1 outranks
-// TierShippedOverride = 4.
+// TierBuiltinOverride = 4.
 type OverrideTier int
 const (
     OverrideTierUserProject OverrideTier = iota // requirements tier 1b
     OverrideTierUserDep                         // requirements tier 1a
-    OverrideTierShipped                         // requirements tier 4
+    OverrideTierBuiltin                         // requirements tier 4
 )
 
 // Effective is the merged result for a single member. It carries
@@ -550,13 +550,13 @@ func Build(
     tc TypeChecker,
     root string,
     deps []DepInfo,
-    shipped fs.FS,
+    builtin fs.FS,
     originals map[string]*ModuleScope,
 ) (*OverrideStore, []error)
 ```
 
-1. Walk `shipped` (embedded `fs.FS` populated in §6) — emit
-   `Entry`s with `OverrideTier = OverrideTierShipped`.
+1. Walk `builtin` (embedded `fs.FS` populated in §6) — emit
+   `Entry`s with `OverrideTier = OverrideTierBuiltin`.
 2. For each dep in `deps`, walk `<dep.Dir>/overrides/**/*.esc` — emit
    with `OverrideTier = OverrideTierUserDep`. `dep.Dir` is the
    directory containing that dep's `package.json`.
@@ -593,7 +593,7 @@ func Build(
    collapsed[slot] := first non-nil of (
        userProject[slot],
        userDep[slot],
-       shipped[slot])
+       builtin[slot])
    ```
 
    Concretely, the walk descends `Modules` → `Container` (`Free`
@@ -664,7 +664,7 @@ wins when present, original otherwise), and produce a fresh
     wrapper stripped from `SelfParam.Type` (so `ReceiverIsMut`
     reports false), and `Source` set per the contributing
     `OverrideTier` — `TierUserOverride` for UserProject/UserDep,
-    `TierShippedOverride` for Shipped. Free functions and static
+    `TierBuiltinOverride` for Built-in. Free functions and static
     methods (`SelfParam == nil`) are unaffected by `@all_pure`.
 
 Generics arity is checked at two places:
@@ -849,18 +849,18 @@ Extend `ClassifyContext` with `Store *OverrideStore` (nil
 is allowed and means "no overrides registered"). `Classify` calls
 `Store.Resolve(path)` exactly once at the very top of the cascade.
 The merge has already decided whether a user-project, user-dep, or
-shipped entry won, and stamped that decision on `Effective.Source`
-as either `TierUserOverride` or `TierShippedOverride`. So:
+built-in entry won, and stamped that decision on `Effective.Source`
+as either `TierUserOverride` or `TierBuiltinOverride`. So:
 
 - If `Resolve` returns nil: fall through to tier 2 (`@esctype`).
 - If `Resolve` returns an `Effective` with `Source =
   TierUserOverride`: the result lands at ladder tier 1.
 - If `Resolve` returns an `Effective` with `Source =
-  TierShippedOverride`: the result lands at ladder tier 4 — but
+  TierBuiltinOverride`: the result lands at ladder tier 4 — but
   *only* if no earlier tier (2 or 3) supersedes it. Concretely:
   `Classify` evaluates tier 1 (the `TierUserOverride` case), then
   tier 2 (`@esctype`), then tier 3 (strong signals), and only
-  then accepts a `TierShippedOverride` hit. The override store
+  then accepts a `TierBuiltinOverride` hit. The override store
   thus contributes to two non-adjacent ladder rungs; in code,
   consult the store once at the top, save the result, and apply
   it at the right tier.
@@ -905,7 +905,7 @@ All tests live in `internal/interop/`:
   parse → check → extract → merge → resolve pipeline.
 
 Exit criteria: loader + merge covered by unit tests; `Classify`
-consults the merged store but no overrides are shipped yet
+consults the merged store but no built-in overrides exist yet
 (§6 ships them).
 
 ### 5.13 Deferred to a follow-up PR
@@ -1032,28 +1032,28 @@ reviewable:
   destructured patterns in override files with a clear
   error.
 
-## 6. Shipped overrides
+## 6. Built-in overrides
 
 Goal: author the data tables that the resolver loads at startup.
 
 ### 6.1 Bundling mechanism
 
-Shipped override `.esc` files live under
+Built-in override `.esc` files live under
 `internal/interop/data/` and are embedded into the binary with
 `//go:embed data/builtins/* data/libs/*` declared in
 `interop/data.go`:
 
 ```go
 //go:embed data
-var ShippedFS embed.FS
+var BuiltinFS embed.FS
 ```
 
-`loader.Load` accepts `ShippedFS` as its `shipped` argument so tests
+`loader.Load` accepts `BuiltinFS` as its `builtin` argument so tests
 can substitute a synthetic FS without touching disk.
 
 ### 6.2 Module-name mapping
 
-A shipped override file declares which TS module(s) it applies to
+A built-in override file declares which TS module(s) it applies to
 with a header pragma (defined in §2's grammar):
 
 ```escalier
@@ -1078,7 +1078,7 @@ Three sub-tasks, the first two parallelizable:
     (`Number`, `BigInt`, `String`, `Boolean`), plus `Symbol` and
     `Promise`. Every method declares `self` (non-mutating
     receiver). These are written out explicitly rather than
-    special-cased in `Classify` — over time we want shipped
+    special-cased in `Classify` — over time we want built-in
     overrides to be the primary source of mutability / lifetime /
     throws information, independent of any one version of
     TypeScript's lib declarations.
@@ -1123,7 +1123,7 @@ Three sub-tasks, the first two parallelizable:
   than per-method.
 
 - **Consistency test against original `.d.ts`.** Test in the
-  compiler suite that runs over every shipped override entry. Every
+  compiler suite that runs over every built-in override entry. Every
   override has a corresponding original `.d.ts` — Escalier-authored
   libraries also ship `.d.ts` for TypeScript back-compat, so there
   is no "no original types" case:
@@ -1134,7 +1134,7 @@ Three sub-tasks, the first two parallelizable:
     consistency baseline.
   - FP / immutability libraries → corresponding `@types/*` package
     (or the library's own bundled types), also pinned via
-    `package.json` alongside the shipped override.
+    `package.json` alongside the built-in override.
   For each entry, look up the original declaration, compare
   non-receiver arity / parameter types / return type under the
   same mapping the merge uses, and fail the build on divergence.
@@ -1149,8 +1149,8 @@ Three sub-tasks, the first two parallelizable:
   change the version in `package.json`, run the consistency test,
   resolve any reported drift.
 
-  The consistency test (`shipped_consistency_test.go`) iterates
-  every entry in `ShippedFS`, parses the corresponding original
+  The consistency test (`builtin_consistency_test.go`) iterates
+  every entry in `BuiltinFS`, parses the corresponding original
   declaration from the installed `node_modules/typescript/lib/`
   or `node_modules/@types/<lib>/` path (per the **Sourcing**
   paragraph above), and calls `consistency.CheckSet` — the same
@@ -1159,10 +1159,10 @@ Three sub-tasks, the first two parallelizable:
 Tests:
 
 - Fixture per library under
-  `fixtures/interop_mutability/shipped_<lib>/` that imports a
+  `fixtures/interop_mutability/builtin_<lib>/` that imports a
   representative subset and asserts the receiver mutability via
   call-site type errors (mutate through immutable binding fails).
-- `shipped_consistency_test.go` as described above.
+- `builtin_consistency_test.go` as described above.
 - A regression test asserting that the embedded FS is non-empty
   and every embedded file parses.
 
@@ -1183,14 +1183,14 @@ existing `classifyTier2`.
 Note: built-in classes whose instances have no mutable surface
 (the primitive wrappers `Number`/`BigInt`/`String`/`Boolean`,
 plus `Symbol` and `Promise`) are **not** modelled here. They are
-authored as explicit per-method shipped overrides in §6 alongside
+authored as explicit per-method built-in overrides in §6 alongside
 the rest of the stdlib. The rationale is the longer-term goal of
 decoupling Escalier from any one version of TypeScript's lib
 declarations: mutability, lifetimes, and throws information
 should ultimately come from primary sources (ECMAScript spec,
 MDN, library docs), with TypeScript's `.d.ts` being just one
 input. Special-casing these classes inside `Classify` would
-short-circuit that pipeline; routing them through shipped
+short-circuit that pipeline; routing them through built-in
 overrides keeps the same authoritative path the rest of the
 stdlib uses.
 
@@ -1506,7 +1506,7 @@ type ClassifyResult struct {
     Source      ResolutionTier
     // Replacement is non-nil for tiers that supply a full type
     // (tier 1 / TierUserOverride, tier 2 / TierEsctype, tier 4 /
-    // TierShippedOverride). When set, decl.go uses it wholesale
+    // TierBuiltinOverride). When set, decl.go uses it wholesale
     // and ignores SelfMut — the receiver shape lives on
     // Replacement.(*FuncType).SelfParam.
     Replacement *type_system.Type
@@ -1529,8 +1529,8 @@ store's `TierUserOverride` path *before* `classifyTier2`. If both
 apply, the store wins and the symbol's `Source` is
 `TierUserOverride` — never `TierEsctype` — which is what the "user
 override beats `@esctype`" fixture verifies. The store's
-`TierShippedOverride` path is evaluated *after* `classifyTier2`
-(see §5.11), so `@esctype` outranks shipped overrides.
+`TierBuiltinOverride` path is evaluated *after* `classifyTier2`
+(see §5.11), so `@esctype` outranks built-in overrides.
 
 ### 9.4 TSDoc tooling
 
@@ -1717,7 +1717,7 @@ the diagnostic includes the "add an explicit signal" suggestion —
 this is the one place a heuristic produces a hard error rather
 than the §11 warning. `TierUserSource` and the
 explicit tiers (`TierUserOverride`, `TierEsctype`,
-`TierExplicitSignal`, `TierShippedOverride`) do not trigger the
+`TierExplicitSignal`, `TierBuiltinOverride`) do not trigger the
 suggestion.
 
 **Import direction.** `checker` already depends on `interop` for
@@ -1861,7 +1861,7 @@ rather than the bare number.
 The warning must **not** fire when:
 
 - `Source ∈ {TierUserSource, TierUserOverride, TierEsctype,
-  TierExplicitSignal, TierShippedOverride, TierDefault}`. (The
+  TierExplicitSignal, TierBuiltinOverride, TierDefault}`. (The
   `TierDefault` case is "assume mutating"; non-mutating calls
   can't reach that tier, so it can't trigger the warning in
   practice — listed for completeness.)
@@ -1876,7 +1876,7 @@ The warning must **not** fire when:
 - `heuristic_warns/` — non-mutating call resolved by tier 6;
   flag on → warning, flag off → silent. Compare diagnostic
   snapshots for both runs.
-- `override_silent/` — same call but a shipped override pins the
+- `override_silent/` — same call but a built-in override pins the
   classification; flag on → silent.
 - `esctype_silent/` — `@esctype` provides the type; flag on → silent.
 - `strong_signal_silent/` — `readonly this` on the method; flag on
@@ -1926,7 +1926,7 @@ Resolved:
 - Override-file location precedence — see requirements
   §"Override file format". Tier 1b consuming-project wins over
   tier 1a `node_modules/<dep>/overrides/`; both win over tier 4
-  shipped.
+  built-in.
 - `@esctype` `*/`-in-strings escape — `*\/` on emit, unescape on
   consume (see §2).
 - Type printer reparseability — covered by §8.

--- a/planning/interop_mutability/override_merge_semantics.md
+++ b/planning/interop_mutability/override_merge_semantics.md
@@ -212,10 +212,10 @@ Multiple files may declare overrides for the same module:
   the union of all member declarations across files. Each individual
   member must still appear in only one file.
 
-Shipped overrides and user overrides cannot collide because they
+Built-in overrides and user overrides cannot collide because they
 load at different precedence tiers (resolution-order tiers 4 and 3
 respectively); the user's wins. The diagnostic for the silent override
-suggests the user verify the shipped override is wrong rather than
+suggests the user verify the built-in override is wrong rather than
 out-of-date.
 
 ## Order independence

--- a/planning/interop_mutability/requirements.md
+++ b/planning/interop_mutability/requirements.md
@@ -110,7 +110,7 @@ itself cannot represent.
   information directly in their `.d.ts`. (Round-trip emission from
   `.esc` is the same path.) This makes Escalier-to-Escalier interop
   lossless across the `.d.ts` boundary.
-- **Precedence.** `@esctype` outranks core principles, shipped
+- **Precedence.** `@esctype` outranks core principles, built-in
   overrides, and all heuristics, but **user overrides win over
   `@esctype`**. This gives the consuming project a way to correct a
   vendored `.d.ts` whose `@esctype` tag is wrong, stale, or
@@ -137,7 +137,7 @@ stop at the first match:
 3. **Explicit author signals** — `readonly this`, getters/setters,
    `Readonly<T>` collection variant, `readonly` properties (principle
    #6), well-known symbol methods.
-4. **Shipped overrides** — built-ins (principle covers `Array`/`Map`/`Set`
+4. **Built-in overrides** — built-ins (principle covers `Array`/`Map`/`Set`
    readonly variants by shape; explicit override entries cover `Date`,
    `RegExp`, `Promise`, etc.) and known FP libraries (principle #5).
 5. **Primitive wrapper classes** (principle #3) — `Number`, `BigInt`,
@@ -255,7 +255,7 @@ classifier for any library where the compiler ships explicit knowledge
 (built-ins, well-known FP / immutability libraries per principle #5).
 The same machinery serves user-supplied corrections for third-party APIs.
 
-- **Shipped overrides** — bundled with the compiler. Cover built-in
+- **Built-in overrides** — bundled with the compiler. Cover built-in
   classes that don't have a `Readonly*` variant in TS's lib
   files (`Date`, `RegExp`, `Promise`, `Error`, typed arrays, `URL`,
   `URLSearchParams`, `WeakRef`/`WeakMap`/`WeakSet`, etc.) plus
@@ -265,7 +265,7 @@ The same machinery serves user-supplied corrections for third-party APIs.
   `Readonly*` / mutable interface split that TypeScript ships.
 - **User override files** — checked into the consuming project,
   declaring per-module corrections for third-party APIs. Loaded
-  through the same machinery as the shipped overrides.
+  through the same machinery as the built-in overrides.
 
 Inline overrides on a TS symbol are expressed via `@esctype` (see
 Round-tripping section) — that mechanism subsumes any narrower
@@ -321,16 +321,16 @@ divergence. This keeps overrides honest: an override can refine
 *mutability* (and, later, lifetimes / throws) but cannot quietly
 fork the shape of a built-in API.
 
-To keep shipped overrides in sync as upstream `.d.ts` files evolve,
+To keep built-in overrides in sync as upstream `.d.ts` files evolve,
 the compiler test suite includes a **consistency test** that runs
-over every shipped override entry:
+over every built-in override entry:
 
 - For TS built-in symbols, the upstream is the bundled TS lib
   `.d.ts` set pinned to the compiler's TS lib version.
-- For shipped third-party overrides (Ramda, fp-ts, Effect,
+- For built-in third-party overrides (Ramda, fp-ts, Effect,
   Immutable.js, lodash/fp, etc.), the upstream is the corresponding
   `@types/*` package (or the library's own bundled types) at a
-  pinned version recorded alongside the shipped override.
+  pinned version recorded alongside the built-in override.
 
 Every overridden symbol has an upstream `.d.ts` counterpart: even
 Escalier-authored libraries ship `.d.ts` for TypeScript
@@ -356,7 +356,7 @@ drift as a deliberate fix-up step rather than letting it accumulate.
   directory at the root of a package — i.e. the directory containing
   the package's `package.json`. The compiler walks the following
   locations in order, with later locations winning on conflict:
-  1. Shipped overrides bundled with the compiler (resolution-order
+  1. Built-in overrides bundled with the compiler (resolution-order
      tier 4).
   2. `node_modules/<dep>/overrides/**/*.esc` — overrides shipped by
      a dependency for itself or its own deps (resolution-order


### PR DESCRIPTION
## Summary
Final slice of the #603 stack — the user-visible integration point.

- `mutability.go` — minor exports used by classification.
- `internal/checker/infer_stmt.go` — allow `ClassDecl` inference inside override declare blocks (removes a guard panic).

Together these make the override machinery from 5.1–5.3 reachable from the checker.

## Stack
- 5.1 — store + errors + plan doc (#606)
- 5.2 — extract + consistency (#607)
- 5.3 — merge + loader (#608)
- **5.4 (this PR)** — wire into checker

## Test plan
- [x] go build ./...
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mutability overrides in TypeScript declaration handling, enabling user-defined and built-in customizations when processing external type definitions.
  * Added support for override-prefixed ambient `declare` blocks to apply custom type conversion rules.

* **Refactor**
  * Enhanced internal conversion context threading to propagate override store information through declaration processing pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->