### PR TITLE
Standard Library 2: URI-scheme imports + binding-shape flags

### DIFF
--- a/cmd/escalier/fixture_test.go
+++ b/cmd/escalier/fixture_test.go
@@ -111,6 +111,11 @@ func checkFixture(t *testing.T, repoRoot string, fixtureDir string) {
 	// not contain `internal/interop/data`, so the loader's repo-root
 	// walk would otherwise fail to find the overrides.
 	t.Setenv("ESCALIER_BUILTINS_DIR", filepath.Join(repoRoot, "internal", "interop", "data"))
+	// Same story for the builtins workstream's stdlib data dir: the
+	// resolver's lazy interop.StdlibDir("") call won't find the repo
+	// root from the tmpDir-relocated test binary, so we point it at
+	// the in-repo data tree directly.
+	t.Setenv("ESCALIER_STDLIB_DIR", filepath.Join(repoRoot, "internal", "interop", "data"))
 
 	err = os.Chdir(tmpDir)
 	require.NoError(t, err)

--- a/cmd/escalier/main.go
+++ b/cmd/escalier/main.go
@@ -8,6 +8,14 @@ import (
 
 func main() {
 	buildCmd := flag.NewFlagSet("build", flag.ExitOnError)
+	// `--stdlib-dir` is the highest-precedence channel for locating the
+	// stdlib `.esc` files per planning/builtins §2.2a. When supplied,
+	// it overrides ESCALIER_STDLIB_DIR and the executable-relative
+	// discovery paths. We propagate it by setting the env var so the
+	// checker's lazy `interop.StdlibDir("")` call picks it up without
+	// further plumbing — the resolution order still ends up
+	// flag > env > sibling > repo-relative.
+	buildStdlibDir := buildCmd.String("stdlib-dir", "", "directory containing the stdlib `.esc` files (std/, dom/, node/)")
 	formatCmd := flag.NewFlagSet("format", flag.ExitOnError)
 
 	if len(os.Args) < 2 {
@@ -21,6 +29,9 @@ func main() {
 		if err != nil {
 			fmt.Println("failed to parse build command")
 			os.Exit(1)
+		}
+		if *buildStdlibDir != "" {
+			_ = os.Setenv("ESCALIER_STDLIB_DIR", *buildStdlibDir)
 		}
 		build(os.Stdout, os.Stderr, buildCmd.Args())
 	case "format":

--- a/cmd/lsp-server/completion_test.go
+++ b/cmd/lsp-server/completion_test.go
@@ -870,7 +870,7 @@ func parseModuleAndInferWithPackages(
 		IsAsync:    false,
 		IsPatMatch: false,
 	}
-	typeErrors := c.InferModule(inferCtx, module)
+	_, typeErrors := c.InferModule(inferCtx, module)
 	for _, err := range typeErrors {
 		t.Logf("type error: %s", err.Message())
 	}

--- a/cmd/lsp-server/main.go
+++ b/cmd/lsp-server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net/url"
 	"os"
@@ -23,6 +24,16 @@ var (
 )
 
 func main() {
+	// Mirror cmd/escalier's `--stdlib-dir` plumbing so the LSP server
+	// can be launched with a non-default stdlib data dir (per
+	// planning/builtins §2.2a). Editors that don't know how to pass
+	// flags can still use the ESCALIER_STDLIB_DIR env var.
+	stdlibDir := flag.String("stdlib-dir", "", "directory containing the stdlib `.esc` files (std/, dom/, node/)")
+	flag.Parse()
+	if *stdlibDir != "" {
+		_ = os.Setenv("ESCALIER_STDLIB_DIR", *stdlibDir)
+	}
+
 	fmt.Fprintf(os.Stderr, "Hello, from lsp-server\n")
 
 	server := glsp_server.NewServer(NewServer(), lsName, false)

--- a/fixtures/stdlib_import_flag_conflict/build/lib/index.js
+++ b/fixtures/stdlib_import_flag_conflict/build/lib/index.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_flag_conflict/build/lib/index.js.map
+++ b/fixtures/stdlib_import_flag_conflict/build/lib/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"std:math?local\u0026flat\"\n"],"names":[],"mappings":""}

--- a/fixtures/stdlib_import_flag_conflict/error.txt
+++ b/fixtures/stdlib_import_flag_conflict/error.txt
@@ -1,0 +1,5 @@
+lib/index.esc:1:1: binding-shape flags "flat" and "local" are mutually exclusive; pick one
+
+1:  import "std:math?local&flat"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/fixtures/stdlib_import_flag_conflict/lib/index.esc
+++ b/fixtures/stdlib_import_flag_conflict/lib/index.esc
@@ -1,0 +1,1 @@
+import "std:math?local&flat"

--- a/fixtures/stdlib_import_flag_conflict/package.json
+++ b/fixtures/stdlib_import_flag_conflict/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "stdlib-import-flag-conflict",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/stdlib_import_flat/build/lib/index.d.ts
+++ b/fixtures/stdlib_import_flat/build/lib/index.d.ts
@@ -1,0 +1,1 @@
+export declare const pi: number;

--- a/fixtures/stdlib_import_flat/build/lib/index.js
+++ b/fixtures/stdlib_import_flat/build/lib/index.js
@@ -1,0 +1,2 @@
+export const pi = std.PI;
+//# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_flat/build/lib/index.js.map
+++ b/fixtures/stdlib_import_flat/build/lib/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"std:math?flat\"\n\nexport val pi: number = std.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,IAAI"}

--- a/fixtures/stdlib_import_flat/lib/index.esc
+++ b/fixtures/stdlib_import_flat/lib/index.esc
@@ -1,0 +1,3 @@
+import "std:math?flat"
+
+export val pi: number = std.PI

--- a/fixtures/stdlib_import_flat/package.json
+++ b/fixtures/stdlib_import_flat/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "stdlib-import-flat",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/stdlib_import_local/build/lib/index.d.ts
+++ b/fixtures/stdlib_import_local/build/lib/index.d.ts
@@ -1,0 +1,1 @@
+export declare const pi: number;

--- a/fixtures/stdlib_import_local/build/lib/index.js
+++ b/fixtures/stdlib_import_local/build/lib/index.js
@@ -1,0 +1,2 @@
+export const pi = math.PI;
+//# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_local/build/lib/index.js.map
+++ b/fixtures/stdlib_import_local/build/lib/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"std:math\"\n\nexport val pi: number = math.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,KAAK"}

--- a/fixtures/stdlib_import_local/lib/index.esc
+++ b/fixtures/stdlib_import_local/lib/index.esc
@@ -1,0 +1,3 @@
+import "std:math"
+
+export val pi: number = math.PI

--- a/fixtures/stdlib_import_local/package.json
+++ b/fixtures/stdlib_import_local/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "stdlib-import-local",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/stdlib_import_nested/build/lib/index.d.ts
+++ b/fixtures/stdlib_import_nested/build/lib/index.d.ts
@@ -1,0 +1,1 @@
+export declare const pi: number;

--- a/fixtures/stdlib_import_nested/build/lib/index.js
+++ b/fixtures/stdlib_import_nested/build/lib/index.js
@@ -1,0 +1,2 @@
+export const pi = std.math.PI;
+//# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_nested/build/lib/index.js.map
+++ b/fixtures/stdlib_import_nested/build/lib/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"std:math?nested\"\n\nexport val pi: number = std.math.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,AAAA,IAAI,KAAK"}

--- a/fixtures/stdlib_import_nested/lib/index.esc
+++ b/fixtures/stdlib_import_nested/lib/index.esc
@@ -1,0 +1,3 @@
+import "std:math?nested"
+
+export val pi: number = std.math.PI

--- a/fixtures/stdlib_import_nested/package.json
+++ b/fixtures/stdlib_import_nested/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "stdlib-import-nested",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/fixtures/stdlib_import_single_class/build/lib/index.d.ts
+++ b/fixtures/stdlib_import_single_class/build/lib/index.d.ts
@@ -1,0 +1,2 @@
+export declare const arr: Array<number>;
+export declare const isArr: boolean;

--- a/fixtures/stdlib_import_single_class/build/lib/index.js
+++ b/fixtures/stdlib_import_single_class/build/lib/index.js
@@ -1,0 +1,3 @@
+export const arr = new Array(5);
+export const isArr = Array.isArray(0);
+//# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_single_class/build/lib/index.js.map
+++ b/fixtures/stdlib_import_single_class/build/lib/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"std:array\"\n\nexport val isArr: boolean = Array.isArray(0)\nexport val arr: Array\u003cnumber\u003e = Array(5)\n"],"names":[],"mappings":"aAGW,AAAA,MAAqB,IAAA,MAAM;aAD3B,AAAA,QAAiB,AAAA,AAAA,MAAM,QAAQ"}

--- a/fixtures/stdlib_import_single_class/lib/index.esc
+++ b/fixtures/stdlib_import_single_class/lib/index.esc
@@ -1,0 +1,4 @@
+import "std:array"
+
+export val isArr: boolean = Array.isArray(0)
+export val arr: Array<number> = Array(5)

--- a/fixtures/stdlib_import_single_class/package.json
+++ b/fixtures/stdlib_import_single_class/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "stdlib-import-single-class",
+    "version": "0.0.1",
+    "type": "module",
+    "main": "build/lib/index.js"
+}

--- a/internal/ast/stmt.go
+++ b/internal/ast/stmt.go
@@ -75,12 +75,17 @@ func (i *ImportSpecifier) Span() Span { return i.span }
 
 type ImportStmt struct {
 	Specifiers  []*ImportSpecifier
-	PackageName string // e.g., "lodash", "@types/node", "lodash/fp"
+	PackageName string   // module specifier without the `?flag` suffix, e.g. "lodash", "std:math"
+	Flags       []string // `?flag1&flag2` suffix parsed into a list, preserving order; nil if none
 	span        Span
 }
 
