### PR TITLE
Fix #614: Wire interop.Classify heuristics into checker prelude for .d.ts lib types

### DIFF
--- a/internal/checker/method_helpers_test.go
+++ b/internal/checker/method_helpers_test.go
@@ -152,7 +152,7 @@ func TestStripMutSelfFromMethods(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			obj, fns := build(tc.methods...)
-			stripMutSelfFromMethods(obj, set.FromSlice(tc.overrides))
+			applyMethodMutability(obj, set.FromSlice(tc.overrides))
 			for name, wantMut := range tc.expectedMut {
 				fn := fns[name]
 				_, isMut := fn.SelfParam.Type.(*type_system.MutType)
@@ -161,4 +161,48 @@ func TestStripMutSelfFromMethods(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestUpdateMethodMutability_HeuristicFallthrough pins the issue #614
+// behaviour: a .d.ts-loaded method on a class with no entry in
+// mutabilityOverrides still gets the name-only interop heuristics
+// applied. Before #614 the second pass only iterated the override map's
+// keys, so `getFoo` on an unlisted class stayed `mut self` and was
+// hidden on non-mut receivers despite tier 5 unambiguously classifying
+// it non-mutating.
+func TestUpdateMethodMutability_HeuristicFallthrough(t *testing.T) {
+	t.Parallel()
+
+	makeMethod := func(name string) (*type_system.MethodElem, *type_system.FuncType) {
+		fn := type_system.NewFuncType(nil, nil, nil,
+			type_system.NewNeverType(nil), type_system.NewNeverType(nil))
+		return type_system.NewMethodElem(type_system.NewStrKey(name), fn), fn
+	}
+
+	getFoo, getFooFn := makeMethod("getFoo")
+	push, pushFn := makeMethod("push")
+	frobnicate, frobnicateFn := makeMethod("frobnicate")
+
+	obj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{getFoo, push, frobnicate})
+
+	ns := type_system.NewNamespace()
+	// "Widget" is intentionally NOT a key in mutabilityOverrides — the
+	// whole point is heuristics must run even with no override entry.
+	ns.Types["Widget"] = &type_system.TypeAlias{Type: obj}
+
+	populateSelfParams(ns)
+	UpdateMethodMutability(Context{}, ns)
+
+	checkMut := func(fn *type_system.FuncType, wantMut bool, label string) {
+		require.NotNil(t, fn.SelfParam, label)
+		_, isMut := fn.SelfParam.Type.(*type_system.MutType)
+		require.Equalf(t, wantMut, isMut, "%s: want mut=%v, got mut=%v", label, wantMut, isMut)
+	}
+
+	// Tier 5 `get*` prefix → non-mut self.
+	checkMut(getFooFn, false, "getFoo")
+	// Tier 6 mutating prefix `push` → stays at default mut self.
+	checkMut(pushFn, true, "push")
+	// No heuristic match → stays at default mut self.
+	checkMut(frobnicateFn, true, "frobnicate")
 }

--- a/internal/checker/method_helpers_test.go
+++ b/internal/checker/method_helpers_test.go
@@ -163,46 +163,48 @@ func TestStripMutSelfFromMethods(t *testing.T) {
 	}
 }
 
-// TestUpdateMethodMutability_HeuristicFallthrough pins the issue #614
+// TestUpdateMethodMutability_HeuristicFallthrough pins the fall-through
 // behaviour: a .d.ts-loaded method on a class with no entry in
 // mutabilityOverrides still gets the name-only interop heuristics
-// applied. Before #614 the second pass only iterated the override map's
-// keys, so `getFoo` on an unlisted class stayed `mut self` and was
-// hidden on non-mut receivers despite tier 5 unambiguously classifying
-// it non-mutating.
+// applied, so `getFoo` on an unlisted class is classified non-mutating
+// by tier 5 rather than being left at the default `mut self` and hidden
+// on non-mut receivers.
 func TestUpdateMethodMutability_HeuristicFallthrough(t *testing.T) {
 	t.Parallel()
 
-	makeMethod := func(name string) (*type_system.MethodElem, *type_system.FuncType) {
-		fn := type_system.NewFuncType(nil, nil, nil,
-			type_system.NewNeverType(nil), type_system.NewNeverType(nil))
-		return type_system.NewMethodElem(type_system.NewStrKey(name), fn), fn
+	tests := []struct {
+		name    string
+		method  string
+		wantMut bool
+	}{
+		// Tier 5 `get*` prefix → non-mut self.
+		{"tier 5 get* prefix", "getFoo", false},
+		// Tier 6 mutating prefix `push` → stays at default mut self.
+		{"tier 6 mutating prefix", "push", true},
+		// No heuristic match → stays at default mut self.
+		{"no heuristic match", "frobnicate", true},
 	}
 
-	getFoo, getFooFn := makeMethod("getFoo")
-	push, pushFn := makeMethod("push")
-	frobnicate, frobnicateFn := makeMethod("frobnicate")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	obj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{getFoo, push, frobnicate})
+			fn := type_system.NewFuncType(nil, nil, nil,
+				type_system.NewNeverType(nil), type_system.NewNeverType(nil))
+			method := type_system.NewMethodElem(type_system.NewStrKey(tc.method), fn)
+			obj := type_system.NewObjectType(nil, []type_system.ObjTypeElem{method})
 
-	ns := type_system.NewNamespace()
-	// "Widget" is intentionally NOT a key in mutabilityOverrides — the
-	// whole point is heuristics must run even with no override entry.
-	ns.Types["Widget"] = &type_system.TypeAlias{Type: obj}
+			ns := type_system.NewNamespace()
+			// "Widget" is intentionally NOT a key in mutabilityOverrides — the
+			// whole point is heuristics must run even with no override entry.
+			ns.Types["Widget"] = &type_system.TypeAlias{Type: obj}
 
-	populateSelfParams(ns)
-	UpdateMethodMutability(Context{}, ns)
+			populateSelfParams(ns)
+			UpdateMethodMutability(Context{}, ns)
 
-	checkMut := func(fn *type_system.FuncType, wantMut bool, label string) {
-		require.NotNil(t, fn.SelfParam, label)
-		_, isMut := fn.SelfParam.Type.(*type_system.MutType)
-		require.Equalf(t, wantMut, isMut, "%s: want mut=%v, got mut=%v", label, wantMut, isMut)
+			require.NotNil(t, fn.SelfParam)
+			_, isMut := fn.SelfParam.Type.(*type_system.MutType)
+			require.Equal(t, tc.wantMut, isMut)
+		})
 	}
-
-	// Tier 5 `get*` prefix → non-mut self.
-	checkMut(getFooFn, false, "getFoo")
-	// Tier 6 mutating prefix `push` → stays at default mut self.
-	checkMut(pushFn, true, "push")
-	// No heuristic match → stays at default mut self.
-	checkMut(frobnicateFn, true, "frobnicate")
 }

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -220,24 +220,24 @@ type MethodNames = set.Set[string]
 
 // TODO(#500): extend mutabilityOverrides for Promise, Error, and other
 // classes whose non-mutating methods should be callable on non-mut
-// receivers. Methods on classes not listed here default to `mut self`
-// (set by populateSelfParams), which means they are hidden by
-// isMemberVisible on non-mut receivers. Adding an entry like
-// `"Date": set.FromSlice([]string{"getHours", ...})` strips the default
-// `mut` for those non-mutating methods.
+// receivers. Entries here are exceptions the name-only heuristics in
+// interop.ClassifyMethodByName (issue #614) either miss (e.g.
+// String.charAt — no prefix match) or actively mis-classify (e.g.
+// String.replace — `replace` is a mutating-prefix). Method names
+// already covered by the heuristics — `get*`, `to*`, `is*`, `has*`,
+// well-known `toString`/`valueOf`, and so on — are redundant and must
+// not be re-listed here; the prelude pass applies the heuristics as a
+// fall-through whenever a method has no override entry.
 //
 // the key is the interface name
 var mutabilityOverrides = map[string]MethodNames{
 	"String": set.FromSlice([]string{
-		"at",
+		// Heuristic misses (no prefix/exact match) and active
+		// mis-classifications (`replace`/`replaceAll` look mutating).
 		"charAt",
 		"charCodeAt",
 		"codePointAt",
-		"concat",
 		"endsWith",
-		"includes",
-		"indexOf",
-		"lastIndexOf",
 		"localeCompare",
 		"match",
 		"matchAll",
@@ -248,96 +248,41 @@ var mutabilityOverrides = map[string]MethodNames{
 		"replace",
 		"replaceAll",
 		"search",
-		"slice",
 		"split",
 		"startsWith",
 		"substr",
 		"substring",
-		"toLocaleLowerCase",
-		"toLocaleUpperCase",
-		"toLowerCase",
-		"toUpperCase",
 		"trim",
 		"trimEnd",
 		"trimStart",
-		"valueOf",
 	}),
-	"RegExp": set.FromSlice([]string{
-		// `compile`, `exec` (with global/sticky), and `test` (with
-		// global/sticky) are mutating and inherit the default `mut self`.
-		// `Symbol.search` / `Symbol.split` are non-mutating per spec but
-		// can't be expressed in this string-keyed map — see #620.
-		"toString",
-	}),
-	"Number": set.FromSlice([]string{
-		"toExponential",
-		"toFixed",
-		"toLocaleString",
-		"toPrecision",
-		"toString",
-		"valueOf",
-	}),
-	"Boolean": set.FromSlice([]string{
-		"valueOf",
-	}),
+	// RegExp.toString is covered by the well-known allow-list in
+	// ClassifyMethodByName. `compile`, `exec` (with global/sticky), and
+	// `test` (with global/sticky) are mutating and inherit the default
+	// `mut self`. `Symbol.search` / `Symbol.split` are non-mutating per
+	// spec but can't be expressed in this string-keyed map — see #620.
 	"Object": set.FromSlice([]string{
-		// All Object.prototype methods are non-mutating. Without this
-		// entry, derived types that inherit toString/valueOf/etc. from
-		// Object (e.g. RegExp.toString) become invisible on non-mut
-		// receivers after the polarity flip.
-		"hasOwnProperty",
-		"isPrototypeOf",
+		// Heuristic miss: `propertyIsEnumerable` doesn't start with any
+		// known non-mutating prefix. The rest of Object.prototype
+		// (hasOwnProperty, isPrototypeOf, toLocaleString, toString,
+		// valueOf) is covered by the heuristics.
 		"propertyIsEnumerable",
-		"toLocaleString",
-		"toString",
-		"valueOf",
 	}),
 	"Function": set.FromSlice([]string{
+		// Heuristic misses; `toString` is covered by the well-known list.
 		"apply",
 		"bind",
 		"call",
-		"toString",
 	}),
-	"Date": set.FromSlice([]string{
-		// `get*` accessors are non-mutating; `set*` accessors mutate and
-		// inherit the default `mut self`. `toISOString`, `toJSON`,
-		// `toLocaleDateString`, `toLocaleTimeString`, `toDateString`,
-		// `toTimeString`, and `toUTCString` are all stringifiers and
-		// non-mutating.
-		"getDate",
-		"getDay",
-		"getFullYear",
-		"getHours",
-		"getMilliseconds",
-		"getMinutes",
-		"getMonth",
-		"getSeconds",
-		"getTime",
-		"getTimezoneOffset",
-		"getUTCDate",
-		"getUTCDay",
-		"getUTCFullYear",
-		"getUTCHours",
-		"getUTCMilliseconds",
-		"getUTCMinutes",
-		"getUTCMonth",
-		"getUTCSeconds",
-		"toDateString",
-		"toISOString",
-		"toJSON",
-		"toLocaleDateString",
-		"toLocaleString",
-		"toLocaleTimeString",
-		"toString",
-		"toTimeString",
-		"toUTCString",
-		"valueOf",
-	}),
+	// `Number`, `Boolean`, and `Date` had every entry covered by the
+	// name-only heuristics (`get*`, `to*`, well-known `toString`/`valueOf`)
+	// — issue #614 removed the redundant bootstrap blocks.
 	"Console": set.FromSlice([]string{
+		// Heuristic misses (most Console methods are bare nouns) plus
+		// `clear` (mis-classified as mutating by the `clear` prefix —
+		// Console.clear is non-mutating on the Console object itself).
 		"assert",
 		"clear",
-		"count",
-		"countReset",
 		"debug",
 		"dir",
 		"dirxml",
@@ -356,6 +301,7 @@ var mutabilityOverrides = map[string]MethodNames{
 		"warn",
 	}),
 	"Body": set.FromSlice([]string{
+		// Heuristic misses — every Body method is a bare noun.
 		"arrayBuffer",
 		"blob",
 		"bytes",
@@ -364,33 +310,38 @@ var mutabilityOverrides = map[string]MethodNames{
 		"text",
 	}),
 	"Response": set.FromSlice([]string{
+		// Heuristic misses; `clone` is covered by the `clone` prefix.
 		"arrayBuffer",
 		"blob",
 		"bytes",
-		"clone",
 		"formData",
 		"json",
 		"text",
 	}),
 	"Request": set.FromSlice([]string{
+		// Heuristic misses; `clone` is covered by the `clone` prefix.
 		"arrayBuffer",
 		"blob",
 		"bytes",
-		"clone",
 		"formData",
 		"json",
 		"text",
 	}),
 }
 
-// stripMutSelfFromMethods strips `mut self` from any method in objType
-// whose name appears in names.
+// applyMethodMutability classifies each MethodElem on objType using the
+// per-class override set first and the name-only interop heuristics as
+// the fall-through (issue #614). When neither source positively
+// classifies the method as non-mutating it keeps the default `mut self`
+// set by populateSelfParams. The override entries always win — they
+// encode known exceptions that the heuristics either miss or
+// mis-classify (e.g. String.replace, Console.clear).
 //
 // Only MethodElem is consulted. GetterElem / SetterElem polarity is
 // fixed by populateSelfParams (getters non-mut, setters mut) — passing
 // an accessor name in `names` would silently miss here. If an accessor
 // ever needs its polarity overridden, extend the type switch below.
-func stripMutSelfFromMethods(objType *type_system.ObjectType, names MethodNames) {
+func applyMethodMutability(objType *type_system.ObjectType, names MethodNames) {
 	for _, elem := range objType.Elems {
 		me, ok := elem.(*type_system.MethodElem)
 		if !ok {
@@ -399,7 +350,12 @@ func stripMutSelfFromMethods(objType *type_system.ObjectType, names MethodNames)
 		if me.Name.Kind != type_system.StrObjTypeKeyKind {
 			continue
 		}
-		if names.Contains(me.Name.Str) {
+		name := me.Name.Str
+		if names.Contains(name) {
+			setReceiverMut(me.Fn, false)
+			continue
+		}
+		if mut, classified := interop.ClassifyMethodByName(name); classified && !mut {
 			setReceiverMut(me.Fn, false)
 		}
 	}
@@ -451,18 +407,10 @@ func UpdateMethodMutability(ctx Context, namespace *type_system.Namespace) {
 				if it, ok := type_system.Prune(instTypeAlias.Type).(*type_system.ObjectType); ok {
 					// TypeScript .d.ts has no mut-self annotation, so
 					// methods default to `mut self` (set by
-					// populateSelfParams). We strip `mut` for methods
-					// listed in the per-interface overrides set.
-					for _, elem := range it.Elems {
-						if me, ok := elem.(*type_system.MethodElem); ok {
-							if me.Name.Kind != type_system.StrObjTypeKeyKind {
-								continue
-							}
-							if overrides.Contains(me.Name.Str) {
-								setReceiverMut(me.Fn, false)
-							}
-						}
-					}
+					// populateSelfParams). Apply per-interface overrides
+					// and, as a fall-through for any unlisted method,
+					// the name-only interop heuristics (#614).
+					applyMethodMutability(it, overrides)
 				} else {
 					panic("Instance type is not an ObjectType: " + instTypeAlias.Type.String())
 				}
@@ -470,30 +418,35 @@ func UpdateMethodMutability(ctx Context, namespace *type_system.Namespace) {
 		}
 	}
 
-	// Second pass: types declared via `declare var X: {...}` (e.g. Response,
-	// Request) or as bare interfaces (e.g. Function, Body) — apply overrides
-	// by direct name lookup. The trio pass above already handled the
-	// constructor-shaped classes; for the rest we look up the instance type
-	// alias directly. Duplicate work is harmless because setReceiverMut is
-	// idempotent.
+	// Second pass: every named ObjectType in the namespace, including
+	// types declared via `declare var X: {...}` (e.g. Response, Request)
+	// or as bare interfaces (e.g. Function, Body), and any class with no
+	// override entry at all. Without the per-class entry the override
+	// set is empty and only the name-only interop heuristics fire — that
+	// fall-through is the point of #614, so a `.d.ts` getFoo on a class
+	// the override map never heard of still ends up non-mut.
+	//
+	// The trio pass above already touched constructor-shaped classes
+	// (via their resolved instance types); duplicate work on those is
+	// harmless because setReceiverMut is idempotent. This pass also
+	// visits the `*Constructor` types themselves, so heuristic-only
+	// classifications now reach static methods like Array.isArray and
+	// Object.keys/values/entries.
 	//
 	// Iterate in a deterministic order so snapshot tests downstream don't
 	// pick up map iteration randomness.
-	names := make([]string, 0, len(mutabilityOverrides))
-	for name := range mutabilityOverrides {
-		names = append(names, name)
+	typeNames = typeNames[:0]
+	for name := range namespace.Types {
+		typeNames = append(typeNames, name)
 	}
-	slices.Sort(names)
-	for _, overrideName := range names {
-		typeAlias, ok := namespace.Types[overrideName]
-		if !ok {
-			continue
-		}
+	slices.Sort(typeNames)
+	for _, name := range typeNames {
+		typeAlias := namespace.Types[name]
 		objType, ok := type_system.Prune(typeAlias.Type).(*type_system.ObjectType)
 		if !ok {
 			continue
 		}
-		stripMutSelfFromMethods(objType, mutabilityOverrides[overrideName])
+		applyMethodMutability(objType, mutabilityOverrides[name])
 	}
 }
 

--- a/internal/interop/mutability.go
+++ b/internal/interop/mutability.go
@@ -124,6 +124,66 @@ func Classify(ctx ClassifyContext) ClassifyResult {
 	return ClassifyResult{Mut: true, Source: TierDefault}
 }
 
+// ClassifyMethodByName runs the name-only tiers of Classify against a bare
+// method name and returns the resulting receiver-mutability classification.
+// It covers the well-known non-mutating method allow-list (from tier 3),
+// the tier-5 `get*` prefix rule, and the tier-6 name-based heuristics —
+// i.e. every tier whose decision depends only on the method's name.
+//
+// Used by the checker prelude pass on .d.ts-loaded lib types, where the
+// caller has a type_system.MethodElem and a string name but no
+// dts_parser.ClassMember to feed the full Classify entry point.
+//
+// Returns (mut, true) when a tier classifies the name; (false, false)
+// when no tier matches and the caller should keep its own default.
+func ClassifyMethodByName(name string) (mut bool, ok bool) {
+	if name == "" {
+		return false, false
+	}
+	// Tier 3 (name-only subset): well-known non-mutating method names
+	// that apply regardless of the containing type.
+	if wellKnownNonMutatingMethods.Contains(name) {
+		return false, true
+	}
+	// Tier 5: `get*` prefix with documented mutate-on-miss fall-throughs.
+	if classifyGetPrefixByName(name) {
+		return false, true
+	}
+	// Tier 6: name-based heuristics. Mutating wins when both match.
+	isMut := matchesAnyPrefix(name, mutatingPrefixes) || mutatingExact.Contains(name)
+	isNonMut := matchesAnyPrefix(name, nonMutatingPrefixes) || nonMutatingExact.Contains(name)
+	switch {
+	case isMut:
+		return true, true
+	case isNonMut:
+		return false, true
+	}
+	return false, false
+}
+
+// classifyGetPrefixByName is the name-only counterpart to
+// classifyGetPrefix. Returns true iff `name` should be classified
+// non-mutating under the tier-5 rule (bare `get` or `get` + uppercase
+// continuation, excluding the `getOr*` mutate-on-miss prefixes).
+func classifyGetPrefixByName(name string) bool {
+	if name != "get" && !hasPrefixWithUpperContinuation(name, "get") {
+		return false
+	}
+	for _, p := range getOrMutatingPrefixes {
+		if !strings.HasPrefix(name, p) {
+			continue
+		}
+		if len(name) == len(p) {
+			return false
+		}
+		r, _ := utf8.DecodeRuneInString(name[len(p):])
+		if !unicode.IsLower(r) {
+			return false
+		}
+	}
+	return true
+}
+
 // classifyGetPrefix implements tier 5: `get*` methods are non-mutating,
 // except for the documented mutate-on-miss prefixes (`getOrInsert`,
 // `getOrUpdate`, `getOrCreate`), which fall through to tier 6 and get

--- a/internal/interop/mutability_test.go
+++ b/internal/interop/mutability_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dts_parser"
+	"github.com/stretchr/testify/require"
 )
 
 // span is a zero-value span used throughout these tests.
@@ -510,4 +511,55 @@ func TestClassifyInheritance(t *testing.T) {
 			t.Errorf("got Mut=%v Source=%d, want Mut=false Source=TierExplicitSignal", result.Mut, result.Source)
 		}
 	})
+}
+
+// TestClassifyMethodByName covers the name-only entry point used by the
+// checker prelude pass on .d.ts-loaded lib types (issue #614). The
+// classification must match the corresponding tiers in Classify when
+// called with the same name, even without a dts_parser.ClassMember.
+func TestClassifyMethodByName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		method  string
+		wantMut bool
+		wantOK  bool
+	}{
+		// Tier 3 well-known non-mutating allow-list.
+		{"toString well-known", "toString", false, true},
+		{"valueOf well-known", "valueOf", false, true},
+		{"toJSON well-known", "toJSON", false, true},
+		{"toLocaleString well-known", "toLocaleString", false, true},
+
+		// Tier 5 get* prefix.
+		{"bare get", "get", false, true},
+		{"getFoo", "getFoo", false, true},
+		{"getter falls through", "getter", false, false},
+		{"getOrInsertFoo mutating fall-through", "getOrInsertFoo", true, true},
+		{"getOrInsert exact mutating fall-through", "getOrInsert", true, true},
+		{"getOrInserter stays non-mut", "getOrInserter", false, true},
+
+		// Tier 6 mutating prefixes / exacts.
+		{"push", "push", true, true},
+		{"setName", "setName", true, true},
+		{"sort exact", "sort", true, true},
+
+		// Tier 6 non-mutating prefixes / exacts.
+		{"toUpperCase", "toUpperCase", false, true},
+		{"isEmpty", "isEmpty", false, true},
+		{"includes exact", "includes", false, true},
+
+		// No classification.
+		{"unknown", "frobnicate", false, false},
+		{"empty", "", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mut, ok := ClassifyMethodByName(tc.method)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantMut, mut)
+		})
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for method mutability classification heuristics and name-based fallthrough logic.

* **Refactor**
  * Improved method receiver mutability classification with simplified configuration and enhanced heuristic-based fallthrough for built-in TypeScript types.
  * Unified mutability application logic for more consistent behavior across type declaration processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->