-func NewImportStmt(specifiers []*ImportSpecifier, packageName string, span Span) *ImportStmt {
-	return &ImportStmt{Specifiers: specifiers, PackageName: packageName, span: span}
+// Bare reports whether this import has no binding clause (no specifiers and no
+// namespace alias), as in `import "std:math"`.
+func (s *ImportStmt) Bare() bool { return len(s.Specifiers) == 0 }
+
+func NewImportStmt(specifiers []*ImportSpecifier, packageName string, flags []string, span Span) *ImportStmt {
+	return &ImportStmt{Specifiers: specifiers, PackageName: packageName, Flags: flags, span: span}
 }
 func (*ImportStmt) isStmt()      {}
 func (s *ImportStmt) Span() Span { return s.span }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"context"
+	"sync"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/interop"
@@ -39,6 +40,21 @@ type Checker struct {
 	// declarations. nil means "no overrides registered"; Classify falls
 	// through to its built-in heuristics.
 	OverrideStore *interop.OverrideStore
+
+	// Stdlib data directory (resolved lazily on first scheme-prefixed
+	// import). Holds the path that contains the `std/`, `dom/`, and
+	// `node/` subtrees. stdlibDirOnce gates the resolution so the
+	// fatal-on-missing diagnostic fires at most once per Checker; the
+	// error is reported as a regular import error at the offending
+	// import statement.
+	stdlibDir     string
+	stdlibDirErr  error
+	stdlibDirOnce sync.Once
+
+	// Next SourceID to allocate when loading a stdlib `.esc` file.
+	// Lives in a high range so it doesn't collide with user source IDs
+	// (which start at 0 and grow with the file count).
+	stdlibNextSourceID int
 }
 
 func NewChecker(ctx context.Context) *Checker {
@@ -57,6 +73,7 @@ func NewChecker(ctx context.Context) *Checker {
 		expandCache:           make(expandSeen),
 		substCache:            make(expandSeen),
 		memberCache:           make(memberCache),
+		stdlibNextSourceID:    1 << 20, // 1,048,576 — well above any plausible user source ID
 	}
 }
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -55,6 +55,14 @@ type Checker struct {
 	// Lives in a high range so it doesn't collide with user source IDs
 	// (which start at 0 and grow with the file count).
 	stdlibNextSourceID int
+
+	// Per-file, per-scheme tracking of which URI contributed each
+	// identifier merged via `?flat`. Used to produce taxonomy-aligned
+	// "?flat name collision" diagnostics that name the prior package.
+	// Outer key is the file scope, middle key is the scheme
+	// (`std`/`dom`), inner key is the identifier; value is the
+	// contributing URI (e.g. `dom:canvas`).
+	flatContributors map[*Scope]map[string]map[string]string
 }
 
 func NewChecker(ctx context.Context) *Checker {

--- a/internal/checker/infer_import.go
+++ b/internal/checker/infer_import.go
@@ -941,6 +941,15 @@ func (c *Checker) loadPackageFromPath(ctx Context, dtsFilePath string, packageNa
 // For type 2, we can use the name of the module declaration to determine the package
 // name.  For type 3, we need to know what npm package the .d.ts file belongs to.
 func (c *Checker) inferImport(ctx Context, importStmt *ast.ImportStmt) []Error {
+	// Route scheme-prefixed imports (`std:`, `dom:`, `node:`, and any
+	// other lowercase-scheme URI) to the stdlib loader. The dispatch
+	// happens here — at the highest level — so the npm-style resolver
+	// never sees these specifiers and the user gets taxonomy-aligned
+	// diagnostics for unknown schemes / packages.
+	if isSchemePrefixedImport(importStmt.PackageName) {
+		return c.inferStdlibImport(ctx, importStmt)
+	}
+
 	errors := []Error{}
 
 	// First, check if the package is already registered in the PackageRegistry.

--- a/internal/checker/infer_import.go
+++ b/internal/checker/infer_import.go
@@ -410,13 +410,13 @@ func (c *Checker) inferParsedTypeDef(
 			IsAsync:    false,
 			IsPatMatch: false,
 		}
-		globalErrors := c.InferModule(globalCtx, parsedTypeDef.GlobalModule)
+		_, globalErrors := c.InferModule(globalCtx, parsedTypeDef.GlobalModule)
 		errors = append(errors, globalErrors...)
 	}
 
 	// 5. Infer PackageModule into the package namespace (if present)
 	if parsedTypeDef.PackageModule != nil {
-		pkgErrors := c.InferModule(pkgCtx, parsedTypeDef.PackageModule)
+		_, pkgErrors := c.InferModule(pkgCtx, parsedTypeDef.PackageModule)
 		errors = append(errors, pkgErrors...)
 	}
 
@@ -779,7 +779,7 @@ func (c *Checker) loadPathReferencedFile(filePath string) []Error {
 			IsAsync:    false,
 			IsPatMatch: false,
 		}
-		globalErrors := c.InferModule(globalCtx, parsedTypeDef.PackageModule)
+		_, globalErrors := c.InferModule(globalCtx, parsedTypeDef.PackageModule)
 		errors = append(errors, globalErrors...)
 	}
 
@@ -868,7 +868,7 @@ func (c *Checker) loadPackageFromPath(ctx Context, dtsFilePath string, packageNa
 			IsPatMatch: false,
 		}
 
-		moduleErrors := c.InferModule(moduleCtx, namedModule)
+		_, moduleErrors := c.InferModule(moduleCtx, namedModule)
 		if len(moduleErrors) > 0 {
 			errors = append(errors, moduleErrors...)
 			continue

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1309,6 +1309,14 @@ func (c *Checker) InferComponent(
 						}
 
 					case *ast.MethodElem:
+						// `declare class` methods are ambient — they have a
+						// signature but no body. Skip the body-inference path
+						// entirely; the method type was already built from the
+						// signature when the class type was constructed.
+						if decl.Declare() || bodyElem.Fn.Body == nil {
+							continue
+						}
+
 						var methodType *type_system.MethodElem
 						var isStatic bool = bodyElem.Static
 
@@ -1883,7 +1891,12 @@ const DEBUG = false
 // graph and codegen will ensure that the declarations are emitted in the correct
 // order.
 // TODO: all interface declarations in a namespace to shadow previous ones.
-func (c *Checker) InferModule(ctx Context, m *ast.Module) (errors []Error) {
+//
+// Returns the dep graph built during Phase 2 alongside the diagnostics.
+// Callers that need the dep graph for downstream work (e.g. codegen)
+// can reuse it instead of rebuilding from the module; callers that
+// don't care discard it with `_`.
+func (c *Checker) InferModule(ctx Context, m *ast.Module) (depGraph *dep_graph.DepGraph, errors []Error) {
 	defer recoverTimeout(&errors)
 	clear(c.expandCache) // Reset cross-call expansion cache for this inference pass
 	clear(c.substCache)  // Reset substitution cache for this inference pass
@@ -1933,13 +1946,13 @@ func (c *Checker) InferModule(ctx Context, m *ast.Module) (errors []Error) {
 			// If there were errors loading React types, we can stop here since
 			// JSX code won't type-check without them.
 			if len(loadErrors) > 0 {
-				return errors
+				return depGraph, errors
 			}
 		}
 	}
 
 	// Phase 2: Build unified DepGraph for ALL declarations across all files.
-	depGraph := dep_graph.BuildDepGraph(m)
+	depGraph = dep_graph.BuildDepGraph(m)
 
 	// print out all of the dependencies in depGraph for debugging
 	if DEBUG {
@@ -1970,7 +1983,7 @@ func (c *Checker) InferModule(ctx Context, m *ast.Module) (errors []Error) {
 	exportErrors := c.processModuleExportAssignments(ctx, m)
 	errors = append(errors, exportErrors...)
 
-	return errors
+	return depGraph, errors
 }
 
 // inferTypeParams infers type parameters from AST type parameters by creating

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -133,20 +133,19 @@ func (c *Checker) inferStdlibImport(ctx Context, importStmt *ast.ImportStmt) []E
 		return nil // in-progress / cycle sentinel; cycles are permitted per §4
 	}
 
-	// Bind per shape. Only ?local is implemented in this slice; ?nested
-	// and ?flat will be wired up in the follow-up alongside the
-	// single-class shortcut.
-	if shape.local {
+	// Bind per shape. Single-class shortcut applies only to ?local
+	// (per §2.4 last bullet).
+	switch {
+	case shape.local:
 		return c.bindStdlibLocal(ctx, pkg, pkgNs, span)
+	case shape.nested:
+		return c.bindStdlibNested(ctx, scheme, pkg, pkgNs, span)
+	case shape.flat:
+		return c.bindStdlibFlat(ctx, scheme, importStmt.PackageName, pkgNs, span)
+	default:
+		// Unreachable: resolveStdlibFlags always sets exactly one shape.
+		return nil
 	}
-	flag := "nested"
-	if shape.flat {
-		flag = "flat"
-	}
-	return []Error{&GenericError{
-		message: fmt.Sprintf("?%s binding-shape is not yet implemented; use ?local", flag),
-		span:    span,
-	}}
 }
 
 // splitScheme cracks `scheme:pkg` into its parts. Returns ok=false if
@@ -352,11 +351,32 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 	return pkgNs, inferErrs
 }
 
-// bindStdlibLocal binds the package namespace under the lowercased
-// last URI segment in the importing file's scope.
+// bindStdlibLocal binds the package under the lowercased last URI
+// segment in the importing file's scope. If the package declares a
+// top-level class whose name matches the package name
+// case-insensitively (FR5 single-class shortcut), bind that class
+// directly with its original capitalization instead.
 func (c *Checker) bindStdlibLocal(ctx Context, pkg string, pkgNs *type_system.Namespace, span ast.Span) []Error {
-	bindingName := lastSegmentLower(pkg)
 	filtered := filterExportedNamespace(pkgNs)
+
+	// Single-class shortcut: look for a class whose name matches the
+	// package name case-insensitively. Activation requires the package
+	// to expose both a value (the constructor) and a type alias under
+	// the same identifier — which is exactly the shape a class
+	// declaration produces.
+	if className, ok := findSingleClassShortcut(filtered, pkg); ok {
+		ns := ctx.Scope.Namespace
+		ns.Values[className] = filtered.Values[className]
+		ns.Types[className] = filtered.Types[className]
+		// TODO (§2.4): also expose other package exports as namespace
+		// members on the same binding, with static methods winning on
+		// collision. Deferred until a stdlib package actually has both
+		// a class and non-class exports — the current `std:array` stub
+		// has only the class.
+		return nil
+	}
+
+	bindingName := lastSegmentLower(pkg)
 	if err := ctx.Scope.Namespace.SetNamespace(bindingName, filtered); err != nil {
 		return []Error{&GenericError{
 			message: fmt.Sprintf("cannot bind stdlib namespace %q: %s", bindingName, err.Error()),
@@ -364,6 +384,145 @@ func (c *Checker) bindStdlibLocal(ctx Context, pkg string, pkgNs *type_system.Na
 		}}
 	}
 	return nil
+}
+
+// findSingleClassShortcut returns the original-capitalization class
+// name when ns exposes a value+type pair whose identifier matches pkg
+// case-insensitively. Returns ("", false) otherwise.
+func findSingleClassShortcut(ns *type_system.Namespace, pkg string) (string, bool) {
+	for name := range ns.Values {
+		if !strings.EqualFold(name, pkg) {
+			continue
+		}
+		if _, hasType := ns.Types[name]; hasType {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// bindStdlibNested binds the package under <scheme>.<pkg> in the file
+// scope, lazily creating the per-scheme namespace. Duplicate ?nested
+// imports of the same package within a single file are silently
+// idempotent — bookkeeping keys on the URI (per §2.3) so the first
+// import "won" and any subsequent ones add nothing.
+func (c *Checker) bindStdlibNested(ctx Context, scheme, pkg string, pkgNs *type_system.Namespace, span ast.Span) []Error {
+	schemeNs, err := getOrCreateSchemeNamespace(ctx.Scope.Namespace, scheme)
+	if err != nil {
+		return []Error{&GenericError{message: err.Error(), span: span}}
+	}
+	if _, exists := schemeNs.GetNamespace(pkg); exists {
+		// Already bound from an earlier ?nested import of the same URI.
+		return nil
+	}
+	filtered := filterExportedNamespace(pkgNs)
+	if err := schemeNs.SetNamespace(pkg, filtered); err != nil {
+		return []Error{&GenericError{
+			message: fmt.Sprintf("cannot bind %s.%s: %s", scheme, pkg, err.Error()),
+			span:    span,
+		}}
+	}
+	return nil
+}
+
+// bindStdlibFlat merges exported package members directly into the
+// per-scheme namespace. Name collisions across two ?flat-imported
+// packages in the same file are hard errors per FR4 — the second
+// import is rejected and the diagnostic names the prior contributing
+// package.
+func (c *Checker) bindStdlibFlat(ctx Context, scheme, uri string, pkgNs *type_system.Namespace, span ast.Span) []Error {
+	schemeNs, err := getOrCreateSchemeNamespace(ctx.Scope.Namespace, scheme)
+	if err != nil {
+		return []Error{&GenericError{message: err.Error(), span: span}}
+	}
+	filtered := filterExportedNamespace(pkgNs)
+	contributors := c.flatContributorsFor(ctx.Scope, scheme)
+
+	// Iterate identifiers in a deterministic order so the diagnostic
+	// chosen on a multi-name collision is stable across runs.
+	names := flatMergeNames(filtered)
+	for _, name := range names {
+		if prior, ok := contributors[name]; ok && prior != uri {
+			return []Error{&GenericError{
+				message: fmt.Sprintf(
+					"?flat name collision: %q is contributed by both %q and %q; "+
+						"rename upstream or drop one import's ?flat flag",
+					name, prior, uri),
+				span: span,
+			}}
+		}
+	}
+	for _, name := range names {
+		if binding, ok := filtered.Values[name]; ok {
+			schemeNs.Values[name] = binding
+		}
+		if alias, ok := filtered.Types[name]; ok {
+			schemeNs.Types[name] = alias
+		}
+		if subNs, ok := filtered.Namespaces[name]; ok {
+			if _, exists := schemeNs.Namespaces[name]; !exists {
+				schemeNs.Namespaces[name] = subNs
+			}
+		}
+		contributors[name] = uri
+	}
+	return nil
+}
+
+// flatMergeNames returns the union of identifier names in a filtered
+// package namespace (values + types + sub-namespaces), sorted for
+// deterministic iteration.
+func flatMergeNames(ns *type_system.Namespace) []string {
+	set := make(map[string]struct{}, len(ns.Values)+len(ns.Types)+len(ns.Namespaces))
+	for name := range ns.Values {
+		set[name] = struct{}{}
+	}
+	for name := range ns.Types {
+		set[name] = struct{}{}
+	}
+	for name := range ns.Namespaces {
+		set[name] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for name := range set {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// getOrCreateSchemeNamespace returns the `<scheme>` sub-namespace on
+// ns, creating it on first access. Returns an error if a non-namespace
+// binding (value/type) already occupies that name in ns.
+func getOrCreateSchemeNamespace(ns *type_system.Namespace, scheme string) (*type_system.Namespace, error) {
+	if existing, ok := ns.GetNamespace(scheme); ok {
+		return existing, nil
+	}
+	schemeNs := type_system.NewNamespace()
+	if err := ns.SetNamespace(scheme, schemeNs); err != nil {
+		return nil, fmt.Errorf("cannot create per-scheme namespace %q: %w", scheme, err)
+	}
+	return schemeNs, nil
+}
+
+// flatContributorsFor returns the per-file, per-scheme map tracking
+// which URI contributed each ?flat-merged identifier. The map is
+// lazily created so files that never use ?flat pay no cost.
+func (c *Checker) flatContributorsFor(fileScope *Scope, scheme string) map[string]string {
+	if c.flatContributors == nil {
+		c.flatContributors = make(map[*Scope]map[string]map[string]string)
+	}
+	perFile, ok := c.flatContributors[fileScope]
+	if !ok {
+		perFile = make(map[string]map[string]string)
+		c.flatContributors[fileScope] = perFile
+	}
+	perScheme, ok := perFile[scheme]
+	if !ok {
+		perScheme = make(map[string]string)
+		perFile[scheme] = perScheme
+	}
+	return perScheme
 }
 
 // lastSegmentLower returns the last `_`-separated segment of pkg,

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -1,0 +1,379 @@
+package checker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/interop"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// stdlibSchemes lists the URI schemes the resolver recognizes for
+// pseudo-package imports. Ordering matters only for "unknown scheme"
+// diagnostic text — display recognized schemes in a stable order.
+var stdlibSchemes = []string{"std", "dom", "node"}
+
+// stdlibKnownFlags is the recognized set of binding-shape flags.
+// Per §2.3 the slot is extensible (future `?type-only`, `?lazy`, …); the
+// table-driven check means new entries slot in without restructuring.
+var stdlibKnownFlags = map[string]bool{
+	"local":  true,
+	"nested": true,
+	"flat":   true,
+}
+
+// stdlibBindingShape captures the resolved binding-shape for a single
+// import statement. Exactly one of the three booleans is true.
+type stdlibBindingShape struct {
+	local, nested, flat bool
+}
+
+// isSchemePrefixedImport reports whether spec begins with one of the
+// recognized scheme prefixes (`std:`, `dom:`, `node:`). Used by
+// inferImport to dispatch between the npm-style loader and the stdlib
+// loader before path resolution.
+func isSchemePrefixedImport(spec string) bool {
+	for _, scheme := range stdlibSchemes {
+		if strings.HasPrefix(spec, scheme+":") {
+			return true
+		}
+	}
+	// Any other `<word>:` shape is also a scheme — treated as an
+	// unknown-scheme diagnostic by the resolver. Detecting that here
+	// instead of bailing to the npm loader means the user gets the
+	// taxonomy-aligned message ("unknown scheme") rather than a
+	// confusing "could not find package.json".
+	if colon := strings.IndexByte(spec, ':'); colon > 0 {
+		scheme := spec[:colon]
+		if isASCIILower(scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+func isASCIILower(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 'a' || c > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// inferStdlibImport handles `import "<scheme>:<pkg>"` resolution and
+// binding. Mirrors inferImport's contract: returns the diagnostics for
+// the import statement, side-effecting bindings into ctx.Scope.
+func (c *Checker) inferStdlibImport(ctx Context, importStmt *ast.ImportStmt) []Error {
+	span := importStmt.Span()
+
+	scheme, pkg, ok := splitScheme(importStmt.PackageName)
+	if !ok || !isRecognizedScheme(scheme) {
+		return []Error{&GenericError{
+			message: fmt.Sprintf("unknown import scheme %q; recognized schemes: %s",
+				scheme, strings.Join(stdlibSchemes, ", ")),
+			span: span,
+		}}
+	}
+	if pkg == "" {
+		return []Error{&GenericError{
+			message: fmt.Sprintf("missing package name after %q scheme", scheme),
+			span:    span,
+		}}
+	}
+
+	// Named imports from scheme-prefixed URIs are rejected per FR4 /
+	// "Named import from a pseudo-package URI" in the error taxonomy.
+	if !importStmt.Bare() {
+		return []Error{&GenericError{
+			message: fmt.Sprintf(
+				"named imports from pseudo-package %q are not supported; "+
+					"use a bare-string import (`import %q`) and access members through the namespace",
+				importStmt.PackageName, importStmt.PackageName),
+			span: span,
+		}}
+	}
+
+	// Validate flags and resolve the binding shape.
+	shape, flagErrs := resolveStdlibFlags(importStmt.Flags, span)
+	if len(flagErrs) > 0 {
+		return flagErrs
+	}
+
+	// node:* is reserved; the resolver rejects every package until Node
+	// support lands.
+	if scheme == "node" {
+		return []Error{&GenericError{
+			message: fmt.Sprintf("%q: node:* is reserved; not yet populated", importStmt.PackageName),
+			span:    span,
+		}}
+	}
+
+	// Resolve to a file path under the stdlib data directory.
+	filePath, resolveErrs := c.resolveStdlibPath(scheme, pkg, span)
+	if len(resolveErrs) > 0 {
+		return resolveErrs
+	}
+
+	// Load the package's namespace, with PackageRegistry as the cache.
+	pkgNs, loadErrs := c.loadStdlibPackage(importStmt.PackageName, filePath, span)
+	if len(loadErrs) > 0 {
+		return loadErrs
+	}
+	if pkgNs == nil {
+		return nil // in-progress / cycle sentinel; cycles are permitted per §4
+	}
+
+	// Bind per shape. Only ?local is implemented in this slice; ?nested
+	// and ?flat will be wired up in the follow-up alongside the
+	// single-class shortcut.
+	if shape.local {
+		return c.bindStdlibLocal(ctx, pkg, pkgNs, span)
+	}
+	flag := "nested"
+	if shape.flat {
+		flag = "flat"
+	}
+	return []Error{&GenericError{
+		message: fmt.Sprintf("?%s binding-shape is not yet implemented; use ?local", flag),
+		span:    span,
+	}}
+}
+
+// splitScheme cracks `scheme:pkg` into its parts. Returns ok=false if
+// there's no colon. The pkg portion may still be empty (caller's job
+// to flag).
+func splitScheme(spec string) (scheme, pkg string, ok bool) {
+	idx := strings.IndexByte(spec, ':')
+	if idx <= 0 {
+		return "", "", false
+	}
+	return spec[:idx], spec[idx+1:], true
+}
+
+func isRecognizedScheme(scheme string) bool {
+	for _, s := range stdlibSchemes {
+		if s == scheme {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveStdlibFlags inspects the parsed flag list and returns the
+// binding shape, defaulting to ?local. Reports unknown-flag,
+// mutually-exclusive, and duplicate-flag diagnostics per the taxonomy.
+func resolveStdlibFlags(flags []string, span ast.Span) (stdlibBindingShape, []Error) {
+	shape := stdlibBindingShape{}
+	if len(flags) == 0 {
+		shape.local = true
+		return shape, nil
+	}
+
+	seen := map[string]bool{}
+	shapeFlags := []string{}
+	var errs []Error
+	for _, f := range flags {
+		if f == "" {
+			errs = append(errs, &GenericError{
+				message: "empty flag in import specifier", span: span,
+			})
+			continue
+		}
+		if !stdlibKnownFlags[f] {
+			recognized := []string{}
+			for k := range stdlibKnownFlags {
+				recognized = append(recognized, k)
+			}
+			sort.Strings(recognized)
+			errs = append(errs, &GenericError{
+				message: fmt.Sprintf("unknown import flag %q; recognized flags: %s",
+					f, strings.Join(recognized, ", ")),
+				span: span,
+			})
+			continue
+		}
+		if seen[f] {
+			errs = append(errs, &GenericError{
+				message: fmt.Sprintf("duplicate import flag %q", f), span: span,
+			})
+			continue
+		}
+		seen[f] = true
+		if f == "local" || f == "nested" || f == "flat" {
+			shapeFlags = append(shapeFlags, f)
+		}
+	}
+	if len(errs) > 0 {
+		return shape, errs
+	}
+
+	if len(shapeFlags) > 1 {
+		sort.Strings(shapeFlags)
+		return shape, []Error{&GenericError{
+			message: fmt.Sprintf("binding-shape flags %q and %q are mutually exclusive; pick one",
+				shapeFlags[0], shapeFlags[1]),
+			span: span,
+		}}
+	}
+	switch shapeFlags[0] {
+	case "local":
+		shape.local = true
+	case "nested":
+		shape.nested = true
+	case "flat":
+		shape.flat = true
+	}
+	return shape, nil
+}
+
+// resolveStdlibPath maps a `scheme:pkg` URI to an on-disk `.esc` file
+// path under the configured stdlib data directory. Reports a not-found
+// diagnostic when the file is missing.
+func (c *Checker) resolveStdlibPath(scheme, pkg string, span ast.Span) (string, []Error) {
+	dir, err := c.getStdlibDir()
+	if err != nil {
+		return "", []Error{&GenericError{message: err.Error(), span: span}}
+	}
+	if !isValidPackagePath(pkg) {
+		return "", []Error{&GenericError{
+			message: fmt.Sprintf("invalid package name %q in %s:%s; expected lowercase letters, digits, and underscores",
+				pkg, scheme, pkg),
+			span: span,
+		}}
+	}
+	path := filepath.Join(dir, scheme, pkg+".esc")
+	if info, statErr := os.Stat(path); statErr != nil || info.IsDir() {
+		return "", []Error{&GenericError{
+			message: fmt.Sprintf("unknown package %q in %s: scheme (no %s/%s.esc under %s)",
+				pkg, scheme, scheme, pkg, dir),
+			span: span,
+		}}
+	}
+	return path, nil
+}
+
+// isValidPackagePath enforces the FR2 naming rule: lowercase letters,
+// digits, and underscores. Hyphens are not allowed in URI portion; the
+// `-`→`_` substitution lives in the third-party workstream, not here.
+func isValidPackagePath(pkg string) bool {
+	if pkg == "" {
+		return false
+	}
+	for i := 0; i < len(pkg); i++ {
+		c := pkg[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9':
+		case c == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (c *Checker) getStdlibDir() (string, error) {
+	c.stdlibDirOnce.Do(func() {
+		c.stdlibDir, c.stdlibDirErr = interop.StdlibDir("")
+	})
+	return c.stdlibDir, c.stdlibDirErr
+}
+
+// loadStdlibPackage parses and infers the stdlib `.esc` file at
+// filePath into a fresh namespace, caching the result in
+// PackageRegistry keyed by the full URI. Per §2.3 bookkeeping keys on
+// the URI, not the binding-shape flag.
+func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_system.Namespace, []Error) {
+	if pkgNs, found := c.PackageRegistry.Lookup(uri); found {
+		// nil sentinel signals an in-progress (cyclic) load; callers
+		// treat it as "skip binding for now" per §4's "import cycles
+		// are permitted" note.
+		return pkgNs, nil
+	}
+	c.PackageRegistry.MarkInProgress(uri)
+
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		delete(c.PackageRegistry.packages, uri)
+		return nil, []Error{&GenericError{
+			message: fmt.Sprintf("failed to read stdlib file %s: %s", filePath, err.Error()),
+			span:    span,
+		}}
+	}
+
+	sourceID := c.stdlibNextSourceID
+	c.stdlibNextSourceID++
+	source := &ast.Source{
+		ID: sourceID,
+		// Strip the directory off so deriveNamespaceFromPath returns ""
+		// — stdlib files live in a flat namespace, not the directory
+		// hierarchy of their on-disk location.
+		Path:     filepath.Base(filePath),
+		Contents: string(contents),
+	}
+
+	mod, parseErrs := parser.ParseLibFiles(c.ctx, []*ast.Source{source})
+	if len(parseErrs) > 0 {
+		delete(c.PackageRegistry.packages, uri)
+		// Surface parse errors with the importing-file span so the user
+		// sees the diagnostic at the import statement, not in a file
+		// they didn't write.
+		errs := make([]Error, 0, len(parseErrs))
+		for _, pe := range parseErrs {
+			errs = append(errs, &GenericError{
+				message: fmt.Sprintf("parse error in %s: %s", filePath, pe.String()),
+				span:    span,
+			})
+		}
+		return nil, errs
+	}
+
+	pkgNs := type_system.NewNamespace()
+	pkgScope := &Scope{Parent: c.GlobalScope, Namespace: pkgNs}
+	pkgCtx := Context{Scope: pkgScope, IsAsync: false, IsPatMatch: false}
+	inferErrs := c.InferModule(pkgCtx, mod)
+
+	if updateErr := c.PackageRegistry.Update(uri, pkgNs); updateErr != nil {
+		inferErrs = append(inferErrs, &GenericError{
+			message: fmt.Sprintf("failed to register stdlib package %s: %s", uri, updateErr.Error()),
+			span:    span,
+		})
+	}
+	return pkgNs, inferErrs
+}
+
+// bindStdlibLocal binds the package namespace under the lowercased
+// last URI segment in the importing file's scope.
+func (c *Checker) bindStdlibLocal(ctx Context, pkg string, pkgNs *type_system.Namespace, span ast.Span) []Error {
+	bindingName := lastSegmentLower(pkg)
+	filtered := filterExportedNamespace(pkgNs)
+	if err := ctx.Scope.Namespace.SetNamespace(bindingName, filtered); err != nil {
+		return []Error{&GenericError{
+			message: fmt.Sprintf("cannot bind stdlib namespace %q: %s", bindingName, err.Error()),
+			span:    span,
+		}}
+	}
+	return nil
+}
+
+// lastSegmentLower returns the last `_`-separated segment of pkg,
+// lowercased. For `math` it returns `math`; for `typed_arrays` it
+// returns `typed_arrays` (the package portion is already the "last
+// segment" of the URI under our flat scheme:pkg layout).
+func lastSegmentLower(pkg string) string {
+	// The URI layout is `scheme:pkg` with `pkg` already being a single
+	// segment (multi-word packages use `_`, not `/`). So the "last URI
+	// segment" is just pkg itself; lowercasing is the only normalization
+	// required here.
+	return strings.ToLower(pkg)
+}

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -508,20 +508,17 @@ func (c *Checker) bindStdlibFlat(ctx Context, scheme, uri string, pkgNs *type_sy
 // type_system.Namespace.SetNamespace. ?flat collision detection works
 // on identifiers, not slots, per FR4.
 func flatIdentifiers(ns *type_system.Namespace) []string {
-	set := make(map[string]struct{}, len(ns.Values)+len(ns.Types)+len(ns.Namespaces))
+	ids := set.NewSet[string]()
 	for name := range ns.Values {
-		set[name] = struct{}{}
+		ids.Add(name)
 	}
 	for name := range ns.Types {
-		set[name] = struct{}{}
+		ids.Add(name)
 	}
 	for name := range ns.Namespaces {
-		set[name] = struct{}{}
+		ids.Add(name)
 	}
-	out := make([]string, 0, len(set))
-	for name := range set {
-		out = append(out, name)
-	}
+	out := ids.ToSlice()
 	sort.Strings(out)
 	return out
 }

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -10,22 +10,23 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/interop"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
-// stdlibSchemes lists the URI schemes the resolver recognizes for
-// pseudo-package imports. Ordering matters only for "unknown scheme"
-// diagnostic text — display recognized schemes in a stable order.
+// stdlibSchemes is the display-ordered list of URI schemes the
+// resolver recognizes for pseudo-package imports. The slice form is
+// used only for the "unknown scheme" diagnostic; membership tests go
+// through stdlibSchemesSet.
 var stdlibSchemes = []string{"std", "dom", "node"}
+
+// stdlibSchemesSet is the membership view of stdlibSchemes.
+var stdlibSchemesSet = set.FromSlice(stdlibSchemes)
 
 // stdlibKnownFlags is the recognized set of binding-shape flags.
 // Per §2.3 the slot is extensible (future `?type-only`, `?lazy`, …); the
 // table-driven check means new entries slot in without restructuring.
-var stdlibKnownFlags = map[string]bool{
-	"local":  true,
-	"nested": true,
-	"flat":   true,
-}
+var stdlibKnownFlags = set.FromSlice([]string{"local", "nested", "flat"})
 
 // stdlibBindingShape captures the resolved binding-shape for a single
 // import statement. Exactly one of the three booleans is true.
@@ -34,27 +35,18 @@ type stdlibBindingShape struct {
 }
 
 // isSchemePrefixedImport reports whether spec begins with one of the
-// recognized scheme prefixes (`std:`, `dom:`, `node:`). Used by
-// inferImport to dispatch between the npm-style loader and the stdlib
-// loader before path resolution.
+// recognized scheme prefixes (`std:`, `dom:`, `node:`) or any other
+// lowercase `<word>:` shape. Anything matching the second branch but
+// not the first is routed to the stdlib loader so the user gets the
+// taxonomy-aligned "unknown scheme" diagnostic rather than the npm
+// loader's "could not find package.json".
 func isSchemePrefixedImport(spec string) bool {
-	for _, scheme := range stdlibSchemes {
-		if strings.HasPrefix(spec, scheme+":") {
-			return true
-		}
+	colon := strings.IndexByte(spec, ':')
+	if colon <= 0 {
+		return false
 	}
-	// Any other `<word>:` shape is also a scheme — treated as an
-	// unknown-scheme diagnostic by the resolver. Detecting that here
-	// instead of bailing to the npm loader means the user gets the
-	// taxonomy-aligned message ("unknown scheme") rather than a
-	// confusing "could not find package.json".
-	if colon := strings.IndexByte(spec, ':'); colon > 0 {
-		scheme := spec[:colon]
-		if isASCIILower(scheme) {
-			return true
-		}
-	}
-	return false
+	scheme := spec[:colon]
+	return stdlibSchemesSet.Contains(scheme) || isASCIILower(scheme)
 }
 
 func isASCIILower(s string) bool {
@@ -75,77 +67,95 @@ func isASCIILower(s string) bool {
 // the import statement, side-effecting bindings into ctx.Scope.
 func (c *Checker) inferStdlibImport(ctx Context, importStmt *ast.ImportStmt) []Error {
 	span := importStmt.Span()
+	var errs []Error
 
-	scheme, pkg, ok := splitScheme(importStmt.PackageName)
-	if !ok || !isRecognizedScheme(scheme) {
-		return []Error{&GenericError{
+	// --- Validation phase. Each check is independent and accumulates,
+	// so a malformed import surfaces every problem at once rather than
+	// forcing the user through fix-recompile-repeat.
+
+	scheme, pkg, hasColon := splitScheme(importStmt.PackageName)
+	schemeKnown := hasColon && isRecognizedScheme(scheme)
+	switch {
+	case !schemeKnown:
+		errs = append(errs, &GenericError{
 			message: fmt.Sprintf("unknown import scheme %q; recognized schemes: %s",
 				scheme, strings.Join(stdlibSchemes, ", ")),
 			span: span,
-		}}
-	}
-	if pkg == "" {
-		return []Error{&GenericError{
+		})
+	case pkg == "":
+		errs = append(errs, &GenericError{
 			message: fmt.Sprintf("missing package name after %q scheme", scheme),
 			span:    span,
-		}}
+		})
 	}
 
 	// Named imports from scheme-prefixed URIs are rejected per FR4 /
 	// "Named import from a pseudo-package URI" in the error taxonomy.
 	if !importStmt.Bare() {
-		return []Error{&GenericError{
+		errs = append(errs, &GenericError{
 			message: fmt.Sprintf(
 				"named imports from pseudo-package %q are not supported; "+
 					"use a bare-string import (`import %q`) and access members through the namespace",
 				importStmt.PackageName, importStmt.PackageName),
 			span: span,
-		}}
+		})
 	}
 
-	// Validate flags and resolve the binding shape.
 	shape, flagErrs := resolveStdlibFlags(importStmt.Flags, span)
-	if len(flagErrs) > 0 {
-		return flagErrs
-	}
+	errs = append(errs, flagErrs...)
 
 	// node:* is reserved; the resolver rejects every package until Node
-	// support lands.
-	if scheme == "node" {
-		return []Error{&GenericError{
+	// support lands. Gated on schemeKnown so an unknown-scheme URI
+	// doesn't also pretend to be a "node:* reserved" case.
+	if schemeKnown && scheme == "node" {
+		errs = append(errs, &GenericError{
 			message: fmt.Sprintf("%q: node:* is reserved; not yet populated", importStmt.PackageName),
 			span:    span,
-		}}
+		})
 	}
 
-	// Resolve to a file path under the stdlib data directory.
+	// Load+bind require a clean validation pass: we need a usable
+	// scheme/pkg pair, a non-rejected import form, and a resolved
+	// binding shape.
+	if len(errs) > 0 {
+		return errs
+	}
+
+	// --- Resolution + load phase. ---
+
 	filePath, resolveErrs := c.resolveStdlibPath(scheme, pkg, span)
 	if len(resolveErrs) > 0 {
-		return resolveErrs
+		errs = append(errs, resolveErrs...)
+		return errs
 	}
 
-	// Load the package's namespace, with PackageRegistry as the cache.
 	pkgNs, loadErrs := c.loadStdlibPackage(importStmt.PackageName, filePath, span)
-	if len(loadErrs) > 0 {
-		return loadErrs
-	}
+	errs = append(errs, loadErrs...)
 	if pkgNs == nil {
-		return nil // in-progress / cycle sentinel; cycles are permitted per §4
+		// Either a load error already accumulated above, or an
+		// in-progress sentinel (cycle); cycles are permitted per §4.
+		return errs
 	}
 
-	// Bind per shape. Single-class shortcut applies only to ?local
+	// --- Bind phase. Single-class shortcut applies only to ?local
 	// (per §2.4 last bullet).
+
+	var bindErrs []Error
+
 	switch {
 	case shape.local:
-		return c.bindStdlibLocal(ctx, pkg, pkgNs, span)
+		bindErrs = c.bindStdlibLocal(ctx, pkg, pkgNs, span)
 	case shape.nested:
-		return c.bindStdlibNested(ctx, scheme, pkg, pkgNs, span)
+		bindErrs = c.bindStdlibNested(ctx, scheme, pkg, pkgNs, span)
 	case shape.flat:
-		return c.bindStdlibFlat(ctx, scheme, importStmt.PackageName, pkgNs, span)
-	default:
-		// Unreachable: resolveStdlibFlags always sets exactly one shape.
-		return nil
+		bindErrs = c.bindStdlibFlat(ctx, scheme, importStmt.PackageName, pkgNs, span)
+		// default: unreachable — resolveStdlibFlags always sets exactly
+		// one shape.
 	}
+
+	errs = append(errs, bindErrs...)
+
+	return errs
 }
 
 // splitScheme cracks `scheme:pkg` into its parts. Returns ok=false if
@@ -160,12 +170,7 @@ func splitScheme(spec string) (scheme, pkg string, ok bool) {
 }
 
 func isRecognizedScheme(scheme string) bool {
-	for _, s := range stdlibSchemes {
-		if s == scheme {
-			return true
-		}
-	}
-	return false
+	return stdlibSchemesSet.Contains(scheme)
 }
 
 // resolveStdlibFlags inspects the parsed flag list and returns the
@@ -178,7 +183,7 @@ func resolveStdlibFlags(flags []string, span ast.Span) (stdlibBindingShape, []Er
 		return shape, nil
 	}
 
-	seen := map[string]bool{}
+	seen := set.NewSet[string]()
 	shapeFlags := []string{}
 	var errs []Error
 	for _, f := range flags {
@@ -188,11 +193,8 @@ func resolveStdlibFlags(flags []string, span ast.Span) (stdlibBindingShape, []Er
 			})
 			continue
 		}
-		if !stdlibKnownFlags[f] {
-			recognized := []string{}
-			for k := range stdlibKnownFlags {
-				recognized = append(recognized, k)
-			}
+		if !stdlibKnownFlags.Contains(f) {
+			recognized := stdlibKnownFlags.ToSlice()
 			sort.Strings(recognized)
 			errs = append(errs, &GenericError{
 				message: fmt.Sprintf("unknown import flag %q; recognized flags: %s",
@@ -201,13 +203,13 @@ func resolveStdlibFlags(flags []string, span ast.Span) (stdlibBindingShape, []Er
 			})
 			continue
 		}
-		if seen[f] {
+		if seen.Contains(f) {
 			errs = append(errs, &GenericError{
 				message: fmt.Sprintf("duplicate import flag %q", f), span: span,
 			})
 			continue
 		}
-		seen[f] = true
+		seen.Add(f)
 		if f == "local" || f == "nested" || f == "flat" {
 			shapeFlags = append(shapeFlags, f)
 		}
@@ -324,9 +326,12 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 	mod, parseErrs := parser.ParseLibFiles(c.ctx, []*ast.Source{source})
 	if len(parseErrs) > 0 {
 		delete(c.PackageRegistry.packages, uri)
-		// Surface parse errors with the importing-file span so the user
-		// sees the diagnostic at the import statement, not in a file
-		// they didn't write.
+		// Re-anchor each parse error to the importing-file `span` so the
+		// IDE underlines the user's `import` statement, not a location
+		// inside the stdlib file (which the user did not write and
+		// cannot navigate to without leaving their project). The
+		// original file:line:col is kept in the message body for
+		// compiler contributors debugging the stub.
 		errs := make([]Error, 0, len(parseErrs))
 		for _, pe := range parseErrs {
 			errs = append(errs, &GenericError{
@@ -340,7 +345,7 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 	pkgNs := type_system.NewNamespace()
 	pkgScope := &Scope{Parent: c.GlobalScope, Namespace: pkgNs}
 	pkgCtx := Context{Scope: pkgScope, IsAsync: false, IsPatMatch: false}
-	inferErrs := c.InferModule(pkgCtx, mod)
+	_, inferErrs := c.InferModule(pkgCtx, mod)
 
 	if updateErr := c.PackageRegistry.Update(uri, pkgNs); updateErr != nil {
 		inferErrs = append(inferErrs, &GenericError{
@@ -440,7 +445,7 @@ func (c *Checker) bindStdlibFlat(ctx Context, scheme, uri string, pkgNs *type_sy
 
 	// Iterate identifiers in a deterministic order so the diagnostic
 	// chosen on a multi-name collision is stable across runs.
-	names := flatMergeNames(filtered)
+	names := flatIdentifiers(filtered)
 	for _, name := range names {
 		if prior, ok := contributors[name]; ok && prior != uri {
 			return []Error{&GenericError{
@@ -453,26 +458,56 @@ func (c *Checker) bindStdlibFlat(ctx Context, scheme, uri string, pkgNs *type_sy
 		}
 	}
 	for _, name := range names {
+		// Sub-namespaces go through SetNamespace so the
+		// "namespace-vs-value/type at the same name" invariant is
+		// enforced locally. Values/Types use a manual cross-check
+		// against schemeNs.Namespaces for the symmetric case (the
+		// type_system package has no setter for those slots).
+		// Belt-and-suspenders: the contributors check above should
+		// already have caught any of these cases, but the local
+		// invariant check protects against future drift.
+		if subNs, ok := filtered.Namespaces[name]; ok {
+			if _, exists := schemeNs.Namespaces[name]; !exists {
+				if setErr := schemeNs.SetNamespace(name, subNs); setErr != nil {
+					return []Error{&GenericError{message: setErr.Error(), span: span}}
+				}
+			}
+		}
 		if binding, ok := filtered.Values[name]; ok {
+			if _, conflict := schemeNs.Namespaces[name]; conflict {
+				return []Error{&GenericError{
+					message: fmt.Sprintf(
+						"cannot merge value %q from %q: name already occupied by a sub-namespace in `%s`",
+						name, uri, scheme),
+					span: span,
+				}}
+			}
 			schemeNs.Values[name] = binding
 		}
 		if alias, ok := filtered.Types[name]; ok {
-			schemeNs.Types[name] = alias
-		}
-		if subNs, ok := filtered.Namespaces[name]; ok {
-			if _, exists := schemeNs.Namespaces[name]; !exists {
-				schemeNs.Namespaces[name] = subNs
+			if _, conflict := schemeNs.Namespaces[name]; conflict {
+				return []Error{&GenericError{
+					message: fmt.Sprintf(
+						"cannot merge type %q from %q: name already occupied by a sub-namespace in `%s`",
+						name, uri, scheme),
+					span: span,
+				}}
 			}
+			schemeNs.Types[name] = alias
 		}
 		contributors[name] = uri
 	}
 	return nil
 }
 
-// flatMergeNames returns the union of identifier names in a filtered
-// package namespace (values + types + sub-namespaces), sorted for
-// deterministic iteration.
-func flatMergeNames(ns *type_system.Namespace) []string {
+// flatIdentifiers returns the union of identifier names exposed by ns
+// across values, types, and sub-namespaces, sorted for deterministic
+// iteration. Unioning is correct here because Namespace's invariants
+// treat the three slots as a single identifier space (with the
+// value+type carve-out for the class pattern) — see
+// type_system.Namespace.SetNamespace. ?flat collision detection works
+// on identifiers, not slots, per FR4.
+func flatIdentifiers(ns *type_system.Namespace) []string {
 	set := make(map[string]struct{}, len(ns.Values)+len(ns.Types)+len(ns.Namespaces))
 	for name := range ns.Values {
 		set[name] = struct{}{}

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -663,7 +663,7 @@ func (c *Checker) loadGlobalDefinitions(globalScope *Scope) {
 		IsPatMatch: false,
 	}
 
-	fatalErrors := c.InferModule(inferCtx, combinedModule)
+	_, fatalErrors := c.InferModule(inferCtx, combinedModule)
 	if len(fatalErrors) > 0 {
 		for _, err := range fatalErrors {
 			sourceID := err.Span().SourceID

--- a/internal/checker/tests/async_test.go
+++ b/internal/checker/tests/async_test.go
@@ -296,7 +296,7 @@ func TestAsyncFunctionInferenceModule(t *testing.T) {
 				IsPatMatch: false,
 			}
 
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if testCase.expectedErr {
 				assert.NotEmpty(t, inferErrors, "Should have inference errors")

--- a/internal/checker/tests/benchmark_test.go
+++ b/internal/checker/tests/benchmark_test.go
@@ -174,7 +174,7 @@ func BenchmarkModuleWithImports(b *testing.B) {
 			Scope:   Prelude(c),
 			IsAsync: false,
 		}
-		_ = c.InferModule(inferCtx, module)
+		_, _ = c.InferModule(inferCtx, module)
 	}
 }
 
@@ -225,7 +225,7 @@ func BenchmarkMultiFileModule(b *testing.B) {
 			Scope:   Prelude(c),
 			IsAsync: false,
 		}
-		_ = c.InferModule(inferCtx, module)
+		_, _ = c.InferModule(inferCtx, module)
 	}
 }
 
@@ -260,7 +260,7 @@ func BenchmarkCrossFileCyclicTypes(b *testing.B) {
 			Scope:   Prelude(c),
 			IsAsync: false,
 		}
-		_ = c.InferModule(inferCtx, module)
+		_, _ = c.InferModule(inferCtx, module)
 	}
 }
 
@@ -309,7 +309,7 @@ func BenchmarkFileScopedImports(b *testing.B) {
 			Scope:   Prelude(c),
 			IsAsync: false,
 		}
-		_ = c.InferModule(inferCtx, module)
+		_, _ = c.InferModule(inferCtx, module)
 	}
 }
 
@@ -594,7 +594,7 @@ func BenchmarkGenericPropertyAccessModule(b *testing.B) {
 			Scope:   Prelude(c),
 			IsAsync: false,
 		}
-		_ = c.InferModule(inferCtx, module)
+		_, _ = c.InferModule(inferCtx, module)
 	}
 }
 
@@ -684,7 +684,7 @@ func BenchmarkComplexProject(b *testing.B) {
 			Scope:   Prelude(c),
 			IsAsync: false,
 		}
-		_ = c.InferModule(inferCtx, module)
+		_, _ = c.InferModule(inferCtx, module)
 	}
 }
 

--- a/internal/checker/tests/class_test.go
+++ b/internal/checker/tests/class_test.go
@@ -451,7 +451,7 @@ func TestClassImplementsConformance(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			conformanceErrs := filterConformanceErrors(inferErrors)
 			otherErrs := otherInferErrors(inferErrors)
@@ -605,7 +605,7 @@ func TestClassImplementsLifetimeConformance(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			var lifetimeErrs []Error
 			var otherErrs []Error
@@ -849,7 +849,7 @@ func TestConstructorRejectsSelfLifetime(t *testing.T) {
 
 	c := NewChecker(ctx)
 	inferCtx := Context{Scope: Prelude(c)}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	count := 0
 	for _, e := range inferErrors {
@@ -911,7 +911,7 @@ func TestInstanceMethodMissingSelfReceiver(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			count := 0
 			for _, e := range inferErrors {
@@ -948,7 +948,7 @@ func TestObjectTypeAnnRejectsReceiverLifetime(t *testing.T) {
 
 	c := NewChecker(ctx)
 	inferCtx := Context{Scope: Prelude(c)}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	count := 0
 	for _, e := range inferErrors {
@@ -1039,7 +1039,7 @@ func TestLifetimeArgArityMismatch(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			var arityErrs []Error
 			var otherErrs []Error
@@ -1147,7 +1147,7 @@ func TestInterfaceMergeLifetimeParamMismatch(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			var paramErrs []Error
 			var otherErrs []Error

--- a/internal/checker/tests/conditional_test.go
+++ b/internal/checker/tests/conditional_test.go
@@ -183,7 +183,7 @@ func TestConditionalTypeAliasBasic(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			for i, err := range inferErrors {
 				fmt.Printf("Infer Error[%d]: %s\n", i, err)
@@ -412,7 +412,7 @@ func TestConditionalTypeAliasAdvanced(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if len(inferErrors) > 0 {
 				assert.Equal(t, inferErrors, []*Error{})
@@ -633,7 +633,7 @@ func TestConditionalTypeAliasEdgeCases(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 
 			// Some tests may have inference errors if conditional types aren't fully implemented

--- a/internal/checker/tests/constructor_test.go
+++ b/internal/checker/tests/constructor_test.go
@@ -27,7 +27,8 @@ func inferModuleErrors(t *testing.T, input string) []Error {
 
 	c := NewChecker(ctx)
 	inferCtx := Context{Scope: Prelude(c)}
-	return c.InferModule(inferCtx, module)
+	_, errs := c.InferModule(inferCtx, module)
+	return errs
 }
 
 // TestInBodyConstructorBasic checks that a class with a single in-body

--- a/internal/checker/tests/file_scope_test.go
+++ b/internal/checker/tests/file_scope_test.go
@@ -131,7 +131,7 @@ func TestCrossFileDeclarationVisibility(t *testing.T) {
 	}
 
 	// Infer the module - this should succeed because UserId should be visible to utils.esc
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	// Check that inference completed without errors
 	for i, err := range inferErrors {
@@ -254,7 +254,7 @@ func TestFileScopedImportsBasic(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -319,7 +319,7 @@ func TestFileScopedImportsIsolation(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	// We expect an error because file2.esc cannot see 'pkg' which was imported in file1.esc
 	assert.NotEmpty(t, inferErrors, "Should have errors - pkg should not be visible in file2.esc")
@@ -381,7 +381,7 @@ func TestFileScopedImportsSamePackageDifferentFiles(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -442,7 +442,7 @@ func TestFileScopedImportsDifferentAliases(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -508,7 +508,7 @@ func TestNamedImportsFromPackage(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -565,7 +565,7 @@ func TestScopeChainTraversal(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -617,7 +617,7 @@ func TestGlobalNamespaceIsolation(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -682,7 +682,7 @@ func TestCrossFileCyclicDependencies(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -752,7 +752,7 @@ func TestCrossFileCyclesWithImports(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -825,7 +825,7 @@ func TestCrossFileCyclesImportIsolation(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	// We expect an error because file_b.esc uses pkg.SomeType without importing pkg
 	assert.NotEmpty(t, inferErrors, "Should have errors - file_b cannot use pkg from file_a's import")

--- a/internal/checker/tests/getter_setter_test.go
+++ b/internal/checker/tests/getter_setter_test.go
@@ -288,7 +288,7 @@ func TestGetterSetterAccess(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			var errorMessages []string
 			for _, err := range inferErrors {

--- a/internal/checker/tests/import_load_test.go
+++ b/internal/checker/tests/import_load_test.go
@@ -91,7 +91,7 @@ func TestPackageReloadFromRegistry(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 	assert.Empty(t, inferErrors, "Should infer without errors")
 }
 
@@ -142,7 +142,7 @@ func TestNamedImportFromRegisteredPackage(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for _, err := range inferErrors {
 		t.Logf("Error: %s", err.Message())
@@ -187,7 +187,7 @@ func TestNamedImportWithAlias(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for _, err := range inferErrors {
 		t.Logf("Error: %s", err.Message())
@@ -231,7 +231,7 @@ func TestNamedImportNotFound(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	// Should have an error about the missing export
 	require.Len(t, inferErrors, 1, "Should have exactly one error")
@@ -288,7 +288,7 @@ func TestSubpathImportSeparateEntries(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for _, err := range inferErrors {
 		t.Logf("Error: %s", err.Message())
@@ -355,7 +355,7 @@ func TestNonExportedItemsAreFilteredFromNamespaceImport(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, moduleGood)
+	_, inferErrors := c.InferModule(inferCtx, moduleGood)
 	assert.Empty(t, inferErrors, "Exported items should be accessible via namespace import")
 
 	// Test that non-exported items cause errors when accessed
@@ -382,7 +382,7 @@ func TestNonExportedItemsAreFilteredFromNamespaceImport(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrorsBadValue := c2.InferModule(inferCtx2, moduleBadValue)
+	_, inferErrorsBadValue := c2.InferModule(inferCtx2, moduleBadValue)
 	require.NotEmpty(t, inferErrorsBadValue, "Non-exported value should not be accessible via namespace import")
 	assert.Contains(t, inferErrorsBadValue[0].Message(), "internalHelper",
 		"Error should mention the non-exported value")
@@ -411,7 +411,7 @@ func TestNonExportedItemsAreFilteredFromNamespaceImport(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrorsBadType := c3.InferModule(inferCtx3, moduleBadType)
+	_, inferErrorsBadType := c3.InferModule(inferCtx3, moduleBadType)
 	require.NotEmpty(t, inferErrorsBadType, "Non-exported type should not be accessible via namespace import")
 	assert.Contains(t, inferErrorsBadType[0].Message(), "InternalType",
 		"Error should mention the non-exported type")
@@ -457,7 +457,7 @@ func TestNamespaceImportFromSubNamespace(t *testing.T) {
 		IsAsync: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for _, err := range inferErrors {
 		t.Logf("Error: %s", err.Message())

--- a/internal/checker/tests/infer_class_decl_test.go
+++ b/internal/checker/tests/infer_class_decl_test.go
@@ -676,7 +676,7 @@ func TestCheckClassDeclNoErrors(t *testing.T) {
 				IsPatMatch: false,
 			}
 			c.Schema = schema
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
@@ -750,7 +750,7 @@ func TestNominalClassUnificationTerminates(t *testing.T) {
 		IsAsync:    false,
 		IsPatMatch: false,
 	}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 	assert.Len(t, inferErrors, 1)
 	assert.Equal(t, "Node cannot be assigned to Leaf", inferErrors[0].Message())
 }
@@ -847,7 +847,7 @@ func TestCheckBodyLevelClassDeclNoErrors(t *testing.T) {
 				IsPatMatch: false,
 			}
 			c.Schema = schema
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
 					fmt.Printf("Infer Error[%d]: %s\n", i, err.Message())
@@ -915,7 +915,7 @@ func TestCheckBodyLevelClassDeclErrors(t *testing.T) {
 				IsPatMatch: false,
 			}
 			c.Schema = schema
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			actualMsgs := make([]string, 0, len(inferErrors))
 			for _, err := range inferErrors {
@@ -1128,7 +1128,7 @@ func TestGetterSetterPreservesSignatureContext(t *testing.T) {
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
 			c.Schema = schema
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
 					fmt.Printf("Infer Error[%d]: %s\n", i, err.Message())

--- a/internal/checker/tests/infer_test.go
+++ b/internal/checker/tests/infer_test.go
@@ -1766,7 +1766,7 @@ func TestCheckModuleNoErrors(t *testing.T) {
 				IsPatMatch: false,
 			}
 			c.Schema = schema
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
@@ -1924,7 +1924,7 @@ func TestIfLetExprInference(t *testing.T) {
 			}
 			schema := loadSchema(t)
 			c.Schema = schema
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
@@ -2069,7 +2069,7 @@ func TestCheckModuleWithErrors(t *testing.T) {
 				IsPatMatch: false,
 			}
 			c.Schema = schema
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			// Verify we got the expected number of errors
 			assert.Len(t, inferErrors, len(test.expectedErrors), "Expected %d errors but got %d", len(test.expectedErrors), len(inferErrors))
@@ -2130,7 +2130,7 @@ func TestIssue371(t *testing.T) {
 	}
 	schema := loadSchema(t)
 	c.Schema = schema
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	assert.Len(t, inferErrors, 3, "Expected 3 errors (all in add function)")
 
@@ -2447,7 +2447,7 @@ func TestCheckModuleTypeAliases(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if len(inferErrors) > 0 {
 				assert.Equal(t, inferErrors, []*Error{})
@@ -2500,7 +2500,7 @@ func TestExpandingTypeAliasMultipleTimes(t *testing.T) {
 		IsAsync:    false,
 		IsPatMatch: false,
 	}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 	scope := inferCtx.Scope.Namespace
 	if len(inferErrors) > 0 {
 		assert.Equal(t, inferErrors, []*Error{})
@@ -2620,7 +2620,7 @@ func TestCheckMultifileModuleNoErrors(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if len(inferErrors) > 0 {
 				assert.Equal(t, inferErrors, []*Error{})
@@ -4545,7 +4545,7 @@ func TestMutableTypes(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
@@ -4801,7 +4801,7 @@ func TestMatchExprInference(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 
 			if len(inferErrors) > 0 {
@@ -5307,7 +5307,7 @@ func TestInterfaceMergingModule(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 
 			if len(inferErrors) > 0 {
@@ -5530,7 +5530,7 @@ func TestInterfaceMergingModuleErrors(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			// Verify we got the expected number of errors
 			assert.Len(t, inferErrors, test.expectedErrorCount, "Expected %d errors, got %d", test.expectedErrorCount, len(inferErrors))

--- a/internal/checker/tests/integration_test.go
+++ b/internal/checker/tests/integration_test.go
@@ -137,7 +137,7 @@ func TestE2E_FullWorkflow(t *testing.T) {
 	require.NoError(t, c.PackageRegistry.Register("lodash", lodashNs))
 	require.NoError(t, c.PackageRegistry.Register("ramda", ramdaNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	// Log any errors for debugging
 	for i, err := range inferErrors {
@@ -233,7 +233,7 @@ func TestE2E_FileImportIsolation(t *testing.T) {
 	)
 	require.NoError(t, c.PackageRegistry.Register("my-utils", utilsNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	// Should have an error because non_importer.esc cannot use 'utils' namespace
 	require.NotEmpty(t, inferErrors, "Should have errors - file-scoped import isolation violated")
@@ -316,7 +316,7 @@ func TestE2E_MultiplePackagesWithSameSymbols(t *testing.T) {
 	require.NoError(t, c.PackageRegistry.Register("lodash", lodashNs))
 	require.NoError(t, c.PackageRegistry.Register("ramda", ramdaNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -382,7 +382,7 @@ func TestE2E_GlobalThisBypassesShadowing(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -489,7 +489,7 @@ func TestE2E_CrossFileCyclicTypesWithImports(t *testing.T) {
 	)
 	require.NoError(t, c.PackageRegistry.Register("tree-utils", treeUtilsNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -567,7 +567,7 @@ func TestE2E_NamedImportsWithAliases(t *testing.T) {
 	)
 	require.NoError(t, c.PackageRegistry.Register("my-pkg", mockNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -661,7 +661,7 @@ func TestE2E_SubpathImportsIsolation(t *testing.T) {
 	require.NoError(t, c.PackageRegistry.Register("lodash", mainNs))
 	require.NoError(t, c.PackageRegistry.Register("lodash/fp", fpNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -874,7 +874,7 @@ func TestE2E_ComplexProjectSimulation(t *testing.T) {
 	require.NoError(t, c.PackageRegistry.Register("database", dbNs))
 	require.NoError(t, c.PackageRegistry.Register("config", configNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -1009,7 +1009,7 @@ func TestE2E_RealisticMonorepoStructure(t *testing.T) {
 
 	require.NoError(t, c.PackageRegistry.Register("lodash", lodashNs))
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())
@@ -1063,7 +1063,7 @@ func TestE2E_GlobalAugmentation(t *testing.T) {
 		IsPatMatch: false,
 	}
 
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for i, err := range inferErrors {
 		t.Logf("Error[%d]: %s", i, err.Message())

--- a/internal/checker/tests/intersection_test.go
+++ b/internal/checker/tests/intersection_test.go
@@ -756,7 +756,7 @@ func TestIntersectionMemberAccess(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 
 			if tc.wantErr {
@@ -987,7 +987,7 @@ func TestFunctionOverloads(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 
 			if tc.wantErr {

--- a/internal/checker/tests/iterator_test.go
+++ b/internal/checker/tests/iterator_test.go
@@ -124,7 +124,7 @@ func inferModule(t *testing.T, input string) (map[string]string, []Error) {
 		IsAsync:    false,
 		IsPatMatch: false,
 	}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	actualTypes := make(map[string]string)
 	for name, binding := range inferCtx.Scope.Namespace.Values {

--- a/internal/checker/tests/jsx_test.go
+++ b/internal/checker/tests/jsx_test.go
@@ -2848,7 +2848,7 @@ func TestAutoLoadReactTypesForJSX(t *testing.T) {
 
 		// InferModule should attempt to load React types and return an error
 		// because @types/react is not installed in tempDir
-		errors := c.InferModule(checkerCtx, module)
+		_, errors := c.InferModule(checkerCtx, module)
 
 		// Should return an error about @types/react not being found
 		found := false
@@ -2888,7 +2888,7 @@ func TestAutoLoadReactTypesForJSX(t *testing.T) {
 		}
 
 		// InferModule should NOT attempt to load React types for non-JSX modules
-		errors := c.InferModule(checkerCtx, module)
+		_, errors := c.InferModule(checkerCtx, module)
 
 		// Should NOT have any errors about @types/react
 		found := false

--- a/internal/checker/tests/let_generalize_test.go
+++ b/internal/checker/tests/let_generalize_test.go
@@ -213,7 +213,7 @@ func TestBodyLetGeneralization(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			for i, err := range inferErrors {
 				fmt.Printf("Infer Error[%d]: %s\n", i, err.Message())
@@ -338,7 +338,7 @@ func TestBodyLetGeneralizationNegatives(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			actualMessages := make([]string, len(inferErrors))
 			for i, e := range inferErrors {
 				actualMessages[i] = e.Message()

--- a/internal/checker/tests/lifetime_test.go
+++ b/internal/checker/tests/lifetime_test.go
@@ -1477,7 +1477,7 @@ func mustInferAsModule(t *testing.T, input string) *type_system.Namespace {
 
 	c := NewChecker(ctx)
 	inferCtx := Context{Scope: Prelude(c)}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 
 	for _, err := range inferErrors {
 		if _, ok := err.(*MutabilityTransitionError); ok {

--- a/internal/checker/tests/mut_prefix_test.go
+++ b/internal/checker/tests/mut_prefix_test.go
@@ -185,7 +185,7 @@ func TestMutPrefixMutationBehavior(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			assertExpectedErrors(t, test.expectedErrors, inferErrors)
 		})

--- a/internal/checker/tests/mutation_test.go
+++ b/internal/checker/tests/mutation_test.go
@@ -290,7 +290,7 @@ func TestClassMutation(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			if test.expectErrors {
 				assert.NotEmpty(t, inferErrors, "Expected inference errors for %s", name)

--- a/internal/checker/tests/pattern_mut_test.go
+++ b/internal/checker/tests/pattern_mut_test.go
@@ -201,7 +201,7 @@ func TestPatternLevelMut_MutationBehavior(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			assertExpectedErrors(t, test.expectedErrors, inferErrors)
 		})
@@ -295,7 +295,7 @@ func TestPatternLevelMut_ForInPreservesMut(t *testing.T) {
 
 	c := NewChecker(ctx)
 	inferCtx := Context{Scope: Prelude(c)}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 	if len(inferErrors) > 0 {
 		for i, err := range inferErrors {
 			t.Logf("Unexpected Error[%d]: %s", i, err.Message())
@@ -382,7 +382,7 @@ func TestPatternLevelMut_NoLeakIntoParentContainer(t *testing.T) {
 			require.Empty(t, parseErrors, "expected no parse errors")
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			_ = c.InferModule(inferCtx, module)
+			_, _ = c.InferModule(inferCtx, module)
 
 			pat := findDestructurePattern(module, test.patternKind)
 			require.NotNil(t, pat, "expected to find destructure pattern in module")

--- a/internal/checker/tests/row_types_test.go
+++ b/internal/checker/tests/row_types_test.go
@@ -46,7 +46,7 @@ func inferModuleTypesAndErrors(t *testing.T, input string) (map[string]string, [
 		IsAsync:    false,
 		IsPatMatch: false,
 	}
-	inferErrors := c.InferModule(inferCtx, module)
+	_, inferErrors := c.InferModule(inferCtx, module)
 	scope := inferCtx.Scope.Namespace
 
 	actualTypes := make(map[string]string)
@@ -395,7 +395,7 @@ func TestRowTypesErrors(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 
 			require.Len(t, inferErrors, len(test.expectedErrs), "expected %d errors, got %d", len(test.expectedErrs), len(inferErrors))
 			for i, expectedErr := range test.expectedErrs {
@@ -1038,7 +1038,7 @@ func TestRowTypesPropertyWidening(t *testing.T) {
 					IsAsync:    false,
 					IsPatMatch: false,
 				}
-				inferErrors := c.InferModule(inferCtx, module)
+				_, inferErrors := c.InferModule(inferCtx, module)
 				require.NotEmpty(t, inferErrors, "Expected type error")
 				if test.expectedError != "" {
 					found := false

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	. "github.com/escalier-lang/escalier/internal/checker"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// inferStdlibImportSource parses input as a single lib file, runs
+// InferModule, and returns the file-scope namespace and inference
+// errors. Tests in this file exercise scheme-prefixed imports, so the
+// returned namespace is the importing file's scope (where ?local
+// bindings land), not the package's namespace.
+func inferStdlibImportSource(t *testing.T, input string) (fileNs map[int]*Scope, errs []Error) {
+	t.Helper()
+	source := &ast.Source{ID: 0, Path: "lib/main.esc", Contents: input}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	module, parseErrs := parser.ParseLibFiles(ctx, []*ast.Source{source})
+	require.Empty(t, parseErrs, "expected no parse errors")
+
+	c := NewChecker(ctx)
+	inferCtx := Context{Scope: Prelude(c)}
+	errs = c.InferModule(inferCtx, module)
+	return c.FileScopes, errs
+}
+
+func errorMessages(errs []Error) []string {
+	out := make([]string, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, e.Message())
+	}
+	return out
+}
+
+func TestStdlibImport_BareLocalBindsByLastSegment(t *testing.T) {
+	fileScopes, errs := inferStdlibImportSource(t, `
+		import "std:math"
+		val x: number = math.PI
+	`)
+	require.Empty(t, errorMessages(errs))
+
+	fileScope, ok := fileScopes[0]
+	require.True(t, ok, "file scope for source 0 missing")
+	_, ok = fileScope.Namespace.GetNamespace("math")
+	require.True(t, ok, "expected `math` namespace bound in the file scope")
+}
+
+func TestStdlibImport_ExplicitLocalFlag(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `
+		import "std:math?local"
+		val x: number = math.PI
+	`)
+	require.Empty(t, errorMessages(errs))
+}
+
+func TestStdlibImport_UnknownScheme(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "foo:bar"`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		`unknown import scheme "foo"; recognized schemes: std, dom, node`,
+		errs[0].Message(),
+	)
+}
+
+func TestStdlibImport_UnknownPackageInKnownScheme(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "std:nonexistent"`)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message(), `unknown package "nonexistent" in std: scheme`)
+}
+
+func TestStdlibImport_NodeSchemeReserved(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "node:fs"`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		`"node:fs": node:* is reserved; not yet populated`,
+		errs[0].Message(),
+	)
+}
+
+func TestStdlibImport_NamedImportFromSchemeURIRejected(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import { PI } from "std:math"`)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message(), `named imports from pseudo-package "std:math" are not supported`)
+}
+
+func TestStdlibImport_NamespaceImportFromSchemeURIRejected(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import * as M from "std:math"`)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message(), `named imports from pseudo-package "std:math" are not supported`)
+}
+
+func TestStdlibImport_UnknownFlag(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "std:math?wat"`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		`unknown import flag "wat"; recognized flags: flat, local, nested`,
+		errs[0].Message(),
+	)
+}
+
+func TestStdlibImport_MutuallyExclusiveFlags(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "std:math?local&flat"`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		`binding-shape flags "flat" and "local" are mutually exclusive; pick one`,
+		errs[0].Message(),
+	)
+}
+
+func TestStdlibImport_NestedFlagNotYetImplemented(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "std:math?nested"`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		`?nested binding-shape is not yet implemented; use ?local`,
+		errs[0].Message(),
+	)
+}
+
+func TestStdlibImport_FlatFlagNotYetImplemented(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "std:math?flat"`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		`?flat binding-shape is not yet implemented; use ?local`,
+		errs[0].Message(),
+	)
+}
+
+func TestStdlibImport_InvalidPackageName(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "std:Math"`)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message(), `invalid package name "Math"`)
+}

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,6 +12,23 @@ import (
 	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/stretchr/testify/require"
 )
+
+// makeCustomStdlibDir builds a t.TempDir-rooted stdlib data layout
+// from a {relative-path → contents} map and returns the directory.
+// Used by tests that need synthetic packages (e.g. the ?flat collision
+// case) without polluting the committed `internal/interop/data/`
+// tree.
+func makeCustomStdlibDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "std"), 0o755))
+	for rel, contents := range files {
+		full := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(contents), 0o644))
+	}
+	return dir
+}
 
 // inferStdlibImportSource parses input as a single lib file, runs
 // InferModule, and returns the file-scope namespace and inference
@@ -114,22 +133,106 @@ func TestStdlibImport_MutuallyExclusiveFlags(t *testing.T) {
 	)
 }
 
-func TestStdlibImport_NestedFlagNotYetImplemented(t *testing.T) {
-	_, errs := inferStdlibImportSource(t, `import "std:math?nested"`)
-	require.Len(t, errs, 1)
-	require.Equal(t,
-		`?nested binding-shape is not yet implemented; use ?local`,
-		errs[0].Message(),
-	)
+func TestStdlibImport_NestedBindsUnderSchemeNamespace(t *testing.T) {
+	fileScopes, errs := inferStdlibImportSource(t, `
+		import "std:math?nested"
+		val x: number = std.math.PI
+	`)
+	require.Empty(t, errorMessages(errs))
+
+	fileScope, ok := fileScopes[0]
+	require.True(t, ok)
+	schemeNs, ok := fileScope.Namespace.GetNamespace("std")
+	require.True(t, ok, "expected `std` namespace bound in file scope")
+	_, ok = schemeNs.GetNamespace("math")
+	require.True(t, ok, "expected `std.math` sub-namespace")
 }
 
-func TestStdlibImport_FlatFlagNotYetImplemented(t *testing.T) {
-	_, errs := inferStdlibImportSource(t, `import "std:math?flat"`)
+func TestStdlibImport_MultipleNestedSharesSchemeNamespace(t *testing.T) {
+	fileScopes, errs := inferStdlibImportSource(t, `
+		import "std:math?nested"
+		import "std:array?nested"
+		val x: number = std.math.PI
+		val isArr: boolean = std.array.Array.isArray(0)
+	`)
+	require.Empty(t, errorMessages(errs))
+
+	fileScope := fileScopes[0]
+	schemeNs, ok := fileScope.Namespace.GetNamespace("std")
+	require.True(t, ok)
+	_, ok = schemeNs.GetNamespace("math")
+	require.True(t, ok)
+	_, ok = schemeNs.GetNamespace("array")
+	require.True(t, ok)
+}
+
+func TestStdlibImport_FlatMergesIntoSchemeNamespace(t *testing.T) {
+	fileScopes, errs := inferStdlibImportSource(t, `
+		import "std:math?flat"
+		val x: number = std.PI
+	`)
+	require.Empty(t, errorMessages(errs))
+
+	fileScope := fileScopes[0]
+	schemeNs, ok := fileScope.Namespace.GetNamespace("std")
+	require.True(t, ok)
+	_, ok = schemeNs.Values["PI"]
+	require.True(t, ok, "expected PI merged directly into `std` namespace")
+}
+
+func TestStdlibImport_FlatNameCollision(t *testing.T) {
+	// Both packages export the same identifier; the second ?flat
+	// import must fail with the taxonomy-aligned collision message.
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"std/alpha.esc": `export val Common: number = 1`,
+		"std/beta.esc":  `export val Common: number = 2`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `
+		import "std:alpha?flat"
+		import "std:beta?flat"
+	`)
 	require.Len(t, errs, 1)
-	require.Equal(t,
-		`?flat binding-shape is not yet implemented; use ?local`,
-		errs[0].Message(),
-	)
+	require.Contains(t, errs[0].Message(), `?flat name collision: "Common"`)
+	require.Contains(t, errs[0].Message(), `"std:alpha"`)
+	require.Contains(t, errs[0].Message(), `"std:beta"`)
+}
+
+func TestStdlibImport_SingleClassShortcut(t *testing.T) {
+	// std:array stub exposes `class Array<T>` — FR5 binds the class
+	// with its original capitalization (not lowercased "array") when
+	// imported as ?local.
+	fileScopes, errs := inferStdlibImportSource(t, `
+		import "std:array"
+		val isArr: boolean = Array.isArray(0)
+		val arr: Array<number> = Array(5)
+	`)
+	require.Empty(t, errorMessages(errs))
+
+	fileScope := fileScopes[0]
+	_, hasValue := fileScope.Namespace.Values["Array"]
+	require.True(t, hasValue, "expected Array value binding")
+	_, hasType := fileScope.Namespace.Types["Array"]
+	require.True(t, hasType, "expected Array type binding")
+
+	// The lowercased fallback namespace should NOT be present when the
+	// shortcut fires.
+	_, hasNs := fileScope.Namespace.GetNamespace("array")
+	require.False(t, hasNs, "single-class shortcut should suppress lowercased namespace")
+}
+
+func TestStdlibImport_SingleClassShortcutDoesNotApplyToNested(t *testing.T) {
+	fileScopes, errs := inferStdlibImportSource(t, `import "std:array?nested"`)
+	require.Empty(t, errorMessages(errs))
+
+	fileScope := fileScopes[0]
+	schemeNs, ok := fileScope.Namespace.GetNamespace("std")
+	require.True(t, ok)
+	pkgNs, ok := schemeNs.GetNamespace("array")
+	require.True(t, ok, "?nested must bind the package as a sub-namespace, not the class")
+	_, hasArray := pkgNs.Values["Array"]
+	require.True(t, hasArray, "Array class should be reachable via std.array.Array")
 }
 
 func TestStdlibImport_InvalidPackageName(t *testing.T) {

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +47,7 @@ func inferStdlibImportSource(t *testing.T, input string) (fileNs map[int]*Scope,
 
 	c := NewChecker(ctx)
 	inferCtx := Context{Scope: Prelude(c)}
-	errs = c.InferModule(inferCtx, module)
+	_, errs = c.InferModule(inferCtx, module)
 	return c.FileScopes, errs
 }
 
@@ -91,7 +92,13 @@ func TestStdlibImport_UnknownScheme(t *testing.T) {
 func TestStdlibImport_UnknownPackageInKnownScheme(t *testing.T) {
 	_, errs := inferStdlibImportSource(t, `import "std:nonexistent"`)
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(), `unknown package "nonexistent" in std: scheme`)
+	// Stdlib dir is set by TestMain via SetStdlibDirForTest; interpolate
+	// it so the full message matches across machines.
+	stdlibDir := os.Getenv("ESCALIER_STDLIB_DIR")
+	require.Equal(t,
+		fmt.Sprintf(`unknown package "nonexistent" in std: scheme (no std/nonexistent.esc under %s)`, stdlibDir),
+		errs[0].Message(),
+	)
 }
 
 func TestStdlibImport_NodeSchemeReserved(t *testing.T) {
@@ -106,13 +113,21 @@ func TestStdlibImport_NodeSchemeReserved(t *testing.T) {
 func TestStdlibImport_NamedImportFromSchemeURIRejected(t *testing.T) {
 	_, errs := inferStdlibImportSource(t, `import { PI } from "std:math"`)
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(), `named imports from pseudo-package "std:math" are not supported`)
+	require.Equal(t,
+		"named imports from pseudo-package \"std:math\" are not supported; "+
+			"use a bare-string import (`import \"std:math\"`) and access members through the namespace",
+		errs[0].Message(),
+	)
 }
 
 func TestStdlibImport_NamespaceImportFromSchemeURIRejected(t *testing.T) {
 	_, errs := inferStdlibImportSource(t, `import * as M from "std:math"`)
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(), `named imports from pseudo-package "std:math" are not supported`)
+	require.Equal(t,
+		"named imports from pseudo-package \"std:math\" are not supported; "+
+			"use a bare-string import (`import \"std:math\"`) and access members through the namespace",
+		errs[0].Message(),
+	)
 }
 
 func TestStdlibImport_UnknownFlag(t *testing.T) {
@@ -194,9 +209,11 @@ func TestStdlibImport_FlatNameCollision(t *testing.T) {
 		import "std:beta?flat"
 	`)
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(), `?flat name collision: "Common"`)
-	require.Contains(t, errs[0].Message(), `"std:alpha"`)
-	require.Contains(t, errs[0].Message(), `"std:beta"`)
+	require.Equal(t,
+		`?flat name collision: "Common" is contributed by both "std:alpha" and "std:beta"; `+
+			`rename upstream or drop one import's ?flat flag`,
+		errs[0].Message(),
+	)
 }
 
 func TestStdlibImport_SingleClassShortcut(t *testing.T) {
@@ -238,5 +255,8 @@ func TestStdlibImport_SingleClassShortcutDoesNotApplyToNested(t *testing.T) {
 func TestStdlibImport_InvalidPackageName(t *testing.T) {
 	_, errs := inferStdlibImportSource(t, `import "std:Math"`)
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(), `invalid package name "Math"`)
+	require.Equal(t,
+		`invalid package name "Math" in std:Math; expected lowercase letters, digits, and underscores`,
+		errs[0].Message(),
+	)
 }

--- a/internal/checker/tests/testmain_test.go
+++ b/internal/checker/tests/testmain_test.go
@@ -13,5 +13,9 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	if err := interop.SetStdlibDirForTest(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	os.Exit(m.Run())
 }

--- a/internal/checker/tests/throw_inference_test.go
+++ b/internal/checker/tests/throw_inference_test.go
@@ -401,7 +401,7 @@ func TestCallSiteThrowsInference(t *testing.T) {
 
 			c := NewChecker(ctx)
 			inferCtx := Context{Scope: Prelude(c)}
-			errors := c.InferModule(inferCtx, module)
+			_, errors := c.InferModule(inferCtx, module)
 			assert.Empty(t, errors, "Expected no type errors, got: %v", errors)
 
 			binding, ok := inferCtx.Scope.Namespace.Values["testFunc"]

--- a/internal/checker/tests/try_catch_test.go
+++ b/internal/checker/tests/try_catch_test.go
@@ -406,7 +406,7 @@ func TestTryCatchInferenceModule(t *testing.T) {
 				IsPatMatch: false,
 			}
 
-			inferErrors := c.InferModule(inferCtx, module)
+			_, inferErrors := c.InferModule(inferCtx, module)
 			scope := inferCtx.Scope.Namespace
 			if testCase.expectedErr {
 				assert.NotEmpty(t, inferErrors, "Should have inference errors")

--- a/internal/checker/tests/type_param_sort_test.go
+++ b/internal/checker/tests/type_param_sort_test.go
@@ -253,11 +253,16 @@ func TestTypeParamCyclicDependency(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
+			// shouldSucceed here means "the topological sort detects the
+			// cycle and preserves original order without panicking" — not
+			// "inference is error-free". Cyclic constraints (e.g. `T<T: T>`)
+			// are inherently meaningless and inference does produce
+			// diagnostics; the contract this test pins is that the sort and
+			// module construction survive the cycle. We intentionally
+			// discard inferErrors here.
 			_, _ = checker.InferModule(inferCtx, module)
 
 			if test.shouldSucceed {
-				// For cyclic references, we should still be able to parse and check
-				// The topological sort should detect the cycle and preserve original order
 				assert.NotNil(t, module, "Module should not be nil even with cyclic type params")
 			}
 		})

--- a/internal/checker/tests/type_param_sort_test.go
+++ b/internal/checker/tests/type_param_sort_test.go
@@ -164,7 +164,7 @@ func TestTypeParamTopologicalSort(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := checker.InferModule(inferCtx, module)
+			_, inferErrors := checker.InferModule(inferCtx, module)
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
 					fmt.Printf("Infer Error[%d]: %#v\n", i, err)
@@ -253,7 +253,7 @@ func TestTypeParamCyclicDependency(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			_ = checker.InferModule(inferCtx, module)
+			_, _ = checker.InferModule(inferCtx, module)
 
 			if test.shouldSucceed {
 				// For cyclic references, we should still be able to parse and check
@@ -336,7 +336,7 @@ func TestTypeParamSortingWithUsage(t *testing.T) {
 				IsAsync:    false,
 				IsPatMatch: false,
 			}
-			inferErrors := checker.InferModule(inferCtx, module)
+			_, inferErrors := checker.InferModule(inferCtx, module)
 			if len(inferErrors) > 0 {
 				for i, err := range inferErrors {
 					fmt.Printf("Infer Error[%d]: %#v\n", i, err)

--- a/internal/checker/tests/unify_recursion_test.go
+++ b/internal/checker/tests/unify_recursion_test.go
@@ -34,7 +34,8 @@ func inferWithTimeout(t *testing.T, source string, timeout time.Duration) []Erro
 		IsAsync:    false,
 		IsPatMatch: false,
 	}
-	return c.InferModule(inferCtx, module)
+	_, errs := c.InferModule(inferCtx, module)
+	return errs
 }
 
 // ============================================================================

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/checker"
 	"github.com/escalier-lang/escalier/internal/codegen"
-	"github.com/escalier-lang/escalier/internal/dep_graph"
 	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
@@ -75,7 +74,7 @@ func CheckLib(ctx context.Context, libSources []*ast.Source) CheckLibOutput {
 		IsAsync:    false,
 		IsPatMatch: false,
 	}
-	typeErrors := c.InferModule(inferCtx, module)
+	_, typeErrors := c.InferModule(inferCtx, module)
 
 	return CheckLibOutput{
 		Module:      module,
@@ -252,10 +251,9 @@ func CompilePackage(sources []*ast.Source) CompilerOutput {
 		// InferModule (rather than the lower-level InferDepGraph) so
 		// per-file imports — including pseudo-package `import "std:*"`
 		// statements — are processed before declarations are checked.
-		// Codegen below still wants the dep_graph; we rebuild it
-		// (deterministic from the parsed module).
-		typeErrors := c.InferModule(inferCtx, inMod)
-		depGraph := dep_graph.BuildDepGraph(inMod)
+		// It returns the dep_graph it builds in Phase 2; we reuse that
+		// here for codegen instead of rebuilding from scratch.
+		depGraph, typeErrors := c.InferModule(inferCtx, inMod)
 
 		// No longer need MergeOverloadedFunctions - overloads are already grouped by BindingKey
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -241,7 +241,6 @@ func CompilePackage(sources []*ast.Source) CompilerOutput {
 
 	if len(libSources) > 0 {
 		inMod, parseErrors := parser.ParseLibFiles(ctx, libSources)
-		depGraph := dep_graph.BuildDepGraph(inMod)
 
 		c := checker.NewChecker(ctx)
 		inferCtx := checker.Context{
@@ -250,7 +249,13 @@ func CompilePackage(sources []*ast.Source) CompilerOutput {
 			IsAsync:    false,
 			IsPatMatch: false,
 		}
-		typeErrors := c.InferDepGraph(inferCtx, depGraph)
+		// InferModule (rather than the lower-level InferDepGraph) so
+		// per-file imports — including pseudo-package `import "std:*"`
+		// statements — are processed before declarations are checked.
+		// Codegen below still wants the dep_graph; we rebuild it
+		// (deterministic from the parsed module).
+		typeErrors := c.InferModule(inferCtx, inMod)
+		depGraph := dep_graph.BuildDepGraph(inMod)
 
 		// No longer need MergeOverloadedFunctions - overloads are already grouped by BindingKey
 

--- a/internal/interop/data/dom/README.md
+++ b/internal/interop/data/dom/README.md
@@ -1,0 +1,7 @@
+# `dom:*` pseudo-packages
+
+Browser / DOM APIs. The resolver maps `dom:foo` to `dom/foo.esc` in
+this directory. Multi-word packages use underscores
+(`dom:web_rtc` → `dom/web_rtc.esc`).
+
+See `planning/builtins/implementation_plan.md` §2.2.

--- a/internal/interop/data/node/README.md
+++ b/internal/interop/data/node/README.md
@@ -1,0 +1,7 @@
+# `node:*` pseudo-package scheme
+
+Reserved for Node.js runtime APIs. No `.esc` files are populated yet.
+
+The resolver recognizes the `node:` scheme but errors with
+`node:* is reserved; not yet populated` for any import until Node support
+lands. See `planning/builtins/implementation_plan.md` §2.2.

--- a/internal/interop/data/std/README.md
+++ b/internal/interop/data/std/README.md
@@ -1,0 +1,7 @@
+# `std:*` pseudo-packages
+
+ECMAScript / language-level builtins. The resolver maps `std:foo` to
+`std/foo.esc` in this directory. Multi-word packages use underscores
+(`std:typed_arrays` → `std/typed_arrays.esc`).
+
+See `planning/builtins/implementation_plan.md` §2.2.

--- a/internal/interop/data/std/array.esc
+++ b/internal/interop/data/std/array.esc
@@ -1,7 +1,7 @@
 // Stub for §2's single-class shortcut gate. The real Array surface is
 // authored by the converter (§7); this minimal declaration exists so
 // the resolver's FR5 path has something to bind.
-export class Array<T> {
-    constructor(mut self, length: number) {},
-    static isArray(value: unknown) -> boolean { return true },
+export declare class Array<T> {
+    constructor(mut self, length: number),
+    static isArray(value: unknown) -> boolean,
 }

--- a/internal/interop/data/std/array.esc
+++ b/internal/interop/data/std/array.esc
@@ -1,0 +1,7 @@
+// Stub for §2's single-class shortcut gate. The real Array surface is
+// authored by the converter (§7); this minimal declaration exists so
+// the resolver's FR5 path has something to bind.
+export class Array<T> {
+    constructor(mut self, length: number) {},
+    static isArray(value: unknown) -> boolean { return true },
+}

--- a/internal/interop/data/std/math.esc
+++ b/internal/interop/data/std/math.esc
@@ -1,0 +1,1 @@
+export val PI: number = 3.14

--- a/internal/interop/data_test.go
+++ b/internal/interop/data_test.go
@@ -110,6 +110,12 @@ func TestBuiltinsDir_HasNoEscFilesYet(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
+			// Skip the stdlib scheme subtrees — those belong to the
+			// builtins (FR1-FR16) workstream, not the override system
+			// this invariant pins.
+			if p != root && isStdlibSchemeSubtree(filepath.Base(p), "") {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if strings.HasSuffix(p, ".esc") {

--- a/internal/interop/loader.go
+++ b/internal/interop/loader.go
@@ -132,6 +132,14 @@ func parseFromFS(
 			return nil
 		}
 		if d.IsDir() {
+			// The shared `internal/interop/data/` parent holds both
+			// override subtrees (builtins/, libs/) and the new stdlib
+			// scheme subtrees (std/, dom/, node/) introduced by the
+			// builtins workstream. The override loader has no business
+			// in the scheme subtrees, so skip them at the top level.
+			if p != root && isStdlibSchemeSubtree(p, root) {
+				return fs.SkipDir
+			}
 			return nil
 		}
 		if !strings.HasSuffix(p, ".esc") {

--- a/internal/interop/stdlib_dir.go
+++ b/internal/interop/stdlib_dir.go
@@ -1,0 +1,122 @@
+package interop
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// StdlibDir resolves the on-disk directory containing the stdlib `.esc`
+// files (`std/`, `dom/`, `node/` subtrees) shipped with the compiler.
+// The path returned is the directory that contains those subtrees, not
+// one of the subtrees themselves.
+//
+// `cliOverride` is the value passed to `--stdlib-dir` on the CLI;
+// callers pass "" when the flag was not supplied.
+//
+// Discovery order, first hit wins:
+//
+//  1. `cliOverride` (the `--stdlib-dir` CLI flag).
+//  2. The `ESCALIER_STDLIB_DIR` environment variable.
+//  3. Sibling to the executable: `<exe-dir>/../share/escalier/data/`,
+//     falling back to `<exe-dir>/data/` for single-directory installs.
+//  4. Repo-relative: walk up from the executable looking for a directory
+//     containing `internal/interop/data/`. Makes `go run ./cmd/escalier`
+//     work without setup.
+//
+// Both `cliOverride` and the env var must point at a directory that
+// contains a `std/` subdirectory; otherwise the call errors without
+// falling through. The sibling and repo-relative paths silently skip
+// when the candidate doesn't exist. If nothing resolves, the returned
+// error names every discovery channel so the caller can surface a
+// fatal startup diagnostic.
+func StdlibDir(cliOverride string) (string, error) {
+	exe, _ := os.Executable()
+	return resolveStdlibDir(stdlibDirInputs{
+		cliOverride: cliOverride,
+		envVar:      os.Getenv("ESCALIER_STDLIB_DIR"),
+		exePath:     exe,
+	})
+}
+
+// stdlibDirInputs captures the ambient state StdlibDir consults. Pulling
+// it into a struct lets tests drive each discovery branch in isolation
+// without mutating real env vars or filesystem layout.
+type stdlibDirInputs struct {
+	cliOverride string
+	envVar      string
+	exePath     string // result of os.Executable; "" if unavailable
+}
+
+func resolveStdlibDir(in stdlibDirInputs) (string, error) {
+	if in.cliOverride != "" {
+		if !looksLikeStdlibDir(in.cliOverride) {
+			return "", fmt.Errorf(
+				"--stdlib-dir %q does not contain a std/ subdirectory",
+				in.cliOverride,
+			)
+		}
+		return filepath.Clean(in.cliOverride), nil
+	}
+	if in.envVar != "" {
+		if !looksLikeStdlibDir(in.envVar) {
+			return "", fmt.Errorf(
+				"ESCALIER_STDLIB_DIR=%q does not contain a std/ subdirectory",
+				in.envVar,
+			)
+		}
+		return filepath.Clean(in.envVar), nil
+	}
+	if in.exePath != "" {
+		exeDir := filepath.Dir(in.exePath)
+		for _, candidate := range []string{
+			filepath.Join(exeDir, "..", "share", "escalier", "data"),
+			filepath.Join(exeDir, "data"),
+		} {
+			if looksLikeStdlibDir(candidate) {
+				return filepath.Clean(candidate), nil
+			}
+		}
+		if root := findEscalierRoot(exeDir); root != "" {
+			candidate := filepath.Join(root, "internal", "interop", "data")
+			if looksLikeStdlibDir(candidate) {
+				return candidate, nil
+			}
+		}
+	}
+	return "", fmt.Errorf(
+		"could not locate Escalier stdlib data directory; pass --stdlib-dir, " +
+			"set ESCALIER_STDLIB_DIR, or install share/escalier/data/ next to " +
+			"the escalier binary",
+	)
+}
+
+// SetStdlibDirForTest configures ESCALIER_STDLIB_DIR so callers can
+// resolve stdlib imports during tests. The production lookup
+// (executable-relative walk) doesn't work in tests because the test
+// binary lives in a tmp dir; this helper walks up from the current
+// working directory — which `go test` sets to the package source
+// dir — to find the repo root.
+//
+// Call from TestMain in each test package that transitively resolves
+// `std:`/`dom:`/`node:` imports.
+func SetStdlibDirForTest() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	root := findEscalierRoot(cwd)
+	if root == "" {
+		return fmt.Errorf("could not locate Escalier repo root from %s", cwd)
+	}
+	return os.Setenv("ESCALIER_STDLIB_DIR", filepath.Join(root, "internal", "interop", "data"))
+}
+
+// looksLikeStdlibDir reports whether path looks like a stdlib data
+// directory — i.e. contains a `std/` subdirectory. The `dom/` and
+// `node/` subtrees are not required; either may be absent in a stripped
+// distribution.
+func looksLikeStdlibDir(path string) bool {
+	info, err := os.Stat(filepath.Join(path, "std"))
+	return err == nil && info.IsDir()
+}

--- a/internal/interop/stdlib_dir.go
+++ b/internal/interop/stdlib_dir.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // StdlibDir resolves the on-disk directory containing the stdlib `.esc`
@@ -99,7 +100,15 @@ func resolveStdlibDir(in stdlibDirInputs) (string, error) {
 // dir — to find the repo root.
 //
 // Call from TestMain in each test package that transitively resolves
-// `std:`/`dom:`/`node:` imports.
+// `std:`/`dom:`/`node:` imports. Current call sites include
+// `internal/interop`, `internal/checker/tests`, and any future test
+// package whose checker reaches the stdlib resolver.
+//
+// This helper lives in a non-test file (despite its `ForTest` name)
+// because symbols defined in `*_test.go` files are visible only within
+// the same package's test binary; cross-package test callers require a
+// regular .go file. The same constraint applies to
+// `SetBuiltinsDirForTest`.
 func SetStdlibDirForTest() error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -120,27 +129,17 @@ func SetStdlibDirForTest() error {
 func isStdlibSchemeSubtree(p, root string) bool {
 	rel := p
 	if root != "" && root != "." {
-		// fs.WalkDir paths are joined under root; strip the prefix so
-		// "<root>/std" becomes "std".
-		if r, ok := stripDirPrefix(rel, root); ok {
-			rel = r
-		}
+		// fs.WalkDir paths are joined under root with `/`; strip the
+		// `<root>/` prefix so "<root>/std" becomes "std". TrimPrefix is
+		// a no-op when there's no match, which leaves `rel == p` for
+		// callers that pass an already-relative path.
+		rel = strings.TrimPrefix(rel, root+"/")
 	}
 	switch rel {
 	case "std", "dom", "node":
 		return true
 	}
 	return false
-}
-
-func stripDirPrefix(p, prefix string) (string, bool) {
-	if p == prefix {
-		return "", true
-	}
-	if len(p) > len(prefix) && p[:len(prefix)] == prefix && p[len(prefix)] == '/' {
-		return p[len(prefix)+1:], true
-	}
-	return "", false
 }
 
 // looksLikeStdlibDir reports whether path looks like a stdlib data

--- a/internal/interop/stdlib_dir.go
+++ b/internal/interop/stdlib_dir.go
@@ -112,6 +112,37 @@ func SetStdlibDirForTest() error {
 	return os.Setenv("ESCALIER_STDLIB_DIR", filepath.Join(root, "internal", "interop", "data"))
 }
 
+// isStdlibSchemeSubtree reports whether p, relative to root, names a
+// top-level scheme subdirectory (`std`, `dom`, `node`) that belongs to
+// the builtins workstream rather than the override system. The
+// override loader uses this to skip those subtrees while walking the
+// shared `internal/interop/data/` directory.
+func isStdlibSchemeSubtree(p, root string) bool {
+	rel := p
+	if root != "" && root != "." {
+		// fs.WalkDir paths are joined under root; strip the prefix so
+		// "<root>/std" becomes "std".
+		if r, ok := stripDirPrefix(rel, root); ok {
+			rel = r
+		}
+	}
+	switch rel {
+	case "std", "dom", "node":
+		return true
+	}
+	return false
+}
+
+func stripDirPrefix(p, prefix string) (string, bool) {
+	if p == prefix {
+		return "", true
+	}
+	if len(p) > len(prefix) && p[:len(prefix)] == prefix && p[len(prefix)] == '/' {
+		return p[len(prefix)+1:], true
+	}
+	return "", false
+}
+
 // looksLikeStdlibDir reports whether path looks like a stdlib data
 // directory — i.e. contains a `std/` subdirectory. The `dom/` and
 // `node/` subtrees are not required; either may be absent in a stripped

--- a/internal/interop/stdlib_dir_test.go
+++ b/internal/interop/stdlib_dir_test.go
@@ -1,6 +1,7 @@
 package interop
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,8 +28,8 @@ func TestResolveStdlibDir_CLIOverride(t *testing.T) {
 func TestResolveStdlibDir_CLIOverrideRejectsBadPath(t *testing.T) {
 	bad := t.TempDir() // empty dir — no std/ subtree
 	_, err := resolveStdlibDir(stdlibDirInputs{cliOverride: bad})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "--stdlib-dir")
+	require.EqualError(t, err,
+		fmt.Sprintf("--stdlib-dir %q does not contain a std/ subdirectory", bad))
 }
 
 func TestResolveStdlibDir_CLIOverrideBeatsEnv(t *testing.T) {
@@ -49,8 +50,8 @@ func TestResolveStdlibDir_EnvVar(t *testing.T) {
 func TestResolveStdlibDir_EnvVarRejectsBadPath(t *testing.T) {
 	bad := t.TempDir()
 	_, err := resolveStdlibDir(stdlibDirInputs{envVar: bad})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "ESCALIER_STDLIB_DIR")
+	require.EqualError(t, err,
+		fmt.Sprintf("ESCALIER_STDLIB_DIR=%q does not contain a std/ subdirectory", bad))
 }
 
 func TestResolveStdlibDir_SiblingShareLayout(t *testing.T) {
@@ -105,9 +106,10 @@ func TestResolveStdlibDir_NoneResolveFatalError(t *testing.T) {
 	require.NoError(t, os.WriteFile(fakeExe, []byte{}, 0o755))
 
 	_, err := resolveStdlibDir(stdlibDirInputs{exePath: fakeExe})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not locate Escalier stdlib data directory")
-	require.Contains(t, err.Error(), "ESCALIER_STDLIB_DIR")
+	require.EqualError(t, err,
+		"could not locate Escalier stdlib data directory; pass --stdlib-dir, "+
+			"set ESCALIER_STDLIB_DIR, or install share/escalier/data/ next to "+
+			"the escalier binary")
 }
 
 func TestSetStdlibDirForTest_ResolvesRealRepoData(t *testing.T) {

--- a/internal/interop/stdlib_dir_test.go
+++ b/internal/interop/stdlib_dir_test.go
@@ -1,0 +1,130 @@
+package interop
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// makeFakeStdlib creates a directory tree that looksLikeStdlibDir
+// accepts (contains a `std/` subdirectory). Returns the root path.
+func makeFakeStdlib(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "std"), 0o755))
+	return root
+}
+
+func TestResolveStdlibDir_CLIOverride(t *testing.T) {
+	dir := makeFakeStdlib(t)
+	got, err := resolveStdlibDir(stdlibDirInputs{cliOverride: dir})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(dir), got)
+}
+
+func TestResolveStdlibDir_CLIOverrideRejectsBadPath(t *testing.T) {
+	bad := t.TempDir() // empty dir — no std/ subtree
+	_, err := resolveStdlibDir(stdlibDirInputs{cliOverride: bad})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--stdlib-dir")
+}
+
+func TestResolveStdlibDir_CLIOverrideBeatsEnv(t *testing.T) {
+	cli := makeFakeStdlib(t)
+	env := makeFakeStdlib(t)
+	got, err := resolveStdlibDir(stdlibDirInputs{cliOverride: cli, envVar: env})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(cli), got)
+}
+
+func TestResolveStdlibDir_EnvVar(t *testing.T) {
+	dir := makeFakeStdlib(t)
+	got, err := resolveStdlibDir(stdlibDirInputs{envVar: dir})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(dir), got)
+}
+
+func TestResolveStdlibDir_EnvVarRejectsBadPath(t *testing.T) {
+	bad := t.TempDir()
+	_, err := resolveStdlibDir(stdlibDirInputs{envVar: bad})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ESCALIER_STDLIB_DIR")
+}
+
+func TestResolveStdlibDir_SiblingShareLayout(t *testing.T) {
+	// Simulate a `bin/` + `share/escalier/data/` install layout.
+	install := t.TempDir()
+	binDir := filepath.Join(install, "bin")
+	share := filepath.Join(install, "share", "escalier", "data")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(share, "std"), 0o755))
+	fakeExe := filepath.Join(binDir, "escalier")
+	require.NoError(t, os.WriteFile(fakeExe, []byte{}, 0o755))
+
+	got, err := resolveStdlibDir(stdlibDirInputs{exePath: fakeExe})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(share), got)
+}
+
+func TestResolveStdlibDir_SiblingSingleDirLayout(t *testing.T) {
+	// `<exe-dir>/data/` fallback for single-directory installs.
+	install := t.TempDir()
+	data := filepath.Join(install, "data")
+	require.NoError(t, os.MkdirAll(filepath.Join(data, "std"), 0o755))
+	fakeExe := filepath.Join(install, "escalier")
+	require.NoError(t, os.WriteFile(fakeExe, []byte{}, 0o755))
+
+	got, err := resolveStdlibDir(stdlibDirInputs{exePath: fakeExe})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(data), got)
+}
+
+func TestResolveStdlibDir_RepoRelative(t *testing.T) {
+	// Simulate the build-tree layout: a fake repo root containing
+	// `internal/interop/data/std/`, with the executable nested
+	// somewhere inside (mimicking `go run`'s tmp-built binary).
+	root := t.TempDir()
+	data := filepath.Join(root, "internal", "interop", "data")
+	require.NoError(t, os.MkdirAll(filepath.Join(data, "std"), 0o755))
+	exeDir := filepath.Join(root, "some", "nested", "tmp")
+	require.NoError(t, os.MkdirAll(exeDir, 0o755))
+	fakeExe := filepath.Join(exeDir, "escalier")
+	require.NoError(t, os.WriteFile(fakeExe, []byte{}, 0o755))
+
+	got, err := resolveStdlibDir(stdlibDirInputs{exePath: fakeExe})
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+}
+
+func TestResolveStdlibDir_NoneResolveFatalError(t *testing.T) {
+	// Empty exe dir, no env, no override, no candidate found.
+	emptyDir := t.TempDir()
+	fakeExe := filepath.Join(emptyDir, "escalier")
+	require.NoError(t, os.WriteFile(fakeExe, []byte{}, 0o755))
+
+	_, err := resolveStdlibDir(stdlibDirInputs{exePath: fakeExe})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "could not locate Escalier stdlib data directory")
+	require.Contains(t, err.Error(), "ESCALIER_STDLIB_DIR")
+}
+
+func TestSetStdlibDirForTest_ResolvesRealRepoData(t *testing.T) {
+	// SetStdlibDirForTest is what other test packages call from TestMain
+	// to point ESCALIER_STDLIB_DIR at the in-repo `internal/interop/data/`
+	// tree. Verify it lands on a directory containing std/.
+	t.Setenv("ESCALIER_STDLIB_DIR", "")
+	require.NoError(t, SetStdlibDirForTest())
+	dir := os.Getenv("ESCALIER_STDLIB_DIR")
+	require.NotEmpty(t, dir)
+	require.Contains(t, dir, filepath.Join("internal", "interop", "data"))
+	info, err := os.Stat(filepath.Join(dir, "std"))
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	// And the public entry point should agree.
+	got, err := StdlibDir("")
+	require.NoError(t, err)
+	require.Equal(t, dir, got)
+}

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -8469,6 +8469,7 @@
         },
     },
     PackageName: "module",
+    Flags:       nil,
     span:        ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:36},
@@ -8509,6 +8510,7 @@
         },
     },
     PackageName: "module",
+    Flags:       nil,
     span:        ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:39},
@@ -8531,6 +8533,7 @@
         },
     },
     PackageName: "module",
+    Flags:       nil,
     span:        ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:29},
@@ -8553,6 +8556,7 @@
         },
     },
     PackageName: "module",
+    Flags:       nil,
     span:        ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:29},
@@ -8593,6 +8597,7 @@
         },
     },
     PackageName: "module",
+    Flags:       nil,
     span:        ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:46},
@@ -10101,6 +10106,68 @@
     span: ast.Span{
         Start:    ast.Location{Line:1, Column:1},
         End:      ast.Location{Line:1, Column:46},
+        SourceID: 0,
+    },
+}
+---
+
+[TestParseStmtNoErrors/ImportBareWithFlags - 1]
+&ast.ImportStmt{
+    Specifiers:  nil,
+    PackageName: "std:math",
+    Flags:       {"flag1", "flag2"},
+    span:        ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:30},
+        SourceID: 0,
+    },
+}
+---
+
+[TestParseStmtNoErrors/ImportBare - 1]
+&ast.ImportStmt{
+    Specifiers:  nil,
+    PackageName: "std:math",
+    Flags:       nil,
+    span:        ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:18},
+        SourceID: 0,
+    },
+}
+---
+
+[TestParseStmtNoErrors/ImportBareWithFlag - 1]
+&ast.ImportStmt{
+    Specifiers:  nil,
+    PackageName: "std:math",
+    Flags:       {"nested"},
+    span:        ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:25},
+        SourceID: 0,
+    },
+}
+---
+
+[TestParseStmtNoErrors/ImportNamedWithFlag - 1]
+&ast.ImportStmt{
+    Specifiers: {
+        &ast.ImportSpecifier{
+            Name:  "foo",
+            Alias: "",
+            span:  ast.Span{
+                Start:    ast.Location{Line:1, Column:10},
+                End:      ast.Location{Line:1, Column:13},
+                SourceID: 0,
+            },
+        },
+    },
+    PackageName: "std:math",
+    Flags:       {"local"},
+    span:        ast.Span{
+        Start:    ast.Location{Line:1, Column:1},
+        End:      ast.Location{Line:1, Column:37},
         SourceID: 0,
     },
 }

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strings"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 )
 
@@ -327,25 +329,9 @@ func (p *Parser) importStmt() ast.Stmt {
 // An empty flag (e.g. trailing `&` or `?&foo`) is preserved as ""; semantic
 // validation lives in the resolver.
 func splitImportFlags(spec string) (string, []string) {
-	idx := -1
-	for i := 0; i < len(spec); i++ {
-		if spec[i] == '?' {
-			idx = i
-			break
-		}
-	}
-	if idx < 0 {
+	pkg, rest, ok := strings.Cut(spec, "?")
+	if !ok {
 		return spec, nil
 	}
-	pkg := spec[:idx]
-	rest := spec[idx+1:]
-	flags := []string{}
-	start := 0
-	for i := 0; i <= len(rest); i++ {
-		if i == len(rest) || rest[i] == '&' {
-			flags = append(flags, rest[start:i])
-			start = i + 1
-		}
-	}
-	return pkg, flags
+	return pkg, strings.Split(rest, "&")
 }

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -210,9 +210,13 @@ func (p *Parser) parseForInStmt() ast.Stmt {
 		ast.MergeSpans(startSpan, body.Span))
 }
 
-// importStmt = 'import' importSpecifiers 'from' string
+// importStmt = 'import' (importSpecifiers 'from')? string
 // importSpecifiers = '{' namedImport (',' namedImport)* '}' | '*' 'as' identifier
 // namedImport = identifier ('as' identifier)?
+//
+// A bare-string form (`import "std:math"`) has no binding clause and no
+// `from`. The module specifier may carry a `?flag1&flag2` suffix that the
+// parser splits off and stores in ImportStmt.Flags.
 func (p *Parser) importStmt() ast.Stmt {
 	importToken := p.lexer.next()
 	if importToken.Type != Import {
@@ -222,6 +226,14 @@ func (p *Parser) importStmt() ast.Stmt {
 
 	var specifiers []*ast.ImportSpecifier
 	token := p.lexer.peek()
+
+	// Bare-string import: `import "uri"` with no binding clause.
+	if token.Type == StrLit {
+		moduleToken := p.lexer.next()
+		pkg, flags := splitImportFlags(moduleToken.Value)
+		span := ast.MergeSpans(importToken.Span, moduleToken.Span)
+		return ast.NewImportStmt(nil, pkg, flags, span)
+	}
 
 	// Parse import specifiers
 	if token.Type == Asterisk {
@@ -306,5 +318,34 @@ func (p *Parser) importStmt() ast.Stmt {
 	}
 
 	span := ast.MergeSpans(importToken.Span, moduleToken.Span)
-	return ast.NewImportStmt(specifiers, moduleToken.Value, span)
+	pkg, flags := splitImportFlags(moduleToken.Value)
+	return ast.NewImportStmt(specifiers, pkg, flags, span)
+}
+
+// splitImportFlags splits a module specifier into the package portion and a
+// list of `?flag1&flag2` flags. Returns (specifier, nil) if no `?` is present.
+// An empty flag (e.g. trailing `&` or `?&foo`) is preserved as ""; semantic
+// validation lives in the resolver.
+func splitImportFlags(spec string) (string, []string) {
+	idx := -1
+	for i := 0; i < len(spec); i++ {
+		if spec[i] == '?' {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return spec, nil
+	}
+	pkg := spec[:idx]
+	rest := spec[idx+1:]
+	flags := []string{}
+	start := 0
+	for i := 0; i <= len(rest); i++ {
+		if i == len(rest) || rest[i] == '&' {
+			flags = append(flags, rest[start:i])
+			start = i + 1
+		}
+	}
+	return pkg, flags
 }

--- a/internal/parser/stmt_test.go
+++ b/internal/parser/stmt_test.go
@@ -313,6 +313,18 @@ func TestParseStmtNoErrors(t *testing.T) {
 		"ImportNamespace": {
 			input: `import * as ns from "module"`,
 		},
+		"ImportBare": {
+			input: `import "std:math"`,
+		},
+		"ImportBareWithFlag": {
+			input: `import "std:math?nested"`,
+		},
+		"ImportBareWithFlags": {
+			input: `import "std:math?flag1&flag2"`,
+		},
+		"ImportNamedWithFlag": {
+			input: `import { foo } from "std:math?local"`,
+		},
 		"ForInBasic": {
 			input: `for item in items { console.log(item) }`,
 		},

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -179,18 +179,23 @@ func (p *Printer) printImportStmt(s *ast.ImportStmt) {
 		}
 		p.writeString(" from")
 	}
-	p.space()
-	p.writeString("\"")
-	p.writeString(s.PackageName)
+	// Reassemble the module specifier (URI + `?flag1&flag2` suffix) and
+	// emit it as a properly escaped string literal — matches the
+	// strconv.Quote treatment used for `*ast.StrLit` elsewhere in this
+	// printer, so a PackageName or flag containing quotes/backslashes
+	// round-trips correctly.
+	var spec strings.Builder
+	spec.WriteString(s.PackageName)
 	for i, flag := range s.Flags {
 		if i == 0 {
-			p.writeString("?")
+			spec.WriteByte('?')
 		} else {
-			p.writeString("&")
+			spec.WriteByte('&')
 		}
-		p.writeString(flag)
+		spec.WriteString(flag)
 	}
-	p.writeString("\"")
+	p.space()
+	p.writeString(strconv.Quote(spec.String()))
 }
 
 // Declaration printing

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -146,11 +146,51 @@ func (p *Printer) printStmt(stmt ast.Stmt) {
 			p.space()
 			p.printExpr(s.Expr)
 		}
+	case *ast.ImportStmt:
+		p.printImportStmt(s)
 	case *ast.ErrorStmt:
 		// Skip error recovery nodes
 	default:
 		p.writeString("/* unknown statement */")
 	}
+}
+
+func (p *Printer) printImportStmt(s *ast.ImportStmt) {
+	p.writeString("import")
+	if !s.Bare() {
+		p.space()
+		// Namespace import is a single specifier with Name == "*".
+		if len(s.Specifiers) == 1 && s.Specifiers[0].Name == "*" {
+			p.writeString("* as ")
+			p.writeString(s.Specifiers[0].Alias)
+		} else {
+			p.writeString("{ ")
+			for i, spec := range s.Specifiers {
+				if i > 0 {
+					p.writeString(", ")
+				}
+				p.writeString(spec.Name)
+				if spec.Alias != "" {
+					p.writeString(" as ")
+					p.writeString(spec.Alias)
+				}
+			}
+			p.writeString(" }")
+		}
+		p.writeString(" from")
+	}
+	p.space()
+	p.writeString("\"")
+	p.writeString(s.PackageName)
+	for i, flag := range s.Flags {
+		if i == 0 {
+			p.writeString("?")
+		} else {
+			p.writeString("&")
+		}
+		p.writeString(flag)
+	}
+	p.writeString("\"")
 }
 
 // Declaration printing

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1518,6 +1518,37 @@ func collectMutLeaves(script *ast.Script) map[string]bool {
 	return out
 }
 
+func TestPrintImportStmt(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"named single", `import { foo } from "module"`},
+		{"named multiple", `import { foo, bar, baz } from "module"`},
+		{"named with alias", `import { foo as bar } from "module"`},
+		{"named mixed", `import { foo, bar as baz, qux } from "module"`},
+		{"namespace", `import * as ns from "module"`},
+		{"bare", `import "std:math"`},
+		{"bare with flag", `import "std:math?nested"`},
+		{"bare with flags", `import "std:math?flag1&flag2"`},
+		{"named with flag", `import { foo } from "std:math?local"`},
+	}
+
+	opts := DefaultOptions()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := parseScript(t, tt.input)
+			result, err := Print(script, opts)
+			if err != nil {
+				t.Fatalf("Print error: %v", err)
+			}
+			if result != tt.input {
+				t.Errorf("Expected %q, got %q", tt.input, result)
+			}
+		})
+	}
+}
+
 // TODO: Add support MatchTypeAnn in the parser
 // func TestPrintMatchTypeAnn(t *testing.T) {
 // 	tests := []struct {

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -14,7 +14,7 @@ Status legend: ✅ done, 🚧 partial, ⬜ not started.
 | §   | Phase                                                | FRs         | Status | Depends on | Notes                                                                                                                                                                                                                                                |
 | --- | ---------------------------------------------------- | ----------- | ------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Declaration-printer audit                            | FR14        | ✅      | —          | Audit test lives in [internal/printer/print_decl_audit_test.go](../../internal/printer/print_decl_audit_test.go); every in-scope form round-trips. Notes on converter-side syntax decisions below.                                                  |
-| 2   | URI-scheme imports + binding-shape flags             | FR2–FR5     | ⬜      | §1         | Parser change (bare-string imports, `?flag` suffix), resolver routes to a stdlib data directory on disk, scope-insertion applies `?local`/`?nested`/`?flat`. Placeholder `std:math` stub is the gate.                                              |
+| 2   | URI-scheme imports + binding-shape flags             | FR2–FR5     | ✅      | §1         | Parser, resolver, all three binding shapes, single-class shortcut, `?flat` collisions, and the `--stdlib-dir` flag (+ env var, sibling-to-exe, repo-relative discovery) all landed. Gate satisfied via `std:math` and `std:array` stubs; unit + fixture coverage in place. Two follow-ups deferred to later sections — see §8 for the two-package `?flat` `dom` fixture, §7 for the FR5 "non-class package exports as namespace members on the same binding" surface. |
 | 3   | Codegen lowering and `@js` decorators                | FR3         | ⬜      | §1         | Decorator parser support (new grammar); per-declaration `@js("...")` carries the JS-runtime expression each pseudo-package member lowers to; codegen drops scheme-prefixed `import` lines and emits the decorator's argument at each reference. |
 | 4   | Cross-package augmentation + inter-package imports   | FR6–FR9     | ⬜      | §2         | Confirm §6 interface-merge can be reused for cross-package augmentation (registry interfaces only) with per-importing-file activation. Pseudo-package import cycles are permitted. Well-known symbols stay on `Symbol`; domain packages re-export aliases (FR8). |
 | 5   | Converter MVP (`tools/dts_to_esc/`)                  | FR10        | ⬜      | §1, §3     | Two tiny slices: a trio-idiom class (`Boolean`) and a small `declare namespace` block (e.g. `JSON`). AST-to-AST translation; emit to stdout; no partition logic. Exercises trio recognition + namespace flattening; emits `@js` decorators per §3. |
@@ -352,6 +352,24 @@ it lazily on first scheme-prefixed import.
 binding-shape flags; two-package `?flat` fixture merges; flag
 collision errors. Single-class shortcut works for the `std:array`
 stub.
+
+**Deferred to later sections.** Two items from §2.5 require
+material that does not yet exist:
+
+- The **two-package `?flat` merge into a `dom` binding** fixture
+  needs `dom:*` stubs. Deferred to §8 (fixture migration) where
+  the §7 bootstrap has produced the real DOM tree. Note that the
+  `?flat` merge mechanic and collision diagnostic are already
+  exercised by unit tests and by the `stdlib_import_flat` /
+  `stdlib_import_flag_conflict` fixtures landed here; §8's
+  fixture pins the cross-scheme `dom` case specifically.
+- The **FR5 "non-class package exports as namespace members on
+  the same binding"** surface is not implemented yet — the
+  current `std:array` stub has only the class. The shortcut
+  itself works; merging companion exports onto the class binding
+  is wired up in §7 once real packages pair a class with helpers.
+  A TODO marker lives in
+  [bindStdlibLocal](../../internal/checker/infer_stdlib_import.go).
 
 ---
 
@@ -1100,6 +1118,20 @@ files as the source of truth.
    `T | Promise<T>`, generic propagation). If a concrete
    blocker surfaces, fall back to a checker-resident intrinsic
    and document the specific failure.
+4. **FR5 finalization — non-class package exports as namespace
+   members.** §2's single-class shortcut binds the class itself
+   when activated; the FR5 spec also calls for other package
+   exports to remain accessible *as namespace members on the
+   same binding*, with static methods winning on name collision.
+   The §2 implementation left this as a TODO in
+   [bindStdlibLocal](../../internal/checker/infer_stdlib_import.go)
+   because the §2-era stubs (`std:math`, `std:array`) have only
+   a single export. Once the §7 bootstrap produces real packages
+   that pair a class with non-class exports (e.g. `std:array`
+   gaining helper functions or constants alongside `Array`),
+   wire the merge: copy `pkgNs.Values` and `pkgNs.Types` onto
+   the class binding's static surface, and add a unit test pinning
+   the static-method-wins tiebreaker.
 4. Commit. After this point, the converter persists only as
    `--check` review tool; ongoing edits are direct to the
    committed `.esc` files.
@@ -1144,6 +1176,27 @@ rely on.
 **Gate.** `go test ./...` passes with every fixture using
 explicit `import "std:*"` statements; no fixture relies on
 ambient resolution — except for the third-party carve-out below.
+
+**Carries-over from §2.** §2 landed five binding-shape fixtures
+under [fixtures/](../../fixtures/) (`stdlib_import_local`,
+`stdlib_import_nested`, `stdlib_import_flat`,
+`stdlib_import_single_class`, `stdlib_import_flag_conflict`).
+Two §2.5 fixtures were deferred to this phase because they need
+material that does not exist until §7:
+
+- A **two-package `?flat` merge into a `dom` binding**. Requires
+  at least two `dom:*` stubs; §7 produces the full DOM tree. Add
+  the fixture here, asserting that non-colliding members from
+  two `?flat`-imported `dom:*` packages co-exist in the same
+  `dom` namespace.
+- A **single-class shortcut fixture with non-class package exports**
+  on the same binding. §2's `std:array` stub has only the class;
+  once §7 populates `std:array` with companion helpers (or another
+  package mixes a class with constants/functions), add a fixture
+  that exercises both the class and a non-class export through the
+  same shortcut binding, including the static-method-wins
+  tiebreaker (the work itself lives in §7 — this fixture is the
+  end-to-end gate).
 
 ### 8.1 Third-party `.d.ts` fixture carve-out
 


### PR DESCRIPTION
- **parser + AST + printer round-trip for bare imports and ?flag**
- **stdlib-dir discovery infra**
- **resolver scheme routing + ?local binding**
- **?nested/?flat + single-class shortcut + collision errors**
- **add fixtures, move remaining work into future sections in implementation plan**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standard-library scheme imports (e.g. import "std:math") with binding-shape flags (?local, ?nested, ?flat)
  * CLI flag to specify stdlib location (--stdlib-dir) supported by build and LSP commands
  * Added stdlib modules (math PI, Array type stub) for immediate use

* **Documentation**
  * Added READMEs describing std:, dom:, and node: pseudo-package resolution

* **Tests**
  * Comprehensive tests covering stdlib import shapes, collisions, and resolution behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->